### PR TITLE
Trivial: add "photomechanical prints" genre

### DIFF
--- a/app/models/work/controlled_lists.rb
+++ b/app/models/work/controlled_lists.rb
@@ -59,6 +59,7 @@ class Work
       'Personal correspondence',
       'Pesticides',
       'Photographs',
+      'Photomechanical prints',
       'Plastics',
       'Portraits',
       'Postage stamps',


### PR DESCRIPTION
Fixes https://github.com/sciencehistory/chf-sufia/issues/1224 .