### PR TITLE
index URLs as rights_facet, not translated human labels

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -10,6 +10,9 @@ class CatalogController < ApplicationController
 
   include Blacklight::Catalog
 
+  # Not totally sure why we need this, instead of Rails loading all helpers automatically
+  helper LocalBlacklightHelpers
+
   # a Blacklight override
   def render_bookmarks_control?
     false
@@ -115,7 +118,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'place_facet', label: "Place", limit: 5
     # TODO -- not showing up?
     config.add_facet_field 'language_facet', label: "Language", limit: 5
-    config.add_facet_field "rights_facet", label: "Rights", limit: 5
+    config.add_facet_field "rights_facet", helper_method: :rights_label, label: "Rights", limit: 5
     config.add_facet_field 'department_facet', label: "Department", limit: 5
     config.add_facet_field 'exhibition_facet', label: "Exhibition", limit: 5
     config.add_facet_field 'project_facet',    label: "Project",    limit: 5

--- a/app/helpers/local_blacklight_helpers.rb
+++ b/app/helpers/local_blacklight_helpers.rb
@@ -1,0 +1,10 @@
+module LocalBlacklightHelpers
+  # A Blacklight facet field helper_method; maps rights URI to String
+  # @param [String] facet field uri value
+  # @return [String] rights statement label
+  def rights_label(rights_url)
+    # If not found, just return the original rights_url, to have an
+    # easier to debug failure mode.
+    RightsTerms.label_for(rights_url) || rights_url
+  end
+end

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -28,8 +28,8 @@ class WorkIndexer < Kithe::Indexer
     to_field ["text_no_boost_tesim", "department_facet"], obj_extract("department")
     to_field ["text_no_boost_tesim", "medium_facet"], obj_extract("medium")
     to_field ["text_no_boost_tesim", "format_facet"], obj_extract("format")
-    to_field "text_no_boost_tesim", obj_extract("rights") # URL id
-    to_field ["text_no_boost_tesim", "rights_facet"], obj_extract("rights"), transform(->(v) { RightsTerms.label_for(v) }) # human label
+    to_field ["text_no_boost_tesim", "rights_facet"], obj_extract("rights") # URL id
+    to_field ["text_no_boost_tesim"], obj_extract("rights"), transform(->(v) { RightsTerms.label_for(v) }) # human label
     to_field "text_no_boost_tesim", obj_extract("rights_holder")
     to_field "text_no_boost_tesim", obj_extract("series_arrangement")
 


### PR DESCRIPTION
This now matches how we did it in the sufia app. 

1. We index the rights _url_ (eg `http://rightsstatements.org/vocab/InC/1.0/`) to the Solr field to be facetted upon
2. We configure Blacklight to _display_ the human readable label in the sidebar facet list. 
  * We do this by telling Blacklight to use a Rails "helper" method to translate. Which is a feature in Blacklight which seems like the appropriate one here, and the one we were using before. 
  * Normally all Rails modules are loaded globally, but for some reason that wasn't working here (I think it's Blacklight's architecture as an "isolated Rails engine"). So we had to tell the CatalogController to load the new helper module we created to hold the translator method. 

Having the URL be the actual indexed value that we use to limit upon seems better than using the human-readable layer here, as the URL is the "identifier" that is unlikely to change, even if we change how the labels are displayed to user. 

However, this does mean the actual label is what shows up in our URLs, kind of an ugly value. Ie, a URL facet that looks like this: `?f%5Brights_sim%5D%5B%5D=http%3A%2F%2Frightsstatements.org%2Fvocab%2FInC-RUU%2F1.0%2F`

There is an argument to be made both ways, or doing something even more sophisticated, but rather than dig into it, doing it the same way we did in chf_sufia seems like a fine way to go. 

I was going to say it also keeps bookmarked URLs from chf_sufia working -- but I just realized I changed facet field names, it was `rights_sim` in chf_sufia, but is `rights_facet` in this app. That means we are breaking URLs. The actual Solr field name is exposed in the browser-facing bookmarkable URLs in Blacklight. 

The "_facet" ending seemed less confusing but perhaps we should change them all back to `_sim` to keep our URLs identical in new app. I think perhaps we should, and will make a new ticket/do extra work on that. 