### PR TITLE
Better controller param protection and handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
   remote: https://github.com/jrochkind/attr_json
-  revision: 78155dc97762982cd8ebb9f149fe254e4fa0c293
+  revision: 7bc3a3611fd59ca97f6318994a81d606819245f0
   specs:
-    attr_json (0.5.0)
+    attr_json (0.6.0)
       activerecord (>= 5.0.0, < 6.1)
 
 GIT
   remote: https://github.com/sciencehistory/kithe.git
-  revision: fa81dfe39edbb9a0f76ca16542d5a6652378cf2f
+  revision: 2785842d0c44095432838911cbfac24f9302de40
   branch: master
   specs:
     kithe (0.1.0)

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -73,6 +73,13 @@ class Admin::CollectionsController < ApplicationController
     # This could be done in a form object or otherwise abstracted, but this is good
     # enough for now.
     def collection_params
-      params.require(:collection).permit!
+      params.
+        require(:collection).
+        permit(:title, :description, :related_url_attributes => []).tap do |hash|
+          # sanitize description
+          if hash[:description].present?
+            hash[:description] = DescriptionSanitizer.new.sanitize(hash[:description])
+          end
+        end
     end
 end

--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -128,7 +128,9 @@ class Admin::WorksController < ApplicationController
     # This could be done in a form object or otherwise abstracted, but this is good
     # enough for now.
     def work_params
-      params.require(:work).permit!.tap do |params|
+      Kithe::Parameters.new(params).require(:work).permit_attr_json(Work).permit(
+        :title, :parent_id, :representative_id, :contained_by_ids => []
+      ).tap do |params|
         # sanitize description
         if params[:description].present?
           params[:description] = DescriptionSanitizer.new.sanitize(params[:description])

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,6 +33,10 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  # Only in dev or test, let us know if we are passing params that haven't
+  # been permitted, cause we have complicated params easy to miss one.
+  config.action_controller.action_on_unpermitted_parameters = :raise
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,6 +38,10 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  # Only in dev or test, let us know if we are passing params that haven't
+  # been permitted, cause we have complicated params easy to miss one.
+  config.action_controller.action_on_unpermitted_parameters = :raise
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end


### PR DESCRIPTION
With Kithe::Parameters class that let's us white-list our attr_json fields more easily than rails built-in strong params.