### PR TITLE
switch solr restart to systemctl command

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -112,7 +112,7 @@ namespace :chf do
   task :restart_or_reload_solr do
     on roles(:solr) do
       if ENV['solr_restart'] == "true"
-        execute :sudo, "/usr/sbin/service solr restart"
+        execute :sudo, "/bin/systemctl restart solr"
       else
         # Note this is NOT using our solr variable in local_env.yml, it's just hard-coded
         # where to restart, sorry.


### PR DESCRIPTION
Moved to the systemctl command to match what we're using for passenger and also be more forward prepared with any other systemd changes that might affect the service command in the future.