### PR TITLE
Use :with_representative_derivatives scope now in kithe

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,9 +7,9 @@ GIT
 
 GIT
   remote: https://github.com/sciencehistory/kithe.git
-  revision: 3c90736d2ace4dad1091fec4ed0d214790e46ef4
+  revision: 7ac64ad9af19d9cae026b27aa146e578349134bc
   specs:
-    kithe (0.2.0)
+    kithe (0.3.0)
       attr_json (< 2.0.0)
       fastimage (~> 2.0.0)
       marcel
@@ -204,7 +204,7 @@ GEM
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     dot-properties (0.1.3)
-    down (4.8.0)
+    down (4.8.1)
       addressable (~> 2.5)
     draper (3.1.0)
       actionpack (>= 5.0)
@@ -215,7 +215,7 @@ GEM
     dropbox_api (0.1.16)
       faraday (>= 0.8, <= 0.15.4)
       oauth2 (~> 1.1)
-    equatable (0.5.0)
+    equatable (0.6.1)
     erubi (1.8.0)
     ethon (0.12.0)
       ffi (>= 1.3.0)
@@ -304,7 +304,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    marc (1.0.3)
+    marc (1.0.4)
       scrub_rb (>= 1.0.1, < 2)
       unf
     marc-fastxmlwriter (1.0.0)
@@ -324,7 +324,7 @@ GEM
     msgpack (1.2.4)
     multi_json (1.13.1)
     multi_xml (0.6.0)
-    multipart-post (2.0.0)
+    multipart-post (2.1.1)
     mustermann (1.0.3)
     namae (1.0.1)
     net-scp (1.2.1)
@@ -342,9 +342,9 @@ GEM
       rack (>= 1.2, < 3)
     orm_adapter (0.5.0)
     os (1.0.0)
-    pastel (0.7.2)
-      equatable (~> 0.5.0)
-      tty-color (~> 0.4.0)
+    pastel (0.7.3)
+      equatable (~> 0.6)
+      tty-color (~> 0.5)
     pdf-reader (2.2.0)
       Ascii85 (~> 1.0.0)
       afm (~> 0.2.1)
@@ -359,7 +359,7 @@ GEM
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
-    public_suffix (3.0.3)
+    public_suffix (3.1.1)
     puma (3.12.0)
     rack (2.0.7)
     rack-protection (2.0.5)
@@ -457,7 +457,7 @@ GEM
       json
       multipart-post
       oauth2
-    ruby-progressbar (1.10.0)
+    ruby-progressbar (1.10.1)
     ruby-rc4 (0.1.5)
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
@@ -475,7 +475,7 @@ GEM
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
-    shrine (2.16.0)
+    shrine (2.18.0)
       content_disposition (~> 1.0)
       down (~> 4.1)
     shrine-url (2.2.1)
@@ -528,7 +528,7 @@ GEM
       slop (>= 3.4.5, < 4.0)
       yell
     ttfunk (1.5.1)
-    tty-color (0.4.3)
+    tty-color (0.5.0)
     tty-command (0.8.2)
       pastel (~> 0.7.0)
     typhoeus (1.3.1)
@@ -567,14 +567,14 @@ GEM
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)
-    websocket-driver (0.7.0)
+    websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.3)
+    websocket-extensions (0.1.4)
     whenever (0.11.0)
       chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yell (2.1.0)
+    yell (2.2.0)
 
 PLATFORMS
   ruby

--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -18,7 +18,7 @@ class Admin::WorksController < AdminController
     @q = Work.ransack(params[:q])
     @q.sorts = 'updated_at desc' if @q.sorts.empty?
 
-    @works = @q.result.includes(:derivatives).includes(:leaf_representative => :derivatives).page(params[:page]).per(20)
+    @works = @q.result.with_representative_derivatives.page(params[:page]).per(20)
   end
 
 

--- a/app/decorators/work_show_decorator.rb
+++ b/app/decorators/work_show_decorator.rb
@@ -89,7 +89,7 @@ class WorkShowDecorator < Draper::Decorator
     @related_works ||= Work.where(
         friendlier_id: related_url_filter.related_work_friendlier_ids,
         published: true
-      ).includes(:derivatives, leaf_representative: :derivatives).all
+      ).with_representative_derivatives.all
   end
 
   def public_collections
@@ -107,7 +107,7 @@ class WorkShowDecorator < Draper::Decorator
   def member_list_for_display
     @member_list_display ||= begin
       members = model.members.
-        includes(:derivatives, leaf_representative: :derivatives).
+        with_representative_derivatives.
         where(published: true).
         order(:position).
         to_a

--- a/app/views/admin/works/_member_list_table.html.erb
+++ b/app/views/admin/works/_member_list_table.html.erb
@@ -12,7 +12,7 @@
     </thead>
 
     <tbody>
-      <% work.members.order(:position).includes(:derivatives).includes(:leaf_representative => :derivatives).each do |member| %>
+      <% work.members.order(:position).with_representative_derivatives.each do |member| %>
         <tr>
           <td>
             <% if member.leaf_representative_id %>

--- a/app/views/admin/works/reorder_members_form.html.erb
+++ b/app/views/admin/works/reorder_members_form.html.erb
@@ -23,7 +23,7 @@
     </thead>
 
     <tbody>
-      <% @work.members.order(:position).includes(:derivatives).includes(:leaf_representative => :derivatives).each do |member| %>
+      <% @work.members.order(:position).with_representative_derivatives.each do |member| %>
         <tr>
           <td>
             <% if member.representative %>


### PR DESCRIPTION
Update kithe to get new :with_representative_derivatives scope, and then use it: 

To pre-load all representatives and their derivatives from a hetereogenous member list of Assets and (child) Works. Avoiding n+1 queries, using Rails eager loading to do bulk queries on result set. A bit tricky how to do this, so we provided a scope in kithe to do it, now we replace our explicit code doing it with use of the scope from kithe.

Part of what makes it tricky is that when you have a hetereogenous list of members that are Assets and Works. Assets don't really have their own 'leaf_representative', they need :derivatives pre-loaded directly. But child works need their :leaf_representatives loaded, and then for those :leaf_representatives need :derivatives loaded on them. So we load *both* to catch em all, [:derivatives, leaf_representative: :derivatives].