### PR TITLE
Citable attributes port, with tests.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -144,3 +144,9 @@ gem 'aws-sdk-core'
   # gem 'devise-guests', '~> 0.6'
 # end BL generated
 
+# we use for data structures for citation models, and for generating citations
+gem "citeproc-ruby", '~> 1.0'
+gem 'csl-styles', '~> 1.0' # Need to load the styles so we can use chicago
+# On MRI <= 2.3, citeproc-ruby insists upon `unicode` or `unicode_utils` gem. :(
+# https://github.com/inukshuk/citeproc/commit/c14d3cd272698dd4aa52625dd140864b7a7bd6cb
+gem 'unicode'

--- a/Gemfile
+++ b/Gemfile
@@ -145,8 +145,4 @@ gem 'aws-sdk-core'
 # end BL generated
 
 # we use for data structures for citation models, and for generating citations
-gem "citeproc-ruby", '~> 1.0'
-gem 'csl-styles', '~> 1.0' # Need to load the styles so we can use chicago
-# On MRI <= 2.3, citeproc-ruby insists upon `unicode` or `unicode_utils` gem. :(
-# https://github.com/inukshuk/citeproc/commit/c14d3cd272698dd4aa52625dd140864b7a7bd6cb
-gem 'unicode'
+ gem "citeproc-ruby", '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,8 +186,6 @@ GEM
     crass (1.0.4)
     csl (1.5.0)
       namae (~> 1.0)
-    csl-styles (1.0.1.9)
-      csl (~> 1.0)
     database_cleaner (1.7.0)
     db-query-matchers (0.9.0)
       activesupport (>= 4.0, <= 6.0)
@@ -543,7 +541,6 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
-    unicode (0.4.4.4)
     uppy-s3_multipart (0.3.0)
       aws-sdk-s3 (~> 1.0)
       content_disposition (~> 1.0)
@@ -605,7 +602,6 @@ DEPENDENCIES
   cocoon
   coffee-rails (~> 4.2)
   content_disposition
-  csl-styles (~> 1.0)
   database_cleaner (~> 1.7)
   db-query-matchers (< 2.0)
   devise (~> 4.5)
@@ -638,7 +634,6 @@ DEPENDENCIES
   sprockets-rails (>= 2.3.2)
   tzinfo-data
   uglifier (>= 1.3.0)
-  unicode
   uppy-s3_multipart
   web-console (>= 3.3.0)
   webdrivers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,11 @@ GEM
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
+    citeproc (1.0.9)
+      namae (~> 1.0)
+    citeproc-ruby (1.1.10)
+      citeproc (~> 1.0, >= 1.0.9)
+      csl (~> 1.5)
     cocoon (1.2.12)
     coderay (1.1.2)
     coffee-rails (4.2.2)
@@ -179,6 +184,10 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
+    csl (1.5.0)
+      namae (~> 1.0)
+    csl-styles (1.0.1.9)
+      csl (~> 1.0)
     database_cleaner (1.7.0)
     db-query-matchers (0.9.0)
       activesupport (>= 4.0, <= 6.0)
@@ -319,6 +328,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     mustermann (1.0.3)
+    namae (1.0.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (5.1.0)
@@ -533,6 +543,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
+    unicode (0.4.4.4)
     uppy-s3_multipart (0.3.0)
       aws-sdk-s3 (~> 1.0)
       content_disposition (~> 1.0)
@@ -590,9 +601,11 @@ DEPENDENCIES
   capistrano-rake
   capybara (>= 2.15)
   capybara-screenshot
+  citeproc-ruby (~> 1.0)
   cocoon
   coffee-rails (~> 4.2)
   content_disposition
+  csl-styles (~> 1.0)
   database_cleaner (~> 1.7)
   db-query-matchers (< 2.0)
   devise (~> 4.5)
@@ -625,6 +638,7 @@ DEPENDENCIES
   sprockets-rails (>= 2.3.2)
   tzinfo-data
   uglifier (>= 1.3.0)
+  unicode
   uppy-s3_multipart
   web-console (>= 3.3.0)
   webdrivers

--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -52,7 +52,7 @@ module ScihistDigicoll
 
     # where our web app is located, https://WHAT
     define_key :web_hostname, default: -> {
-      if Rails.env.test?
+      unless Rails.env.production?
         "https://localhost"
       end
     }

--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -51,7 +51,11 @@ module ScihistDigicoll
     define_key :aws_region, default: "us-east-1"
 
     # where our web app is located, https://WHAT
-    define_key :web_hostname
+    define_key :web_hostname, default: -> {
+      if Rails.env.test?
+        "https://localhost"
+      end
+    }
 
     define_key :opac_link_template, default: "https://othmerlib.sciencehistory.org/record=%s"
 

--- a/app/presenters/citable_attributes.rb
+++ b/app/presenters/citable_attributes.rb
@@ -1,0 +1,569 @@
+# Extract attributes more common to reference manager/citation models.
+#
+# Using the CSL-data model, including some classes from the citeproc gem.
+#
+# For certain museum/archival "objects", we treat them as photographs taken here,
+# rather than trying to cite the original object.  We have two implementaiton subclasses,
+# so the local photograph treatment can 'override' things from standard treatment.
+# We use inheritance with TreatAsLocalPhotograph inheriting from StandardTreatment, which
+# may be non-ideal as we ARE doing this to inherit implementation, but makes implementation
+# a lot easier, and we'll keep the implementation classes for non-public use.
+#
+# Takes a Work object and returns a hash of its citable attributes.
+#
+#     CitableAttributes.new(work).attributes
+#     # => A hash of attributes.
+#
+# Ported from Sufia: app/models/chf/citable_attributes.rb
+
+class CitableAttributes
+
+  attr_reader :work, :implementation
+
+  def initialize(work, edge_case_date_literals: true)
+    @work = work
+    @edge_case_date_literals = !!edge_case_date_literals
+
+    if treat_as_oral_history?
+      @implementation = TreatAsOralHistory.new(@work)
+    elsif treat_as_local_photograph?
+      @implementation = TreatAsLocalPhotograph.new(@work)
+    else
+      @implementation = StandardTreatment.new(@work)
+    end
+  end
+
+
+  # Photos of objects we want to cite as an Institute photo, not the object
+  def treat_as_local_photograph?
+    @treat_as_local_photograph ||= work.department && work.department.include?("Museum") &&
+      work.format && work.format.include?("physical_object") &&
+      work.format.count == 1
+  end
+
+  # Oral histories
+  def treat_as_oral_history?
+    work.genre != nil && work.genre.include?('Oral histories')
+  end
+
+
+  # just a bit of syntactic sugar for a common pattern in attr_json.
+  # In sufia you will often have e.g.
+  # work.place_of_publication
+  # In this code, use instead work_lookup(work, "place", "place_of_publication")
+  # work_lookup("place", "place_of_publication")
+  # => returns ["New York (State)--New York"]
+  # Returns empty array if main_attribute or sub_attribute are not present.
+  def self.work_lookup(work, main_attribute, sub_attribute)
+    work.send(main_attribute).
+      select{|p| p.category == sub_attribute }.
+      map { |y| y.value}
+  end
+
+  # ruby-csl can't really do date ranges yet.
+  # And the CSL chicago style isn't marking "circa" dates for some reason.
+  # So for these cases, we'll format it ourselves  and send it along as a literal.
+  # We're not formatting as well as CSL spec, just something good enough -- we resort to just years
+  # when we do this, ignoring month/day.
+  def formatted_date_literal
+    open_date = date.parts.first
+    close_date = date.parts.second
+
+    unless date.uncertain? || (open_date && close_date)
+      # let csl-ruby handle it normally, it's a single date or no date at all, not a range!
+      return nil
+    end
+
+    # We're just gonna do years, if they're both the same year, just call it a year.
+    formatted_date = if close_date.nil? || open_date.year == close_date.year
+      open_date.year.to_s
+    else
+      # that's an en-dash not a hyphen.
+      "#{open_date.year}–#{close_date.year}"
+    end
+
+    if date.uncertain?
+      formatted_date ="circa #{formatted_date}"
+    end
+
+    return formatted_date
+  end
+
+  # adds formatted date range as a literal if present.
+  def issued_date_csl
+    return nil unless date
+
+    date_csl = date.to_citeproc
+
+    if edge_case_date_literals?
+      literal = formatted_date_literal
+      date_csl["literal"] = literal if literal
+    end
+
+    return date_csl
+  end
+
+
+  def edge_case_date_literals?
+    @edge_case_date_literals
+  end
+
+  delegate :authors, :publisher, :publisher_place, :date, :container_title,
+    :medium, :archive_location, :archive, :archive_place, :title, :csl_id,
+    :abstract, :csl_type, :url, :authors_formatted,
+    to:  :implementation
+
+  # A _hash_ (not a serialized json string) representing in the csl-data.json
+  # format. https://github.com/citation-style-language/schema/blob/master/csl-data.json
+  def as_csl_json
+    {
+      type: csl_type,
+      title: title,
+      id: csl_id,
+      abstract: abstract,
+      author: authors.collect(&:to_citeproc),
+      issued: issued_date_csl,
+      publisher: publisher,
+      "publisher-place": publisher_place,
+      medium: medium,
+      "URL": url,
+      archive: archive,
+      'archive-place': archive_place,
+      archive_location: archive_location,
+      "container-title": container_title
+    }.compact
+  end
+
+  def to_csl_json
+    JSON.dump(as_csl_json)
+  end
+
+  protected
+
+  def implementation
+    @implementation
+  end
+
+  class StandardTreatment
+    attr_reader :work
+
+    def initialize(work)
+      @work = work
+    end
+
+    def title
+      work.title
+    end
+
+    def csl_id
+      "scihist#{work.friendlier_id}"
+    end
+
+    # Map to valid csl type in schema https://github.com/citation-style-language/schema/blob/master/csl-data.json
+    # When in doubt we tend to default to 'manuscript', cause that usually ends up getting cited correctly
+    # for archival material.
+    def csl_type
+      genre_string = work.genre || []
+
+      if genre_string.include?('Manuscripts')
+        return "manuscript"
+      elsif (genre_string & ['Rare books', 'Sample books']).present?
+        if container_title.present?
+          return "chapter"
+        else
+          return "book"
+        end
+      elsif genre_string.include?('Documents') && title =~ /report/i
+        return "report"
+      elsif  department?("Archives")
+        # if it's not one of above known to use archival metadata, and it's in
+        # Archives, insist on Manuscript.
+        return "manuscript"
+      elsif (genre_string & %w{Paintings}).present?
+        return "graphic"
+      elsif genre_string.include?('Slides')
+        return "graphic"
+      elsif genre_string.include?('Encyclopedias and dictionaries')
+        if container_title.present?
+          return "chapter"
+        else
+          return "book"
+        end
+      else
+        return "manuscript"
+      end
+    end
+
+    def abstract
+      work.description.present? ? ActionView::Base.full_sanitizer.sanitize(work.description.join(" ")) : nil
+    end
+
+    # an array of CiteProc::Name objects, suitable for using as cited creator(s)
+    def authors
+      memoize(:authors) do
+        # ordered list of maker fields we're willing to use for author, when we
+        # find one with elements, we stop and use those.
+        first_present_field_values(%w{creator_of_work author artist photographer engraver interviewer}).collect do |str_name|
+          parse_name(str_name)
+        end
+      end
+    end
+
+
+    # An array of formatted `lastname, first` like typical for RIS AU field and other
+    # non-structured single-string author uses.
+    #
+    # Code extracted from:
+    # https://github.com/inukshuk/citeproc/blob/52fb498b59e4d1c30eb9a44d18bb7a5e10cfaae8/lib/citeproc/names.rb#L314-L337
+    def authors_formatted
+      memoize(:authors_formatted) do
+        authors.collect do |citeproc_name|
+          if citeproc_name.literal.present?
+            citeproc_name.literal
+          elsif !citeproc_name.demote_particle?
+            [
+              [citeproc_name.particle, citeproc_name.family].compact.join(' '),
+              [citeproc_name.initials, citeproc_name.dropping_particle].compact.join(' '),
+              citeproc_name.suffix
+            ].compact.join(citeproc_name.comma)
+          else
+            [
+              citeproc_name.family,
+              [citeproc_name.initials, citeproc_name.dropping_particle, citeproc_name.particle].compact.join(' '),
+              citeproc_name.suffix
+            ].compact.join(citeproc_name.comma)
+          end
+        end
+      end
+    end
+
+    def publisher
+      memoize(:publisher) do
+        # ordered list of fields we're willing to look for publisher, if we find
+        # one we take only the FIRST thing, and use that.
+        raw_name = first_present_field_values(%w{publisher printer printer_of_plates}).first
+        # use parse name to print out in direct order
+        raw_name ? parse_name(raw_name).print : nil
+      end
+    end
+
+    def publisher_place
+      memoize(:publisher_place) do
+        place_of_publication = CitableAttributes::work_lookup(work, "place", "place_of_publication")
+        place_of_publication.present? ? normalize_place(place_of_publication.first) : nil
+      end
+    end
+
+    # Returns a single CiteProc::Date object, which is capable of being a single date
+    # or a single range, possibly having a "circa" qualifier, and dates can have non-defined month or day.
+    # Can not return multiple distinct dates though, so we try to collapse them when we have them.
+    def date
+      memoize(:date) do
+        if work.date_of_work.present?
+          cite_proc_dates = work.date_of_work.collect { |d| local_date_to_citeproc_date(d) }.compact
+
+          min_date_part = cite_proc_dates.collect(&:date_parts).flatten.min
+          max_date_part = cite_proc_dates.collect(&:date_parts).flatten.max
+
+          if min_date_part.nil? && max_date_part.nil?
+            return nil
+          end
+
+          date = if min_date_part == max_date_part
+            ::CiteProc::Date.new(min_date_part.to_a.compact)
+          else
+            ::CiteProc::Date.new([min_date_part.to_a.compact, max_date_part.to_a.compact])
+          end
+
+          if cite_proc_dates.any?(&:uncertain?)
+            date.uncertain!
+          end
+
+          return date
+        end
+      end
+    end
+
+    def medium
+      memoize(:medium) do
+        if work.medium.present?
+          work.medium.collect(&:downcase).join(", ")
+        else
+          nil
+        end
+      end
+    end
+
+    def url
+      # TODO fix this once we have the actual public facing work id. Need the full absolute URL.
+      # "#{CHF::Env.lookup(:app_url_base)}/works/#{work.id}"
+      "/admin/works/#{work.friendlier_id}"
+    end
+
+    def container_title
+      memoize(:container_title) do
+        if work.source.present?
+          work.source.first
+        elsif work.parent && work.parent.title.present?
+          work.parent.title
+        end
+      end
+    end
+
+    def shelfmark
+      memoize(:shelfmark) do
+        if work.physical_container.present?
+          work.physical_container.attributes['shelfmark']
+        end
+      end
+    end
+
+    # We decided NOT to include series/subseries in citation, just collection and physical lcoation
+    def archive_location
+      memoize(:archive_location) do
+        if department?("Archives")
+          parts = []
+          # Collection is work.contained_by.first.
+          if work.contained_by.present? && work.contained_by.first.title.present?
+            parts << work.contained_by.first.title
+          end
+          parts << work.physical_container.as_human_string if work.physical_container.present?
+          parts.collect(&:presence).compact.join(', ')
+        elsif department?("Library") && self.shelfmark
+          self.shelfmark
+        end
+      end
+    end
+
+    def archive_place
+      if department?("Archives", "Museum") || shelfmark
+        "Philadelphia"
+      end
+    end
+
+    def archive
+      if department?("Archives", "Museum") || shelfmark
+        "Science History Institute"
+      end
+    end
+
+    protected
+
+    # we use our own :memoize instead of `||=` so it can memoize nil
+    def memoize(key)
+      key = key.to_sym
+      @__memoized ||= {}
+      unless @__memoized.has_key?(key)
+        @__memoized[key] = yield
+      end
+      @__memoized[key]
+    end
+
+    def department?(*departments)
+      work.department && (departments.include? work.department)
+    end
+
+    # _single_ local date object to a citeproc date
+    def local_date_to_citeproc_date(date)
+      # we consider 'before' or 'after' not enough info for a date for citation at present,
+      # haven't figured out how to interact with CSL to represent these, may be possible.
+      if ([date.start_qualifier, date.finish_qualifier].compact & ['before', 'after']).count > 0
+        return nil
+      end
+
+      if date.start_qualifier == "decade"
+        open_year = date.start.to_i / 10 * 10 # cut off year
+        close_year = open_year + 9
+        return CiteProc::Date.new([[open_year], [close_year]])
+      end
+
+
+      if date.start_qualifier == "century"
+        open_year = date.start.to_i / 100 * 100 # cut off tens and units
+        close_year = open_year + 99
+        return CiteProc::Date.new([[open_year], [close_year]])
+      end
+
+      # year, month, date
+      start_part = date.start.presence && date.start.scan(/\d+/).slice(0..2)
+      finish_part = date.finish.presence && date.finish.scan(/\d+/).slice(0..2)
+
+      args = []
+      args << start_part if start_part
+      args << finish_part if finish_part
+      return nil if args.empty?
+
+      CiteProc::Date.new(args).tap do |citeproc_date|
+        if date.start_qualifier == "circa" || date.finish_qualifier == "circa"
+          citeproc_date.uncertain!
+        end
+      end
+    end
+
+    # first_present_field_values(["publisher", "printer", "printer_of_places"])
+    # will return the array of values of the first of those that is non-empty, or
+    # an empty array if they are all empty.
+    def first_present_field_values(fields)
+      maker_fields_present = work.creator.map &:category
+      first_present = fields.find { |attr| maker_fields_present.include? attr }
+      first_present ? CitableAttributes::work_lookup(work, "creator", first_present) : []
+    end
+
+    # Try to change "New York (State) -- New York" into "New York, New York"
+    # Can't quite do it, (State)
+    def normalize_place(str)
+      if str =~ /--/
+        str.split("--").reverse.join(", ").sub(" (State)", '')
+      else
+        str
+      end
+    end
+
+    # returns a Citeproc::Name object, which is composed of possible
+    # given, family, and suffix; or just literal.
+    #
+    # Tries to parse the AACR2-style names we have. Not knowing if it's a personal
+    # or corporate name makes this hard, if it's personal comma means inverted family, given.
+    # If it's corporate... comma may just be part of name. We're going to get it wrong, I guarantee.
+    def parse_name(str)
+      str = str.dup
+      date_suffix = /,? (active |approximately )?\d\d\d\d\??-((approximately )?\d\d\d\d\??)?|,? -\d\d\d\d\??\Z/
+
+      # remove 'inc'
+      str.sub!(/, inc\. */, '')
+
+      parsed_name = nil
+
+      if str =~ date_suffix
+        # looks like a personal name with birth/death dates, remove em and parse
+        str.sub!(date_suffix, '')
+        parsed_name = Namae::Name.parse(str)
+        parsed_name = nil if parsed_name.empty?
+      end
+
+      if parsed_name.nil? && str =~ /\A *[A-Z][^,()]*(, *[A-Z][^,()]*)+ *\Z/
+        # looks like a personal name in inverted form
+        parsed_name = Namae::Name.parse(str)
+        parsed_name = nil if parsed_name.empty?
+      end
+
+      if parsed_name
+        CiteProc::Name.new(parsed_name)
+      else
+        # a corporate name, or something we didn't succesfully parse
+        CiteProc::Name.new(literal: str)
+      end
+    end
+
+    # we use our own :memoize instead of `||=` so it can memoize nil
+    def memoize(key)
+      key = key.to_sym
+      @__memoized ||= {}
+      unless @__memoized.has_key?(key)
+        @__memoized[key] = yield
+      end
+      @__memoized[key]
+    end
+
+    def department?(*departments)
+      work.department && (departments.include? work.department)
+    end
+  end
+
+  class TreatAsLocalPhotograph < StandardTreatment
+    def csl_type
+      "graphic"
+    end
+
+    def authors
+      memoize(:authors) do
+        [CiteProc::Name.new(literal: "Science History Institute")]
+      end
+    end
+
+    def medium
+      "photograph".freeze
+    end
+
+    def date
+      # I think this is best way we got to get date of photo
+      date_of_photo = work.created_at.strftime('%Y')
+      # we only give it the year, we don't really trust the other stuff anyway.
+      date_of_photo ? CiteProc::Date.new([date_of_photo]) : nil
+    end
+
+    def publisher
+      nil
+    end
+
+    def publisher_place
+      nil
+    end
+
+    def archive_location
+      nil
+    end
+  end
+
+  class TreatAsOralHistory < StandardTreatment
+    def title
+      interviewee = CitableAttributes::work_lookup(work, "creator", "interviewee")
+      interviewer = CitableAttributes::work_lookup(work, "creator", "interviewer")
+      return work.title if interviewee.blank? || interviewer.blank?
+      interview_place = CitableAttributes::work_lookup(work, "place", "place_of_interview")
+      place = interview_place.blank? ? "" : "in #{normalize_place(interview_place.first)}"
+      time = original_date.nil? ? "" : "on #{original_date.strftime("%B %-d, %Y")}"
+      "#{parse_name(interviewee.first).format}, interviewed by #{parse_name(interviewer.first).format} #{place} #{time}"
+    end
+
+    def csl_type
+      "interview"
+    end
+
+    def authors
+      [] # Having no "authors" is regrettable, but such is the consequence
+      # of having ruby-csl treat this as an "interview".
+    end
+
+    def medium
+      nil
+    end
+
+    def publisher_place
+      'Philadelphia'
+    end
+
+    def publisher
+      'Science History Institute'.freeze
+    end
+
+    # no date in CSL, we're embedding it in title instead
+    def date
+      nil
+    end
+
+    # we don't want to be used in CSL, but we want to pull it out to use in title
+    def original_date
+      return nil if work.date_of_work.blank?
+      begin
+        date_recorded = Date.strptime(work.date_of_work.first.start, '%Y-%m-%d')
+      rescue ArgumentError
+        return nil
+      end
+      date_recorded ? CiteProc::Date.new(date_recorded) : nil
+    end
+
+    def archive_location
+      the_interview_id = interview_id
+      "Oral History Transcript #{the_interview_id}" if the_interview_id
+    end
+
+    def interview_id
+      interview_ids = CitableAttributes::work_lookup(work, "external_id", "interview")
+      return nil if interview_ids.blank?
+      interview_ids.first
+    end
+
+  end
+
+end # class

--- a/app/presenters/citable_attributes.rb
+++ b/app/presenters/citable_attributes.rb
@@ -295,9 +295,7 @@ class CitableAttributes
     end
 
     def url
-      # TODO fix this once we have the actual public facing work id. Need the full absolute URL.
-      # "#{CHF::Env.lookup(:app_url_base)}/works/#{work.id}"
-      "/admin/works/#{work.friendlier_id}"
+      "#{ScihistDigicoll::Env.lookup!(:web_hostname)}/works/#{work.friendlier_id}"
     end
 
     def container_title

--- a/spec/factories/work_factory.rb
+++ b/spec/factories/work_factory.rb
@@ -1,7 +1,4 @@
 FactoryBot.define do
-
-
-
   factory :work, class: Work do
     title { 'Test title' }
     published { true }
@@ -156,37 +153,24 @@ FactoryBot.define do
       end
     end
 
-    trait :oral_history_work do
-      title { "Oral history interview with William John Bailey" }
-
-      external_id {
-        [
-          {'category' => 'bib', 'value' => 'b1043559'},
-          {'category' => 'interview', 'value' => '0012'}
-        ]
-      }
-
-      creator {
-        [
-          {category: "interviewee", value:"Bailey, William John, 1921-1989"},
-          {category: "interviewer", value:"Bohning, James J."},
-        ]
-      }
-
-      date_of_work { [ Work::DateOfWork.new(start: "1986-06-03") ] }
-
-      place {
-        [
-          {category: "place_of_interview", value:"University of Maryland, College Park"},
-        ]
-      }
-      format { ['Text'] }
-      genre { ["Oral histories"] }
-      extent { ['50 pages'] }
-      language { ['English'] }
-      department { 'Center for Oral History' }
-      created_at { DateTime.now }
+    factory :oral_history_work do
+      title  "Oral history interview with William John Bailey"
+      external_id [
+        {'category' => 'bib', 'value' => 'b1043559'},
+        {'category' => 'interview', 'value' => '0012'}
+      ]
+      creator [
+        {category: "interviewee", value:"Bailey, William John, 1921-1989"},
+        {category: "interviewer", value:"Bohning, James J."}
+      ]
+      date_of_work [ Work::DateOfWork.new(start: "1986-06-03") ]
+      place  [{category: "place_of_interview", value:"University of Maryland, College Park"}]
+      format ['text']
+      genre ["Oral histories"]
+      extent ['50 pages']
+      language ['English']
+      department 'Center for Oral History'
+      created_at DateTime.now
     end
-
   end
 end

--- a/spec/factories/work_factory.rb
+++ b/spec/factories/work_factory.rb
@@ -1,4 +1,7 @@
 FactoryBot.define do
+
+
+
   factory :work, class: Work do
     title { 'Test title' }
     published { true }
@@ -151,6 +154,38 @@ FactoryBot.define do
           work.contained_by << build(:collection)
         end
       end
+    end
+
+    trait :oral_history_work do
+      title { "Oral history interview with William John Bailey" }
+
+      external_id {
+        [
+          {'category' => 'bib', 'value' => 'b1043559'},
+          {'category' => 'interview', 'value' => '0012'}
+        ]
+      }
+
+      creator {
+        [
+          {category: "interviewee", value:"Bailey, William John, 1921-1989"},
+          {category: "interviewer", value:"Bohning, James J."},
+        ]
+      }
+
+      date_of_work { [ Work::DateOfWork.new(start: "1986-06-03") ] }
+
+      place {
+        [
+          {category: "place_of_interview", value:"University of Maryland, College Park"},
+        ]
+      }
+      format { ['Text'] }
+      genre { ["Oral histories"] }
+      extent { ['50 pages'] }
+      language { ['English'] }
+      department { 'Center for Oral History' }
+      created_at { DateTime.now }
     end
 
   end

--- a/spec/presenters/citable_attributes_spec.rb
+++ b/spec/presenters/citable_attributes_spec.rb
@@ -372,7 +372,7 @@ describe CitableAttributes do
 
   describe "Special case oral history" do
 
-    let(:work) { FactoryBot.build( :work, :oral_history_work) }
+    let(:work) { FactoryBot.build( :oral_history_work) }
 
     it "has oral-history-style title" do
       expect(citable_attributes.title).to eq("William John Bailey, interviewed by James J. Bohning in University of Maryland, College Park on June 3, 1986")
@@ -398,8 +398,7 @@ describe CitableAttributes do
   #   end
 
     describe "unusual interviewee name format" do
-      let(:work) { FactoryBot.build(:work,
-        :oral_history_work,
+      let(:work) { FactoryBot.build(:oral_history_work,
         creator: [
           { category: "interviewer", value:"Marsha P. Johnson" },
           { category: "interviewee", value:"Biemann, K. (Klaus)" }
@@ -413,8 +412,7 @@ describe CitableAttributes do
     end
 
     describe "place with dashes" do
-      let(:work) { FactoryBot.build(:work,
-          :oral_history_work,
+      let(:work) { FactoryBot.build(:oral_history_work,
           place: [
             { category: "place_of_interview", value:'New Hampshire--Alton Bay'},
           ],

--- a/spec/presenters/citable_attributes_spec.rb
+++ b/spec/presenters/citable_attributes_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe CitableAttributes do
   let(:citable_attributes) { CitableAttributes.new(work)}
 
+
   describe "standard treatment" do
   let(:work) { FactoryBot.create(:work, date_of_work: nil)}
     describe "authors" do
@@ -322,7 +323,7 @@ describe CitableAttributes do
             :title=>"pH means Beckman",
             :id=>"scihist123456",
             :issued => {"date-parts"=>[[1957]]},
-            :URL=>"/admin/works/123456",
+            :URL=>"https://localhost/works/123456",
             :archive=>"Science History Institute",
             :'archive-place'=>"Philadelphia",
             :archive_location=>"Box 49, Folder 14"},

--- a/spec/presenters/citable_attributes_spec.rb
+++ b/spec/presenters/citable_attributes_spec.rb
@@ -1,0 +1,457 @@
+require 'rails_helper'
+
+describe CitableAttributes do
+  let(:citable_attributes) { CitableAttributes.new(work)}
+
+  describe "standard treatment" do
+  let(:work) { FactoryBot.create(:work, date_of_work: nil)}
+    describe "authors" do
+      describe "inverted without dates" do
+        before do
+          work.creator = [{category: "creator_of_work", value: "Allen, Ken"}]
+        end
+        it "parses" do
+          expect(citable_attributes.authors).to include(CiteProc::Name.new(family: "Allen", given: "Ken"))
+        end
+      end
+
+      describe "inverted without dates, initials" do
+        before do
+          work.creator = [{category: "creator_of_work", value:"Hawes, R. C."}]
+        end
+        it "parses" do
+          expect(citable_attributes.authors).to include(CiteProc::Name.new(family: "Hawes", given: "R. C."))
+        end
+      end
+
+      describe "inverted with dates" do
+        before do
+          work.creator = [{category: "creator_of_work", value:"Sackett, Israel, 1809-1880"}]
+        end
+        it "parses" do
+          expect(citable_attributes.authors).to include(CiteProc::Name.new(family: "Sackett", given: "Israel"))
+        end
+      end
+
+      describe "corporate name" do
+        before do
+          work.creator = [{category: "creator_of_work", value: "Beckman Instruments, inc."}]
+        end
+        it "parses" do
+          expect(citable_attributes.authors).to include(CiteProc::Name.new(literal: "Beckman Instruments"))
+        end
+      end
+
+      describe "corporate name that looks kinda like a personal name" do
+        before do
+          work.creator = [{category: "creator_of_work", value:"Simpkin, Mashall, and Co."}]
+        end
+        it "parses as literal" do
+          expect(citable_attributes.authors).to include(CiteProc::Name.new(literal: "Simpkin, Mashall, and Co."))
+        end
+      end
+
+      describe "creators preferred over other makers" do
+        before do
+          work.creator = [
+            {category: "creator_of_work",      value:"Creator, John"     },
+            {category: "creator_of_work",      value:"Creator, Sue"      },
+            {category: "author",               value:"Author, Bill"      },
+            {category: "author",               value:"Author, Jane"      },
+            {category: "contributor",          value:"Contributor, Jaime"}
+          ]
+        end
+        it "parses" do
+          expect(citable_attributes.authors.length).to eq(2)
+          expect(citable_attributes.authors).to include(CiteProc::Name.new(family: "Creator", given: "John"))
+          expect(citable_attributes.authors).to include(CiteProc::Name.new(family: "Creator", given: "Sue"))
+        end
+      end
+
+      describe "authors used if no creators" do
+        before do
+          work.creator = [
+            {category: "author",               value:"Author, Bill"      },
+            {category: "author",               value:"Author, Jane"      },
+            {category: "contributor",          value:"Contributor, Jaime"}
+          ]
+        end
+        it "parses" do
+          expect(citable_attributes.authors.length).to eq(2)
+          expect(citable_attributes.authors).to include(CiteProc::Name.new(family: "Author", given: "Bill"))
+          expect(citable_attributes.authors).to include(CiteProc::Name.new(family: "Author", given: "Jane"))
+        end
+      end
+
+      describe "this one" do
+        before do
+          work.creator = [{category: "creator_of_work", value:"Chemists' Club (New York, N.Y.)"}]
+        end
+        it "parses" do
+          expect(citable_attributes.authors).to include(CiteProc::Name.new(literal: "Chemists' Club (New York, N.Y.)"))
+        end
+      end
+
+      describe "all sorts of dates" do
+        {
+          'Backus, Standish, 1910-1989' => {family: "Backus", given: "Standish"},
+          "Van Sompel, Pieter 1600?-1643?" => {family: "Van Sompel", given: "Pieter"}, # from work id qj72p783g
+          "Antonius, Wilhelm, -1611" => {family: "Antonius", given: "Wilhelm"}, # from work id vd66vz91p
+          "Ramelli, Agostino, 1531-approximately 1600" => {family: "Ramelli", given: "Agostino"},
+          "Siemienowicz, Kazimierz, -1651?" => {family: "Siemienowicz", given: "Kazimierz"},
+          "Bonus, Petrus, active 1323-1330" => {family: "Bonus", given: "Petrus"},
+          "Faber, John, 1695?-1756" => {family: "Faber", given: "John"}
+        }.each do |str, formatted|
+          describe str do
+            before do
+              work.creator = [{category: "creator_of_work", value:str}]
+            end
+            it "parses" do
+              expect(citable_attributes.authors).to include(CiteProc::Name.new(formatted))
+            end
+          end
+        end
+      end
+
+
+      describe "publisher" do
+        describe "with inverted form with dates" do
+          before do
+            work.creator = [{category: "publisher", value:"Sackett, Israel, 1809-1880"}]
+          end
+          it "uses in direct form" do
+            expect(citable_attributes.publisher).to eq("Israel Sackett")
+          end
+        end
+        describe "with corporate name" do
+          before do
+            work.creator = [{category: "publisher", value:"Beckman Instruments, inc."}]
+          end
+          it "uses direct corporate name" do
+            expect(citable_attributes.publisher).to eq("Beckman Instruments")
+          end
+        end
+      end
+
+    describe "publisher place" do
+      before do
+        work.place = [{category: "place_of_publication", value:"New York (State)--New York"}]
+      end
+      it "uses directly ordered name" do
+        expect(citable_attributes.publisher_place).to eq("New York, New York")
+      end
+    end
+
+    describe "medium" do
+      before do
+        work.medium = ["Vellum", "Leather"]
+      end
+      it "joins" do
+        expect(citable_attributes.medium.split(", ")).to contain_exactly('vellum', 'leather')
+      end
+    end
+
+    describe "archival location" do
+      describe "Non-archives" do
+        before do
+          work.department = "Library"
+          work.series_arrangement = ["Subseries B", "Series XIV"]
+          work.physical_container = {volume:'8', part:'2', page:'100' }
+        end
+        it "ignores" do
+          expect(citable_attributes.archive_location).to be_nil
+        end
+      end
+      describe "Archives" do
+        let(:collection) { FactoryBot.create(:collection, title: "Collection Name") }
+        before do
+          collection.contains << work
+          work.department = "Archives"
+          work.series_arrangement = ["Subseries B", "Series XIV"]
+          work.physical_container = {box:'56', folder:'47' }
+        end
+        it "includes collection box and folder but not series" do
+          expect(citable_attributes.archive_location).to eq("Collection Name, Box 56, Folder 47")
+        end
+      end
+    end
+
+    describe "dates" do
+      before do
+        test_dates.each { |d| work.build_date_of_work(d) }
+      end
+      describe "one date year-only" do
+        let(:test_dates) { [{ start: "1916", finish: "", start_qualifier: "", finish_qualifier: "", note: ""}] }
+        it "gets one date with year only" do
+          expect(citable_attributes.date).to eq(CiteProc::Date.new([1916]))
+        end
+      end
+      describe "one date all parts" do
+        let(:test_dates) { [{start: "1916/04/12" } ]}
+        it "gets all parts" do
+          expect(citable_attributes.date).to eq(CiteProc::Date.new([1916, 4, 12]))
+        end
+      end
+      describe "start and finish date just years" do
+        let(:test_dates) {[ {start: "1916", finish: "1920" }] }
+        it ("gets a CiteProc::Date range") do
+          expect(citable_attributes.date).to eq(CiteProc::Date.new([[1916], [1920]]))
+        end
+      end
+      describe "Multiple dates with start and finish" do
+        let(:test_dates) do
+          [
+            { start: "1901", start_qualifier: "after"}, # right now ignores 'after'
+            { start: "1916", finish: "1920"},
+            { start: "1940", finish: "1960"},
+            { start: "1910"},
+            { finish: "2000", finish_qualifier: "before"}  # right now ignores 'before'
+          ]
+        end
+
+        it ("gets the right CiteProc::Date range") do
+          expect(citable_attributes.date).to eq(CiteProc::Date.new([[1910], [1960]]))
+          expect(citable_attributes.issued_date_csl).to eq ({"date-parts"=>[[1910], [1960]], "literal"=>"1910–1960"})
+        end
+      end
+
+      describe "decade" do
+        let(:test_dates) do
+          [{ "start": "1900", start_qualifier: "decade"}]
+        end
+        it ("gets a decade range") do
+          expect(citable_attributes.date).to eq(CiteProc::Date.new([[1900], [1909]]))
+        end
+      end
+
+      describe "century" do
+        let(:test_dates) do
+          [{ "start": "1900", start_qualifier: "century"}]
+        end
+        it ("gets a century range") do
+          expect(citable_attributes.date).to eq(CiteProc::Date.new([[1900], [1999]]))
+        end
+      end
+
+      describe "circa" do
+        let(:test_dates) do
+          [{ "start": "1947", start_qualifier: "circa"}]
+        end
+        it ("sets citeproc date as circa") do
+          date = citable_attributes.date
+          # citeproc equality isn't actually taking circa into account, so we test separately too
+          expect(date.uncertain?).to be true
+          expect(citable_attributes.date).to eq(CiteProc::Date.new([[1947]]).tap {|d| d.uncertain! })
+          expect(citable_attributes.issued_date_csl).to eq({"date-parts" => [[1947]], "circa"=>true, "literal" => "circa 1947"})
+        end
+      end
+
+      describe "no dates" do
+        let(:test_dates) {[]}
+        it "has no date" do
+          expect(citable_attributes.date).to eq(nil)
+        end
+      end
+
+      describe "undated date" do
+        let(:test_dates) {[{ start: "", finish: "", start_qualifier: "Undated", finish_qualifier: "", note: ""}]}
+        it "has no date" do
+          expect(citable_attributes.date).to eq(nil)
+        end
+      end
+     end
+
+    describe :as_csl do
+      describe "barely metadata" do
+        let(:work) { FactoryBot.build(:work, title: "something", date_of_work: nil) }
+        it "still creates something" do
+          expect(citable_attributes.as_csl_json).to be_kind_of(Hash)
+        end
+      end
+
+      describe "library with shelfmark" do
+        let(:work) {
+          FactoryBot.build(:work,
+            title: ["Pretiosa margarita novella"],
+            creator: [{category: "creator_of_work", value:"Bonus, Petrus"}],
+            format: ["text"],
+            genre: ["Rare Books", "Manuscripts"],
+            department: "Library",
+            physical_container: {shelfmark:'MS 3' },
+            date_of_work: [ Work::DateOfWork.new(start: "1450", finish: "1480", start_qualifier: "circa") ]
+          )
+        }
+        before do
+          allow(work).to receive(:friendlier_id).and_return("pn89d712c")
+        end
+
+        it "exports CSL we expect" do
+          csl_hash = citable_attributes.as_csl_json
+          expect(csl_hash[:type]).to eq "manuscript"
+          expect(csl_hash[:archive]).to eq "Science History Institute"
+          expect(csl_hash[:'archive-place']).to eq "Philadelphia"
+          expect(csl_hash[:archive_location]).to eq "MS 3"
+        end
+      end
+
+      describe "archival" do
+        let(:work) {
+          # based on https://digital.sciencehistory.org/works/2r36tx526
+          FactoryBot.build(:work,
+            title: "pH means Beckman",
+            creator: [
+              {category: "creator_of_work", value:"Beckman Instruments, inc."},
+              {category: "creator_of_work", value:"Charles Bowes Advertising, inc."},
+            ],
+            format: ["image", "text"],
+            genre: ["Advertisements"],
+            extent: ["8.5 in. W x 11 in. L"],
+            language: ["English"],
+            subject: ["Beckman Instruments, inc.", "Scientific apparatus and instruments", "Hydrogen-ion concentration--Measurement--Instruments"],
+            department: "Archives",
+            date_of_work: [ Work::DateOfWork.new(start: "1957") ],
+            series_arrangement: ["Sub-series 2. Advertisements", "Series VIII. Clippings and Advertisements"],
+            physical_container: {box:'49', folder:'14' },
+            friendlier_id: "123456")
+        }
+
+        it "exports CSL we expect" do
+          csl_hash = citable_attributes.as_csl_json
+          expect(csl_hash).to include({
+            :type=>"manuscript",
+            :title=>"pH means Beckman",
+            :id=>"scihist123456",
+            :issued => {"date-parts"=>[[1957]]},
+            :URL=>"/admin/works/123456",
+            :archive=>"Science History Institute",
+            :'archive-place'=>"Philadelphia",
+            :archive_location=>"Box 49, Folder 14"},
+            :author=>[{"literal"=>"Beckman Instruments"}, {"literal"=>"Charles Bowes Advertising"}]
+          )
+        end
+      end
+    end
+  # end
+  # TODO figure out what this last end goes with.
+
+  describe "Special case museum photo" do
+    let(:work) { FactoryBot.build(
+      :work,
+      department: "Museum",
+      format: ["physical_object"],
+      creator: [
+        {category: "creator_of_work", value:"Joe Factory"},
+        {category: "publisher", value:"Not Publisher"},
+      ],
+      place: [
+        {category: "place_of_publication", value:"Not this place"},
+      ],
+      medium: ["Iron", "Wood"],
+      created_at: DateTime.now,
+      date_of_work:[ Work::DateOfWork.new(start: "1916") ]
+    )}
+
+    it "replaces authors" do
+      expect(citable_attributes.authors.length).to eq(1)
+      expect(citable_attributes.authors).to include(CiteProc::Name.new(literal: "Science History Institute"))
+    end
+    it "replaces medium" do
+      expect(citable_attributes.medium).to eq("photograph")
+    end
+    it "has no publisher" do
+      expect(citable_attributes.publisher).to be_nil
+    end
+    it "has no publisher_place" do
+      expect(citable_attributes.publisher_place).to be_nil
+    end
+    it "uses date_uploaded for date" do
+      expect(citable_attributes.date).to eq(CiteProc::Date.new([DateTime.now.year]))
+    end
+  end
+
+  describe "Special case oral history" do
+
+    let(:work) { FactoryBot.build( :work, :oral_history_work) }
+
+    it "has oral-history-style title" do
+      expect(citable_attributes.title).to eq("William John Bailey, interviewed by James J. Bohning in University of Maryland, College Park on June 3, 1986")
+    end
+    it "has no authors" do
+      expect(citable_attributes.authors.length).to eq(0)
+    end
+    it "has no medium" do
+     expect(citable_attributes.medium).to eq(nil)
+    end
+    it "replaces publisher" do
+      expect(citable_attributes.publisher).to eq("Science History Institute")
+    end
+    it "replaces publisher place" do
+      expect(citable_attributes.publisher_place).to eq ('Philadelphia')
+    end
+    it "supplies OH interview number as archive location" do
+      expect(citable_attributes.archive_location).to eq ('Oral History Transcript 0012')
+    end
+    # TODO figure out what this renderer is
+  #   it "renders html" do
+  #     expect(CHF::CitableAttributes::Renderer.from_work_presenter(presenter).render_html).to eq "William John Bailey, interviewed by James J. Bohning in University of Maryland, College Park on June 3, 1986. Philadelphia: Science History Institute, n.d. Oral History Transcript 0012. http://test.app/works/."
+  #   end
+
+    describe "unusual interviewee name format" do
+      let(:work) { FactoryBot.build(:work,
+        :oral_history_work,
+        creator: [
+          { category: "interviewer", value:"Marsha P. Johnson" },
+          { category: "interviewee", value:"Biemann, K. (Klaus)" }
+        ],
+        )
+      }
+
+      it "has interviewee in title" do
+        expect(citable_attributes.title).to start_with("Biemann, K. (Klaus), interviewed by")
+      end
+    end
+
+    describe "place with dashes" do
+      let(:work) { FactoryBot.build(:work,
+          :oral_history_work,
+          place: [
+            { category: "place_of_interview", value:'New Hampshire--Alton Bay'},
+          ],
+        )
+      }
+
+      it "has place reversed in title" do
+        expect(citable_attributes.title).to include("in Alton Bay, New Hampshire")
+      end
+    end
+
+    # TODO check these once the renderer is implemented.
+    describe "weird citation missing fields" do
+      let(:work) { FactoryBot.build(:work, :with_complete_metadata,
+        creator: [
+          {"value"=>nil, "category"=>"interviewer"},
+          {"value"=>nil, "category"=>"interviewee"}
+        ],
+        date_of_work: [],
+        genre: ["Oral histories"],
+        department: "Center for Oral History")}
+      it "does not raise" do
+        citable_attributes
+        #CHF::CitableAttributes::Renderer.from_work_presenter(presenter).render_html
+      end
+    end
+    describe "weird citation missing fields (2)" do
+      let(:work) { FactoryBot.build(:work, :with_complete_metadata,
+        date_of_work: nil,
+        genre: ["Oral histories"],
+        department: "Center for Oral History")
+      }
+      it "does not raise" do
+        citable_attributes
+        # CHF::CitableAttributes::Renderer.from_work_presenter(presenter).render_html
+      end
+    end
+    end
+    end
+  end # describe special case oral history
+end


### PR DESCRIPTION
A basic port of the citable_attributes object, along with all the tests.
Includes a default test setting for :web_hostname.
Note: does not include a port of app/models/chf/citable_attributes/renderer.rb. This will go in a separate PR.