### PR TITLE
Featured topic title css adjustment

### DIFF
--- a/app/assets/stylesheets/local/homepage.scss
+++ b/app/assets/stylesheets/local/homepage.scss
@@ -201,7 +201,7 @@
 
             .featured-topic-title-wrapper {
                 position: absolute;
-                bottom: 0;
+                bottom: -0.05rem;
                 left: 0;
                 width: 100%;
                 height: 3.5rem;

--- a/app/assets/stylesheets/local/homepage.scss
+++ b/app/assets/stylesheets/local/homepage.scss
@@ -201,7 +201,7 @@
 
             .featured-topic-title-wrapper {
                 position: absolute;
-                bottom: -0.05rem;
+                bottom: -1px;
                 left: 0;
                 width: 100%;
                 height: 3.5rem;


### PR DESCRIPTION
Move the title down by a small fraction of a rem, just to completely cover the bottom edge of the thumbnail in e.g. Safari.
This shouldn't be necessary but it is.