### PR TITLE
Tell kithe to index friendlier_id to Solr id field, instead of pk id

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
   remote: https://github.com/jrochkind/attr_json
-  revision: c1564dbdd88ddddc529b8cf83c1fe03f45498877
+  revision: 3676174b637496507c526d09c776d3877ff99426
   specs:
-    attr_json (0.6.0)
+    attr_json (0.7.0)
       activerecord (>= 5.0.0, < 6.1)
 
 GIT
   remote: https://github.com/sciencehistory/kithe.git
-  revision: 5b97fd1ed54742e491c5030286b2cd0c61456ff9
+  revision: 3d67573f4258124411d1c6a8ac0303d3cafd263d
   specs:
     kithe (0.2.0)
       attr_json (< 2.0.0)
@@ -301,7 +301,7 @@ GEM
     net-ssh (5.1.0)
     net_http_ssl_fix (0.0.10)
     nio4r (2.3.1)
-    nokogiri (1.10.2)
+    nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     oauth2 (1.4.1)
       faraday (>= 0.8, < 0.16.0)

--- a/config/initializers/kithe_indexable.rb
+++ b/config/initializers/kithe_indexable.rb
@@ -1,1 +1,3 @@
 Kithe::Indexable.settings.solr_url = ScihistDigicoll::Env.lookup!(:solr_url)
+# index to solr with solr `id` field being our friendlier_id
+Kithe::Indexable.settings.solr_id_value_attribute = :friendlier_id

--- a/spec/models/work/work_solr_indexable_spec.rb
+++ b/spec/models/work/work_solr_indexable_spec.rb
@@ -24,12 +24,12 @@ describe "Work auto-indexes in Solr with kithe", indexable_callbacks: true do
   describe "with real solr", solr: true do
     it "indexes to real solr" do
       work = FactoryBot.create(:work, title: "to be indexed")
-      solr_query_url = "#{ScihistDigicoll::Env.lookup!(:solr_url)}/select?q=id:#{CGI.escape work.id}"
+      solr_query_url = "#{ScihistDigicoll::Env.lookup!(:solr_url)}/select?q=id:#{CGI.escape work.friendlier_id}"
       response = Net::HTTP.get_response(URI.parse(solr_query_url))
 
       solr_docs = JSON.parse(response.body)["response"]["docs"]
 
-      indexed_doc = solr_docs.find { |h| h["id"] == work.id }
+      indexed_doc = solr_docs.find { |h| h["id"] == work.friendlier_id }
       expect(indexed_doc).to be_present
     end
   end


### PR DESCRIPTION
After you have an app with this change (including on staging), must run:
    ./bin/rake scihist:solr:delete_all scihist:solr:reindex

(should take under 30 seconds)