### PR TITLE
Adding school_of

### DIFF
--- a/app/models/work/creator.rb
+++ b/app/models/work/creator.rb
@@ -3,7 +3,7 @@ class Work
     CATEGORY_VALUES = %w{addressee after artist attributed_to author
                     contributor creator_of_work editor engraver interviewee
                     interviewer manufacturer manner_of photographer
-                    printer printer_of_plates publisher}
+                    printer printer_of_plates publisher school_of}
 
     include AttrJson::Model
     validates_presence_of :category, :value


### PR DESCRIPTION
Note: the import audit explicitly checks for *all* the items in the Work::Creator::CATEGORY_VALUES array, so if an import file specifies a `school_of` and the resulting imported item has none or a different value, the audit will catch it.