### PR TITLE
Clean up and flesh out ThumbDisplay view model

### DIFF
--- a/app/presenters/thumb_display.rb
+++ b/app/presenters/thumb_display.rb
@@ -67,17 +67,25 @@ class ThumbDisplay < ViewModel
   # URLs depending on shrine settings (beware of performance issues
   # if they are signed?)
   def thumb_image_tag
-    res_1x_url = model.derivative_for("thumb_#{thumb_size}").try(:url)
-    res_2x_url = model.derivative_for("thumb_#{thumb_size}_2X").try(:url)
-
     unless res_1x_url && res_2x_url
       return placeholder_image_tag
     end
 
-    tag("img",
-         alt: "",
-         src: res_1x_url,
-         srcset: "#{res_1x_url} 1x, #{res_2x_url} 2x"
-    )
+    tag("img", {alt: ""}.merge(src_attributes))
+  end
+
+  def res_1x_url
+    @res_1x_url ||= model.derivative_for("thumb_#{thumb_size}").try(:url)
+  end
+
+  def res_2x_url
+    @res_2x_url ||= model.derivative_for("thumb_#{thumb_size}_2X").try(:url)
+  end
+
+  def src_attributes
+    {
+       src: res_1x_url,
+       srcset: "#{res_1x_url} 1x, #{res_2x_url} 2x"
+    }
   end
 end

--- a/app/presenters/thumb_display.rb
+++ b/app/presenters/thumb_display.rb
@@ -71,7 +71,20 @@ class ThumbDisplay < ViewModel
       return placeholder_image_tag
     end
 
-    tag("img", {alt: ""}.merge(src_attributes))
+    # used for lazysizes-aspectratio
+    # https://github.com/aFarkas/lazysizes/tree/gh-pages/plugins/aspectratio
+    aspect_ratio = if model && model.width && model.height
+      "#{model.width}/#{model.height}"
+    end
+
+    tag("img",
+      {
+        alt: "",
+        data: {
+          aspectratio: aspect_ratio
+        }
+      }.merge(src_attributes)
+    )
   end
 
   def res_1x_url

--- a/app/presenters/thumb_display.rb
+++ b/app/presenters/thumb_display.rb
@@ -16,6 +16,8 @@ class ThumbDisplay < ViewModel
 
   attr_accessor :placeholder_img_url, :thumb_size
 
+  alias_method :asset, :model
+
   # collection_page for CollectionThumbAssets only, oh well we allow them all for now.
   ALLOWED_THUMB_SIZES = Asset::THUMB_WIDTHS.keys + [:collection_page]
 
@@ -39,7 +41,7 @@ class ThumbDisplay < ViewModel
     # for non-pdf/image assets, we currently just return a placeholder. We could in future
     # return a default audio/video icon thumb or something. At present we don't intend to use
     # a/v as representative images.
-    if model.nil? || model.content_type.nil? || !(model.content_type == "application/pdf" || model.content_type.start_with?("image/"))
+    if asset.nil? || asset.content_type.nil? || !(asset.content_type == "application/pdf" || asset.content_type.start_with?("image/"))
       return placeholder_image_tag
     end
 
@@ -100,25 +102,25 @@ class ThumbDisplay < ViewModel
   # used for lazysizes-aspectratio
   # https://github.com/aFarkas/lazysizes/tree/gh-pages/plugins/aspectratio
   def aspect_ratio
-    if model && model.width && model.height
-      "#{model.width}/#{model.height}"
+    if asset && asset.width && asset.height
+      "#{asset.width}/#{asset.height}"
     else
       nil
     end
   end
 
   def res_1x_url
-    @res_1x_url ||= model.derivative_for("thumb_#{thumb_size}").try(:url)
+    @res_1x_url ||= asset.derivative_for("thumb_#{thumb_size}").try(:url)
   end
 
   def res_2x_url
-    @res_2x_url ||= model.derivative_for("thumb_#{thumb_size}_2X").try(:url)
+    @res_2x_url ||= asset.derivative_for("thumb_#{thumb_size}_2X").try(:url)
   end
 
   def src_attributes
     {
        src: res_1x_url,
-       srcset: "#{res_1x_url} 1x, #{res_2x_url} 2x" if
+       srcset: "#{res_1x_url} 1x, #{res_2x_url} 2x"
     }
   end
 end

--- a/app/presenters/thumb_display.rb
+++ b/app/presenters/thumb_display.rb
@@ -71,7 +71,7 @@ class ThumbDisplay < ViewModel
     res_2x_url = model.derivative_for("thumb_#{thumb_size}_2X").try(:url)
 
     unless res_1x_url && res_2x_url
-      return placeholder_image
+      return placeholder_image_tag
     end
 
     tag("img",

--- a/app/presenters/thumb_display.rb
+++ b/app/presenters/thumb_display.rb
@@ -1,4 +1,4 @@
-# A ViewModel presenter that displays an image for a given Kithe::Asset.
+# A ViewModel presenter that displays an image tag, for a thumbnail derivative for a given Kithe::Asset.
 #
 # The Kithe::Asset provided as an arg will usually be a leaf_representative of a Work or Collection.
 #
@@ -6,11 +6,22 @@
 #
 # In a search results list, leaf_representatives should be eager loaded to avoid n+1 queries in search results display.
 #
-# By default, it will display thumb size :standard, suitable for use in results display, but you can
-# supply another thumb size initializer arg.
+# * ThumbDisplay uses `srcset` tag for high-res images on high-res displays, using our _2x derivatives.
 #
-# By default, it will use our standard placeholder image if no derivaties are availalble, but you can
-# supply an alternate placeholder image path in initializer arg.
+# * By default it will display thumb size `standard`, suitable for use in results display, but you
+#   can supply any other thumb size we support, eg, :mini, :large, or for collections :collection_page
+#
+# * Optionally pass `lazy:true` to produce an image tag suitable for lazyloading with lazysizes.js,
+#   https://github.com/aFarkas/lazysizes , including a data-aspectratio tag for
+#   https://github.com/aFarkas/lazysizes/tree/gh-pages/plugins/aspectratio
+#
+# ## Placeholders
+#
+# By default, if suitable derivatives can't be found, it will use our standard placeholder image. Alternate
+# placeholders can be specified (such as our collection defaut icon). Note that most of our placeholders
+# are svg's, which may not have internal widths specified, so image tags should always be in containers
+# with a CSS width/max-width -- and should usually have their own CSS width set to 100% --
+# and you should probably manually visually test your layout with placeholders.
 class ThumbDisplay < ViewModel
   valid_model_type_names "Kithe::Asset", "NilClass"
 
@@ -21,9 +32,18 @@ class ThumbDisplay < ViewModel
   # collection_page for CollectionThumbAssets only, oh well we allow them all for now.
   ALLOWED_THUMB_SIZES = Asset::THUMB_WIDTHS.keys + [:collection_page]
 
+  # @param model [Kithe::Asset] the asset whose derivatives we will display
+  # @param thumb_size [Symbol] which set of thumb derivatives? :standard, :mini, :large,
+  #   :collection_page (for colletions). Both a 1x and 2x derivative must exist. Default
+  #   :standard.
+  # @param placeholder_img_url [String] url (likely relative path) to a placeholder image
+  #   to use if thumb can't be displayed. By default our standard placeholderbox.svg,
+  #   but you may want to use the collection default image for collections, etc.
+  # @param lazy [Boolean] default false. If true, will use data-src and data-srcset attributes,
+  #   and NOT src/srcset direct attributes, for lazy loading with lazysizes.js.
   def initialize(model,
-    placeholder_img_url: asset_path("placeholderbox.svg"),
     thumb_size: :standard,
+    placeholder_img_url: asset_path("placeholderbox.svg"),
     lazy: false)
 
     @placeholder_img_url = placeholder_img_url

--- a/app/presenters/thumb_display.rb
+++ b/app/presenters/thumb_display.rb
@@ -38,31 +38,35 @@ class ThumbDisplay < ViewModel
     # return a default audio/video icon thumb or something. At present we don't intend to use
     # a/v as representative images.
     if model.nil? || model.content_type.nil? || !(model.content_type == "application/pdf" || model.content_type.start_with?("image/"))
-      return placeholder_image
+      return placeholder_image_tag
     end
 
-    multi_res_standard_thumb
+    thumb_image_tag
   end
 
   private
 
-  def placeholder_image
+  def placeholder_image_tag
     tag "img", alt: "", src: placeholder_img_url, width: "100%";
   end
 
-  # "standard" size thumb, providing srcset wtih double-res image for better
-  # display on high-res screens
+  # A thumb 'img' tag that provides srcset wtih double-res image for better
+  # display on high-res screens.
+  #
+  # Takes the thumb size arg, and assumes derivs are available named "thumb_#{size}"
+  # and "thumb_#{size}_2X"
+  #
+  # If necessary derivatives aren't there, will return placeholder -- right now
+  # it needs 1x and 2x derivatives.
   #
   # alt is "" intentionally, because screen-readers should ignore this thumb,
   # search results are perfectly usable without it and there's nothing we
   # can say about it except "a thumbnail" or something, not useful.
   #
-  # If necessary derivatives aren't there, will return placeholder.
-  #
   # Currently uses direct-to-S3 URLs, provided by shrine. Maybe signed
   # URLs depending on shrine settings (beware of performance issues
   # if they are signed?)
-  def multi_res_standard_thumb
+  def thumb_image_tag
     res_1x_url = model.derivative_for("thumb_#{thumb_size}").try(:url)
     res_2x_url = model.derivative_for("thumb_#{thumb_size}_2X").try(:url)
 

--- a/spec/presenters/thumb_display_spec.rb
+++ b/spec/presenters/thumb_display_spec.rb
@@ -71,10 +71,32 @@ describe ThumbDisplay do
       img_tag = rendered.at_css("img")
 
       expect(img_tag).to be_present
-      expect(img_tag["src"]). to eq(deriv.url)
+      expect(img_tag["src"]).to eq(deriv.url)
       expect(img_tag["srcset"]).to eq("#{deriv.url} 1x, #{deriv_2x.url} 2x")
 
       expect(img_tag["data-aspectratio"]).to eq "#{argument.width}/#{argument.height}"
+    end
+
+    describe "lazy load with lazysizes.js" do
+      let(:thumb_size) { :mini }
+      let(:argument) { create(:asset, :inline_promoted_file)}
+      let(:instance) { ThumbDisplay.new(argument, thumb_size: thumb_size, lazy: true) }
+
+      it "renders with lazysizes class and data- attributes" do
+        deriv    = argument.derivative_for("thumb_#{thumb_size}")
+        deriv_2x = argument.derivative_for("thumb_#{thumb_size}_2X")
+
+        img_tag = rendered.at_css("img")
+
+        expect(img_tag).to be_present
+        expect(img_tag["src"]).not_to be_present
+        expect(img_tag["srcset"]).not_to be_present
+
+        expect(img_tag["class"]).to eq "lazyload"
+        expect(img_tag["data-aspectratio"]).to eq "#{argument.width}/#{argument.height}"
+        expect(img_tag["data-src"]).to eq(deriv.url)
+        expect(img_tag["data-srcset"]).to eq("#{deriv.url} 1x, #{deriv_2x.url} 2x")
+      end
     end
   end
 end

--- a/spec/presenters/thumb_display_spec.rb
+++ b/spec/presenters/thumb_display_spec.rb
@@ -73,6 +73,8 @@ describe ThumbDisplay do
       expect(img_tag).to be_present
       expect(img_tag["src"]). to eq(deriv.url)
       expect(img_tag["srcset"]).to eq("#{deriv.url} 1x, #{deriv_2x.url} 2x")
+
+      expect(img_tag["data-aspectratio"]).to eq "#{argument.width}/#{argument.height}"
     end
   end
 end

--- a/spec/presenters/thumb_display_spec.rb
+++ b/spec/presenters/thumb_display_spec.rb
@@ -13,7 +13,22 @@ describe ThumbDisplay do
   end
 
   describe "asset missing derivatives" do
-    let(:argument) { create(:asset) }
+    let(:argument) do
+      create(:asset).tap do |asset|
+        allow(asset).to receive(:content_type).and_return("image/jpeg")
+      end
+    end
+    it "renders placeholder" do
+      expect(rendered).to have_selector(placeholder_selector)
+    end
+  end
+
+  describe "non-handlable type" do
+    let(:argument) do
+      create(:asset).tap do |asset|
+        allow(asset).to receive(:content_type).and_return("audio/mpeg")
+      end
+    end
     it "renders placeholder" do
       expect(rendered).to have_selector(placeholder_selector)
     end


### PR DESCRIPTION
A general purpose thing for displaying thumbnails from derivatives. Uses srcset for responsive images that display high-res on high-res screens. 
Supplies a placeholder if image is missing. 
Optionally renders as lazy loading image for lazysizes.js

This should handle most of our thumbnail display needs throughout the app. 

I think this approach shows the value of our 'view model' stuff. 

Note that lazysizes.js isn't actually loaded in the app yet, will have to do that later. Probably using webpacker rather than sprockets.