### PR TITLE
All factory values should be in block

### DIFF
--- a/spec/factories/work_factory.rb
+++ b/spec/factories/work_factory.rb
@@ -165,23 +165,27 @@ FactoryBot.define do
     end
 
     factory :oral_history_work do
-      title  "Oral history interview with William John Bailey"
-      external_id [
-        {'category' => 'bib', 'value' => 'b1043559'},
-        {'category' => 'interview', 'value' => '0012'}
-      ]
-      creator [
-        {category: "interviewee", value:"Bailey, William John, 1921-1989"},
-        {category: "interviewer", value:"Bohning, James J."}
-      ]
-      date_of_work [ Work::DateOfWork.new(start: "1986-06-03") ]
-      place  [{category: "place_of_interview", value:"University of Maryland, College Park"}]
-      format ['text']
-      genre ["Oral histories"]
-      extent ['50 pages']
-      language ['English']
-      department 'Center for Oral History'
-      created_at DateTime.now
+      title  { "Oral history interview with William John Bailey" }
+      external_id {
+        [
+          {'category' => 'bib', 'value' => 'b1043559'},
+          {'category' => 'interview', 'value' => '0012'}
+        ]
+      }
+      creator {
+        [
+          {category: "interviewee", value:"Bailey, William John, 1921-1989"},
+          {category: "interviewer", value:"Bohning, James J."}
+        ]
+      }
+      date_of_work { [ Work::DateOfWork.new(start: "1986-06-03") ] }
+      place  { [{category: "place_of_interview", value:"University of Maryland, College Park"}] }
+      format { ['text'] }
+      genre { ["Oral histories"] }
+      extent { ['50 pages'] }
+      language { ['English'] }
+      department { 'Center for Oral History' }
+      created_at { DateTime.now }
     end
   end
 end


### PR DESCRIPTION
Fix FactoryBot deprecation warnings.

Eg

DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:

title { "Oral history interview with William John Bailey" }