### PR TITLE
Add whenever with capistrano integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ gem "content_disposition"
 
 # slack notifications on capistrano deploys
 gem 'slackistrano', "~> 3.8"
+gem "whenever" # automatic crontob maintenance, on capistrano deploys
 
 gem "ransack", "~> 2.1"
 gem "kaminari", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,7 @@ GEM
       launchy
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    chronic (0.10.2)
     cocoon (1.2.12)
     coderay (1.1.2)
     coffee-rails (4.2.2)
@@ -522,6 +523,8 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    whenever (0.11.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yell (2.1.0)
@@ -578,6 +581,7 @@ DEPENDENCIES
   webdrivers
   webmock (~> 3.5)
   webpacker (~> 3.5)
+  whenever
 
 RUBY VERSION
    ruby 2.5.3p105

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -22,9 +22,6 @@ set :passenger_restart_with_touch, false
 set :passenger_restart_command, 'sudo systemctl restart passenger'
 set :passenger_restart_options, ""
 
-# send some data to whenever
-#set :whenever_identifier, ->{ "#{fetch(:application)}_#{fetch(:stage)}" }
-#set :whenever_roles, [:app, :jobs, :cron]
 
 # not all machines should run bundler; some won't have ruby
 set :bundle_roles, [:web, :jobs, :cron]
@@ -46,6 +43,13 @@ set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', '
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }
 
 set :honeybadger_env, fetch(:stage)
+
+
+# Whenever, only deploy cronjobs on server(s) marked with Capistrano :cron role.
+# Right now our cronjobs are general maintenance tasks that _could_ run on any
+# server with the Rails app available. We set the "jobs" server to have "cron"
+# role.
+set :whenever_roles, [:cron]
 
 # When running rake tasks with `cap staging invoke:rake rake:task:name`, via
 # the capistrano-rake gem, run them on the jobs host, that's a good one for

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,13 @@
+# Config file for `whenever, we use with capistrano to add/update/remove cronjobs
+# on deploy servers with capistrano deploys.
+# http://github.com/javan/whenever
+
+env :PATH, ENV['PATH']
+
+# Make sure honeybadger reports errors in crontab'd rake tasks.
+env :HONEYBADGER_EXCEPTIONS_RESCUE_RAKE, true
+
+# every :day, at: '2:00am', roles: [:cron] do
+#   # just for testing, not really gonna do this, although we could
+#   rake "scihist:solr:reindex"
+# end


### PR DESCRIPTION
For maintenance of cronjobs on our deploy servers

Initially, we'll need to run the Blacklight task to clear out old data from the `searches` table. 