### PR TITLE
Give ViewModel a valid_model_type_names macro

### DIFF
--- a/app/presenters/collection_result_display.rb
+++ b/app/presenters/collection_result_display.rb
@@ -1,4 +1,6 @@
 class CollectionResultDisplay < ViewModel
+  valid_model_type_names "Collection"
+
   def display
     render "/presenters/index_result", model: model, view: self
   end

--- a/app/presenters/result_thumb_display.rb
+++ b/app/presenters/result_thumb_display.rb
@@ -7,13 +7,7 @@
 #
 # leaf_representatives should be eager loaded to avoid n+1 queries in search results display.
 class ResultThumbDisplay < ViewModel
-  def initialize(model, *args)
-    unless model.nil? || model.kind_of?(Kithe::Asset)
-      raise ArgumentError.new("#{self.class.name} requires a Kithe::Asset as an argument. (Often a leaf_representative)")
-    end
-
-    super
-  end
+  valid_model_type_names "Kithe::Asset", "NilClass"
 
   def display
     # for non-pdf/image assets, we currently just return a placeholder. We could in future

--- a/app/presenters/work_result_display.rb
+++ b/app/presenters/work_result_display.rb
@@ -1,4 +1,6 @@
 class WorkResultDisplay < ViewModel
+  valid_model_type_names "Work"
+
   delegate :additional_title
 
   def display


### PR DESCRIPTION
to specify what classes are allowed for the first arg to the ViewModel initializer. Fail early to avoid confusing bugs later, since view models are generally intended to handle a particular kind of 'model'.

Abstract out the code that was previously custom in the ResultThumbDisplay, and use the new valid_model_type_names macro in existing view models.