### PR TITLE
account that storage.prefix can be nil when calculating prefix to delete for cleaning up DZI on deletion

### DIFF
--- a/app/models/dzi_files.rb
+++ b/app/models/dzi_files.rb
@@ -195,7 +195,7 @@ class DziFiles
 
       @storage = storage
       @prefix = prefix
-      @total_prefix = File.join(storage.prefix, clear_prefix).to_s
+      @total_prefix = File.join(storage.prefix || "", clear_prefix).to_s
     end
 
     # copy/pasted/modifed from Shrine::Storage::S3#clear!, to let us


### PR DESCRIPTION
As it is on our production machine.

Closes #319