### PR TITLE
Fix bug where admin users could not create Collection

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -75,7 +75,7 @@ class Admin::CollectionsController < AdminController
     # enough for now.
     def collection_params
       permitted_attributes = [:title, :description]
-      permitted_attributes << :published if can?(:publish, @collection)
+      permitted_attributes << :published if can?(:publish, @collection || Collection)
 
       params.
         require(:collection).

--- a/spec/controllers/admin/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin/admin_collections_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Admin::CollectionsController, :logged_in_user, type: :controller do
+  describe "admin user", logged_in_user: :admin do
+    it "can create a published collection" do
+      post :create, params: { collection: { title: "newly created collection", published: "1" } }
+      newly_created = Collection.find_by_title("newly created collection")
+      expect(newly_created).to be_present
+      expect(newly_created.published?).to be true
+    end
+  end
+end


### PR DESCRIPTION
Only admin users can change "published" status. For newly creating a collection, it gave admin users a 'published' checkbox, but then when they submitted, they got a "ActionController::UnpermittedParameters: found unpermitted parameter: :published".

We are using access_granted gem to manage and check permissions, and were trying to make sure current user had permission to edit "publish", but were using the same logic for edits and creates. For creates @collection was nil, so it decided the user didn't have permission. access_granted can support object-specific permissions (like you have permission to edit only if you are an owner), but also supports just passing the general class, for 'create' use cases especially. https://github.com/chaps-io/access-granted

With new spec that failed before fix.