### PR TITLE
Delete conflicting items of other types.

### DIFF
--- a/app/importers/importers/importer.rb
+++ b/app/importers/importers/importer.rb
@@ -28,12 +28,10 @@ module Importers
       @metadata = metadata
       @errors ||= []
       @conflicting_item_was_kept = false
+      explanation = 'options[:keep_conflicting_items] should be true, false or nil.'
+      raise ArgumentError, explanation unless [true,false,nil].include? options[:keep_conflicting_items]
       @keep_conflicting_items = options[:keep_conflicting_items].nil? ? true : options[:keep_conflicting_items]
     end
-
-
-
-
 
     # This is the only method called on this class
     # by the rake task after instantiation.

--- a/app/importers/importers/importer.rb
+++ b/app/importers/importers/importer.rb
@@ -50,7 +50,7 @@ module Importers
       end
     end
 
-    # Is there a preexisting item with the same friendlier_id and the same type?
+    # Is there a preexisting item with the same friendlier_id *and* the same type?
     def preexisting_item?
       # Calling target_item:
       #   * checks for any conflicting items
@@ -119,7 +119,7 @@ module Importers
 
     # After running, check #errors for any errors you may want to report
     # to the user.
-    def save_target_item()
+    def save_target_item
       begin
         target_item.save!
       rescue StandardError => e
@@ -174,7 +174,7 @@ module Importers
 
     # What errors have been accumulated? Includes any validation errors
     # on the record to be saved, and any errors added with #add_error
-    def errors()
+    def errors
       (@errors + (target_item&.errors&.full_messages || [])).collect do |str|
         "#{self.class.importee} #{metadata['id']}: #{str}"
       end
@@ -183,7 +183,7 @@ module Importers
 
     # Take the new item and add all metadata to it.
     # This do not save the item.
-    def common_populate()
+    def common_populate
       target_item.friendlier_id = @metadata['id']
       target_item.title = @metadata['title'].first
 
@@ -214,12 +214,12 @@ module Importers
     end
 
     # the old importee class name, as a string, e.g. 'FileSet'
-    def self.importee()
+    def self.importee
       raise NotImplementedError
     end
 
     # the new importee class, e.g. Asset
-    def self.destination_class()
+    def self.destination_class
       raise NotImplementedError
     end
 
@@ -233,8 +233,5 @@ module Importers
       Kithe::Model.record_timestamps = original
     end
 
-    def same_friendlier_id_different_type
-      Kithe::Model.where(friendlier_id:metadata['id']).where.not(type:self.class.destination_class.to_s).first
-    end
   end
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -87,7 +87,9 @@ namespace :scihist_digicoll do
           progress_bar.log("ERROR: Empty json file at #{path}")
           next
         end
-        Importers::GenericWorkImporter.new(json_str).tap do |importer|
+        Importers::GenericWorkImporter.new(json_str,
+          keep_conflicting_items: keep_conflicting_items
+          ).tap do |importer|
           importer.import
           importer.errors.each { |e| progress_bar.log(e) }
         end
@@ -104,7 +106,9 @@ namespace :scihist_digicoll do
 
       progress_bar.log("INFO: Importing Collections")
       collection_dir.each do |path|
-        Importers::CollectionImporter.new(JSON.parse(File.read(path))).tap do |importer|
+        Importers::CollectionImporter.new(JSON.parse(File.read(path)),
+          keep_conflicting_items: keep_conflicting_items
+          ).tap do |importer|
           importer.import
           importer.errors.each { |e| progress_bar.log(e) }
         end


### PR DESCRIPTION
Summary:

This will report (and, if you request it, delete) pre-existing items of *other* types if the pre-existing item's friendlier_id conflicts with that of the one we're trying to import.

For instance:
We want to import an `asset` with `friendlier_id` `a1b2c3` but we discover there is already a `work` with that same `friendlier_id` in the destination site. We remove the `work` to make room for the `asset`, consistent with our current policy that an import wipes conflicting information.
To report, but not delete, run as usual:
```scripts/import/import.sh```
Once you've moved the conflicting items out of the way, or just determined you don't want to keep them, you can tell the import to remove them automatically:
```KEEP_CONFLICTING_ITEMS=false scripts/import/import.sh```

*****


Details by file:

**In importer.rb:**

- added / refreshed the method documentation
- reordered the three main methods -- `import`, `preexisting_item?` and `target_item` so they appear (to me at any rate) in their logical order. I can imagine refactoring these three methods, but decided against further changes for now.
- updated the `target_item` method to correctly handle conflicting items. If it finds a conflicting item and the `KEEP_CONFLICTING_ITEMS` flag (`true` by default) is in fact `true`, it sets the `@conflicting_item_was_kept` flag and returns from the method. If it finds a conflicting item and the `KEEP_CONFLICTING_ITEMS` is `false`, it deletes the conflicting item and continues as usual.
- added a `check_for_items_with_same_id` method to isolate the process of figuring out what items have the same friendlier_id
- added a new ivar `@conflicting_item_was_kept` as a flag. It gets set if a conflicting item was found AND NOT DELETED, so that the import process knows to skip this item.
- renamed boolean ivar `@preexisting_item` to `@preexisting_item_was_found` -- this was confusing me to no end because I kept imagining it referred to the preexisting item itself.

**In the tests:**

- Added tests to assert that the default options were indeed set to the correct defaults
- Tested that the import behaves as expected when a conflicting item is present, depending on how the `KEEP_CONFLICTING_ITEMS` flag is set.

**In the import.rake task:**

- Checked for said flag and pass it as an option to FileSetImporter, GenericWorkImporter and CollectionImporter.