### PR TITLE
Add "N items" to search results page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,6 +109,7 @@ group :test do
   gem 'factory_bot_rails'
   gem "database_cleaner", "~> 1.7"
   gem "webmock", "~> 3.5"
+  gem "db-query-matchers", "< 2.0"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,9 @@ GEM
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
     database_cleaner (1.7.0)
+    db-query-matchers (0.9.0)
+      activesupport (>= 4.0, <= 6.0)
+      rspec (~> 3.0)
     declarative (0.0.10)
     declarative-option (0.1.0)
     deprecation (1.0.0)
@@ -411,6 +414,10 @@ GEM
     rsolr (2.2.1)
       builder (>= 2.1.2)
       faraday (>= 0.9.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.2)
@@ -576,6 +583,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   content_disposition
   database_cleaner (~> 1.7)
+  db-query-matchers (< 2.0)
   devise (~> 4.5)
   draper (~> 3.0)
   factory_bot_rails

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -45,6 +45,12 @@ class CatalogController < ApplicationController
   end
   helper_method :view_model_class_for
 
+  # Used by our ViewModels for displaying results
+  def child_counter
+    @child_counter ||= ChildCountDisplayFetcher.new(@response.documents.collect(&:id))
+  end
+  helper_method :child_counter
+
   configure_blacklight do |config|
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository

--- a/app/presenters/child_count_display_fetcher.rb
+++ b/app/presenters/child_count_display_fetcher.rb
@@ -1,0 +1,95 @@
+# We display a "child count" in our search results -- for works it's the number of (public) members,
+# for collections it's the number of (public) contained items.
+#
+# We don't want to have to make a separate SQL query per item in results to get this number. (n+1 problem)
+#
+# The ChildCoundDisplayFetcher is initialized with the friendlier_ids of all items in the currently displaying
+# search results, and then will *batch fetch* all child counts in *one fetch* for the entire batch. (Actually one
+# fetch for "contains" count and one for "members" count).
+#
+#     count_fetcher = ChildCountDisplayFetcher.new(array_of_friendlier_ids)
+#
+#     count_fetcher.member_count_for_friendlier_id(friendlier_id)
+#     # => returns integer count of _public_ members of item with that friendlier_id
+#
+#     count_fetcher.contains_count_for_friendlier_id(friendlier_id)
+#     # => returns integer count of _public_ members of item with that friendlier_id
+#
+# As a convenience, `#display_count_for` takes a *model*, and will return the correct child
+# count for display regardless of whether it's a Collection (we want "contains" count), or
+# a Work (we want "members" count).
+#
+#     count_fetcher.display_count_for(collection_or_work_obj)
+#
+# A ChildCountDisplayFetcher is expected to be created in a Controller, initialized with
+# the batch of current displayed search results. And then made available to the view somehow.
+class ChildCountDisplayFetcher
+  attr_reader :friendlier_ids
+  def initialize(friendlier_ids)
+    @friendlier_ids = friendlier_ids
+  end
+
+  # Convenience method you can pass in a Work or a Collection, and it will return the
+  # correct "child count" for search results display -- for a Collection a *contains* count,
+  # for a Work, a *members* count.
+  def display_count_for(model)
+    if model.kind_of?(Collection)
+      contains_count_for_friendlier_id(model.friendlier_id)
+    else
+      member_count_for_friendlier_id(model.friendlier_id)
+    end
+  end
+
+  # Returns integer (possibly 0) count of _public_ members belonging to item with
+  # supplied friendlier_id
+  def member_count_for_friendlier_id(friendlier_id)
+    unless friendlier_ids.include?(friendlier_id)
+      raise ArgumentError.new("This #{self.class.name} can not provide count for '#{friendlier_id}', was initialized for #{friendlier_ids.inspect}")
+    end
+
+    member_count_hash.fetch(friendlier_id) { 0 }
+  end
+
+  # Returns integer (possibly 0) count of _public_ `contains` items belonging to item with
+  # supplied friendlier_id
+  def contains_count_for_friendlier_id(friendlier_id)
+    unless friendlier_ids.include?(friendlier_id)
+      raise ArgumentError.new("This #{self.class.name} can not provide count for '#{friendlier_id}', was initialized for #{friendlier_ids.inspect}")
+    end
+
+    contains_count_hash.fetch(friendlier_id) { 0 }
+  end
+
+  private
+
+  def member_count_hash
+    # Tricky ActiveRecord to do a single SQL query that will fetch member counts for all works in friendlier_ids
+    # -- limited to count of members that are 'published'
+    #
+    #
+    # Requires us to have discovered how ActiveRecord aliases self-joined tables mentioned twice in the query,
+    # in this case "member_kithe_models"
+    #
+    # Will return a hash where the key is the friendlier_id, and the value is the integer count of members.
+    # Will be nil if no members.
+    @member_count_hash ||= Kithe::Model.
+                            where(friendlier_id: friendlier_ids).
+                            joins(:members).where("members_kithe_models.published" => true).
+                            group("friendlier_id").count
+  end
+
+  def contains_count_hash
+    # Tricky ActiveRecord to do a single SQL query that will fetch 'contains' counts for all works in friendlier_ids
+    # # -- limited to count of contained objects that are 'published'
+    #
+    # Requires us to have discovered how ActiveRecord aliases self-joined tables mentioned twice in the query,
+    # in this case "contains_kithe_models"
+    #
+    # Will return a hash where the key is the friendlier_id, and the value is the integer count of members.
+    # Will be nil if no members.
+    @contains_count_hash ||= Kithe::Model.
+                              where(friendlier_id: friendlier_ids).
+                              joins(:contains).where("contains_kithe_models.published" => true).
+                              group("friendlier_id").count
+  end
+end

--- a/app/presenters/collection_result_display.rb
+++ b/app/presenters/collection_result_display.rb
@@ -1,3 +1,8 @@
+# Displays an element in search results for a "Work"
+#
+# * requires controller to provide a helper method `child_counter` that returns
+# a ChildCountDisplayFetcher for efficient fetching and provision of "N Items"
+# child count on display.
 class CollectionResultDisplay < ViewModel
   valid_model_type_names "Collection"
 
@@ -8,6 +13,17 @@ class CollectionResultDisplay < ViewModel
   # TODO, link to Collections page, when it exists
   def display_genres
     ["Collection"]
+  end
+
+  # Requires helper method `child_counter` to be available, returning a
+  # ChildCountDisplayFetcher. Provided by CatalogController.
+  def display_num_children
+    count = child_counter.display_count_for(model)
+    return "" unless count > 0
+
+    content_tag("div", class: "chf-results-list-item-num-members") do
+      number_with_delimiter(count) + ' item'.pluralize(count)
+    end
   end
 
   # TODO, link to Collection detail page when it exists.

--- a/app/presenters/work_result_display.rb
+++ b/app/presenters/work_result_display.rb
@@ -1,3 +1,8 @@
+# Displays an element in search results for a "Work"
+#
+# * requires controller to provide a helper method `child_counter` that returns
+# a ChildCountDisplayFetcher for efficient fetching and provision of "N Items"
+# child count on display.
 class WorkResultDisplay < ViewModel
   valid_model_type_names "Work"
 
@@ -18,6 +23,16 @@ class WorkResultDisplay < ViewModel
     @display_dates = DateDisplayFormatter.new(model.date_of_work).display_dates
   end
 
+  # Requires helper method `child_counter` to be available, returning a
+  # ChildCountDisplayFetcher. Provided by CatalogController.
+  def display_num_children
+    count = child_counter.display_count_for(model)
+    return "" unless count > 0
+
+    content_tag("div", class: "chf-results-list-item-num-members") do
+      number_with_delimiter(count) + ' item'.pluralize(count)
+    end
+  end
 
   def link_to_href
     work_path(model)

--- a/app/views/presenters/_index_result.html.erb
+++ b/app/views/presenters/_index_result.html.erb
@@ -1,7 +1,7 @@
 <%# originally copied from chf_sufia app/views/curation_concerns/generic_works/_generic_work.html.erb
     Modified for cleaner architecture using our draper-based "view models" %>
 
-<li id="document_<%# generic_work.to_param %>" class="chf-results-list-item document <%# render_document_class generic_work %>" itemscope itemtype="<%# generic_work.itemtype %>">
+<li id="document_<%= model.friendlier_id %>" class="chf-results-list-item document <%# render_document_class generic_work %>" itemscope itemtype="<%# generic_work.itemtype %>">
 
 
     <div class="chf-results-list-item-thumb">

--- a/app/views/presenters/_index_result.html.erb
+++ b/app/views/presenters/_index_result.html.erb
@@ -8,7 +8,7 @@
       <%= link_to view.link_to_href do %>
         <%= ResultThumbDisplay.new(model.leaf_representative).display %>
       <% end %>
-      <%# doc_presenter.render_num_members %>
+      <%= view.display_num_children %>
     </div>
 
     <div class="chf-results-list-item-content">

--- a/spec/factories/collection_factory.rb
+++ b/spec/factories/collection_factory.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     title { 'Test title' }
     description { "Test collection description" }
     related_url { ["http://example.com"] }
+    published { true }
   end
 end

--- a/spec/factories/work_factory.rb
+++ b/spec/factories/work_factory.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :work, class: Work do
     title { 'Test title' }
+    published { true }
     external_id do [
         Work::ExternalId.new({"value"=>"Past Perfect ID 1",   "category"=>"object"}),
         Work::ExternalId.new({"value"=>"Sierra Bib Number 1", "category"=>"bib"   }),

--- a/spec/presenters/child_count_display_fetcher_spec.rb
+++ b/spec/presenters/child_count_display_fetcher_spec.rb
@@ -1,0 +1,133 @@
+require 'rails_helper'
+
+describe ChildCountDisplayFetcher do
+  let(:items) { [item] } # override if you want more than one
+  let(:item_counter) { ChildCountDisplayFetcher.new(items.collect(&:friendlier_id)) }
+
+  describe "for Works" do
+    describe "with published items" do
+      let(:item) { create(:work, members: [create(:work), create(:work)]) }
+
+      it "fetches member count" do
+        expect(item_counter.member_count_for_friendlier_id(item.friendlier_id)).to eq(2)
+        expect(item_counter.display_count_for(item)).to eq(2)
+      end
+    end
+
+    describe "for unpublished work members" do
+      let(:item) { create(:work, members: [create(:work), create(:work, published: false)]) }
+
+      it "does not include unpublished members" do
+        expect(item_counter.member_count_for_friendlier_id(item.friendlier_id)).to eq(1)
+        expect(item_counter.display_count_for(item)).to eq(1)
+      end
+    end
+
+    describe "with no members" do
+      let(:item) { create(:work) }
+
+      it "returns zero" do
+        expect(item_counter.member_count_for_friendlier_id(item.friendlier_id)).to eq(0)
+        expect(item_counter.display_count_for(item)).to eq(0)
+      end
+    end
+
+    describe "for multiple works in batch" do
+      # force initial creation outside of our db query count expectation
+      # with let! (exclamation point). Also force fetch of friendlier_id
+      # from db!
+      let!(:items) {
+        [
+          create(:work, members: [create(:work)]),
+          create(:work, members: [create(:work)]),
+          create(:work, members: [create(:work)]),
+        ].tap do |arr|
+          arr.each(&:friendlier_id)
+        end
+      }
+
+      it "makes only one DB query" do
+        expect {
+          item_counter.display_count_for(items.first)
+          item_counter.display_count_for(items.second)
+          item_counter.display_count_for(items.third)
+        }.to make_database_queries(count: 1)
+      end
+    end
+  end
+
+  describe "for Collections" do
+    describe "with published items" do
+      let(:item) { create(:collection, contains: [create(:work), create(:work)]) }
+
+      it "fetches contains count" do
+        expect(item_counter.contains_count_for_friendlier_id(item.friendlier_id)).to eq(2)
+        expect(item_counter.display_count_for(item)).to eq(2)
+      end
+    end
+
+    describe "for unpublished work members" do
+      let(:item) { create(:collection, contains: [create(:work), create(:work, published: false)]) }
+
+      it "does not include unpublished contained" do
+        expect(item_counter.contains_count_for_friendlier_id(item.friendlier_id)).to eq(1)
+        expect(item_counter.display_count_for(item)).to eq(1)
+      end
+    end
+
+    describe "with no contained" do
+      let(:item) { create(:collection) }
+
+      it "returns zero" do
+        expect(item_counter.contains_count_for_friendlier_id(item.friendlier_id)).to eq(0)
+        expect(item_counter.display_count_for(item)).to eq(0)
+      end
+    end
+
+    describe "for multiple collections in batch" do
+      # force initial creation outside of our db query count expectation
+      # with let! (exclamation point). Also force fetch of friendlier_id
+      # from db!
+      let!(:items) {
+        [
+          create(:collection, contains: [create(:work)]),
+          create(:collection, contains: [create(:work)]),
+          create(:collection, contains: [create(:work)]),
+        ].tap do |arr|
+          arr.each(&:friendlier_id)
+        end
+      }
+
+      it "makes only one DB query" do
+        expect {
+          item_counter.display_count_for(items.first)
+          item_counter.display_count_for(items.second)
+          item_counter.display_count_for(items.third)
+        }.to make_database_queries(count: 1)
+      end
+    end
+  end
+
+  describe "for friendlier_id not in batch" do
+    let(:item) { create(:work) }
+    let(:other_work) { create(:work) }
+
+    it "raises ArgumentError when requested" do
+      expect {
+        item_counter.display_count_for(other_work)
+      }.to raise_error(ArgumentError)
+
+      expect {
+        item_counter.member_count_for_friendlier_id(other_work.friendlier_id)
+      }.to raise_error(ArgumentError)
+
+      expect {
+        item_counter.contains_count_for_friendlier_id(other_work.friendlier_id)
+      }.to raise_error(ArgumentError)
+
+      expect {
+        item_counter.member_count_for_friendlier_id("non-existing_friendlier_id")
+      }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/presenters/collection_result_display_spec.rb
+++ b/spec/presenters/collection_result_display_spec.rb
@@ -1,12 +1,21 @@
 require 'rails_helper'
 
 describe CollectionResultDisplay do
-
-  let(:collection) { FactoryBot.create(:collection) }
+  let(:collection) { FactoryBot.create(:collection, contains: [create(:work)]) }
   let(:rendered) { Nokogiri::HTML.fragment(described_class.new(collection).display) }
+
+  before do
+    # normally provided by CatalogController, the WorkResultDisplay does
+    # expect controller to provide this, we mock it here.
+    without_partial_double_verification do
+      allow(helpers).to receive(:child_counter).and_return(ChildCountDisplayFetcher.new([collection.friendlier_id]))
+    end
+  end
+
 
   it "displays" do
     expect(rendered).to have_text("Collection") #genre
     expect(rendered).to have_selector("h2 > a", text: collection.title)
+    expect(rendered).to have_content("1 item")
   end
 end

--- a/spec/presenters/work_result_display_spec.rb
+++ b/spec/presenters/work_result_display_spec.rb
@@ -18,6 +18,15 @@ describe WorkResultDisplay do
     end
   end
 
+  before do
+    # normally provided by CatalogController, the WorkResultDisplay does
+    # expect controller to provide this, we mock it here.
+    without_partial_double_verification do
+      allow(helpers).to receive(:child_counter).and_return(ChildCountDisplayFetcher.new([work.friendlier_id]))
+    end
+  end
+
+
   let(:parent_work) { create(:work) }
 
   let(:work) { FactoryBot.create(:work, :with_complete_metadata,
@@ -27,7 +36,8 @@ describe WorkResultDisplay do
     genre: ["Advertisements", "Artifacts"],
     additional_title: "An Additional Title",
     subject: ["Subject1", "Subject2"],
-    creator: [{category: "contributor", value: "Joe Smith"}, {category: "contributor", value: "Moishe Brown"}, {category: "interviewer", value: "Mary Sue"}]
+    creator: [{category: "contributor", value: "Joe Smith"}, {category: "contributor", value: "Moishe Brown"}, {category: "interviewer", value: "Mary Sue"}],
+    members: [create(:work)]
   )}
 
   let(:presenter) { described_class.new(work) }
@@ -51,6 +61,8 @@ describe WorkResultDisplay do
     expect(rendered).to have_selector("a", text: "Joe Smith")
     expect(rendered).to have_selector("a", text: "Moishe Brown")
     expect(rendered).to have_selector("a", text: "Mary Sue")
+
+    expect(rendered).to have_content("1 item")
   end
 
   describe "#metadata_labels_and_values" do

--- a/spec/system/catalog_search_spec.rb
+++ b/spec/system/catalog_search_spec.rb
@@ -16,14 +16,23 @@ describe CatalogController, solr: true, indexable_callbacks: true do
   # Creating real representatives with derivatives is a bit slow, only do it for our own
   # smoke test.
   describe "with real representative with derivatives" do
-    let!(:work1) { create(:work, representative: create(:asset, :inline_promoted_file)) }
-    let!(:collection) { create(:collection, representative: create(:asset, :inline_promoted_file)) }
+    let!(:work1) do
+      create(:work,
+        representative: create(:asset, :inline_promoted_file),
+        members: [create(:work), create(:work)])
+    end
+
+    let!(:collection) do
+      create(:collection,
+        representative: create(:asset, :inline_promoted_file),
+        contains: [work1] )
+    end
 
     # just a smoke test
     it "loads" do
       visit search_catalog_path(search_field: "all_fields")
 
-      expect(page).to have_content("1 - 3 of 3")
+      expect(page).to have_content("1 - 5 of 5")
       expect(page).to have_content(work1.title)
       expect(page).to have_content(work_with_admin_note.title)
       expect(page).to have_content(collection.title)
@@ -31,6 +40,10 @@ describe CatalogController, solr: true, indexable_callbacks: true do
       # thumbs for work and collection
       expect(page).to have_selector("img[src='#{work1.leaf_representative.derivative_for(:thumb_standard).url}']")
       expect(page).to have_selector("img[src='#{collection.leaf_representative.derivative_for(:thumb_standard).url}']")
+
+      # cheesy check for "Num items", not distinguishing in test which is work and which is collection
+      expect(page).to have_content("1 item")
+      expect(page).to have_content("2 items")
     end
   end
 

--- a/spec/system/catalog_search_spec.rb
+++ b/spec/system/catalog_search_spec.rb
@@ -33,17 +33,20 @@ describe CatalogController, solr: true, indexable_callbacks: true do
       visit search_catalog_path(search_field: "all_fields")
 
       expect(page).to have_content("1 - 5 of 5")
-      expect(page).to have_content(work1.title)
+
+      within("#document_#{work1.friendlier_id}") do
+        expect(page).to have_content(work1.title)
+        expect(page).to have_content("2 items")
+        expect(page).to have_selector("img[src='#{work1.leaf_representative.derivative_for(:thumb_standard).url}']")
+      end
+
       expect(page).to have_content(work_with_admin_note.title)
-      expect(page).to have_content(collection.title)
 
-      # thumbs for work and collection
-      expect(page).to have_selector("img[src='#{work1.leaf_representative.derivative_for(:thumb_standard).url}']")
-      expect(page).to have_selector("img[src='#{collection.leaf_representative.derivative_for(:thumb_standard).url}']")
-
-      # cheesy check for "Num items", not distinguishing in test which is work and which is collection
-      expect(page).to have_content("1 item")
-      expect(page).to have_content("2 items")
+      within("#document_#{collection.friendlier_id}") do
+        expect(page).to have_content(collection.title)
+        expect(page).to have_selector("img[src='#{collection.leaf_representative.derivative_for(:thumb_standard).url}']")
+        expect(page).to have_content("1 item")
+      end
     end
   end
 

--- a/spec/system/catalog_search_spec.rb
+++ b/spec/system/catalog_search_spec.rb
@@ -7,15 +7,7 @@ require 'rails_helper'
 # trust that future versions of Blacklight wouldn't break our unit tests assumptions, a
 # full integration test on UI is safest and easiest.
 describe CatalogController, solr: true, indexable_callbacks: true do
-  let(:admin_note_text) { "an admin note" }
-  let(:admin_note_query) { "\"#{admin_note_text}\"" }
-  let!(:work1) { create(:work) }
-  let!(:collection) { create(:collection) }
-  let!(:work_with_admin_note) { create(:work, admin_note: admin_note_text) }
-
-  # Creating real representatives with derivatives is a bit slow, only do it for our own
-  # smoke test.
-  describe "with real representative with derivatives" do
+  describe "general smoke test with lots of features" do
     let!(:work1) do
       create(:work,
         description: 'priceless work',
@@ -34,7 +26,7 @@ describe CatalogController, solr: true, indexable_callbacks: true do
     it "loads" do
       visit search_catalog_path(search_field: "all_fields")
 
-      expect(page).to have_content("1 - 5 of 5")
+      expect(page).to have_content("1 - 4 of 4")
 
       within("#document_#{work1.friendlier_id}") do
         expect(page).to have_content(work1.title)
@@ -42,8 +34,6 @@ describe CatalogController, solr: true, indexable_callbacks: true do
         expect(page).to have_content("2 items")
         expect(page).to have_selector("img[src='#{work1.leaf_representative.derivative_for(:thumb_standard).url}']")
       end
-
-      expect(page).to have_content(work_with_admin_note.title)
 
       within("#document_#{collection.friendlier_id}") do
         expect(page).to have_content(collection.title)
@@ -54,15 +44,23 @@ describe CatalogController, solr: true, indexable_callbacks: true do
     end
   end
 
-  it "does not find admin note" do
-    visit search_catalog_path(q: admin_note_query)
-    expect(page).to have_content("No results found")
-  end
+  describe "admin notes" do
+    let(:admin_note_text) { "an admin note" }
+    let(:admin_note_query) { "\"#{admin_note_text}\"" }
+    let!(:work_with_admin_note) { create(:work, admin_note: admin_note_text) }
 
-  describe "with logged in user", logged_in_user: true do
-    it "can find admin note" do
-      visit search_catalog_path(q: admin_note_query)
-      expect(page).to have_content("1 entry found")
+    describe "no logged in user" do
+      it "can not find admin note" do
+        visit search_catalog_path(q: admin_note_query)
+        expect(page).to have_content("No results found")
+      end
+    end
+
+    describe "with logged in user", logged_in_user: true do
+      it "can find admin note" do
+        visit search_catalog_path(q: admin_note_query)
+        expect(page).to have_content("1 entry found")
+      end
     end
   end
 end


### PR DESCRIPTION
For works, this is number of 'members'. For collections, it's number of 'contains' assoc destinations (we use different AR associations for work children (1-N) and collection belonging (N-N). 

The naive approach would end up having a separate SQL query executed for each item on results page, to fetch it's "child count for display". That would be bad. (SQL N+1 problem). 

So we provide a ChildCountDisplayFetcher that can make ONE SQL query to fetch all the counts for everything in result set. (Actually it potentially does two, one for collections#contains and one for works#members, but they are triggered lazily on demand so only if both collections and works are in result set). 
* It uses a bit of fancy ActiveRecord to do a 'group by' query to fetch counts.

Now we have to make this available somehow at view time... to our relevant view models probably. We need to initialize a ChildCountDisplayFetcher with the IDs of everything in the current results page (so it can batch fetch them)... so it winds up in the controller, where that info is easily available. This does introduce some unfortunate coupling between controller and our 'view models' (need to mock the helper method we add to provide a ChildCountDisplayFetcher in specs for the view models). But it works, and seems good enough for now. 
* I did think of some rather clever ways to use a Blacklight SearchService here instead. But I only thought of it after this apporach was complete; I think it would actually result in _more_ lines of code, although better encapsulation/loose coupling/right things knowing about each other... but this is done and working and not *too* bad, so I'm thinking this is good enough for now.