### PR TITLE
Convenience rake task for printing out a value from ScihistDigicoll::Env

### DIFF
--- a/lib/tasks/scihist.rake
+++ b/lib/tasks/scihist.rake
@@ -6,6 +6,15 @@ namespace :scihist do
     end
   end
 
+  desc "print out value for ScihistDigicoll::Env variable. eg ./bin/rake scihist:env_value[solr_url]"
+  task "env_value", [:key] => :environment do |t, args|
+    unless args[:key].present?
+      puts "Error. Run as ./bin/rake scihist:env_value[some_key_name]"
+      exit
+    end
+    puts "#{args[:key]}: #{ScihistDigicoll::Env.lookup(args[:key]).inspect}"
+  end
+
 
   namespace :user do
     desc 'Create a user without a password; they can request one from the UI. `RAILS_ENV=production bundle exec rake chf:user:create[newuser@chemheritage.org]`'


### PR DESCRIPTION
Ie, set in local_env.yml or shell ENV, etc.

Run as ./bin/rake scihist:env_value[solr_url]

Where solr_url is an example key name.