### PR TITLE
Added check that Capistrano_roles tag exists on server, those lacking it are now skipped

### DIFF
--- a/config/deploy/lib/cap_server_autodiscover.rb
+++ b/config/deploy/lib/cap_server_autodiscover.rb
@@ -56,7 +56,8 @@ module CapServerAutodiscover
       filters: [
         {name:'instance-state-code', values:["16"]},
         {name: 'tag:Application', values: [fetch(:server_autodiscover_application)]},
-        {name: 'tag:Service_level', values: [fetch(:server_autodiscover_service_level)]}
+        {name: 'tag:Service_level', values: [fetch(:server_autodiscover_service_level)]},
+        {name: 'tag-key', values:["Capistrano_roles"]}
       ]
     })
 


### PR DESCRIPTION
Closes #280 
The changed line of tag:Service_level isn't actually changed. 