### PR TITLE
Cleaning up a couple leftover details with provenance display.

### DIFF
--- a/app/assets/stylesheets/local/show.scss
+++ b/app/assets/stylesheets/local/show.scss
@@ -1,7 +1,6 @@
 // common styles for work/collection show
 
-
-#collapseProvenanceNotes {
+.provenance-notes {
   margin-top: 1em;
 }
 

--- a/app/views/presenters/_work_provenance.html.erb
+++ b/app/views/presenters/_work_provenance.html.erb
@@ -1,13 +1,13 @@
 <span class="provenance-summary">
   <%= view.provenance_summary %>
 </span>
-<% unless view.provenance_notes.nil? %>
-    <a data-toggle="collapse" href="#collapseProvenanceNotes"
-      role="button" aria-expanded="false"
-      aria-controls="collapseProvenanceNotes">Show notes</a>
-    <div class="collapse" id="collapseProvenanceNotes">
-    <span class="provenance-notes">
+<% unless view.provenance_notes.blank? %>
+  <a data-toggle="collapse" href="#collapseProvenanceNotes"
+    role="button" aria-expanded="false"
+    aria-controls="collapseProvenanceNotes">Show notes</a>
+  <div class="collapse" id="collapseProvenanceNotes">
+    <div class="provenance-notes">
       <%= view.provenance_notes %>
-     </span>
     </div>
+  </div>
 <% end %>


### PR DESCRIPTION
Adjusting css for work provenance, and checking for blank (rather than null) when deciding whether to show provenance notes.

Fixes #181