### PR TITLE
Home page recent items thumbnails should use 100% of their container's width

### DIFF
--- a/app/assets/stylesheets/local/homepage.scss
+++ b/app/assets/stylesheets/local/homepage.scss
@@ -135,11 +135,11 @@
                 width: 100%;
                 height: 100%;
                 background-color: $brand-dark-grey;
+                img {
+                    width: 100%;
+                }
             }
 
-            .recent-items-image {
-                width: 100%;
-            }
             .recent-item-title-wrapper {
                 display: none;
                 position: absolute;


### PR DESCRIPTION
The stylesheet was referring to obsolete `.recent-items-image`, no longer in use: `ThumbDisplay` is doing our thumbnails now.

Fixes #263.