### PR TITLE
New passenger restart using systemctl

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -19,6 +19,8 @@ set :deploytag_utc, false
 
 # use 'passenger-config restart-app' to restart passenger
 set :passenger_restart_with_touch, false
+set :passenger_restart_command, 'sudo systemctl restart passenger'
+set :passenger_restart_options, ""
 
 # send some data to whenever
 #set :whenever_identifier, ->{ "#{fetch(:application)}_#{fetch(:stage)}" }


### PR DESCRIPTION
This updates the restart command for passenger to using the `systemctl restart passenger` command. Right now with our passenger setup running outside apache and not just placing all the files in `/tmp` using the normal passenger command fails unless we set the `PassengerInstanceRegistryDir`.

The downside to just setting it in capistrano is any future changes in Ansible will cause cap deploys to break. By using the slightly less elegant `systemctl` call we only need to make sure that Ansible builds the systemctl.service file for passenger correctly and any changes will happen in one place.

The change required adding a tweak to the sudoers to allow our deploying user to restart passenger.