### PR TITLE
Controllers should use find_by_friendlier_id\! with exclamation mark

### DIFF
--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -27,7 +27,7 @@ class Admin::AssetsController < ApplicationController
   end
 
   def destroy
-    @asset = Asset.find_by_friendlier_id(params[:id])
+    @asset = Asset.find_by_friendlier_id!(params[:id])
 
     authorize! :destroy, @asset
 
@@ -40,14 +40,14 @@ class Admin::AssetsController < ApplicationController
   end
 
   def display_attach_form
-    @parent = Work.find_by_friendlier_id(params[:parent_id])
+    @parent = Work.find_by_friendlier_id!(params[:parent_id])
   end
 
   # Receives json hashes for direct uploaded files in params[:files],
   # and parent_id in params[:parent_id] (friendlier_id)
   # creates filesets for them and attach.
   def attach_files
-    @parent = Work.find_by_friendlier_id(params[:parent_id])
+    @parent = Work.find_by_friendlier_id!(params[:parent_id])
 
     current_position = @parent.members.maximum(:position) || 0
 

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -65,7 +65,7 @@ class Admin::CollectionsController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_collection
-      @collection = Collection.find_by_friendlier_id(params[:id])
+      @collection = Collection.find_by_friendlier_id!(params[:id])
     end
 
     # only allow whitelisted params through (TODO, we're allowing all collection params!)

--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -108,7 +108,7 @@ class Admin::WorksController < ApplicationController
         end
       end
     else # alphabetical
-      work = Work.find_by_friendlier_id(params[:id])
+      work = Work.find_by_friendlier_id!(params[:id])
       sorted_members = work.members.sort_by{ |member| member.title.downcase  }.to_a
       ActiveRecord::Base.transaction do
         sorted_members.each_with_index do |member, index|


### PR DESCRIPTION
So will raise ActiveRecord::RecordNotFound if ID not found, which will turn into a 404. The non-exclamation-point version will just return nil, which will later cause a random nil pointer error of some kind, resulting in a 500. Should fail early with proper RecordNotFound instead.

closes #68