### PR TITLE
port date-formatting for display code from chf_sufia

### DIFF
--- a/app/view_models/date_display_formatter.rb
+++ b/app/view_models/date_display_formatter.rb
@@ -1,7 +1,7 @@
 # Takes an array of `Work::Date` objects (generally from `some_work.date_of_work`),
 # and formats them for display to the user.
 #
-#     DateDisplayFormatter(work.date_of_work).display_dates
+#     DateDisplayFormatter.new(work.date_of_work).display_dates
 #     # => Array of strings, each being a human presentable date/range, like "1901", or "after 1950 -- circa 1990"
 #
 # Copied from old app chf-sufia/app/presenters/chf/dates_of_work_for_display.rb

--- a/app/view_models/date_display_formatter.rb
+++ b/app/view_models/date_display_formatter.rb
@@ -40,6 +40,11 @@ class DateDisplayFormatter
       date_string = "#{date_string} (#{date_of_work.note})"
     end
 
+    # Want to capitalize first letter only, and only if it's in position 0
+    if date_string && date_string[0] =~ /\w/
+      date_string = date_string.slice(0,1).capitalize + date_string.slice(1..-1)
+    end
+
     date_string
   end
 

--- a/app/view_models/date_display_formatter.rb
+++ b/app/view_models/date_display_formatter.rb
@@ -1,0 +1,103 @@
+# Takes an array of `Work::Date` objects (generally from `some_work.date_of_work`),
+# and formats them for display to the user.
+#
+#     DateDisplayFormatter(work.date_of_work).display_dates
+#     # => Array of strings, each being a human presentable date/range, like "1901", or "after 1950 -- circa 1990"
+#
+# Copied from old app chf-sufia/app/presenters/chf/dates_of_work_for_display.rb
+class DateDisplayFormatter
+
+  BEFORE = "before"
+  AFTER = "after"
+  CENTURY = "century"
+  CIRCA = "circa"
+  DECADE = "decade"
+  UNDATED = "Undated"
+
+  def initialize(dates_of_work)
+    @dates_for_display = dates_of_work.collect {|d| display_label(d)}
+  end
+
+  #Return an array of strings, each containing a formatted date.
+  def display_dates
+    @dates_for_display
+  end
+
+  def display_label(date_of_work)
+    start_string = qualified_date(date_of_work.start,
+      date_of_work.start_qualifier)
+    finish_string = qualified_date(date_of_work.finish,
+      date_of_work.finish_qualifier)
+
+    if finish_string.blank?
+      date_string = start_string
+    else
+      # careful, this is an en dash:
+      date_string = [start_string, finish_string].compact.join(" – ")
+    end
+
+    if date_of_work.note.present?
+      date_string = "#{date_string} (#{date_of_work.note})"
+    end
+
+    date_string
+  end
+
+
+  def capitalize (str)
+    if str == nil
+      nil
+    elsif str.blank?
+      str
+    elsif str.length == 1
+      str.capitalize
+    else
+      str.slice(0,1).capitalize + str.slice(1..-1)
+    end
+  end
+
+  def fix_month(date_given)
+    return date_given if date_given.blank?
+    ymd_arr = date_given.split("-")
+    return date_given if ymd_arr.length < 2
+    month_index = ymd_arr[1].to_i
+    return date_given if month_index == 0
+    month_str = Date::ABBR_MONTHNAMES[month_index]
+    ymd_arr [1] = month_str
+    return ymd_arr.join('-')
+  end
+
+  def qualified_date(date, qualifier)
+    begin
+      int_date_value = Integer(date)
+    rescue
+      int_date_value = nil
+    end
+
+    date=fix_month(date)
+
+    if qualifier == (BEFORE) || qualifier == (AFTER) || qualifier == (CIRCA)
+      "#{qualifier} #{date}"
+    elsif qualifier ==  DECADE
+      if int_date_value == nil or int_date_value % 10 != 0 or int_date_value % 100 == 0
+        #for non-obvious decades starting in e.g. 1912 or 1800 or "way back when"
+        "decade starting #{date}"
+      else
+        #ordinary decades (e.g. 1910s)
+        "#{date}s"
+      end
+    elsif qualifier ==  CENTURY
+      if int_date_value == nil  or int_date_value % 100 != 0
+        "century starting #{date}"
+      else
+        "#{date}s"
+      end
+    elsif qualifier ==  UNDATED
+      qualifier
+    elsif date.present?
+      date
+    else
+      ""
+    end
+  end # qualified_date
+end # class

--- a/app/view_models/date_display_formatter.rb
+++ b/app/view_models/date_display_formatter.rb
@@ -23,6 +23,8 @@ class DateDisplayFormatter
     @dates_for_display
   end
 
+  private
+
   def display_label(date_of_work)
     start_string = qualified_date(date_of_work.start,
       date_of_work.start_qualifier)

--- a/app/view_models/date_display_formatter.rb
+++ b/app/view_models/date_display_formatter.rb
@@ -48,7 +48,7 @@ class DateDisplayFormatter
     date_string
   end
 
-  def fix_month(date_given)
+  def numeric_month_to_abbr(date_given)
     return date_given if date_given.blank?
     ymd_arr = date_given.split("-")
     return date_given if ymd_arr.length < 2
@@ -66,7 +66,7 @@ class DateDisplayFormatter
       int_date_value = nil
     end
 
-    date=fix_month(date)
+    date = numeric_month_to_abbr(date)
 
     if qualifier == (BEFORE) || qualifier == (AFTER) || qualifier == (CIRCA)
       "#{qualifier} #{date}"

--- a/app/view_models/date_display_formatter.rb
+++ b/app/view_models/date_display_formatter.rb
@@ -12,7 +12,7 @@ class DateDisplayFormatter
   CENTURY = "century"
   CIRCA = "circa"
   DECADE = "decade"
-  UNDATED = "Undated"
+  UNDATED = "undated"
 
   def initialize(dates_of_work)
     @dates_for_display = dates_of_work.collect {|d| display_label(d)}

--- a/app/view_models/date_display_formatter.rb
+++ b/app/view_models/date_display_formatter.rb
@@ -48,19 +48,6 @@ class DateDisplayFormatter
     date_string
   end
 
-
-  def capitalize (str)
-    if str == nil
-      nil
-    elsif str.blank?
-      str
-    elsif str.length == 1
-      str.capitalize
-    else
-      str.slice(0,1).capitalize + str.slice(1..-1)
-    end
-  end
-
   def fix_month(date_given)
     return date_given if date_given.blank?
     ymd_arr = date_given.split("-")

--- a/spec/view_models/display_date_formatter_spec.rb
+++ b/spec/view_models/display_date_formatter_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe DateDisplayFormatter, type: :model do
+  describe "individual dates" do
+    # Test cases ported from
+    # https://github.com/sciencehistory/chf-sufia/blob/master/spec/presenters/curation_concerns/generic_work_show_presenter_spec.rb#L47
+    # https://github.com/sciencehistory/chf-sufia/blob/master/spec/presenters/curation_concerns/generic_work_show_presenter_spec.rb#L155-L199
+    {
+      Work::DateOfWork.new(start: "1800") => "1800",
+      Work::DateOfWork.new => "",
+      Work::DateOfWork.new(note: "circa") => " (circa)",
+      Work::DateOfWork.new(start: "1912", start_qualifier: "decade") => "Decade starting 1912",
+      Work::DateOfWork.new(start: "1780", start_qualifier: "decade") => "1780s",
+      Work::DateOfWork.new(start: "way back when", start_qualifier: "decade") => "Decade starting way back when",
+      Work::DateOfWork.new(start: "1912", start_qualifier: "century") => "Century starting 1912",
+      Work::DateOfWork.new(start: "1780", start_qualifier: "century") => "Century starting 1780",
+      Work::DateOfWork.new(start: "way back when", start_qualifier: "century") => "Century starting way back when",
+      Work::DateOfWork.new(start: "1700", start_qualifier: "century") => "1700s",
+      Work::DateOfWork.new(start: "the end of time", note: "For real!") => "After the end of time (For real!)",
+      Work::DateOfWork.new(start: "the end of time", start_qualifier: "circa") => "Circa the end of time",
+      Work::DateOfWork.new(start: "1800", finish: "1900", start_qualifier: "century", note: "Note 1") => "1800s – 1900 (Note 1)",
+      Work::DateOfWork.new(start: "1800", finish: "1900", start_qualifier: "century", note: "Note 2") => "1800s – 1900 (Note 2)",
+      Work::DateOfWork.new(start: "1929-01-02", finish: "1929-01-03", start_qualifier: "circa", finish_qualifier: "before", note: "Note 3") => "Circa 1929-Jan-02 – before 1929-Jan-03 (Note 3)",
+      Work::DateOfWork.new(start: "1872", finish: "1929-01-03", start_qualifier: "after", finish_qualifier: "before", note: "Note 4") => "After 1872 – before 1929-Jan-03 (Note 4)",
+      Work::DateOfWork.new(start: "1920", finish: "1928-11", start_qualifier: "decade", note: "Note 5") => "1920s – 1928-Nov (Note 5)"
+    }.each do |input, output|
+      it "should format '#{input.to_s}' as #{output.inspect}" do
+        expect(DateDisplayFormatter.new([input]).display_dates).to eq([output])
+      end
+    end
+  end
+end

--- a/spec/view_models/display_date_formatter_spec.rb
+++ b/spec/view_models/display_date_formatter_spec.rb
@@ -16,7 +16,7 @@ describe DateDisplayFormatter, type: :model do
       Work::DateOfWork.new(start: "1780", start_qualifier: "century") => "Century starting 1780",
       Work::DateOfWork.new(start: "way back when", start_qualifier: "century") => "Century starting way back when",
       Work::DateOfWork.new(start: "1700", start_qualifier: "century") => "1700s",
-      Work::DateOfWork.new(start: "the end of time", note: "For real!") => "After the end of time (For real!)",
+      Work::DateOfWork.new(start: "the end of time", start_qualifier: "after", note: "For real!") => "After the end of time (For real!)",
       Work::DateOfWork.new(start: "the end of time", start_qualifier: "circa") => "Circa the end of time",
       Work::DateOfWork.new(start: "1800", finish: "1900", start_qualifier: "century", note: "Note 1") => "1800s – 1900 (Note 1)",
       Work::DateOfWork.new(start: "1800", finish: "1900", start_qualifier: "century", note: "Note 2") => "1800s – 1900 (Note 2)",

--- a/spec/view_models/display_date_formatter_spec.rb
+++ b/spec/view_models/display_date_formatter_spec.rb
@@ -30,4 +30,19 @@ describe DateDisplayFormatter, type: :model do
       end
     end
   end
+
+  describe "array of dates" do
+    let(:date_array) {[
+      Work::DateOfWork.new(start: "1912", start_qualifier: "century"),
+      Work::DateOfWork.new(start: "1800"),
+      Work::DateOfWork.new(start: "1800", finish: "1900")
+    ]}
+
+    it "formats them all in order" do
+      # should it sort them? It doesn't yet...
+      expect(DateDisplayFormatter.new(date_array).display_dates).to eq( date_array.collect { |d|
+        DateDisplayFormatter.new([d]).display_dates
+      }.flatten)
+    end
+  end
 end

--- a/spec/view_models/display_date_formatter_spec.rb
+++ b/spec/view_models/display_date_formatter_spec.rb
@@ -25,7 +25,7 @@ describe DateDisplayFormatter, type: :model do
       Work::DateOfWork.new(start: "1920", finish: "1928-11", start_qualifier: "decade", note: "Note 5") => "1920s – 1928-Nov (Note 5)",
       Work::DateOfWork.new(start_qualifier: "undated") => "Undated"
     }.each do |input, output|
-      it "should format '#{input.to_s}' as #{output.inspect}" do
+      it "should format '#{input.to_json}' as #{output.inspect}" do
         expect(DateDisplayFormatter.new([input]).display_dates).to eq([output])
       end
     end

--- a/spec/view_models/display_date_formatter_spec.rb
+++ b/spec/view_models/display_date_formatter_spec.rb
@@ -22,7 +22,8 @@ describe DateDisplayFormatter, type: :model do
       Work::DateOfWork.new(start: "1800", finish: "1900", start_qualifier: "century", note: "Note 2") => "1800s – 1900 (Note 2)",
       Work::DateOfWork.new(start: "1929-01-02", finish: "1929-01-03", start_qualifier: "circa", finish_qualifier: "before", note: "Note 3") => "Circa 1929-Jan-02 – before 1929-Jan-03 (Note 3)",
       Work::DateOfWork.new(start: "1872", finish: "1929-01-03", start_qualifier: "after", finish_qualifier: "before", note: "Note 4") => "After 1872 – before 1929-Jan-03 (Note 4)",
-      Work::DateOfWork.new(start: "1920", finish: "1928-11", start_qualifier: "decade", note: "Note 5") => "1920s – 1928-Nov (Note 5)"
+      Work::DateOfWork.new(start: "1920", finish: "1928-11", start_qualifier: "decade", note: "Note 5") => "1920s – 1928-Nov (Note 5)",
+      Work::DateOfWork.new(start_qualifier: "undated") => "Undated"
     }.each do |input, output|
       it "should format '#{input.to_s}' as #{output.inspect}" do
         expect(DateDisplayFormatter.new([input]).display_dates).to eq([output])


### PR DESCRIPTION
Tests not currently passing... becuase it turns out the tests were buggy and testing nothing in current chf_sufia. **fixed**

commit https://github.com/sciencehistory/chf-sufia/commit/fb3b73881a6361567b7d1064326c775282a837ac

Accidentally makes test be a no-op, setting 'expected_dates = correct_results', then checking to make sure expected_dates matches correct_results. At some point after this, code was accidentaly broken to do capitalization that does not match what the tests expect, and the broken test did not warn us. Have not tracked down that commit yet. 

I guess we should fix the code to match specs including expected capitalization, rather than fix the specs to accept accidentally broken capitalization. 

Trivial fixes to capitalization did not work. The code is a bit convoluted, could perhaps be simplified generally. 

Alternately, we can cange the specs to allow 'faulty' behavior, as it's been in production for a while apparently...