### PR TITLE
Explicitly init Bootstrap popover function

### DIFF
--- a/app/assets/javascripts/init_popovers.js
+++ b/app/assets/javascripts/init_popovers.js
@@ -1,0 +1,6 @@
+// Bootstrap 4 popovers are opt-in, we need to activate them.
+// https://getbootstrap.com/docs/4.0/components/popovers/#example-enable-popovers-everywhere
+
+jQuery( document ).ready(function() {
+  $('[data-toggle="popover"]').popover()
+});


### PR DESCRIPTION
Meant to include this in my commits in #189, specifically e08981a . But forgot to `git add` the new file. 

In Bootstrap 4, to get popover func (we use for question mark help button on RIS export), you need to explicitly init it. This file does.

(application.js already has a require statement that picks up any files in the relevant directory, is why just adding this file alone results in it being included in our JS)