### PR TITLE
index actual postgres pk in solr

### DIFF
--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -5,7 +5,7 @@ class CollectionIndexer < Kithe::Indexer
     # that will have similar boosting, to use solr solr more efficiently.
     # text1 is boosted highest, text2 next highest, etc.
 
-    to_field "friendlier_id_ssi", obj_extract("friendlier_id")
+    to_field "model_pk_ssi", obj_extract("id") # the actual db pk, a UUID
 
     to_field "text1_tesim", obj_extract("title")
 

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -8,7 +8,7 @@ class WorkIndexer < Kithe::Indexer
     #
     # Experiment, not necessarily completed indexing logic.
 
-    to_field "friendlier_id_ssi", obj_extract("friendlier_id")
+    to_field "model_pk_ssi", obj_extract("id") # the actual db pk, a UUID
 
     to_field "text1_tesim", obj_extract("title")
     to_field "text1_tesim", obj_extract("additional_title")

--- a/spec/indexers/collection_indexer_spec.rb
+++ b/spec/indexers/collection_indexer_spec.rb
@@ -6,5 +6,7 @@ describe CollectionIndexer do
   it "indexes" do
     output_hash = CollectionIndexer.new.map_record(collection)
     expect(output_hash).to be_present
+
+    expect(output_hash["model_pk_ssi"]).to eq([collection.id])
   end
 end

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -6,5 +6,9 @@ describe WorkIndexer do
   it "indexes" do
     output_hash = WorkIndexer.new.map_record(work)
     expect(output_hash).to be_present
+
+    expect(output_hash["model_pk_ssi"]).to eq([work.id])
   end
+
+
 end


### PR DESCRIPTION
we are now using friendlier_id as the solr 'id', so don't need to index that separately. But will index actual postgres pk id separately, which would now not otherwise be in solr. helpful for debugging if nothing else.