### PR TITLE
search results includes the tabular subject/creator metadata for Works

### DIFF
--- a/app/presenters/collection_result_display.rb
+++ b/app/presenters/collection_result_display.rb
@@ -26,4 +26,10 @@ class CollectionResultDisplay < ViewModel
     []
   end
 
+  # we don't have any Collection result display at present
+  def metadata_labels_and_values
+    {}.freeze
+  end
+
+
 end

--- a/app/presenters/work_result_display.rb
+++ b/app/presenters/work_result_display.rb
@@ -16,8 +16,41 @@ class WorkResultDisplay < ViewModel
     @display_dates = DateDisplayFormatter.new(model.date_of_work).display_dates
   end
 
+
   def link_to_href
     work_path(model)
+  end
+
+  # Returns a hash of lables and values for display on the tabular metadata field, for
+  # subjects and creators.
+  #
+  # The keys are the labels to use for the metadata field, actual literals (if i18n needed,
+  # do it internal here)
+  #
+  # The values of the hash are an ARRAY of 1 more values. Each of those values CAN be html_safe
+  # HTML, for instance a link to a search.
+  def metadata_labels_and_values
+    unless @metadata_labels_and_values
+      @metadata_labels_and_values = {}
+
+      # Add creators, with creator categories separated but multiple values
+      # for same creator category grouped.
+      model.creator.each do |creator_obj|
+        label = creator_obj.category.titlecase # could be i18n here instead
+        @metadata_labels_and_values[label] ||= []
+        @metadata_labels_and_values[label] << link_to(creator_obj.value, search_on_facet_path(:creator_facet, creator_obj.value))
+      end
+
+      # Add subjects
+      if model.subject.present?
+        @metadata_labels_and_values["Subject"] = model.subject.collect do |subject|
+          link_to(subject, search_on_facet_path(:subject_facet, subject))
+        end
+      end
+      @metadata_labels_and_values.freeze
+    end
+
+    return @metadata_labels_and_values
   end
 
   # An array of elements for "part of" listing, includes 'parent' in a link,

--- a/app/views/presenters/_index_result.html.erb
+++ b/app/views/presenters/_index_result.html.erb
@@ -68,16 +68,16 @@
         </div>
       <%# end %>
 
-      <ul class="list-unstyled chf-results-list-values">
-        <%# index_fields(generic_work).each do |field_name, field| -%>
-          <%# if should_render_index_field? generic_work, field %>
-            <li>
-              <span class="attribute-label"><%# render_index_field_label generic_work, field: field_name %></span>
-              <%# doc_presenter.field_value field_name %>
-            </li>
-          <%# end %>
-        <%# end %>
-      </ul>
+      <% if view.metadata_labels_and_values.present? %>
+        <ul class="list-unstyled chf-results-list-values">
+          <% view.metadata_labels_and_values.each do |field_label, field_values| -%>
+              <li>
+                <span class="attribute-label"><%= field_label %></span>
+                <%= safe_join(field_values, ", ") %>
+              </li>
+          <% end %>
+        </ul>
+      <% end %>
 
     </div>
 </li>

--- a/spec/presenters/work_result_display_spec.rb
+++ b/spec/presenters/work_result_display_spec.rb
@@ -1,14 +1,37 @@
 require 'rails_helper'
 
 describe WorkResultDisplay do
+  RSpec::Matchers.define :include_link_to do |facet_param:,value:|
+    match do |actual_array|
+      actual_array.any? do |str|
+        noko = Nokogiri::HTML.fragment(str)
+        noko.children.length == 1 &&
+          (element = noko.children[0]) &&
+          element.name == "a" &&
+          element.text == value &&
+          element['href'] == helper.search_on_facet_path(facet_param, value)
+      end
+    end
+
+    failure_message do |actual|
+      "expected that #{actual} would include an <a> tag for #{facet_param}:#{value}"
+    end
+  end
+
   let(:parent_work) { create(:work) }
+
   let(:work) { FactoryBot.create(:work, :with_complete_metadata,
     date_of_work: [Work::DateOfWork.new(start: "2000-01-01", start_qualifier: "circa"), Work::DateOfWork.new(start: "2019-10-10")],
     parent: parent_work,
     source: "Some Source Title",
     genre: ["Advertisements", "Artifacts"],
-    additional_title: "An Additional Title") }
-  let(:rendered) { Nokogiri::HTML.fragment(described_class.new(work).display) }
+    additional_title: "An Additional Title",
+    subject: ["Subject1", "Subject2"],
+    creator: [{category: "contributor", value: "Joe Smith"}, {category: "contributor", value: "Moishe Brown"}, {category: "interviewer", value: "Mary Sue"}]
+  )}
+
+  let(:presenter) { described_class.new(work) }
+  let(:rendered) { Nokogiri::HTML.fragment(presenter.display) }
 
   it "displays" do
     work.genre.each do |genre|
@@ -22,5 +45,40 @@ describe WorkResultDisplay do
 
     expect(rendered).to have_text("Circa 2000-Jan-01")
     expect(rendered).to have_text("2019-Oct-10")
+
+    expect(rendered).to have_selector("a", text: "Subject1")
+    expect(rendered).to have_selector("a", text: "Subject2")
+    expect(rendered).to have_selector("a", text: "Joe Smith")
+    expect(rendered).to have_selector("a", text: "Moishe Brown")
+    expect(rendered).to have_selector("a", text: "Mary Sue")
+  end
+
+  describe "#metadata_labels_and_values" do
+    it "includes subjects" do
+      subjects = presenter.metadata_labels_and_values["Subject"]
+
+      expect(subjects).to be_present
+      expect(subjects).to be_kind_of(Array)
+      expect(subjects.length).to be(2)
+
+      expect(subjects).to include_link_to(value: "Subject1", facet_param: "subject_facet")
+      expect(subjects).to include_link_to(value: "Subject2", facet_param: "subject_facet")
+    end
+
+    it "separates creators" do
+      contributors = presenter.metadata_labels_and_values["Contributor"]
+      expect(contributors).to be_present
+      expect(contributors).to be_kind_of(Array)
+      expect(contributors.length).to be(2)
+      expect(contributors).to include_link_to(value: "Joe Smith", facet_param: "creator_facet")
+      expect(contributors).to include_link_to(value: "Moishe Brown", facet_param: "creator_facet")
+
+
+      interviewers = presenter.metadata_labels_and_values["Interviewer"]
+      expect(interviewers).to be_present
+      expect(interviewers).to be_kind_of(Array)
+      expect(interviewers.length).to be(1)
+      expect(interviewers).to include_link_to(value: "Mary Sue", facet_param: "creator_facet")
+    end
   end
 end


### PR DESCRIPTION
Some kinda tricky rspec with a custom matcher to try to test the HTML generated. Not bothering to test in the integration test,
although it tests that it doesn't raise an error in integration test. 

This shows the weirdness of _what_ logic goes in the View Model and what in the template. I decided that the decision to display the values seperated with commas is for the template, but constructing the values as _links to searches_ is for the View Model.  Potentially leads to kind of confusing code where you aren't sure where to find what, but I think it'll work out. 

Also shows the weirdness of us polymorphically using the same template for Collections and Works. We don't display metadata in this part of the page for Collections, so CollectionResultsDisplay just has a hard-coded empty hash. And we don't have a great place to define what this new 'metadata_labels_and_values' method is, and the non-obvious 'contract' for what it returns (a Hash whose values are Arrays, possibly of html-safe html).  But it is tested in several places such if the 'contract' is broken tests should fail. And I think/hope this still is cleaner and less convoluted than some approaches to complex view logic.