### PR TITLE
Description display

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,7 @@ gem 'devise', "~> 4.5" # user accounts and login
 gem 'access-granted', "~> 1.0" # authorization
 
 # decorating and truncating html
-gem "rails_autolink"
+gem "rails_autolink", '~> 1.0'
 gem 'html_aware_truncation', '~> 1.0'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,10 @@ gem 'bootstrap4-kaminari-views'
 gem 'devise', "~> 4.5" # user accounts and login
 gem 'access-granted', "~> 1.0" # authorization
 
+# decorating and truncating html
+gem "rails_autolink"
+gem 'html_aware_truncation', '~> 1.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'pry-byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -594,7 +594,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 3.11)
   rails (~> 5.2.1)
-  rails_autolink
+  rails_autolink (~> 1.0)
   ransack (~> 2.1)
   resque (~> 1.0)
   resque-pool

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,8 @@ GEM
     hashery (2.1.2)
     hashie (3.6.0)
     honeybadger (4.1.0)
+    html_aware_truncation (1.0.0)
+      nokogiri (~> 1.0)
     http (3.3.0)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
@@ -368,6 +370,8 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
+    rails_autolink (1.1.6)
+      rails (> 3.1)
     railties (5.2.3)
       actionpack (= 5.2.3)
       activesupport (= 5.2.3)
@@ -580,6 +584,7 @@ DEPENDENCIES
   draper (~> 3.0)
   factory_bot_rails
   honeybadger (~> 4.0)
+  html_aware_truncation (~> 1.0)
   jbuilder (~> 2.5)
   jquery-rails (~> 4.3)
   kaminari (~> 1.0)
@@ -589,6 +594,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 3.11)
   rails (~> 5.2.1)
+  rails_autolink
   ransack (~> 2.1)
   resque (~> 1.0)
   resque-pool

--- a/app/presenters/description_display_formatter.rb
+++ b/app/presenters/description_display_formatter.rb
@@ -6,17 +6,20 @@ require 'rails_autolink'
 # DescriptionDisplayFormatter.new(work.description, truncate:true).format
 
 class DescriptionDisplayFormatter < ViewModel
+  valid_model_type_names 'String', 'NilClass'
 
   def initialize(model, options ={})
+
     # truncate: true is used in _index_result.html.erb .
     @truncate = !! options.delete(:truncate)
-
     super
+
   end
 
   alias_method :description, :model
 
   def format
+    return "".html_safe if description.blank?
     result = sanitize(description)
     if @truncate
       result = truncate_description(result)

--- a/app/presenters/description_display_formatter.rb
+++ b/app/presenters/description_display_formatter.rb
@@ -1,0 +1,56 @@
+require 'rails_autolink'
+# Takes a description string (from a work.description) and formats it for display.
+# Ported from chf-sufia/app/helpers/description_formatter_helper.rb
+
+# DescriptionDisplayFormatter.new(work.description).format
+# DescriptionDisplayFormatter.new(work.description, truncate:true).format
+
+class DescriptionDisplayFormatter
+
+  def initialize(description, truncate: false)
+    @description = description
+    # truncate: true is used in _index_result.html.erb .
+    @truncate = truncate ? true : false
+  end
+
+  def format
+    sanitize
+    truncate_description if @truncate
+    add_line_breaks
+    turn_bare_urls_into_links
+    @description.html_safe
+  end
+
+  private
+
+  # Sanitize the HTML. Should have been sanitized on input, but just to be safe.
+  def sanitize
+     @description = DescriptionSanitizer.new.sanitize(@description)
+  end
+
+  # Truncate, if requested.
+  def truncate_description
+    @description = HtmlAwareTruncation.truncate_html(@description, length: 220, separator: /\s/)
+  end
+
+  # Convert line breaks to paragraphs.
+  def add_line_breaks
+    @description = ActionController::Base.helpers.simple_format(@description, {}, sanitize: false)
+  end
+
+  # Create links out of bare URLs, and add external-link icons to them.
+  # Leave untouched any link *tags* entered in description field.
+  # This is an artifact of
+  # a) the way things worked *before* link tags were allowed in the Sufia description field
+  # b) obsolete communications guidelines.
+  #
+  # We may later decide to overhaul the content such that
+  # the content contains no bare links.
+  def turn_bare_urls_into_links
+    icon = '<i class="fa fa-external-link" aria-hidden="true"></i>'
+    @description = ActionController::Base.helpers.auto_link(@description, sanitize: false) do |text|
+      "#{icon}#{('&nbsp;' + text)}"
+    end
+  end
+
+end # class

--- a/app/views/admin/works/_metadata.html.erb
+++ b/app/views/admin/works/_metadata.html.erb
@@ -147,7 +147,7 @@
 
     <dt>Description</dt>
     <dd>
-      <%= work.description %>
+      <%= raw DescriptionDisplayFormatter.new(work.description).format %>
     </dd>
 
     <dt>Inscription</dt>

--- a/app/views/admin/works/_metadata.html.erb
+++ b/app/views/admin/works/_metadata.html.erb
@@ -147,7 +147,7 @@
 
     <dt>Description</dt>
     <dd>
-      <%= raw DescriptionDisplayFormatter.new(work.description).format %>
+      <%= DescriptionDisplayFormatter.new(work.description).format %>
     </dd>
 
     <dt>Inscription</dt>

--- a/app/views/presenters/_index_result.html.erb
+++ b/app/views/presenters/_index_result.html.erb
@@ -64,6 +64,7 @@
         <div class="chf-results-list-item-description">
           <%# doc_presenter.description.each do |description| %>
             <%# format_description(description, truncate: true) %>
+            <%= raw DescriptionDisplayFormatter.new(work.description, truncate:true).format %>
           <%# end %>
         </div>
       <%# end %>

--- a/app/views/presenters/_index_result.html.erb
+++ b/app/views/presenters/_index_result.html.erb
@@ -63,7 +63,6 @@
       <%# if doc_presenter.has_values_for?(Solrizer.solr_name("description", :stored_searchable)) %>
         <div class="chf-results-list-item-description">
           <%# doc_presenter.description.each do |description| %>
-            <%# format_description(description, truncate: true) %>
             <%= raw DescriptionDisplayFormatter.new(work.description, truncate:true).format %>
           <%# end %>
         </div>

--- a/app/views/presenters/_index_result.html.erb
+++ b/app/views/presenters/_index_result.html.erb
@@ -63,7 +63,7 @@
       <%# if doc_presenter.has_values_for?(Solrizer.solr_name("description", :stored_searchable)) %>
         <div class="chf-results-list-item-description">
           <%# doc_presenter.description.each do |description| %>
-            <%= raw DescriptionDisplayFormatter.new(work.description, truncate:true).format %>
+            <%= raw DescriptionDisplayFormatter.new(model.description, truncate:true).format %>
           <%# end %>
         </div>
       <%# end %>

--- a/app/views/presenters/_index_result.html.erb
+++ b/app/views/presenters/_index_result.html.erb
@@ -60,13 +60,11 @@
       <% end %>
 
 
-      <%# if doc_presenter.has_values_for?(Solrizer.solr_name("description", :stored_searchable)) %>
+      <% if model.description.present? %>
         <div class="chf-results-list-item-description">
-          <%# doc_presenter.description.each do |description| %>
-            <%= raw DescriptionDisplayFormatter.new(model.description, truncate:true).format %>
-          <%# end %>
+            <%= DescriptionDisplayFormatter.new(model.description, truncate:true).format %>
         </div>
-      <%# end %>
+      <% end %>
 
       <% if view.metadata_labels_and_values.present? %>
         <ul class="list-unstyled chf-results-list-values">

--- a/spec/presenters/description_display_formatter_spec.rb
+++ b/spec/presenters/description_display_formatter_spec.rb
@@ -26,11 +26,6 @@ describe DescriptionDisplayFormatter, type: :model do
     it "marks html safe" do
       expect(DescriptionDisplayFormatter.new("some input").format).to be_html_safe
     end
-
-    it "with an array, throws an ArgumentError" do
-      expect(DescriptionDisplayFormatter.new(["some input"]).format).to raise ArgumentError
-    end
-
   end
 
   describe "truncation" do

--- a/spec/presenters/description_display_formatter_spec.rb
+++ b/spec/presenters/description_display_formatter_spec.rb
@@ -13,6 +13,8 @@ describe DescriptionDisplayFormatter, type: :model do
       "Adds\n\nreturns\nproperly" => "<p>Adds</p>\n\n<p>returns\n<br />properly</p>",
       "Strips <goat>unwanted tags </goat>" => "<p>Strips unwanted tags </p>",
       "Adds links to http://www.randomurl.org" => "<p>Adds links to <a href=\"http://www.randomurl.org\"><i class=\"fa fa-external-link\" aria-hidden=\"true\"></i>&nbsp;http://www.randomurl.org</a></p>",
+      nil => "",
+      "" => "",
       untouched => untouched,
 
     }.each do |input, output|
@@ -23,6 +25,10 @@ describe DescriptionDisplayFormatter, type: :model do
 
     it "marks html safe" do
       expect(DescriptionDisplayFormatter.new("some input").format).to be_html_safe
+    end
+
+    it "with an array, throws an ArgumentError" do
+      expect(DescriptionDisplayFormatter.new(["some input"]).format).to raise ArgumentError
     end
 
   end
@@ -36,4 +42,6 @@ describe DescriptionDisplayFormatter, type: :model do
       expect(truncated_output.length).to be < long_html_string.length
     end
   end
+
+
 end

--- a/spec/presenters/description_display_formatter_spec.rb
+++ b/spec/presenters/description_display_formatter_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe DescriptionDisplayFormatter, type: :model do
+  let(:url) { "http://www.randomurl.org" }
+  let(:untouched) { "<p><cite>These</cite><i>tags</i><b>are</b><a href=\"#{url}\">OK</a>.</p>" }
+
+  describe "no truncation" do
+    {
+      "Adds paragraph tags" => "<p>Adds paragraph tags</p>",
+      "Adds \n returns" => "<p>Adds \n<br /> returns</p>",
+      "Adds \n\n returns" => "<p>Adds </p>\n\n<p> returns</p>",
+      "Adds\n\nreturns\nproperly" => "<p>Adds</p>\n\n<p>returns\n<br />properly</p>",
+      "Strips <goat>unwanted tags </goat>" => "<p>Strips unwanted tags </p>",
+      "Adds links to #{url}" => "<p>Adds links to <a href=\"#{url}\"><i class=\"fa fa-external-link\" aria-hidden=\"true\"></i>&nbsp;#{url}</a></p>",
+      untouched => untouched,
+
+    }.each do |input, output|
+      it "should format '#{input}' as #{output}" do
+        expect(DescriptionDisplayFormatter.new(input).format).to eq(output)
+      end # it
+    end # each
+  end # describe do
+
+  describe "truncation" do
+    let(:long_html_string) { untouched * 20 }
+    truncated_output = DescriptionDisplayFormatter.
+      new(long_html_string, truncate:true).format
+
+    it "correctly truncates a long html string" do
+      expect(truncated_output.length).to eq 1178 # not 1760
+      expect(truncated_output).to match(/<i>tags<\/i><b>\u2026<\/b><\/p>$/)
+    end # it
+  end # describe do
+
+end # describe do

--- a/spec/presenters/description_display_formatter_spec.rb
+++ b/spec/presenters/description_display_formatter_spec.rb
@@ -1,35 +1,39 @@
 require 'rails_helper'
 
 describe DescriptionDisplayFormatter, type: :model do
-  let(:url) { "http://www.randomurl.org" }
-  let(:untouched) { "<p><cite>These</cite><i>tags</i><b>are</b><a href=\"#{url}\">OK</a>.</p>" }
+  url = "http://www.randomurl.org"
+  untouched = "<p><cite>These</cite><i>tags</i><b>are</b><a href=\"#{url}\">OK</a>.</p>"
 
   describe "no truncation" do
     {
       "Adds paragraph tags" => "<p>Adds paragraph tags</p>",
+      "escapes things > for html" => "<p>escapes things &gt; for html</p>",
       "Adds \n returns" => "<p>Adds \n<br /> returns</p>",
       "Adds \n\n returns" => "<p>Adds </p>\n\n<p> returns</p>",
       "Adds\n\nreturns\nproperly" => "<p>Adds</p>\n\n<p>returns\n<br />properly</p>",
       "Strips <goat>unwanted tags </goat>" => "<p>Strips unwanted tags </p>",
-      "Adds links to #{url}" => "<p>Adds links to <a href=\"#{url}\"><i class=\"fa fa-external-link\" aria-hidden=\"true\"></i>&nbsp;#{url}</a></p>",
+      "Adds links to http://www.randomurl.org" => "<p>Adds links to <a href=\"http://www.randomurl.org\"><i class=\"fa fa-external-link\" aria-hidden=\"true\"></i>&nbsp;http://www.randomurl.org</a></p>",
       untouched => untouched,
 
     }.each do |input, output|
       it "should format '#{input}' as #{output}" do
         expect(DescriptionDisplayFormatter.new(input).format).to eq(output)
-      end # it
-    end # each
-  end # describe do
+      end
+    end
+
+    it "marks html safe" do
+      expect(DescriptionDisplayFormatter.new("some input").format).to be_html_safe
+    end
+
+  end
 
   describe "truncation" do
-    let(:long_html_string) { untouched * 20 }
+    long_html_string = untouched * 20
     truncated_output = DescriptionDisplayFormatter.
       new(long_html_string, truncate:true).format
 
     it "correctly truncates a long html string" do
-      expect(truncated_output.length).to eq 1178 # not 1760
-      expect(truncated_output).to match(/<i>tags<\/i><b>\u2026<\/b><\/p>$/)
-    end # it
-  end # describe do
-
-end # describe do
+      expect(truncated_output.length).to be < long_html_string.length
+    end
+  end
+end

--- a/spec/system/catalog_search_spec.rb
+++ b/spec/system/catalog_search_spec.rb
@@ -16,8 +16,17 @@ describe CatalogController, solr: true, indexable_callbacks: true do
   # Creating real representatives with derivatives is a bit slow, only do it for our own
   # smoke test.
   describe "with real representative with derivatives" do
-    let!(:work1) { create(:work, representative: create(:asset, :inline_promoted_file)) }
-    let!(:collection) { create(:collection, representative: create(:asset, :inline_promoted_file)) }
+    let!(:work1) {
+      create(:work,
+        representative: create(:asset,
+        :inline_promoted_file),
+        description: 'priceless work')
+    }
+    let!(:collection) {
+      create(:collection,
+        representative: create(:asset, :inline_promoted_file),
+        description: 'priceless collection')
+    }
 
     # just a smoke test
     it "loads" do
@@ -25,8 +34,10 @@ describe CatalogController, solr: true, indexable_callbacks: true do
 
       expect(page).to have_content("1 - 3 of 3")
       expect(page).to have_content(work1.title)
+      expect(page).to have_content(work1.description)
       expect(page).to have_content(work_with_admin_note.title)
       expect(page).to have_content(collection.title)
+      expect(page).to have_content(collection.description)
 
       # thumbs for work and collection
       expect(page).to have_selector("img[src='#{work1.leaf_representative.derivative_for(:thumb_standard).url}']")


### PR DESCRIPTION
This is a port of chf-sufia/app/helpers/description_formatter_helper.rb, with tests.

Note: Just as in Sufia, this code creates links out of any bare URLs it finds, adding external-link icons to them, but leaves untouched any link *tags* entered into metadata.

This is an artifact of
 - the way things worked *before* link tags were allowed in the Sufia description field
 - obsolete communications guidelines.

We may later decide to overhaul the content such that descriptions and provenances contain no bare links, and thus do not need to be processed like this.