### PR TITLE
Removing bug: the template was calling a nonexistant method.

### DIFF
--- a/app/views/featured_topic/index.html.erb
+++ b/app/views/featured_topic/index.html.erb
@@ -9,16 +9,10 @@
         </header>
       </div>
       <div class="show-metadata">
-        <% if current_staff_user? %>
-          <p class="show-item-count">
           <p class="show-item-count"><%= number_with_delimiter(total_count) + ' item'.pluralize(total_count) %></p>
-        </p>
-        <% else %>
-          <p class="show-item-count"><%= "#{number_with_delimiter(@featured_topic.public_count)} #{'item'.pluralize(@featured_topic.public_count)}" %></p>
-        <% end %>
-        <div class="collection-description">
-          <%= DescriptionDisplayFormatter.new(@featured_topic.description).format %>
-        </div>
+          <div class="collection-description">
+            <%= DescriptionDisplayFormatter.new(@featured_topic.description).format %>
+          </div>
       </div>
     </div>
     <div class="collection-thumb">


### PR DESCRIPTION
Erroneously ported some collection code into the featured topic branch.
This is related to https://github.com/sciencehistory/scihist_digicoll/issues/279 .
Solving issue 279 would provide a long-term resolution; this is just a short-term fix, but is consistent with the status quo in Sufia.