### PR TITLE
Don't display num children for work search results unless > 1

### DIFF
--- a/app/presenters/work_result_display.rb
+++ b/app/presenters/work_result_display.rb
@@ -27,7 +27,7 @@ class WorkResultDisplay < ViewModel
   # ChildCountDisplayFetcher. Provided by CatalogController.
   def display_num_children
     count = child_counter.display_count_for(model)
-    return "" unless count > 0
+    return "" unless count > 1
 
     content_tag("div", class: "chf-results-list-item-num-members") do
       number_with_delimiter(count) + ' item'.pluralize(count)

--- a/spec/factories/asset_factory.rb
+++ b/spec/factories/asset_factory.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :asset, class: Asset do
     title { 'Test title' }
+    published { true }
 
     trait :inline_promoted_file do
       file { File.open((Rails.root + "spec/test_support/images/30x30.png")) }

--- a/spec/presenters/child_count_display_fetcher_spec.rb
+++ b/spec/presenters/child_count_display_fetcher_spec.rb
@@ -6,7 +6,7 @@ describe ChildCountDisplayFetcher do
 
   describe "for Works" do
     describe "with published items" do
-      let(:item) { create(:work, members: [create(:work), create(:work)]) }
+      let(:item) { create(:work, members: [create(:work), create(:asset)]) }
 
       it "fetches member count" do
         expect(item_counter.member_count_for_friendlier_id(item.friendlier_id)).to eq(2)

--- a/spec/presenters/work_result_display_spec.rb
+++ b/spec/presenters/work_result_display_spec.rb
@@ -37,7 +37,7 @@ describe WorkResultDisplay do
     additional_title: "An Additional Title",
     subject: ["Subject1", "Subject2"],
     creator: [{category: "contributor", value: "Joe Smith"}, {category: "contributor", value: "Moishe Brown"}, {category: "interviewer", value: "Mary Sue"}],
-    members: [create(:work)]
+    members: [create(:asset), create(:asset)]
   )}
 
   let(:presenter) { described_class.new(work) }
@@ -62,7 +62,16 @@ describe WorkResultDisplay do
     expect(rendered).to have_selector("a", text: "Moishe Brown")
     expect(rendered).to have_selector("a", text: "Mary Sue")
 
-    expect(rendered).to have_content("1 item")
+    expect(rendered).to have_content("2 items")
+  end
+
+  describe "one child" do
+    let(:work) { create(:work, members: [create(:asset)])}
+
+    it "does not display num items" do
+      expect(rendered).not_to have_content("1 item")
+      expect(rendered).not_to have_content("item")
+    end
   end
 
   describe "#metadata_labels_and_values" do


### PR DESCRIPTION
consistent with chf_sufia. forgot this on first implementation, noticed when looking in staging.