### PR TITLE
Only create DZI for image files

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -69,8 +69,6 @@ class Asset < Kithe::Asset
     @dzi_file ||= DziFiles.new(self)
   end
 
-  after_promotion DziFiles
+  after_promotion DziFiles, if: ->(asset) { asset.content_type&.start_with?("image/") }
   after_commit DziFiles, only: [:update, :destroy]
-
-
 end


### PR DESCRIPTION
We still run DZI deletion routines for non-images on asset destroy/update. If they don't
find any existing DZI files to delete, they ought not to complain. This is simpler than
trying to figure out exactly if DZI deletion should be run, especially if an asset has
it's attached file changed from an image to a non-image. Good enough.

Closes #313