### PR TITLE
Ris download name

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -9,25 +9,13 @@ class WorksController < ApplicationController
       format.ris {
         send_data RisSerializer.new(@work).to_ris,
           disposition: 'attachment',
-          filename: ris_download_filename,
+          filename: DownloadFilenameHelper.ris_download_name(@work),
           type: :ris
       }
     end
   end
 
   private
-
-  # The download_filename helper specializes
-  # in originals and derivatives, and the RIS download
-  # isn't really either, so this is a bit more complicated
-  # than  it used to be.
-  def ris_download_filename
-    name_with_ext = DownloadFilenameHelper.
-      filename_for_asset(@work.representative)
-    name_without_ext = Pathname.
-      new(name_with_ext).sub_ext("").to_s
-    "#{name_without_ext}.ris"
-  end
 
   def set_work
     @work = Work.find_by_friendlier_id!(params[:id])

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -7,8 +7,10 @@ class WorksController < ApplicationController
     respond_to do |format|
       format.html
       format.ris {
+        download_name = DownloadFilenameHelper.filename_for_asset(@work.representative)
         send_data RisSerializer.new(@work).to_ris,
           disposition: 'attachment',
+          filename: "#{download_name}.ris",
           type: :ris
       }
     end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -7,19 +7,27 @@ class WorksController < ApplicationController
     respond_to do |format|
       format.html
       format.ris {
-        download_name = Pathname.new(DownloadFilenameHelper.
-          filename_for_asset(@work.representative))
-          .sub_ext("").
-          to_s
         send_data RisSerializer.new(@work).to_ris,
           disposition: 'attachment',
-          filename: "#{download_name}.ris",
+          filename: ris_download_filename,
           type: :ris
       }
     end
   end
 
   private
+
+  # The download_filename helper specializes
+  # in originals and derivatives, and the RIS download
+  # isn't really either, so this is a bit more complicated
+  # than  it used to be.
+  def ris_download_filename
+    name_with_ext = DownloadFilenameHelper.
+      filename_for_asset(@work.representative)
+    name_without_ext = Pathname.
+      new(name_with_ext).sub_ext("").to_s
+    "#{name_without_ext}.ris"
+  end
 
   def set_work
     @work = Work.find_by_friendlier_id!(params[:id])

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -7,7 +7,10 @@ class WorksController < ApplicationController
     respond_to do |format|
       format.html
       format.ris {
-        download_name = DownloadFilenameHelper.filename_for_asset(@work.representative)
+        download_name = Pathname.new(DownloadFilenameHelper.
+          filename_for_asset(@work.representative))
+          .sub_ext("").
+          to_s
         send_data RisSerializer.new(@work).to_ris,
           disposition: 'attachment',
           filename: "#{download_name}.ris",

--- a/app/presenters/download_filename_helper.rb
+++ b/app/presenters/download_filename_helper.rb
@@ -28,11 +28,7 @@ class DownloadFilenameHelper
     # audio files use their whole title instead of parents, with the intended
     # use case of Oral History, our only audio files at present, where archival
     # title is important.
-    base = if asset.content_type && asset.content_type.start_with?("audio/")
-      asset.title
-    else
-      DownloadFilenameHelper.filename_base_from_parent(asset)
-    end
+    base = self.filename_base_for_asset(asset)
 
     if derivative && !asset.content_type.start_with?("audio")
       base = [base, derivative.key].join("_")
@@ -44,7 +40,25 @@ class DownloadFilenameHelper
       asset.content_type
     end
 
-    DownloadFilenameHelper.filename_with_suffix(base, content_type: content_type)
+    self.filename_with_suffix(base, content_type: content_type)
+  end
+
+  # Try to keep the ris download filename similar to the one we use
+  # for originals: filename_for_asset(asset).
+  def self.ris_download_name(work)
+    base = if work.representative.nil?
+      first_three_words(work.title)
+    else
+      self.filename_base_for_asset(work.representative)
+    end
+    "#{base}.ris"
+  end
+
+  def self.filename_base_for_asset(asset)
+    if asset.content_type && asset.content_type.start_with?("audio/")
+      return asset.title
+    end
+    self.filename_base_from_parent(asset)
   end
 
   # Pass in a string, get the first three words separated by underscores, stripping punctuation.

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -3,7 +3,14 @@ require 'rails_helper'
 RSpec.describe WorksController, type: :controller do
   context "smoke tests" do
     context "standard work" do
-      let(:work) { FactoryBot.create(:work, :with_assets)}
+      let(:work){create(:work, members: [create(:asset)])}
+
+      before do
+        work.representative = work.members.first
+        work.save
+        allow(work.members.first).to receive(:content_type).and_return("audio/mpeg")
+      end
+
 
       it "shows the work as expected" do
         get :show, params: { id: work.friendlier_id }, as: :html
@@ -16,7 +23,8 @@ RSpec.describe WorksController, type: :controller do
         expect(response.body).to include "TI  - Test title"
         expect(response.body).to include "M2  - Courtesy of Science History Institute."
         expect(response.content_type).to eq "application/x-research-info-systems"
-        expect(response.headers["Content-Disposition"]).to eq "attachment"
+        expect(response.headers["Content-Disposition"]).
+          to match(/attachment. filename=.test_title[^\.]+\.ris/)
       end
     end
   end


### PR DESCRIPTION
Fixes #198 .

- The download name is now calculated in app/presenters/download_filename_helper.rb rather than the works_controller, which makes the helper more, well, helpful.
- I refactored the common code between the`ris_download_name(work)`  and `filename_for_asset(asset)` into `filename_base_for_asset(asset)`.
- `ris_download_name` is OK to use for works with no representative; it just uses the work's title as the base.