### PR TITLE
Download menu fix

### DIFF
--- a/app/presenters/download_dropdown_display.rb
+++ b/app/presenters/download_dropdown_display.rb
@@ -158,9 +158,9 @@ class DownloadDropdownDisplay < ViewModel
   def has_work_download_options?
     display_parent_work &&
       display_parent_work.members.length > 1 &&
-      display_parent_work.members.all? do |member|
-        member.leaf_representative && member.leaf_representative.content_type.start_with?("image/")
-      end
+       display_parent_work.members.all? do |member|
+         member.leaf_representative && member.leaf_representative.file_data && member.leaf_representative.content_type.start_with?("image/")
+       end
   end
 
 end

--- a/app/presenters/download_dropdown_display.rb
+++ b/app/presenters/download_dropdown_display.rb
@@ -159,7 +159,7 @@ class DownloadDropdownDisplay < ViewModel
     display_parent_work &&
       display_parent_work.members.length > 1 &&
       display_parent_work.members.all? do |member|
-        member.leaf_representative && member.leaf_representative.file_data && member.leaf_representative.content_type.start_with?("image/")
+        member.leaf_representative&.content_type&.start_with?("image/")
       end
   end
 

--- a/app/presenters/download_dropdown_display.rb
+++ b/app/presenters/download_dropdown_display.rb
@@ -158,9 +158,9 @@ class DownloadDropdownDisplay < ViewModel
   def has_work_download_options?
     display_parent_work &&
       display_parent_work.members.length > 1 &&
-       display_parent_work.members.all? do |member|
-         member.leaf_representative && member.leaf_representative.file_data && member.leaf_representative.content_type.start_with?("image/")
-       end
+      display_parent_work.members.all? do |member|
+        member.leaf_representative && member.leaf_representative.file_data && member.leaf_representative.content_type.start_with?("image/")
+      end
   end
 
 end


### PR DESCRIPTION
The download menu presenter iterates through all the siblings of the item being shown, to see if it needs to offer a whole-work PDF download option.
If one of the siblings' leaf representative asset lacks a file, the code fails.

If you run an import without files (the current default), e.g. in dev, you're certain to run into this error.