### PR TITLE
(Import) Catch Shrine error and missing titles in FileSets from staging.

### DIFF
--- a/app/importers/importers/file_set_importer.rb
+++ b/app/importers/importers/file_set_importer.rb
@@ -94,7 +94,14 @@ module Importers
         target_item.file_attacher.set_promotion_directives(create_derivatives: false)
       end
 
-      target_item.file = { "id" => corrected_file_url, "storage" => "remote_url" }
+      # This should never happen with production data,
+      # but it should also not stop the entire import.
+      begin
+        target_item.file = { "id" => corrected_file_url, "storage" => "remote_url" }
+      rescue Shrine::Error => shrine_error
+        add_error("Shrine error: #{shrine_error}")
+      end
+
     end
 
     def self.importee()

--- a/app/importers/importers/importer.rb
+++ b/app/importers/importers/importer.rb
@@ -147,7 +147,15 @@ module Importers
     # This do not save the item.
     def common_populate()
       target_item.friendlier_id = @metadata['id']
-      target_item.title = @metadata['title'].first
+
+      # This should never happen with production data,
+      # but it should also not stop the entire import.
+      if @metadata['title'].nil?
+        add_error("missing title")
+        target_item.title = "No title"
+      else
+        target_item.title = @metadata['title'].first
+      end
 
       if metadata['date_uploaded'].blank?
         add_error("missing 'date_uploaded'")


### PR DESCRIPTION
The last import I ran contained a weird FileSet (present only in staging) that I created for testing and never deleted. It had a missing title and something was wrong with its attached file. (`Shrine error: {"id"=>nil, "storage"=>"remote_url"} isn't valid uploaded file data`) Catch, then report, both of these errors so they don't halt the import.