### PR TITLE
Adding actual search-within-collection function to collection show page.

### DIFF
--- a/app/assets/stylesheets/local/collection_show.scss
+++ b/app/assets/stylesheets/local/collection_show.scss
@@ -63,5 +63,9 @@
     }
   }
 
+  #appliedParams.constraints-container {
+    // undo negatie margin from when it's meant to be at top of page, messy.
+    margin-top: 0;
+  }
 }
 

--- a/app/assets/stylesheets/local/collection_show.scss
+++ b/app/assets/stylesheets/local/collection_show.scss
@@ -33,5 +33,35 @@
   .chf-attributes > tbody >tr:first-child td, .chf-attributes > tbody > tr:first-child th {
     border-top: 0; // nope, not here.
   }
+
+  .collection-search-form {
+    margin: $spacer 0;
+    padding: ($spacer);
+    background-color: $bg-lightly-shaded;
+    display: inline-block;
+
+    width: 100%;
+    max-width: $max-readable-width;
+
+    .search-title {
+      font-size: $h4-font-size;
+      margin-bottom: $spacer;
+      font-weight: 600;
+    }
+
+    .input-group {;
+      // hacky way to have extra rounded corners on search box, matching
+      // nav bar search box.
+      input[type=search] {
+        border-top-left-radius: $btn-border-radius;
+        border-bottom-left-radius: $btn-border-radius;
+      }
+      button:last-child {
+        border-top-right-radius: $btn-border-radius;
+        border-bottom-right-radius: $btn-border-radius;
+      }
+    }
+  }
+
 }
 

--- a/app/assets/stylesheets/local/scihist_main_layout.scss
+++ b/app/assets/stylesheets/local/scihist_main_layout.scss
@@ -36,8 +36,9 @@ body.scihist-main-layout {
     max-width: 81.25rem;
   }
 
-  // kind of like a bootstrap grid column, but with fixed width.
-  #sidebar {
+  // kind of like a bootstrap grid column, but with fixed width. Meant to be
+  // inside a bootstrap `row` next to #column below.
+  #sidebar, .sidebar-col {
     @include make-col-ready;
     padding-bottom: .625rem;
 
@@ -55,7 +56,7 @@ body.scihist-main-layout {
     }
   }
 
-  #content {
+  #content, .content-col {
     @include make-col-ready;
     @include media-breakpoint-up($layout-expand-up) {
       // We need to keep this thing within the screen, so it won't flex-wrap

--- a/app/controllers/collection_show_controller.rb
+++ b/app/controllers/collection_show_controller.rb
@@ -12,6 +12,34 @@ class CollectionShowController < CatalogController
 
   # index action inherited from CatalogController, that's what we use.
 
+
+  #Override from Blacklight: displays values and pagination links for a single facet field
+  #
+  # We need to override to change URL to get facet_id out of :id, which we use for our collection.
+  # Need to copy-and-paste-and-change implementation, which is unfortunate.
+  def facet
+    unless params.key?(:facet_id)
+      redirect_back fallback_location: { action: "index", id: params[:id] }
+      return
+    end
+
+    @facet = blacklight_config.facet_fields[params[:facet_id]]
+    raise ActionController::RoutingError, 'Not Found' unless @facet
+
+    @response = search_service.facet_field_response(@facet.key)
+    @display_facet = @response.aggregations[@facet.field]
+    @pagination = facet_paginator(@facet, @display_facet)
+    respond_to do |format|
+      format.html do
+        # Draw the partial for the "more" facet modal window:
+        return render layout: false if request.xhr?
+        # Otherwise draw the facet selector for users who have javascript disabled.
+      end
+      format.json
+    end
+  end
+
+
   private
 
   def check_auth
@@ -31,5 +59,15 @@ class CollectionShowController < CatalogController
 
   def set_collection
     @collection = Collection.find_by_friendlier_id!(params[:id])
+  end
+
+  # override from Blacklight to put the facet id in :facet_id instead of :id, so we can keep
+  # :id for our parent collection id.
+  # Goes with overridden #facet above.
+  def search_facet_path options = {}
+    if options.has_key?(:id)
+      options[:facet_id] = options.delete(:id)
+    end
+    super(options)
   end
 end

--- a/app/controllers/collection_show_controller.rb
+++ b/app/controllers/collection_show_controller.rb
@@ -8,14 +8,15 @@
 # There may be a less hacky way to do this, esp in Blacklight 7, but this is a port of
 # what was in chf_sufia. There also may not be.
 class CollectionShowController < CatalogController
-  before_action :set_collection
+  before_action :set_collection, :check_auth
 
-  def index
-    authorize! :read, @collection
-    super
-  end
+  # index action inherited from CatalogController, that's what we use.
 
   private
+
+  def check_auth
+    authorize! :read, @collection
+  end
 
   # Technically overrides a Blacklight method, although we do our own thing with it
   def presenter

--- a/app/controllers/collection_show_controller.rb
+++ b/app/controllers/collection_show_controller.rb
@@ -39,8 +39,19 @@ class CollectionShowController < CatalogController
     end
   end
 
+  configure_blacklight do |config|
+    # Our custom sub-class to limit just to docs in collection, with collection id
+    # taken from params[:id]
+    config.search_builder_class = ::SearchBuilder::WithinCollectionBuilder
+  end
+
 
   private
+
+  # Our custom SearchBuilder needs to know collection id (UUID)
+  def search_service_context
+    { collection_id: collection.id }
+  end
 
   def check_auth
     authorize! :read, @collection

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -62,9 +62,20 @@ class WorkIndexer < Kithe::Indexer
       acc << DateIndexHelper.new(record).max_year
     end
 
+    # We need to know what collection(s) this work is in, to support search-within-a-collection.
+    #
+    # NOTE: This will do an SQL query to fetch collection ids, if are you indexing a bunch
+    # at once, you should eager-load contains_contained_by assoc to join table.
+    #
+    # NOTE: If Collection contained by changes for a work, it needs to be reindexed.
+    # Right now we only allow collection membership to be changed in the UI on the Work
+    # edit page, and clicking save will re-index the work anyway (need to test to be sure).
+    # But if you are programmatically changing the join table objects, beware.
+    to_field "collection_id_ssim", obj_extract("contains_contained_by", "to_a", "container_id")
+
+
     # Note standard created_at, updated_at, and published are duplicated
     # in CollectionIndexer. Maybe we want to DRY it somehow.
-
 
     # May want to switch to or add a 'date published' instead, right
     # now we only have date added to DB, which is what we had in sufia.

--- a/app/models/search_builder/within_collection_builder.rb
+++ b/app/models/search_builder/within_collection_builder.rb
@@ -1,0 +1,25 @@
+class SearchBuilder
+  # Applies a limit to search just within a given collection, filtering on solr
+  # field where we've stored the containing collection ids.
+  #
+  # :collection_id needs to be provided in context, the actual UUID pk of collection,
+  # since that's what we index.
+  #
+  # Used on CollectionShowController search within a collection
+  class WithinCollectionBuilder < ::SearchBuilder
+    class_attribute :collection_id_solr_field, default: "collection_id_ssim"
+
+    self.default_processor_chain += [:within_collection]
+
+    def within_collection(solr_parameters)
+      solr_parameters[:fq] ||= []
+      solr_parameters[:fq] << "{!term f=#{collection_id_solr_field}}#{collection_id}"
+    end
+
+    private
+
+    def collection_id
+      scope.context.fetch(:collection_id)
+    end
+  end
+end

--- a/app/views/collection_show/index.html.erb
+++ b/app/views/collection_show/index.html.erb
@@ -7,6 +7,7 @@
       <%= link_to "Edit", edit_admin_collection_path(collection), class: "btn btn-outline-primary" %>
     </div>
   <% end %>
+
   <div class="collection-top">
     <div class="collection-desc clearfix">
       <div class="show-title">
@@ -56,6 +57,39 @@
     <div class="collection-thumb">
       <%= ThumbDisplay.new(presenter.leaf_representative, thumb_size: :collection_page, placeholder_img_url: asset_path("default_collection.svg")).display %>
     </div>
+  </div>
+
+  <div class="collection-search-form">
+      <h2 class="search-title">
+            Search within the <%= presenter.title %>
+      </h2>
+
+      <%= form_tag "", method: :get do |f| %>
+       <div class="input-group">
+          <%= search_field_tag :q, '', class: "q form-control",
+              id: "q",
+              autocomplete: "off",
+              placeholder: t("blacklight.search.form.search.placeholder"),
+              :"aria-label" => t('blacklight.search.form.search_field.label')
+          %>
+
+          <label class="sr-only" for="q"><%= t('blacklight.search.form.search_field.label') %></label>
+
+          <div class="input-group-append">
+            <button type="submit" class="btn btn-emphasis" title="Search" id="search-submit-header">
+              <i class="fa fa-search" aria-hidden="true"></i>
+              <%= t('blacklight.search.form.submit') %>
+            </button>
+          </div>
+        </div>
+
+        <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>
+      <% end %>
+
+  </div>
+
+
+
   </div>
 
 </div>

--- a/app/views/collection_show/index.html.erb
+++ b/app/views/collection_show/index.html.erb
@@ -67,13 +67,13 @@
       <%= form_tag "", method: :get do |f| %>
        <div class="input-group">
           <%= search_field_tag :q, '', class: "q form-control",
-              id: "q",
+              id: "collectionQ",
               autocomplete: "off",
-              placeholder: t("blacklight.search.form.search.placeholder"),
-              :"aria-label" => t('blacklight.search.form.search_field.label')
+              placeholder: t("collection.search_form.search_field.placeholder"),
+              :"aria-label" => t('collection.search_form.search_field.label')
           %>
 
-          <label class="sr-only" for="q"><%= t('blacklight.search.form.search_field.label') %></label>
+          <label class="sr-only" for="collectionQ"><%= t('collection.search_form.search_field.label') %></label>
 
           <div class="input-group-append">
             <button type="submit" class="btn btn-emphasis" title="Search" id="search-submit-header">

--- a/app/views/collection_show/index.html.erb
+++ b/app/views/collection_show/index.html.erb
@@ -88,6 +88,26 @@
 
   </div>
 
+  <div class="chf-constraints-wrapper">
+    <%= render 'catalog/constraints' %>
+  </div>
+
+  <div class="row">
+    <% if @response.documents.present? %>
+      <div class="sidebar-col">
+       <%= render 'facets' %>
+      </div>
+    <% end %>
+    <div class="content-col">
+      <%# per-page and sort controls, from Blacklight partial %>
+      <%= render 'search_header' %>
+
+      <%= render "document_list", documents: @response.documents %>
+    </div>
+  </div>
+
+
+
 
 
   </div>

--- a/app/views/collection_show/index.html.erb
+++ b/app/views/collection_show/index.html.erb
@@ -88,9 +88,9 @@
 
   </div>
 
-  <div class="chf-constraints-wrapper">
-    <%= render 'catalog/constraints' %>
-  </div>
+
+  <%= render 'catalog/constraints' %>
+
 
   <div class="row">
     <% if @response.documents.present? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,3 +61,9 @@ en:
     pagination_compact:
       next: "Next" # get rid of ugly unicode carets
       previous: "Previous" # get rid of ugly unicode carets
+
+  collection:
+    search_form:
+      search_field:
+        label: "Search this collection for"
+        placeholder: "Search"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,12 @@ Rails.application.routes.draw do
 
   # public-facing routes
   resources :works, only: [:show]
+
+  # Our collections show controller provides a Blacklight search, so needs
+  # some additional routes for various search behaviors too.
   get "/collections/:id", to: "collection_show#index", as: :collection
+  get "collections/:id/range_limit" => "collection_show#range_limit"
+  get "collections/:id/facet" => "collection_show#facet"
 
 
   ##

--- a/lib/tasks/scihist.rake
+++ b/lib/tasks/scihist.rake
@@ -67,6 +67,8 @@ namespace :scihist do
     desc "sync all Works and Collections to solr index"
     task :reindex => :environment do
       scope = Kithe::Model.where(kithe_model_type: ["collection", "work"]) # we don't index Assets
+      # we should pre-load contained_by_ids since the work indexer will use
+      scope = scope.includes(:contains_contained_by)
 
       progress_bar = ProgressBar.create(total: scope.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
       Kithe::Indexable.index_with(batching: true) do

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -10,5 +10,16 @@ describe WorkIndexer do
     expect(output_hash["model_pk_ssi"]).to eq([work.id])
   end
 
+  describe "with containers" do
+    let(:collection1) {  create(:collection) }
+    let(:collection2) {  create(:collection) }
+    let(:work) {  create(:work, contained_by: [collection1, collection2] ) }
 
+    it "indexes collection ids" do
+      work.contains_contained_by.reload # not sure what we're working around, but okay
+      output_hash = WorkIndexer.new.map_record(work)
+
+      expect(output_hash["collection_id_ssim"]).to match [collection1.id, collection2.id]
+    end
+  end
 end


### PR DESCRIPTION
Don't review/merge until #174 is merged, then rebase this on master.

Requires some kind of hacky interactions with Blacklight to get Blacklight search functionality embedded on a collection show page. Most of this we figured out in chf_sufia, and just altered a bit for Blacklight 7, and no sufia. (Which did actually simplify the hackiness, although it's still kind of obscure).