### PR TITLE
use eager-loading on work member representatives/derivatives for display

### DIFF
--- a/app/decorators/work_show_decorator.rb
+++ b/app/decorators/work_show_decorator.rb
@@ -89,7 +89,7 @@ class WorkShowDecorator < Draper::Decorator
     @related_works ||= Work.where(
         friendlier_id: related_url_filter.related_work_friendlier_ids,
         published: true
-      ).includes(leaf_representative: :derivatives).all
+      ).includes(:derivatives, leaf_representative: :derivatives).all
   end
 
   def public_collections
@@ -106,7 +106,12 @@ class WorkShowDecorator < Draper::Decorator
   # list, because no reason to duplicate it right after the representative.
   def member_list_for_display
     @member_list_display ||= begin
-      members = model.members.where(published: true).order(:position).to_a
+      members = model.members.
+        includes(:derivatives, leaf_representative: :derivatives).
+        where(published: true).
+        order(:position).
+        to_a
+
       members.delete_at(0) if members[0] == representative_for_display
       members
     end


### PR DESCRIPTION
Without this, was doing a separate SQL query to get each members derivatives and/or representative image (and it's derivatives), which was adding ~800ms to 600-member ramelli, that this one line trims.

Should probably add as a feature to kithe, we need this particular `includes` all the time.