### PR TITLE
DisplayDateFormatter sorts dates

### DIFF
--- a/app/presenters/date_display_formatter.rb
+++ b/app/presenters/date_display_formatter.rb
@@ -15,7 +15,9 @@ class DateDisplayFormatter
   UNDATED = "undated"
 
   def initialize(dates_of_work)
-    @dates_for_display = dates_of_work.collect {|d| display_label(d)}
+    @dates_for_display = dates_of_work.sort_by do |date|
+      date.start || "0"
+    end.collect {|d| display_label(d)}
   end
 
   #Return an array of strings, each containing a formatted date.

--- a/spec/presenters/display_date_formatter_spec.rb
+++ b/spec/presenters/display_date_formatter_spec.rb
@@ -35,14 +35,18 @@ describe DateDisplayFormatter, type: :model do
     let(:date_array) {[
       Work::DateOfWork.new(start: "1912", start_qualifier: "century"),
       Work::DateOfWork.new(start: "1800"),
+      Work::DateOfWork.new,
       Work::DateOfWork.new(start: "1800", finish: "1900")
     ]}
 
     it "formats them all in order" do
       # should it sort them? It doesn't yet...
-      expect(DateDisplayFormatter.new(date_array).display_dates).to eq( date_array.collect { |d|
-        DateDisplayFormatter.new([d]).display_dates
-      }.flatten)
+      expect(DateDisplayFormatter.new(date_array).display_dates).to eq(
+        date_array.
+          sort_by {|d| d.start || "0" }.
+          collect { |d| DateDisplayFormatter.new([d]).display_dates}.
+          flatten
+      )
     end
   end
 end


### PR DESCRIPTION
Just by start date, a basic ordering. Since we kept noticing we wanted this in our display (and probably had it in chf_sufia I believe), and I was thinking of it, figured i'd do it.