### PR TITLE
Better type error message from ViewModel

### DIFF
--- a/app/presenters/view_model.rb
+++ b/app/presenters/view_model.rb
@@ -128,7 +128,7 @@ class ViewModel < Draper::Decorator
   def initialize(model, *other_args)
     if self.class.valid_model_type_names
       unless self.class.valid_model_type_names.any? { |t| model.kind_of?(t.constantize) }
-        raise ArgumentError.new("#{self.class.name} arg must be of one of type #{self.class.valid_model_type_names.inspect}")
+        raise ArgumentError.new("#{self.class.name} arg must be of one of type #{self.class.valid_model_type_names.inspect}, but was #{model.class.name.inspect}")
       end
     end
 


### PR DESCRIPTION
Tell us the class of the non-allowed thing in the error message, makes it much easier to spot the bug.