### PR TITLE
Make ChildCountDisplayFetcher dependency explicit in initializer

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -45,12 +45,6 @@ class CatalogController < ApplicationController
   end
   helper_method :view_model_class_for
 
-  # Used by our ViewModels for displaying results
-  def child_counter
-    @child_counter ||= ChildCountDisplayFetcher.new(@response.documents.collect(&:id))
-  end
-  helper_method :child_counter
-
   configure_blacklight do |config|
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository

--- a/app/presenters/collection_result_display.rb
+++ b/app/presenters/collection_result_display.rb
@@ -1,10 +1,18 @@
 # Displays an element in search results for a "Work"
 #
-# * requires controller to provide a helper method `child_counter` that returns
-# a ChildCountDisplayFetcher for efficient fetching and provision of "N Items"
+# * requires a ChildCountDisplayFetcher for efficient fetching and provision of "N Items"
 # child count on display.
 class CollectionResultDisplay < ViewModel
   valid_model_type_names "Collection"
+
+  attr_reader :child_counter
+
+  # @param collection [Collection]
+  # @param child_counter [ChildCountDisplayFetcher]
+  def initialize(collection, child_counter:)
+    @child_counter = child_counter
+    super(collection)
+  end
 
   def display
     render "/presenters/index_result", model: model, view: self

--- a/app/presenters/work_result_display.rb
+++ b/app/presenters/work_result_display.rb
@@ -1,12 +1,20 @@
 # Displays an element in search results for a "Work"
 #
-# * requires controller to provide a helper method `child_counter` that returns
-# a ChildCountDisplayFetcher for efficient fetching and provision of "N Items"
+# * requires a a ChildCountDisplayFetcher for efficient fetching and provision of "N Items"
 # child count on display.
 class WorkResultDisplay < ViewModel
   valid_model_type_names "Work"
 
   delegate :additional_title
+
+  attr_reader :child_counter
+
+  # @param work [Work]
+  # @param child_counter [ChildCountDisplayFetcher]
+  def initialize(work, child_counter:)
+    @child_counter = child_counter
+    super(work)
+  end
 
   def display
     render "/presenters/index_result", model: model, view: self
@@ -23,8 +31,6 @@ class WorkResultDisplay < ViewModel
     @display_dates = DateDisplayFormatter.new(model.date_of_work).display_dates
   end
 
-  # Requires helper method `child_counter` to be available, returning a
-  # ChildCountDisplayFetcher. Provided by CatalogController.
   def display_num_children
     count = child_counter.display_count_for(model)
     return "" unless count > 0

--- a/app/views/catalog/_document_list.html.erb
+++ b/app/views/catalog/_document_list.html.erb
@@ -1,7 +1,9 @@
 <% # container for all documents in index list view -%>
 
 <ul id="documents" class="list-unstyled documents-<%= document_index_view_type %>">
+  <% child_counter = ChildCountDisplayFetcher.new(documents.collect(&:id)) %>
+
   <% documents.collect(&:model).compact.each do |model| %>
-    <%= view_model_class_for(model).new(model).display %>
+    <%= view_model_class_for(model).new(model, child_counter: child_counter).display %>
   <% end %>
 </ul>

--- a/spec/presenters/collection_result_display_spec.rb
+++ b/spec/presenters/collection_result_display_spec.rb
@@ -2,16 +2,9 @@ require 'rails_helper'
 
 describe CollectionResultDisplay do
   let(:collection) { FactoryBot.create(:collection, contains: [create(:work)]) }
-  let(:rendered) { Nokogiri::HTML.fragment(described_class.new(collection).display) }
+  let(:rendered) { Nokogiri::HTML.fragment(described_class.new(collection, child_counter: child_counter).display) }
 
-  before do
-    # normally provided by CatalogController, the WorkResultDisplay does
-    # expect controller to provide this, we mock it here.
-    without_partial_double_verification do
-      allow(helpers).to receive(:child_counter).and_return(ChildCountDisplayFetcher.new([collection.friendlier_id]))
-    end
-  end
-
+  let(:child_counter) { ChildCountDisplayFetcher.new([collection.friendlier_id]) }
 
   it "displays" do
     expect(rendered).to have_text("Collection") #genre

--- a/spec/presenters/work_result_display_spec.rb
+++ b/spec/presenters/work_result_display_spec.rb
@@ -18,14 +18,7 @@ describe WorkResultDisplay do
     end
   end
 
-  before do
-    # normally provided by CatalogController, the WorkResultDisplay does
-    # expect controller to provide this, we mock it here.
-    without_partial_double_verification do
-      allow(helpers).to receive(:child_counter).and_return(ChildCountDisplayFetcher.new([work.friendlier_id]))
-    end
-  end
-
+  let(:child_counter) { ChildCountDisplayFetcher.new([work.friendlier_id]) }
 
   let(:parent_work) { create(:work) }
 
@@ -40,7 +33,7 @@ describe WorkResultDisplay do
     members: [create(:work)]
   )}
 
-  let(:presenter) { described_class.new(work) }
+  let(:presenter) { described_class.new(work, child_counter: child_counter) }
   let(:rendered) { Nokogiri::HTML.fragment(presenter.display) }
 
   it "displays" do


### PR DESCRIPTION
Small refactor of that display num children stuff.

The Work/Collection ViewModels already had a 'dependency' on a ChildCountDisplayFetcher being available. (To efficiently access child count numbers). But it was a kind of "implicit" dependency/requirement, they required a helper method called `child_count` to be available in the current Rails "view context", which we had the Rails controller provide.

This gave me a bad feeling from the start, introduced coupling between the view models and the controller, in a not entirely obvious way, tried to get around that with copious documentation. Required mocking in the unit tests for the view models to "pretend" the helper was available, which required relying on some odd rspec features and draper-provided test support.

I realized we can instead just make the view models require a ChildCountDisplayFetcher to be passed in to their initializers. Now the dependency/requirement is totally clear, and actually enforced by ruby. Doing this in a spec becomes trivial. And we can have the _document_list partial we were already overriding construct the batched ChildCountDisplayFetcher, and pass it in to all the view models.

While this requires logic in the _document_list partial, when ideally you don't want logic like this in the view... overall I think it's an improvement, keeping the view models nice and self-contained. (I suppose the controller _could_ still provide it in helper method that the _document_list partial _uses_ to pass to the view models... the view models would still be nice and self-contained. I think this is probably good enough how it is, but if you understand what I'm saying and think it would be an improvement I can do that.)