### PR TITLE
Add pagination on "show collection" page

### DIFF
--- a/app/views/collection_show/index.html.erb
+++ b/app/views/collection_show/index.html.erb
@@ -103,6 +103,16 @@
       <%= render 'search_header' %>
 
       <%= render "document_list", documents: @response.documents %>
+      <% if show_pagination? and @response.total_pages > 1 %>
+        <%# expanded will be shown by CSS at large screen sizes, else compact %>
+        <div class="pagination pagination-alt-expanded">
+          <%= paginate @response, :window => 3, :outer_window => 1, :theme => 'local' %>
+        </div>
+        <div class="pagination pagination-alt-compact">
+          <%= paginate @response, :page_entries_info => page_entries_info(@response), :theme => 'blacklight_compact' %>
+        </div>
+      <% end %>
+
     </div>
   </div>
 


### PR DESCRIPTION
It was missing for whatever reason.
Fixes https://github.com/sciencehistory/scihist_digicoll/issues/274 .