### PR TITLE
Only one place to convert a bib into an opac URL

### DIFF
--- a/app/decorators/work_show_decorator.rb
+++ b/app/decorators/work_show_decorator.rb
@@ -31,7 +31,7 @@ class WorkShowDecorator < Draper::Decorator
       end.map(&:value)
 
       (bib_ids + related_url_filter.opac_ids).map do |bib_id|
-        RelatedUrlFilter.opac_url(bib_id)
+        ScihistDigicoll::Util.opac_url(bib_id)
       end
     end
   end

--- a/app/presenters/related_url_filter.rb
+++ b/app/presenters/related_url_filter.rb
@@ -34,11 +34,6 @@ class RelatedUrlFilter
     @opac_ids ||= opac_urls.collect {|u| u.sub(OPAC_PREFIX_RE, '') }
   end
 
-  # Just a convenience class method to turn a bib_id into a link to the OPAC.
-  def self.opac_url(bib_id)
-    "https://othmerlib.sciencehistory.org/record=#{CGI.escape bib_id}"
-  end
-
   private
 
   def filter!


### PR DESCRIPTION
I had accidentally made two of them. Just re-use the first one, get rid of the second one.