### PR TITLE
Viewer gets a download menu

### DIFF
--- a/app/javascript/src/js/scihist_viewer.js
+++ b/app/javascript/src/js/scihist_viewer.js
@@ -12,10 +12,17 @@
 // Assumes a bootstrap modal for viewer is available at DOM id #scihist-image-viewer-modal, it has to have
 // a data-work-id and data-images-info-path (URL to JSON images info) for the work. Yes, that means
 // right now we assume on a given page, a viewer will only be displayed for ONE single work. data-images-info-path
-// is a URL that will return JSON, see ViewerMemberInfoSerializer for what it looks like.
+// is a URL that will return JSON, see ViewerMemberInfoSerializer for what it looks like. It also has
+// a 'template' for download links menu. This is one of the hackiest/least generalizable parts of the implementation.
 //
 // Note the viewer updates the URL to add a "viewer/[memberId]" reference, so you can bookmark or link to viewer open
 // to certain member. Routes need to route that to ordinary show page, let JS pick up the end of the path.
+//
+// ## Extract to a re-usable component for other apps?
+//
+// It would be nice and we're trying to write it with that end in mind, but there are still
+// plenty of places that lack customizability or make odd undocumented assumptions about the
+// app, it would take signifcant more work. :(
 
 import OpenSeadragon from 'openseadragon';
 
@@ -188,7 +195,7 @@ ScihistImageViewer.prototype.selectThumb = function(thumbElement) {
   document.querySelector('*[data-hook="viewer-navbar-info-link"]').href = linkUrl;
   document.getElementsByClassName('viewer-pagination-numerator').item(0).textContent = humanIndex;
 
-  $(this.modal).find("#viewer-download .dropdown-menu").html(this.downloadMenuItems(this.selectedThumbData));
+  $(this.modal).find("#viewer-download *[data-slot='selected-downloads']").html(this.downloadMenuItems(this.selectedThumbData));
 
   if (shouldShowInfo) {
     // spacer shows up when info doesn't.
@@ -397,16 +404,6 @@ ScihistImageViewer.prototype.initModal = function(modalElement) {
 
   this.workId = modalElement.getAttribute("data-work-id");
 
-  var rightsElement = modalElement.querySelector('.parent-rights-inline');
-  if (rightsElement) {
-    this.rightsInlineHtml = rightsElement.innerHTML;
-  }
-
-  var parentDownloadElements = modalElement.querySelector('.parent-download-options-inline');
-  if (parentDownloadElements) {
-    this.parentDownloadInlineHtml = parentDownloadElements.innerHTML;
-  }
-
   var _self = this;
   var imageInfoUrl = modalElement.getAttribute("data-images-info-path");
   // This promise should be used in #show to make sure we don't until this
@@ -456,30 +453,15 @@ ScihistImageViewer.prototype.downloadMenuItems = function(thumbData) {
 
   var htmlElements = []
 
-  if (_self.rightsInlineHtml) {
-    htmlElements.push('<li class="dropdown-header">Rights</li>');
-    htmlElements.push('<li tabindex="-1" role="menuItem">' + _self.rightsInlineHtml + '</li>');
-    htmlElements.push('<li role="separator" class="divider"></li>');
-  }
-  if (_self.parentDownloadInlineHtml) {
-    htmlElements.push(_self.parentDownloadInlineHtml);
-    htmlElements.push('<li role="separator" class="divider"></li>');
-  }
-
-
-  htmlElements.push('<li class="dropdown-header">Download selected image</li>');
-
   htmlElements = htmlElements.concat(
     $.map(thumbData.downloads, function(downloadElement) {
-      return '<li tabindex="-1" role="menuitem">' +
-                '<a target="_new" data-analytics-category="Work"' +
+      return  '<a class="dropdown-item" target="_new" data-analytics-category="Work"' +
                 ' data-analytics-action="' + (downloadElement.analyticsAction || "download") + '"' +
                 ' data-analytics-label="' + _self.workId + '"' +
                 ' href="' + downloadElement.url + '">' +
                   downloadElement.label +
                 ' <small>' + (downloadElement.subhead || '') + '</small>' +
-                '</a>' +
-              '</li>';
+              '</a>';
     })
   );
 

--- a/app/javascript/src/js/scihist_viewer.js
+++ b/app/javascript/src/js/scihist_viewer.js
@@ -195,7 +195,7 @@ ScihistImageViewer.prototype.selectThumb = function(thumbElement) {
   document.querySelector('*[data-hook="viewer-navbar-info-link"]').href = linkUrl;
   document.getElementsByClassName('viewer-pagination-numerator').item(0).textContent = humanIndex;
 
-  $(this.modal).find("#viewer-download *[data-slot='selected-downloads']").html(this.downloadMenuItems(this.selectedThumbData));
+  $(this.modal).find(".downloads *[data-slot='selected-downloads']").html(this.downloadMenuItems(this.selectedThumbData));
 
   if (shouldShowInfo) {
     // spacer shows up when info doesn't.

--- a/app/models/download_option.rb
+++ b/app/models/download_option.rb
@@ -43,4 +43,13 @@ class DownloadOption
     @analyticsAction = analyticsAction
   end
 
+  # Rails architecture gives us #to_json for a string if we provide as_json
+  def as_json(options={})
+    {
+      url: url,
+      label: label,
+      subhead: subhead,
+      analyticsAction: analyticsAction
+    }
+  end
 end

--- a/app/models/download_option.rb
+++ b/app/models/download_option.rb
@@ -1,7 +1,7 @@
 # A simple value object representing a download option, used for constructing our download
 # menus
 class DownloadOption
-  attr_reader :label, :subhead, :url, :analyticsAction
+  attr_reader :label, :subhead, :url, :analyticsAction, :data_attrs
 
   # Formats the sub-head for you, in a standard way, using info about the asset. If you don't
   # want this standard format, just use the ordinary new/initialize instead.
@@ -17,6 +17,8 @@ class DownloadOption
   # @param height [#to_s] number representing height dimension
   # @param size [#to_i] number representing size in bytes
   # @param content_type[#to_s] mime/IANA media/content type like "image/jpeg"
+  # @param data_attrs[Hash] hash compatible with rails content_tag `data:` argument, for additional data attributes
+  #   to add to link.
   def self.with_formatted_subhead(label, url:, analyticsAction:nil, width: nil, height: nil, size: nil, content_type: nil)
     parts = []
     parts << ScihistDigicoll::Util.humanized_content_type(content_type) if content_type.present?
@@ -36,11 +38,12 @@ class DownloadOption
   # @param url [String] the url to link to
   # @param analyticsAction [String] a key to record in our analytics logging, up to caller
   #   to decide what to do with it, but probably will turn into a data- attribute for JS.
-  def initialize(label, subhead:, url:, analyticsAction:nil)
+  def initialize(label, url:, subhead:nil, analyticsAction:nil, data_attrs: {})
     @label = label
     @subhead = subhead
     @url = url
     @analyticsAction = analyticsAction
+    @data_attrs = data_attrs
   end
 
   # Rails architecture gives us #to_json for a string if we provide as_json

--- a/app/presenters/download_dropdown_display.rb
+++ b/app/presenters/download_dropdown_display.rb
@@ -158,7 +158,19 @@ class DownloadDropdownDisplay < ViewModel
 
   def format_download_option(download_option)
     label = safe_join([download_option.label, content_tag("small", download_option.subhead)])
-    content_tag("a", label, class: "dropdown-item", href: download_option.url)
+
+    analytics_data_attr = if display_parent_work
+      {
+        analytics_category: "Work",
+        analytics_action: download_option.analyticsAction,
+        analytics_label: display_parent_work.friendlier_id
+      }
+    end
+
+    content_tag("a", label,
+                      class: "dropdown-item",
+                      href: download_option.url,
+                      data: analytics_data_attr)
   end
 
   def rights_statement_item

--- a/app/presenters/download_dropdown_display.rb
+++ b/app/presenters/download_dropdown_display.rb
@@ -43,6 +43,8 @@ class DownloadDropdownDisplay < ViewModel
   #
   #   We don't just get from asset.parent, because intervening child work hieararchy
   #   may make it complicated, we need to be told our display parent context.
+  # @param use_link [Boolean], default false, if true will make the link that opens the menu an
+  #   ordinary hyperlink, instead of a button (used on audio playlist).
   def initialize(asset, display_parent_work:nil, use_link: false)
     @display_parent_work = display_parent_work
     @use_link = use_link

--- a/app/presenters/download_dropdown_display.rb
+++ b/app/presenters/download_dropdown_display.rb
@@ -45,7 +45,7 @@ class DownloadDropdownDisplay < ViewModel
   #   may make it complicated, we need to be told our display parent context.
   # @param use_link [Boolean], default false, if true will make the link that opens the menu an
   #   ordinary hyperlink, instead of a button (used on audio playlist).
-  def initialize(asset, display_parent_work:nil, use_link: false)
+  def initialize(asset, display_parent_work:, use_link: false)
     @display_parent_work = display_parent_work
     @use_link = use_link
     super(asset)

--- a/app/presenters/download_options/image_download_options.rb
+++ b/app/presenters/download_options/image_download_options.rb
@@ -43,7 +43,7 @@ module DownloadOptions
       if dl_large = asset.derivative_for(:download_large)
         options << DownloadOption.with_formatted_subhead("Large JPG",
           url: download_derivative_path(asset, :download_large),
-          analyticsAction: "download_jpg_medium",
+          analyticsAction: "download_jpg_large",
           width: dl_large.width,
           height: dl_large.height,
           size: dl_large.size

--- a/app/serializers/viewer_member_info_serializer.rb
+++ b/app/serializers/viewer_member_info_serializer.rb
@@ -28,8 +28,8 @@ class ViewerMemberInfoSerializer < ViewModel
         tileSource: asset.dzi_file.url,
         # if tilesource DZI is unavailable, give them a more reasonable sized JPG
         fallbackTileSource: { type: "image", url: download_derivative_path(asset, :download_medium, disposition: "inline") },
-        thumbAspectRatio: ("#{asset.width.to_f / asset.height}" if asset.width && asset.height)
-        # downloads TODO
+        thumbAspectRatio: ("#{asset.width.to_f / asset.height}" if asset.width && asset.height),
+        downloads: download_options(asset).as_json
       }.merge(thumb_src_attributes(asset))
     end
   end
@@ -42,6 +42,10 @@ class ViewerMemberInfoSerializer < ViewModel
       member.leaf_representative.content_type&.start_with?("image/") &&
       member.leaf_representative.stored?
     end
+  end
+
+  def download_options(asset)
+    DownloadOptions::ImageDownloadOptions.new(asset).options
   end
 
 

--- a/app/views/scihist_image_viewer/_scihist_viewer_modal.html.erb
+++ b/app/views/scihist_image_viewer/_scihist_viewer_modal.html.erb
@@ -38,23 +38,8 @@
                 <button href="#" id="viewer-right" class="viewer-image-next" data-trigger="viewer-next" tabindex="0"><i class="fa fa-chevron-right" title="Next"></i></button>
               </div>
 
-              <%= render "scihist_image_viewer/scihist_viewer_navbar" %>
+              <%= render "scihist_image_viewer/scihist_viewer_navbar", work: work %>
             </div>
-
-            <%# just some DOM content that the viewer.js will copy into download
-                menus, we use same rights statement for all members, filesets don't
-                even have rights data, so. would probably be better to commicate
-                this some way other than DOM. %>
-            <% if false && work.rights_url %>
-              <div style="display: none" class="parent-rights-inline">
-                <%= render_rights_statement(work) %>
-              </div>
-            <% end %>
-            <% if false && work.public_member_presenters.size >  1 %>
-              <div style="display: none" class="parent-download-options-inline">
-                <%= safe_join(whole_work_download_options(work)) %>
-              </div>
-            <% end %>
 
             <%# will be filled by JS, from json endpoint data %>
             <%= content_tag "div", "", id:"viewer-thumbs", class: "viewer-thumbs" %>

--- a/app/views/scihist_image_viewer/_scihist_viewer_navbar.html.erb
+++ b/app/views/scihist_image_viewer/_scihist_viewer_navbar.html.erb
@@ -27,24 +27,8 @@
     Yes, this is kinda messy/hacky/non-DRY interaction/duplication with the DownloadDropdownDisplay
     ViewModel. Doesn't yet include whole-work download options. Good enough for now. %>
 
-    <div id="viewer-download" class="viewer-navbar-btn btn-group dropup viewer-download" role="group">
-      <button id="btnViewerDownload" type="button" class="btn btn-lg btn-emphasis dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" tabindex="0">
-        <i class="fa fa-download"></i> <span class="viewer-navbar-label">Download</span>
-      </button>
 
-      <div class="dropdown-menu download-menu" role="menu" aria-labelled-by="btnViewerDownload">
-
-        <% if work.rights.present? %>
-          <h3 class="dropdown-header">Rights</h3>
-          <%= RightsIconDisplay.new(work, mode: :dropdown_item).display %>
-          <div class='dropdown-divider'></div>
-        <% end %>
-
-        <h3 class="dropdown-header">Download selected image</h3>
-        <div data-slot="selected-downloads">
-        </div>
-      </div>
-    </div>
+    <%= DownloadDropdownDisplay.new(nil, display_parent_work: work, viewer_template: true).display %>
 
     <button class="viewer-navbar-btn btn btn-lg btn-emphasis viewer-fullscreen viewer-thin-btn" id="viewer-fullscreen"
             data-trigger="viewer-fullscreen" tabindex="0" title="Fullscreen" aria-label="full screen">

--- a/app/views/scihist_image_viewer/_scihist_viewer_navbar.html.erb
+++ b/app/views/scihist_image_viewer/_scihist_viewer_navbar.html.erb
@@ -22,8 +22,11 @@
         <i class="fa fa-download"></i> <span class="viewer-navbar-label">Download</span>
       </button>
 
-      <ul class="dropdown-menu download-menu" role="menu" aria-labelled-by="btnViewerDownload">
-      </ul>
+      <div class="dropdown-menu download-menu" role="menu" aria-labelled-by="btnViewerDownload">
+        <h3 class="dropdown-header">Download selected image</h3>
+        <div data-slot="selected-downloads">
+        </div>
+      </div>
     </div>
 
     <button class="viewer-navbar-btn btn btn-lg btn-emphasis viewer-fullscreen viewer-thin-btn" id="viewer-fullscreen"

--- a/app/views/scihist_image_viewer/_scihist_viewer_navbar.html.erb
+++ b/app/views/scihist_image_viewer/_scihist_viewer_navbar.html.erb
@@ -1,7 +1,10 @@
 <%# the button navbar at the bottom of the image viewer. Shouldn't really be used
     outside the image viewer, but extracted for clarity.
 
-    Many of the content areas in here are actually filled in by the viewer JS
+    Many of the content areas in here are actually filled in by the viewer JS.
+
+    Needs a 'work' local to generate fixed rights statement and whole-work download
+    options for fixed work this modal is for.
 %>
 
 <div class="viewer-navbar btn-group" role="group" aria-label="actions">
@@ -17,12 +20,26 @@
       <span data-hook="viewer-navbar-title-label"></span>
     </a>
 
+
+    <%# A download menu that has the parts fixed for a given work fixed, with a slot for JS
+    to fill in as selected thumb is changed for member-specific options.
+
+    Yes, this is kinda messy/hacky/non-DRY interaction/duplication with the DownloadDropdownDisplay
+    ViewModel. Doesn't yet include whole-work download options. Good enough for now. %>
+
     <div id="viewer-download" class="viewer-navbar-btn btn-group dropup viewer-download" role="group">
       <button id="btnViewerDownload" type="button" class="btn btn-lg btn-emphasis dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" tabindex="0">
         <i class="fa fa-download"></i> <span class="viewer-navbar-label">Download</span>
       </button>
 
       <div class="dropdown-menu download-menu" role="menu" aria-labelled-by="btnViewerDownload">
+
+        <% if work.rights.present? %>
+          <h3 class="dropdown-header">Rights</h3>
+          <%= RightsIconDisplay.new(work, mode: :dropdown_item).display %>
+          <div class='dropdown-divider'></div>
+        <% end %>
+
         <h3 class="dropdown-header">Download selected image</h3>
         <div data-slot="selected-downloads">
         </div>

--- a/app/views/works/_playlist.html.erb
+++ b/app/views/works/_playlist.html.erb
@@ -26,7 +26,7 @@
                         <i class="fa fa-play-circle" aria-hidden="true"></i>
                         <%= track.title %>
                     </a>
-                    <%= DownloadDropdownDisplay.new(track, use_link:true).display %>
+                    <%= DownloadDropdownDisplay.new(track, display_parent_work: track.parent, use_link:true).display %>
                 </li>
             <% end %>
         </ul>

--- a/spec/models/download_option_spec.rb
+++ b/spec/models/download_option_spec.rb
@@ -31,4 +31,31 @@ describe DownloadOption do
         size: 16384).subhead).to eq "JPEG — 16 KB"
     end
   end
+
+  describe "#as_json" do
+    let(:url) { "http://example.org/faked" }
+    let(:subhead) { "This is a <small>subhead</small>" }
+    let(:label) { "This is a label" }
+    let(:analyticsAction) { "click-on-something" }
+    let(:download_option) { DownloadOption.new(label, url: url, subhead: subhead, analyticsAction: analyticsAction) }
+
+    it "produces hash" do
+      expect(download_option.as_json).to match({
+        url: url,
+        subhead: subhead,
+        label: label,
+        analyticsAction: analyticsAction
+      })
+    end
+
+    it "produces string from to_json" do
+      expect(JSON.parse(download_option.to_json)).to match({
+        "url" => url,
+        "subhead" => subhead,
+        "label" => label,
+        "analyticsAction" => analyticsAction
+      })
+    end
+  end
+
 end

--- a/spec/presenters/download_dropdown_display_spec.rb
+++ b/spec/presenters/download_dropdown_display_spec.rb
@@ -123,8 +123,18 @@ describe DownloadDropdownDisplay do
 
       it "renders whole-work download options" do
         expect(div).to have_selector(".dropdown-header", text: "Download all 3 images")
-        expect(div).to have_selector(".dropdown-item", text: /ZIP/)
-        expect(div).to have_selector(".dropdown-item", text: /PDF/)
+
+        zip_option = div.at_css("a.dropdown-item:contains('ZIP')")
+        expect(zip_option).to be_present
+        expect(zip_option["data-trigger"]).to eq "on-demand-download"
+        expect(zip_option["data-derivative-type"]).to eq "zip_file"
+        expect(zip_option["data-work-id"]).to eq parent_work.friendlier_id
+
+        pdf_option = div.at_css("a.dropdown-item:contains('PDF')")
+        expect(pdf_option).to be_present
+        expect(pdf_option["data-trigger"]).to eq "on-demand-download"
+        expect(pdf_option["data-derivative-type"]).to eq "pdf_file"
+        expect(pdf_option["data-work-id"]).to eq parent_work.friendlier_id
       end
     end
 

--- a/spec/presenters/download_dropdown_display_spec.rb
+++ b/spec/presenters/download_dropdown_display_spec.rb
@@ -129,12 +129,18 @@ describe DownloadDropdownDisplay do
         expect(zip_option["data-trigger"]).to eq "on-demand-download"
         expect(zip_option["data-derivative-type"]).to eq "zip_file"
         expect(zip_option["data-work-id"]).to eq parent_work.friendlier_id
+        expect(zip_option["data-analytics-category"]).to eq "Work"
+        expect(zip_option["data-analytics-action"]).to eq "download_zip"
+        expect(zip_option["data-analytics-label"]).to eq parent_work.friendlier_id
 
         pdf_option = div.at_css("a.dropdown-item:contains('PDF')")
         expect(pdf_option).to be_present
         expect(pdf_option["data-trigger"]).to eq "on-demand-download"
         expect(pdf_option["data-derivative-type"]).to eq "pdf_file"
         expect(pdf_option["data-work-id"]).to eq parent_work.friendlier_id
+        expect(pdf_option["data-analytics-category"]).to eq "Work"
+        expect(pdf_option["data-analytics-action"]).to eq "download_pdf"
+        expect(pdf_option["data-analytics-label"]).to eq parent_work.friendlier_id
       end
     end
 

--- a/spec/presenters/download_dropdown_display_spec.rb
+++ b/spec/presenters/download_dropdown_display_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe DownloadDropdownDisplay do
-  let(:rendered) { Nokogiri::HTML.fragment(DownloadDropdownDisplay.new(asset).display) }
+  let(:rendered) { Nokogiri::HTML.fragment(DownloadDropdownDisplay.new(asset, display_parent_work: asset.parent).display) }
   let(:div) { rendered.at_css("div.action-item.downloads") }
 
   describe "no derivatives existing" do
@@ -53,6 +53,12 @@ describe DownloadDropdownDisplay do
       expect(div).to have_selector("a.dropdown-item", text: /Large JPG/)
       expect(div).to have_selector("a.dropdown-item", text: /Full-sized JPG/)
       expect(div).to have_selector("a.dropdown-item", text: /Original/)
+
+      sample_download_option = div.at_css("a.dropdown-item:contains('Large JPG')")
+      expect(sample_download_option["href"]).to be_present
+      expect(sample_download_option["data-analytics-category"]).to eq("Work")
+      expect(sample_download_option["data-analytics-action"]).to eq("download_jpg_large")
+      expect(sample_download_option["data-analytics-label"]).to eq(asset.parent.friendlier_id)
     end
   end
 

--- a/spec/presenters/download_dropdown_display_spec.rb
+++ b/spec/presenters/download_dropdown_display_spec.rb
@@ -142,6 +142,20 @@ describe DownloadDropdownDisplay do
         expect(pdf_option["data-analytics-action"]).to eq "download_pdf"
         expect(pdf_option["data-analytics-label"]).to eq parent_work.friendlier_id
       end
+
+      describe "template_only" do
+        let(:rendered) { Nokogiri::HTML.fragment(DownloadDropdownDisplay.new(nil, display_parent_work: parent_work, viewer_template: true).display) }
+
+        it "renders only slot" do
+          expect(div).to have_selector(".dropdown-header", text: "Download selected image")
+          expect(div).to have_selector('*[data-slot="selected-downloads"]')
+
+          expect(div).not_to have_selector("a.dropdown-item", text: /Small JPG/)
+          expect(div).not_to have_selector("a.dropdown-item", text: /Medium JPG/)
+          expect(div).not_to have_selector("a.dropdown-item", text: /Large JPG/)
+          expect(div).not_to have_selector("a.dropdown-item", text: /Full-sized JPG/)
+        end
+      end
     end
 
     describe "without image files" do

--- a/spec/serializers/viewer_member_info_serializer_spec.rb
+++ b/spec/serializers/viewer_member_info_serializer_spec.rb
@@ -22,6 +22,9 @@ describe ViewerMemberInfoSerializer, type: :decorator do
     expect(child_serialized[:memberShowUrl]).to eq helper.work_path(child)
     expect(child_serialized[:tileSource]).to eq child.leaf_representative.dzi_file.url
     expect(child_serialized[:fallbackTileSource]).to eq({ type: "image", url: helper.download_derivative_path(child.leaf_representative, :download_medium, disposition: "inline")})
+    expect(child_serialized[:downloads]).to be_kind_of(Array)
+    expect(child_serialized[:downloads]).to be_present
+    expect(child_serialized[:downloads].all? {|d| d[:url].present?}).to be true
 
     asset_serialized = serialized.find { |h| h[:memberId] == asset.friendlier_id }
     expect(asset_serialized).to be_present
@@ -31,5 +34,8 @@ describe ViewerMemberInfoSerializer, type: :decorator do
     expect(asset_serialized[:memberShowUrl]).to be nil
     expect(asset_serialized[:tileSource]).to eq asset.dzi_file.url
     expect(asset_serialized[:fallbackTileSource]).to eq({ type: "image", url: helper.download_derivative_path(asset, :download_medium, disposition: "inline") })
+    expect(child_serialized[:downloads]).to be_kind_of(Array)
+    expect(child_serialized[:downloads]).to be_present
+    expect(child_serialized[:downloads].all? {|d| d[:url].present?}).to be true
   end
 end


### PR DESCRIPTION
It has it's specific-item links filled in by JS for selected item, as you move around pages. 

The DownloadDropdownDisplay viewmodel was enhanced with a mode where it can provide suitable markup for this. It does make the DownloadDropdownDisplay somewhat more byzantine and weird, but it was the least terrible option I came up with (I tried a few). 

This PR also includes some fixes to properly generate data-* tags for (future) GA event tracking of download links, that were missing before.