### PR TITLE
change feature tests to system tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
     capistrano-rails (1.4.0)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
-    capybara (3.12.0)
+    capybara (3.13.2)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)

--- a/spec/system/asset/convert_to_child_work_spec.rb
+++ b/spec/system/asset/convert_to_child_work_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Convert asset to child work", js: true do
+RSpec.describe "Convert asset to child work", type: :system, js: true do
   let(:work) { FactoryBot.create(:work, :with_complete_metadata, :with_collection, :with_assets, asset_count: 5) }
   let(:conversion_source) { work.members[2] }
 

--- a/spec/system/asset/convert_to_child_work_spec.rb
+++ b/spec/system/asset/convert_to_child_work_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe "Convert asset to child work", js: true do
+  let(:work) { FactoryBot.create(:work, :with_complete_metadata, :with_collection, :with_assets, asset_count: 5) }
+  let(:conversion_source) { work.members[2] }
+
+  it "converts" do
+    original_position = conversion_source.position
+    visit admin_asset_path(conversion_source)
+
+    expect do
+      click_on "Convert to child work"
+      expect(page).to have_current_path(%r{\A/admin/works})
+    end.to change { Work.count }.by(1).and change { Asset.count }.by(0)
+
+    expect(conversion_source.reload.persisted?).to be(true)
+    new_work = Work.order(:created_at).last
+
+    expect(new_work.title).to eq(work.title)
+    expect(new_work.parent).to eq(work)
+    expect(new_work.contained_by).to eq(work.contained_by)
+    expect(new_work.position).to eq(original_position)
+
+    # all attr_json attributes
+    expect(new_work.json_attributes).to eq(work.json_attributes)
+  end
+
+end

--- a/spec/system/collection/new_collection_spec.rb
+++ b/spec/system/collection/new_collection_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "New Collection form", js: true do
+RSpec.describe "New Collection form", type: :system, js: true do
   scenario "save, edit, and re-save new work" do
     visit new_admin_collection_path
 

--- a/spec/system/collection/new_collection_spec.rb
+++ b/spec/system/collection/new_collection_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe "New Collection form", js: true do
+  scenario "save, edit, and re-save new work" do
+    visit new_admin_collection_path
+
+    fill_in "collection[title]", with: "New collection title"
+    fill_in "collection[description]", with: "New collection desc with <script>bad tag</script> and <b>bold</b>"
+    fill_in "collection[related_url_attributes][]", with: "http://example.org"
+
+    click_button "Create Collection"
+
+    # Wait for action to complete, and return Collection list page
+    expect(page).to have_css("h1", text: "Collections")
+
+    # check data
+    newly_added_collection = Collection.order(:created_at).last
+
+    expect(newly_added_collection.title).to eq("New collection title")
+    expect(newly_added_collection.description).to eq("New collection desc with bad tag and <b>bold</b>")
+    expect(newly_added_collection.related_url).to eq(["http://example.org"])
+  end
+end

--- a/spec/system/work/demote_to_asset_spec.rb
+++ b/spec/system/work/demote_to_asset_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 # We're not gonna test every possible thing here, but a few
-RSpec.describe "Convert child work to asset", js: true do
+RSpec.describe "Convert child work to asset", type: :system, js: true do
   let(:parent_work) { FactoryBot.create(:work, :with_assets, asset_count: 3) }
   let(:child_work) { FactoryBot.create(:work, :with_assets, parent: parent_work, position: 3) }
 

--- a/spec/system/work/demote_to_asset_spec.rb
+++ b/spec/system/work/demote_to_asset_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+# We're not gonna test every possible thing here, but a few
+RSpec.describe "Convert child work to asset", js: true do
+  let(:parent_work) { FactoryBot.create(:work, :with_assets, asset_count: 3) }
+  let(:child_work) { FactoryBot.create(:work, :with_assets, parent: parent_work, position: 3) }
+
+  it "demotes to asset" do
+    original_position = child_work.position
+    asset = child_work.members.first
+
+    expect do
+      visit admin_work_path(child_work)
+
+      accept_confirm do
+        click_on "Demote to Asset"
+      end
+
+      expect(page).to have_current_path(admin_work_path(parent_work))
+    end.to change { Work.count }.by(-1).and change { Asset.count }.by(0)
+
+    asset.reload # not raise
+    expect(asset.parent).to eq(parent_work)
+    expect(asset.position).to eq(original_position)
+
+    expect { child_work.reload }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+end

--- a/spec/system/work/edit_work_metadata_spec.rb
+++ b/spec/system/work/edit_work_metadata_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+# We're not gonna test every possible thing here, but a few
+RSpec.describe "Edit work metadata form", js: true do
+  let!(:new_collection) { FactoryBot.create(:collection) }
+  let(:work) { FactoryBot.create(:work, :with_complete_metadata, :with_collection, :with_assets, asset_count: 3) }
+
+  # only gonna edit the tricky stuff for now
+  it "edits work" do
+    visit edit_admin_work_path(work)
+
+    # Set collection to a new thing, unselect old thing
+    original_collection = work.contained_by.first
+    find("#work_contained_by_ids option[value='#{original_collection.id}']").unselect_option
+    find("#work_contained_by_ids option[value='#{new_collection.id}']").select_option
+
+    # Set representative to a new thing
+    new_representative = work.members.find {|m| m.id != work.representative_id}
+    find("#work_representative_id option[value='#{new_representative.id}']").select_option
+
+    click_button "Update Work"
+
+    # check page, before checking data, to make sure action has completed.
+    expect(page).to have_css("h1", text: work.title)
+
+    # check data
+    work.reload
+
+    expect(work.representative_id).to eq(new_representative.id)
+    expect(work.contained_by_ids).to include(new_collection.id)
+    expect(work.contained_by_ids).not_to include(original_collection.id)
+  end
+
+  it "sanitizes description" do
+    visit edit_admin_work_path(work)
+
+    fill_in "work[description]", with: <<~EOS
+        <script>evil</script>
+        <p>This is a paragraph</p>
+        This is a line with <b>bold</b>, <i>italic</i>, <cite>cite</cite>, and a <a href='http://example.com' onclick='foo'>link</a>.
+
+        This is a final line
+    EOS
+
+    click_button "Update Work"
+
+    # check page, before checking data, to make sure action has completed.
+    expect(page).to have_css("h1", text: work.title)
+    work.reload
+
+    expect(work.description).to eq(<<~EOS)
+        evil
+        This is a paragraph
+        This is a line with <b>bold</b>, <i>italic</i>, <cite>cite</cite>, and a <a href=\"http://example.com\">link</a>.
+
+        This is a final line
+    EOS
+  end
+end

--- a/spec/system/work/edit_work_metadata_spec.rb
+++ b/spec/system/work/edit_work_metadata_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 # We're not gonna test every possible thing here, but a few
-RSpec.describe "Edit work metadata form", js: true do
+RSpec.describe "Edit work metadata form", type: :system, js: true do
   let!(:new_collection) { FactoryBot.create(:collection) }
   let(:work) { FactoryBot.create(:work, :with_complete_metadata, :with_collection, :with_assets, asset_count: 3) }
 

--- a/spec/system/work/new_work_spec.rb
+++ b/spec/system/work/new_work_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'pp'
 
-RSpec.describe "New Work form", js: true do
+RSpec.describe "New Work form", type: :system, js: true do
   let!(:collection) { FactoryBot.create(:collection) }
   let!(:work) { FactoryBot.create(:work, :with_complete_metadata) }
 

--- a/spec/system/work/new_work_spec.rb
+++ b/spec/system/work/new_work_spec.rb
@@ -1,0 +1,189 @@
+require 'rails_helper'
+require 'pp'
+
+RSpec.describe "New Work form", js: true do
+  let!(:collection) { FactoryBot.create(:collection) }
+  let!(:work) { FactoryBot.create(:work, :with_complete_metadata) }
+
+  scenario "save, edit, and re-save new work" do
+    visit new_admin_work_path
+
+    # Single-value free text
+    %w(title description source admin_note rights_holder).each do |p|
+      fill_in "work[#{p}]", with: work.send(p)
+    end
+
+    # Multi-value free text
+    %w(additional_title language medium subject).each do |p|
+      attr_name = Work.human_attribute_name(p)
+      all_items = work.send(p)
+      all_items.length.times do |i|
+        click_link("Add another #{attr_name}") unless i == 0
+        all("fieldset.work_#{p} input[type=text]")[i].
+          fill_in with: all_items[i]
+      end
+    end
+
+    # Multi-value free text (2)
+    %w(extent series_arrangement related_url).each do |p|
+      attr_name = Work.human_attribute_name(p)
+      all_items = work.send(p)
+      all_items.length.times do |i|
+        click_link("Add another #{attr_name}")
+        all("fieldset.work_#{p} input[type=text]")[i].fill_in with: all_items[i]
+      end
+    end
+
+    # Multi-value free text with associated category dropdown
+    %w(creator place external_id).each do |p|
+      attr_name = Work.human_attribute_name(p)
+      all_items = work.send(p)
+      all_items.length.times do |i|
+        val =  all_items[i].value
+        cat =  all_items[i].category
+        click_link("Add another #{attr_name}") unless i == 0
+        all("fieldset.work_#{p} select")[i].
+          find("option[value='#{cat}']").select_option
+        all("fieldset.work_#{p} input[type=text]")[i].
+          fill_in with: val
+      end
+    end
+
+    #Multi-value dropdown:
+    %w(genre).each do |p|
+      all_items = work.send(p)
+      all_items.length.times do |i|
+        click_link("Add another #{attr_name}") unless i == 0
+        val = work.send(p)[i]
+        all("fieldset.work_#{p} select")[i].
+          find("option[value='#{val}']").
+          select_option
+      end
+    end
+
+    #Custom single-value selects:
+    %w(file_creator department rights).each do |p|
+      val = work.send(p)
+      find("div.work_#{p} select option[value='#{val}']").select_option
+    end
+
+    #Custom single-value selects (2)
+    %w(exhibition).each do |p|
+      attr_name = Work.human_attribute_name(p)
+      all_items = work.send(p)
+      all_items.length.times do |i|
+        click_link("Add another #{attr_name}")
+        val = all_items[i]
+        all("fieldset.work_#{p} select")[i].
+          find("option[value='#{val}']").select_option
+      end
+    end
+
+    # Dates:
+    %w(date_of_work).each do |property|
+      attr_name = Work.human_attribute_name(property)
+      all_items = work.send(property)
+      all_items.length.times do |i|
+        click_link("Add another #{attr_name}") unless i == 0
+        %w(start note finish).each do |p|
+          all("fieldset.work_#{property} input[type=text][name*=#{p}]")[i].
+            fill_in with: all_items[i].attributes[p]
+        end
+        %w(start_qualifier finish_qualifier).each do |p|
+          val = all_items[i].attributes[p]
+          all("fieldset.work_#{property} select[name*=#{p}]")[i].
+            find("option[value='#{val}']").select_option
+        end
+      end
+    end
+
+    #Inscriptions
+    %w(inscription).each do |property|
+      attr_name = Work.human_attribute_name(property)
+      all_items = work.send(property)
+      all_items.length.times do |i|
+        click_link("Add another #{attr_name}")
+        %w(location text).each do |p|
+          all("fieldset.work_#{property} input[type=text][name*=#{p}]")[i].
+            fill_in with: all_items[i].attributes[p]
+        end
+      end
+    end
+
+    # Physical container:
+    %w(box volume page folder part shelfmark).each do |p|
+      fill_in "work[physical_container_attributes][#{p}]",
+        with: work.physical_container.attributes[p]
+    end
+
+    #Format
+    work.format.each do |val|
+      find("input[value=#{val}]").check
+    end
+
+    #Additional Credit
+    %w(additional_credit).each do |property|
+      attr_name = Work.human_attribute_name(property)
+      all_items = work.send(property)
+      all_items.length.times do |i|
+        click_link("Add another #{attr_name}")
+        %w(role name).each do |p|
+          val = all_items[i].attributes[p]
+          all("fieldset.work_#{property} select[name*=#{p}]")[i].
+            find("option[value='#{val}']").select_option
+        end
+      end
+    end
+
+    # Collection membership
+    find("#work_contained_by_ids option[value='#{collection.id}']").select_option
+
+    click_button "Create Work"
+
+    # check page, before checking data, to make sure action has completed.
+    expect(page).to have_css("h1", text: "Add Files").and have_text("To: #{work.title}")
+
+    # check data
+    newly_added_work = Work.order(:created_at).last
+
+    %w(
+      additional_credit additional_title admin_note creator
+      department date_of_work description external_id format
+      file_creator genre inscription language medium
+      physical_container place rights
+      rights_holder source subject title
+    ).each do |prop|
+      expect(newly_added_work.send(prop)).to eq work.send(prop)
+    end
+
+    expect(newly_added_work.contained_by).to include(collection)
+  end
+
+  context "creating a child work" do
+    let(:parent_work) { FactoryBot.create(:work, :with_collection, :with_assets, title: "parent_work") }
+
+    it "creates with proper inherited metadata" do
+      members_max_position = parent_work.members.maximum(:position)
+
+      visit new_admin_work_path(parent_id: parent_work.friendlier_id)
+
+      fill_in "work[title]", with: "child work"
+
+      find("#work_external_id_attributes_0_category option[value=object]").select_option
+      fill_in "work_external_id_attributes_0_value", with: "some_object_id"
+
+      click_button "Create Work"
+
+      # check page, before checking data, to make sure action has completed.
+      expect(page).to have_css("h1", text: "Add Files").and have_text("To: child work")
+
+      # check data
+      added_work = Work.order(:created_at).last
+
+      expect(added_work.title).to eq("child work")
+      expect(added_work.parent_id).to eq(parent_work.id)
+      expect(added_work.contained_by).to eq(parent_work.contained_by)
+      expect(added_work.position).to eq(members_max_position + 1)
+    end
+  end
+end


### PR DESCRIPTION
System tests were added in Rails 5.1, and rspec wraps them, and now
recommends using them instead of feature tests.

https://medium.com/table-xi/a-quick-guide-to-rails-system-tests-in-rspec-b6e9e8a8b5f6
https://github.com/rspec/rspec-rails#system-specs-feature-specs-request-specswhats-the-difference
http://rspec.info/blog/2017/10/rspec-3-7-has-been-released/#rails-actiondispatchsystemtest-integration-system-specs

Hypothetically this gives us faster tests in db transactions, which is the
innovation Rails 5.1 system tests brought. But I think we were getting that
even before with feature tests? Who knows, but let's do what's recommended.