### PR TITLE
Provide a factory for assets that provides real files without real expensive promotion

### DIFF
--- a/spec/factories/asset_factory.rb
+++ b/spec/factories/asset_factory.rb
@@ -3,10 +3,85 @@ FactoryBot.define do
     title { 'Test title' }
     published { true }
 
+    # This will take a real file and send it through the real logic
+    # for extracting metadata and creating derivatives -- but make sure to do it
+    # inline instead of in bg ActiveJobs.
+    #
+    # You will have to actually save the Asset to have everything there, won't
+    # work with `build` strategy.
+    #
+    # Gives you a real file synchronously, but takes some time.
+    #
+    # Will use a default small png, but you can pass `file:` with whatever file you want,
+    # of any media type.
     trait :inline_promoted_file do
       file { File.open((Rails.root + "spec/test_support/images/30x30.png")) }
       after(:build) do |asset|
         asset.file_attacher.set_promotion_directives(promote: :inline, create_derivatives: :inline)
+      end
+    end
+
+    # While it still uses a real file, it skips all of the (slow) standard metadata extraction
+    # and derivative generation, instead just SETTING the metadata and derivatives to fixed
+    # values (which may not be actually right, but that doesn't matter for many tests).
+    #
+    # This is much faster, and does work with unsaved Assets and FactoryBot 'build' strategy.
+    # But gives you a file that might not have accurate metadata or correct derivatives.
+    #
+    # In fact, we set all the derivatives to just be the same as the original file.
+    #
+    # Only is set up to provide metadata and derivatives expected for image/ content-types.
+    trait :faked_image_file do
+      transient do
+        faked_file { File.open((Rails.root + "spec/test_support/images/30x30.png")) }
+        faked_content_type { "image/png" }
+        faked_width { 30 }
+        faked_height { 30 }
+      end
+      after(:build) do |asset, evaluator|
+        # Set our uploaded file
+
+        id = SecureRandom.hex
+        Shrine.storages[:store].upload(evaluator.faked_file, id)
+        uploaded_file = Shrine::UploadedFile.new(
+          "id" => id,
+          "storage" => "store",
+          "metadata" => {
+            "filename"=> File.basename( evaluator.faked_file.path ),
+            "size"=> evaluator.faked_file.size,
+            "mime_type"=> evaluator.faked_content_type,
+            "width"=> evaluator.faked_width,
+            "height"=> evaluator.faked_height
+          }
+        )
+        asset.file_data = uploaded_file.to_json
+
+        # Now add derivatives for any that work for our faked file type
+        asset.class.derivative_definitions.each do |derivative_defn|
+          if derivative_defn.applies_to?(asset)
+            derivative = Kithe::Derivative.new(key: derivative_defn.key)
+
+
+            # We're gonna lie and say the original is a derivative, it won't
+            # be the right size, oh well. It also assumes all derivatives
+            # result in an image of the same type which isn't true, it
+            # won't even be the right type! for many tests, it's okay.
+            uploaded_file = Shrine::UploadedFile.new(
+              "id" => id,
+              "storage" => "store",
+              "metadata" => {
+                "filename"=> File.basename( evaluator.faked_file.path ),
+                "size"=> evaluator.faked_file.size,
+                "mime_type"=> evaluator.faked_content_type,
+                "width"=> evaluator.faked_width,
+                "height"=> evaluator.faked_height
+              }
+            )
+            derivative.file_data = uploaded_file.to_json
+            asset.derivatives << derivative
+          end
+        end
+
       end
     end
 

--- a/spec/presenters/member_image_presentation_spec.rb
+++ b/spec/presenters/member_image_presentation_spec.rb
@@ -6,7 +6,7 @@ describe MemberImagePresentation, type: :decorator do
   let(:presenter) { MemberImagePresentation.new(member) }
 
   describe "with asset" do
-    let(:member) { create(:asset, :inline_promoted_file) }
+    let(:member) { create(:asset, :faked_image_file) }
 
     describe "large size" do
       let(:presenter) { MemberImagePresentation.new(member, size: :large) }
@@ -44,7 +44,7 @@ describe MemberImagePresentation, type: :decorator do
   end
 
   describe "with child work" do
-    let(:member) { create(:work, representative: create(:asset, :inline_promoted_file)) }
+    let(:member) { create(:work, representative: create(:asset, :faked_image_file)) }
 
     describe "large size" do
       let(:presenter) { MemberImagePresentation.new(member, size: :large) }

--- a/spec/presenters/social_share_display_spec.rb
+++ b/spec/presenters/social_share_display_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe SocialShareDisplay do
-  let(:work) { create(:work, :with_complete_metadata, representative: create(:asset, :inline_promoted_file))}
+  let(:work) { create(:work, :with_complete_metadata, representative: create(:asset, :faked_image_file))}
   let(:displayer) { SocialShareDisplay.new(work) }
   let(:rendered) { Nokogiri::HTML.fragment( displayer.display )}
   let(:container_div) { rendered.at_css("div.social-media") }

--- a/spec/presenters/thumb_display_spec.rb
+++ b/spec/presenters/thumb_display_spec.rb
@@ -14,7 +14,7 @@ describe ThumbDisplay do
 
   describe "asset missing derivatives" do
     let(:argument) do
-      create(:asset).tap do |asset|
+      build(:asset).tap do |asset|
         allow(asset).to receive(:content_type).and_return("image/jpeg")
       end
     end
@@ -25,7 +25,7 @@ describe ThumbDisplay do
 
   describe "non-handlable type" do
     let(:argument) do
-      create(:asset).tap do |asset|
+      build(:asset).tap do |asset|
         allow(asset).to receive(:content_type).and_return("audio/mpeg")
       end
     end
@@ -35,7 +35,7 @@ describe ThumbDisplay do
   end
 
   describe "asset with 'standard' size derivatives" do
-    let(:argument) { create(:asset, :inline_promoted_file)}
+    let(:argument) { build(:asset, :faked_image_file)}
     it "renders img with srcset" do
       standard_deriv    = argument.derivative_for(:thumb_standard)
       standard_2x_deriv = argument.derivative_for(:thumb_standard_2X)
@@ -61,7 +61,7 @@ describe ThumbDisplay do
 
   describe "specified thumb size" do
     let(:thumb_size) { :mini }
-    let(:argument) { create(:asset, :inline_promoted_file)}
+    let(:argument) { build(:asset, :faked_image_file)}
     let(:instance) { ThumbDisplay.new(argument, thumb_size: thumb_size) }
 
     it "renders" do
@@ -79,7 +79,7 @@ describe ThumbDisplay do
 
     describe "lazy load with lazysizes.js" do
       let(:thumb_size) { :mini }
-      let(:argument) { create(:asset, :inline_promoted_file)}
+      let(:argument) { build(:asset, :faked_image_file)}
       let(:instance) { ThumbDisplay.new(argument, thumb_size: thumb_size, lazy: true) }
 
       it "renders with lazysizes class and data- attributes" do

--- a/spec/presenters/work_social_share_attributes_spec.rb
+++ b/spec/presenters/work_social_share_attributes_spec.rb
@@ -21,7 +21,7 @@ describe WorkSocialShareAttributes do
   end
 
   describe "#share_media_url" do
-    let(:work) { create(:work, representative: create(:asset, :inline_promoted_file))}
+    let(:work) { create(:work, representative: create(:asset, :faked_image_file))}
     let(:download_medium_derivative) { work.representative.derivative_for(:download_medium) }
 
     it "direct link to 'medium' download derivative of representative" do


### PR DESCRIPTION
In a spec, we might want an Asset that has an attached file available, with derivatives, and metadata -- but actually creating derivatives and extracting metadata can be expensive. 

We provide the ':faked_image_file' trait on the Asset factory, which will attach a file, and attach 'faked' derivatives and metadata.  This code is definitely kind of hacky, and produces metadata that may not be accurate, and derivatives that aren't correct (they are actually just copies of the original file). But it works well enough for many specs, and also can be used with FactoryBot "build" strategy (which does not actually save models to DB) in specs that don't require a saved model, for further speed-up. 

    create(:asset, :faked_image_file)
    build(:asset, :faked_image_file)

I was hoping this would speed up our specs; it did a bit, on my macbook previous to this PR it took 1 minute 34 seconds for entire suite to run, after this PR it took 1 minutes 22 seconds. (12% speed up). Closes #200. 

Will need to do more investigation into our slowest specs and what makes them slow to see if we can speed up specs more.