### PR TITLE
ViewModel delegates :id to it's decorated object

### DIFF
--- a/app/presenters/view_model.rb
+++ b/app/presenters/view_model.rb
@@ -125,6 +125,10 @@ class ViewModel < Draper::Decorator
   # do include all Rails helpers in the ViewModel with:
   include Draper::LazyHelpers
 
+  # Workaround weird Draper bug/gotcha interaction with ActiveRecord
+  # https://github.com/drapergem/draper/issues/859
+  delegate :id
+
   def initialize(model, *other_args)
     if self.class.valid_model_type_names
       unless self.class.valid_model_type_names.any? { |t| model.kind_of?(t.constantize) }


### PR DESCRIPTION
To avoid Draper bug/misfeature where if you don't delegate :id, it will break ActiveRecord #==. Which was for reasons not entirely clear breaking rspec's ability to finish up and report failed specs.

Reported to Draper, PR url in code comment.