### PR TITLE
add font-awesome

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,8 @@ gem 'sprockets-rails', '>= 2.3.2' # bootstrap gem requirement
 
 gem 'jquery-rails', "~> 4.3"
 
+gem 'font-awesome-rails', '~> 4.7'
+
 # temporary kithe indexing branch, for scihist_digicoll indexing branch, do not
 # intend to merge to master like this.
 gem 'kithe', git: "https://github.com/sciencehistory/kithe.git"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,6 +223,8 @@ GEM
     fastimage (2.0.1)
       addressable (~> 2)
     ffi (1.9.25)
+    font-awesome-rails (4.7.0.5)
+      railties (>= 3.2, < 6.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     google-api-client (0.28.4)
@@ -596,6 +598,7 @@ DEPENDENCIES
   devise (~> 4.5)
   draper (~> 3.0)
   factory_bot_rails
+  font-awesome-rails (~> 4.7)
   honeybadger (~> 4.0)
   html_aware_truncation (~> 1.0)
   jbuilder (~> 2.5)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,8 @@
 
 @import "bootstrap";
 
+@import "font-awesome"; // fontawesome v4, CSS
+
 /* Blacklight 7 generator assumed a "blacklight.scss" would be required with sprockets.
    That file consisted of
       @import 'bootstrap';


### PR DESCRIPTION
Adding it with the same rails gem we used in chf_sufia. This is bootstrap v4, not the newer v5.

Decided it was not in our brief to spend time on figuring out v5 upgrade at this point. 

## Finding font-awesome icons

We are using v4, not newest v5. So a good directory of the v4 icons is at:

https://fontawesome.com/v4.7.0/icons/


## Notes on font-awesome and accessibility

It turns out that ALL uses of font-awesome icons via CSS classes should really have `aria-hidden="true"` on them. Eg:

    <i class="fa fa-address-book" aria-hidden="true"></i>

This prevents a screen-reader from trying to read the unicode codepoint that font-awesome is hijacking to be it's own icon. 

We normally try to use icons that are only decorative or supplemental to words already there, so it's okay if a non-visual browser simply skips it. 

If you additionally would want a non-visual browser to have some text in place of the icon, there are some patterns. See:

* https://fontawesome.com/v4.7.0/accessibility/
* https://fontawesome.com/v5.9.0/how-to-use/on-the-web/other-topics/accessibility  (for v5, but basic patterns still applicable)