### PR TITLE
Show original filename in staff asset view

### DIFF
--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -37,6 +37,10 @@
       <dt class="col-sm-4">Last Modified</dt>
       <dd class="col-sm-8"><%= l @asset.updated_at, format: :admin %></dd>
 
+
+      <dt class="col-sm-4">Orig. Filename</dt>
+      <dd class="col-sm-8"><%= @asset&.file&.metadata.try { |h| h["filename"]} %></dd>
+
       <dt class="col-sm-4">Content-type</dt>
       <dd class="col-sm-8"><%= @asset.content_type %></dd>
 


### PR DESCRIPTION
This is metadata captured by shrine. It's separate from the "title", which in our app starts out defaulting to original filename, but can be changed -- the original filename is still preserved in shrine metadata.

We may choose to use the original filename in some features (like download names?) or may not.

Either way, we should expose it to staff users, to avoid confusion with software features and/or for preservation/auditing purposes. The original filename on ingest is preserved, let the staff see it.

Before this PR, it was not visible in any staff UI.