### PR TITLE
Admin-only Search Fields

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ ruby File.read(".ruby-version").chomp
 gem 'rails', '~> 5.2.1'
 gem 'webpacker', '~> 3.5'
 
-gem "blacklight", "~> 7.0"
+gem "blacklight", "~> 7.0", ">= 7.1.0.alpha"
 
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,12 +96,11 @@ GEM
       aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt (3.1.12)
     bindex (0.5.0)
-    blacklight (7.0.1)
+    blacklight (7.1.0.alpha)
       deprecation
       globalid
       jbuilder (~> 2.7)
       kaminari (>= 0.15)
-      nokogiri (~> 1.6)
       rails (~> 5.1)
     bootsnap (1.3.2)
       msgpack (~> 1.0)
@@ -544,7 +543,7 @@ PLATFORMS
 DEPENDENCIES
   access-granted (~> 1.0)
   attr_json!
-  blacklight (~> 7.0)
+  blacklight (~> 7.0, >= 7.1.0.alpha)
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.3)
   bootstrap4-kaminari-views

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -12,6 +12,14 @@ class CatalogController < ApplicationController
     false
   end
 
+  # Tell Blacklight to include things in context, that will become
+  # available to our custom SearchBuilder extensions
+  def search_service_context
+    {
+      current_user: current_user
+    }
+  end
+
   configure_blacklight do |config|
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -9,6 +9,9 @@
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
 
+  # Scihist SearchBuilder extensions
+  include SearchBuilder::AdminOnlySearchFields
+
   ##
   # @example Adding a new step to the processor chain
   #   self.default_processor_chain += [:add_custom_data_to_query]

--- a/app/models/search_builder/admin_only_search_fields.rb
+++ b/app/models/search_builder/admin_only_search_fields.rb
@@ -1,0 +1,26 @@
+class SearchBuilder
+  # An extension to Blacklight's SearchBuilder (which is locally generated in our app), such
+  # that logged in users will have additional field(s) added to their solr `qf` and `pf` fields,
+  # so our logged in users (which are staff), can search staff-only fields.
+  #
+  # See the indexer classes (eg WorkIndexer) to see what is put in what admin-only fields.
+  module AdminOnlySearchFields
+    extend ActiveSupport::Concern
+
+    mattr_accessor :admin_only_search_fields
+    self.admin_only_search_fields = [
+      "admin_only_text_tesim"
+    ]
+
+    included do
+      self.default_processor_chain += [:include_admin_only_search_fields]
+    end
+
+    def include_admin_only_search_fields(solr_params)
+      if scope.context[:current_user]
+        solr_params["qf"] << " " << admin_only_search_fields.join(" ")
+        solr_params["qf"] << " " << admin_only_search_fields.join(" ")
+      end
+    end
+  end
+end

--- a/spec/system/catalog_search_spec.rb
+++ b/spec/system/catalog_search_spec.rb
@@ -1,11 +1,17 @@
 require 'rails_helper'
 
 # Blacklight-powered search
+#
+# System tests are slow, and ideally we might be testing more functionality in unit
+# tests. But Blacklight sometimes makes it hard to set up unit testing, and I don't totally
+# trust that future versions of Blacklight wouldn't break our unit tests assumptions, a
+# full integration test on UI is safest and easiest.
 describe CatalogController, solr: true, indexable_callbacks: true do
+  let(:admin_note_text) { "an admin note" }
+  let(:admin_note_query) { "\"#{admin_note_text}\"" }
   let!(:work1) { create(:work) }
-  let!(:work2) { create(:work) }
   let!(:collection) { create(:collection) }
-
+  let!(:work_with_admin_note) { create(:work, admin_note: admin_note_text) }
 
   # just a smoke test
   it "loads" do
@@ -13,7 +19,19 @@ describe CatalogController, solr: true, indexable_callbacks: true do
 
     expect(page).to have_content("1 - 3 of 3")
     expect(page).to have_content(work1.title)
-    expect(page).to have_content(work2.title)
+    expect(page).to have_content(work_with_admin_note.title)
     expect(page).to have_content(collection.title)
+  end
+
+  it "does not find admin note" do
+    visit search_catalog_path(q: admin_note_query)
+    expect(page).to have_content("No results found")
+  end
+
+  describe "with logged in user", logged_in_user: true do
+    it "can find admin note" do
+      visit search_catalog_path(q: admin_note_query)
+      expect(page).to have_content("1 entry found")
+    end
   end
 end


### PR DESCRIPTION
Closes #124 

The Blacklight "SearchBuilder" is the object that creates the Solr query. 

We want it to include certain Solr fields as search targets only if there is a logged in user, to make sure non-staff isn't searching over staff-only fields. 

To do this, we needed features missing from BL 7, but added in BL 7.1.0.alpha, which we now use (hopefully 7.1.0 final soon). 

We tell Blacklight that `current_user` should be included in context that becomes available to our SearchBuilder. 

And we give the SearchBuilder a very simple extension to, based on presence of current_user, add in search fields.

Tests: We test with system tests (end-to-end browser tests). While these are slow... it's difficult to set up Blacklight-related tests otherwise, especially with confidence they are *really* doing what's expected and not false positives due to wrong assumptions in test setup (or assumptions that become wrong). This is the easiest way to write tests that reliably let us know it's doing what's intended -- making sure only admins can search admin-protected fields.