### PR TITLE
Only return items marked 'published' in Blacklight search results

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -12,6 +12,7 @@ class SearchBuilder < Blacklight::SearchBuilder
 
 
   # Scihist SearchBuilder extensions
+  include SearchBuilder::AccessControlFilter
   include SearchBuilder::AdminOnlySearchFields
   include SearchBuilder::PublicDomainFilter
   include SearchBuilder::CustomSortLogic

--- a/app/models/search_builder/access_control_filter.rb
+++ b/app/models/search_builder/access_control_filter.rb
@@ -1,0 +1,23 @@
+class SearchBuilder
+  # An extension to Blacklight's SearchBuilder (which is locally generated in our app),
+  # that provides access control for public non/public items.
+  #
+  # For now, we just only allow published items to show up in search results. Later we
+  # could let logged in users see non-published items, but we're starting with public
+  # view for everyone.
+  #
+  # (We could also _not index_ non-published things, but kithe indexing routines might need
+  # more features to add/remove something from index if it's pubished status changes).
+  module AccessControlFilter
+    extend ActiveSupport::Concern
+
+    included do
+      self.default_processor_chain += [:access_control_filter]
+    end
+
+    def access_control_filter(solr_params)
+      solr_params[:fq] ||= []
+      solr_params[:fq] << "{!term f=published_bsi}1"
+    end
+  end
+end

--- a/spec/system/catalog_search_spec.rb
+++ b/spec/system/catalog_search_spec.rb
@@ -90,4 +90,18 @@ describe CatalogController, solr: true, indexable_callbacks: true do
       expect(page).not_to have_selector("li#document_#{red2.friendlier_id}")
     end
   end
+
+  describe "non-published items" do
+    let!(:non_published_work) { create(:work, title: "work non-published", published: false) }
+    let!(:non_published_collection) { create(:work, title: "collection non-published", published: false) }
+    let!(:published_work) { create(:work, title: "work published", published: true) }
+
+    it "do not show up in search results" do
+      visit search_catalog_path(search_field: "all_fields")
+
+      expect(page).to have_content(published_work.title)
+      expect(page).not_to have_content(non_published_work.title)
+      expect(page).not_to have_content(non_published_collection.title)
+    end
+  end
 end


### PR DESCRIPTION
For now, for everyone, even if you are logged in staff, the public-facing search UI only includes published items.

This also serves as an example of one of the simplest possible Blacklight SearchBuilder extensions to effect Blacklight's Solr queries.