### PR TITLE
Fix copying of static asset pages on initial deploy

### DIFF
--- a/lib/tasks/assets_compile.rake
+++ b/lib/tasks/assets_compile.rake
@@ -32,11 +32,12 @@ namespace :scihist do
   #   https://stackoverflow.com/questions/17536023/rake-assetsprecompilenodigest-in-rails-4/26049002
   task :create_non_digest_assets => :"assets:environment"  do
     %w{404.html 500.html}.each do |file|
-      digest_relative_path = Rails.application.assets_manifest.assets[file]
-      digest_path          = Rails.root + 'public/assets' + digest_relative_path
-      destination_path     = Rails.root + 'public/' + file
+      digest_relative_path = Rails.application.assets.find_asset("404.html")&.digest_path
 
       if digest_relative_path
+        digest_path          = Rails.root + 'public/assets' + digest_relative_path
+        destination_path     = Rails.root + 'public/' + file
+
         logger.info "(Local asset_compile.rake) Copying to #{destination_path}"
 
         # Use FileUtils.copy_file with true third argument to copy


### PR DESCRIPTION
We have a custom extension to rake assets:precompile that copies our statically compiled error html pages to un-fingerprinted (eg) public/404.html, so it'll be used by Rails.

I believe the routine for looking up the sprockets-compiled digest-named error pages was using a cached value and finding the one compiled _previous_ to this deploy. So it was the wrong one if there were changes in this deploy. And on _first_ deploy to a new server, it was nil, which also produced an uncaught exception with it not expected to be nil.

Rooting around in the sprockets and rails source, I found a different way of looking up compiled asset path. Which seems to find the right current one, not previous one. It is not nil even on initial deploy, so can work on initial deploy.

I also fixed source so if it _can't_ find it, it fails gracefully with an error message instead of halting deploy. Which it was meant to do all along, but it had tried to access the `digest_relative_path` variable prior to the conditional that checked for it being set. That is now fixed.

Closes #336