### PR TITLE
blank out arrays before adding to them

### DIFF
--- a/app/importers/importers/generic_work_importer.rb
+++ b/app/importers/importers/generic_work_importer.rb
@@ -13,7 +13,6 @@ module Importers
     end
 
     def populate()
-      empty_arrays()
       add_external_id()
       add_scalar_attributes()
       add_array_attributes()
@@ -26,16 +25,6 @@ module Importers
       add_physical_container()
     end
 
-    # This may no longer be needed, but having these be nil rather than
-    # empty arrays wasn't handled well by one of the front-end templates.
-    def empty_arrays()
-        target_item.date_of_work = []
-        target_item.place = []
-        target_item.creator = []
-        target_item.exhibition = []
-        target_item.additional_credit = []
-        target_item.inscription = []
-    end
 
     def add_physical_container()
       return if metadata['physical_container'].nil?
@@ -49,6 +38,7 @@ module Importers
     end
 
     def add_creator()
+      target_item.creator = []
       Work::Creator::CATEGORY_VALUES.each do |k|
         next if metadata[k].nil?
         metadata[k].each do |v|
@@ -58,6 +48,7 @@ module Importers
     end
 
     def add_additional_credit()
+      target_item.additional_credit = []
       role_map = {'photographer' => 'photographed_by'}
       return if metadata['additional_credits'].nil?
       metadata['additional_credits'].each do |a_c|
@@ -70,6 +61,7 @@ module Importers
     end
 
     def add_date()
+      target_item.date_of_work = []
       return if metadata['dates'].nil?
 
       metadata['dates'].each do |d|
@@ -83,6 +75,7 @@ module Importers
     end
 
     def add_place()
+      target_item.place = []
       Work::Place::CATEGORY_VALUES.each do |k|
         next if metadata[k].nil?
         metadata[k].each do |v|
@@ -92,6 +85,7 @@ module Importers
     end
 
     def add_inscriptions()
+      target_item.inscription = []
       return if metadata['inscriptions'].nil?
 
       metadata['inscriptions'].each do |ins|
@@ -104,6 +98,7 @@ module Importers
     end
 
     def add_external_id()
+      target_item.external_id = []
       @metadata['identifier'].each do |x|
         category, value = x.split('-')
         target_item.build_external_id({'category' => category, 'value' => value})

--- a/spec/importers/generic_work_importer_spec.rb
+++ b/spec/importers/generic_work_importer_spec.rb
@@ -127,7 +127,11 @@ RSpec.describe Importers::GenericWorkImporter do
     end
 
     describe "with existing item" do
-      let!(:existing_item) { FactoryBot.create(:work, friendlier_id: metadata["id"], title: "old title", published: false)}
+      let!(:existing_item) { FactoryBot.create(:work,
+        friendlier_id: metadata["id"],
+        title: "old title",
+        external_id: { category: "object", value: "old_id"},
+        published: false)}
 
       it "imports and updates data" do
         generic_work_importer.import
@@ -137,6 +141,7 @@ RSpec.describe Importers::GenericWorkImporter do
 
         expect(item.title).to eq "Adulterations of food; with short processes for their detection."
         expect(item.published?).to be(true)
+        expect(item.external_id).to eq([Work::ExternalId.new(category: "bib", value: "b1075796")])
       end
     end
   end


### PR DESCRIPTION
I had noted some cases in kithe staging that seemed to have _double_ external IDs.

I noticed that the previous "empty_ararys" method neglected to blank out external IDs. Still, I couldn't actually reproduce the problem
in the test. Nevertheless, it seems better to blank out the array in every method that is about to set an array-model value, together
with that value, instead of an "empty_arrays" method. Keeping em together seems more clear when you forget one.