### PR TITLE
DRY up determination of appropriate Shrine::Storage for mode

### DIFF
--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -155,7 +155,7 @@ module ScihistDigicoll
       end
 
       # used in dev_file and dev_s3 modes:
-      path_prefix = bucket_key.to_s.sub(/^s3_bucket/, '')
+      path_prefix = bucket_key.to_s.sub(/^s3_bucket_/, '')
 
       if mode == "dev_file"
         Shrine::Storage::FileSystem.new("public", prefix: "shrine_storage_#{Rails.env}/#{path_prefix}")
@@ -182,7 +182,6 @@ module ScihistDigicoll
     # Based on config, supply appropriate shrine cache.
     def self.shrine_cache_storage
       # special handling with "web" prefix, I forget why.
-
       appropriate_shrine_storage( bucket_key: :s3_bucket_uploads,
                                   s3_storage_options: {
                                     prefix: "web"
@@ -204,6 +203,13 @@ module ScihistDigicoll
     # Note we set shrine S3 storage to public, to upload with public ACLs
     def self.shrine_on_demand_derivatives_storage
       appropriate_shrine_storage( bucket_key: :s3_bucket_on_demand_derivatives,
+                                  s3_storage_options: {
+                                    public: true
+                                  })
+    end
+
+    def self.shrine_dzi_storage
+      appropriate_shrine_storage( bucket_key: :s3_bucket_dzi,
                                   s3_storage_options: {
                                     public: true
                                   })

--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -181,40 +181,44 @@ module ScihistDigicoll
 
     # Based on config, supply appropriate shrine cache.
     def self.shrine_cache_storage
-      # special handling with "web" prefix, I forget why.
-      appropriate_shrine_storage( bucket_key: :s3_bucket_uploads,
-                                  s3_storage_options: {
-                                    prefix: "web"
-                                  })
+      @shrine_cache_storage ||=
+        # special handling with "web" prefix, I forget why.
+        appropriate_shrine_storage( bucket_key: :s3_bucket_uploads,
+                                    s3_storage_options: {
+                                      prefix: "web"
+                                    })
     end
 
     def self.shrine_store_storage
-      appropriate_shrine_storage(bucket_key: :s3_bucket_originals)
+      @shrine_store_storage ||=
+        appropriate_shrine_storage(bucket_key: :s3_bucket_originals)
     end
 
     # Note we set shrine S3 storage to public, to upload with public ACLs
     def self.shrine_derivatives_storage
-      appropriate_shrine_storage( bucket_key: :s3_bucket_derivatives,
-                                  s3_storage_options: {
-                                    public: true
-                                  })
+      @shrine_derivatives_storage ||=
+        appropriate_shrine_storage( bucket_key: :s3_bucket_derivatives,
+                                    s3_storage_options: {
+                                      public: true
+                                    })
     end
 
     # Note we set shrine S3 storage to public, to upload with public ACLs
     def self.shrine_on_demand_derivatives_storage
-      appropriate_shrine_storage( bucket_key: :s3_bucket_on_demand_derivatives,
-                                  s3_storage_options: {
-                                    public: true
-                                  })
+      @shrine_on_demand_derivatives_storage ||=
+        appropriate_shrine_storage( bucket_key: :s3_bucket_on_demand_derivatives,
+                                    s3_storage_options: {
+                                      public: true
+                                    })
     end
 
     def self.shrine_dzi_storage
-      appropriate_shrine_storage( bucket_key: :s3_bucket_dzi,
-                                  s3_storage_options: {
-                                    public: true
-                                  })
+      @shrine_dzi_storage ||=
+        appropriate_shrine_storage( bucket_key: :s3_bucket_dzi,
+                                    s3_storage_options: {
+                                      public: true
+                                    })
     end
-
 
     define_key :honeybadger_api_key
 


### PR DESCRIPTION
In development, this will break your various stored assets and files, as we've changed the way we calculate path prefix (to be more consistent and not custom for each storage). In production, no change, everything will keep working. 

Also added a shrine storage for DZI.