### PR TITLE
DownloadDropdownDisplay no longer uses derivative models.

### DIFF
--- a/app/presenters/download_dropdown_display.rb
+++ b/app/presenters/download_dropdown_display.rb
@@ -84,6 +84,7 @@ class DownloadDropdownDisplay < ViewModel
     end
   end
 
+
   private
 
   def viewer_template_mode?
@@ -221,6 +222,7 @@ class DownloadDropdownDisplay < ViewModel
       url: download_path(asset),
       analyticsAction: "download_original",
       content_type: asset.content_type,
+      size: asset.size,
       width: asset.width,
       height: asset.height)
   end

--- a/app/presenters/download_dropdown_display.rb
+++ b/app/presenters/download_dropdown_display.rb
@@ -106,9 +106,12 @@ class DownloadDropdownDisplay < ViewModel
   def asset_download_options
     @asset_download_options ||= if asset&.content_type&.start_with?("audio/")
       DownloadOptions::AudioDownloadOptions.new(asset).options
-    else
+    elsif asset&.content_type&.start_with?("image/")
       DownloadOptions::ImageDownloadOptions.new(asset).options
-   end
+    elsif asset.stored?
+      # only original
+      [original_download_option]
+    end
   end
 
   def menu_button_id
@@ -211,6 +214,15 @@ class DownloadDropdownDisplay < ViewModel
     display_parent_work &&
     display_parent_work.members.size > 1 &&
     display_parent_work.member_content_types.all? {|t| t.start_with?("image/")}
+  end
+
+  def original_download_option
+    DownloadOption.with_formatted_subhead("Original file",
+      url: download_path(asset),
+      analyticsAction: "download_original",
+      content_type: asset.content_type,
+      width: asset.width,
+      height: asset.height)
   end
 
   def whole_work_download_options

--- a/app/presenters/download_dropdown_display.rb
+++ b/app/presenters/download_dropdown_display.rb
@@ -18,16 +18,16 @@
 # of images), and will have it's `members` and their leaf_representatives accessed,
 # so should have them pre-loaded to avoid n+1 queries if needed.
 #
-# ## Preloading required
+# ## Not currently using actual derivative models
 #
-# Uses leaf_representative and it's derivatives, as well as #parent.
-# So these should be pre-loaded with Rails eager-loading if you're going to be displaying a bunch of these,
-# as you usually are.
+# For performance reasons, we are avoiding referencing actual derivative models here. (Performance: fetching
+# them, but even more so seems to be accessing shrine-json metadata. This may be a performance problem
+# fixed in shrine 3.0). So we are unable to provide file sizes of derivatives for UI, or to base
+# our logic on whether derivatives actually exist (we supply download links appropriate for content
+# type regardless).
 #
-# Current code decides what options to display based on derivatives *actually existing*, to avoid
-# providing an option that can't be delivered. That does mean it needs info from the db on what derivs
-# exist though. (It also uses metadata on the existing deriv records to provide nice info on the dl
-# link on file size/dimensions/etc.)
+# But it should not be necessary to eager load any assoications on the models passed in, no associations
+# are used.
 #
 # ## Viewer-template mode
 #

--- a/app/presenters/download_options/audio_download_options.rb
+++ b/app/presenters/download_options/audio_download_options.rb
@@ -10,16 +10,17 @@ module DownloadOptions
     def options
       options = []
 
+      # We generate derivative links without actually checking for derivative presence,
+      # because it is much more efficient. We don't have derivative info though,
+      # so can't include file size,
+
       # We don't use content_type in derivative option subheads,
       # cause it's in the main label. But do use it for original.
 
-      if mp3_deriv = asset.derivative_for(:small_mp3)
-        options << DownloadOption.with_formatted_subhead("Optimized MP3",
-          url: download_derivative_path(asset, :small_mp3),
-          analyticsAction: "download_optimized_mp3",
-          size: mp3_deriv.size
-        )
-      end
+      options << DownloadOption.with_formatted_subhead("Optimized MP3",
+        url: download_derivative_path(asset, :small_mp3),
+        analyticsAction: "download_optimized_mp3"
+      )
 
       if asset.stored?
         options << DownloadOption.with_formatted_subhead("Original file",

--- a/app/presenters/download_options/image_download_options.rb
+++ b/app/presenters/download_options/image_download_options.rb
@@ -53,8 +53,7 @@ module DownloadOptions
           analyticsAction: "download_original",
           content_type: asset.content_type,
           width: asset.width,
-          height: asset.height,
-          size: asset.size
+          height: asset.height
         )
       end
 

--- a/app/presenters/download_options/image_download_options.rb
+++ b/app/presenters/download_options/image_download_options.rb
@@ -1,12 +1,7 @@
 module DownloadOptions
   # Various resized JPG options for a single Asset of type "image/"
   #
-  # It actually checks that a derivative EXISTS before adding it to the options.
-  #
-  # Thus, we can actually use this for producing download options for PDFs too -- none
-  # of the jpg download derivatives will exist, so they won't be included, and it'll just
-  # add an 'original' link. Or for any other type that won't have standard image dl derivs,
-  # and we only want an 'original' option.
+  # It does NOT check that a derivative EXISTS before adding it to the options.
   class ImageDownloadOptions < ViewModel
     alias_method :asset, :model
 
@@ -20,45 +15,37 @@ module DownloadOptions
       # We don't use content_type in derivative option subheads,
       # cause it's in the main label. But do use it for original.
 
-      if dl_small = asset.derivative_for(:download_small)
-        options << DownloadOption.with_formatted_subhead("Small JPG",
-          url: download_derivative_path(asset, :download_small),
-          analyticsAction: "download_jpg_small",
-          width: dl_small.width,
-          height: dl_small.height,
-          size: dl_small.size
-        )
-      end
+      # We generate derivative links without actually checking for derivative presence,
+      # because it is much more efficient. We don't have derivative info though,
+      # so can't include file size, and have to estimate calculate width and height.
 
-      if dl_medium = asset.derivative_for(:download_medium)
-        options << DownloadOption.with_formatted_subhead("Medium JPG",
-          url: download_derivative_path(asset, :download_medium),
-          analyticsAction: "download_jpg_medium",
-          width: dl_medium.width,
-          height: dl_medium.height,
-          size: dl_medium.size
-        )
-      end
+      options << DownloadOption.with_formatted_subhead("Small JPG",
+        url: download_derivative_path(asset, :download_small),
+        analyticsAction: "download_jpg_small",
+        width: width_for(:small),
+        height: height_for(:small)
+      )
 
-      if dl_large = asset.derivative_for(:download_large)
-        options << DownloadOption.with_formatted_subhead("Large JPG",
-          url: download_derivative_path(asset, :download_large),
-          analyticsAction: "download_jpg_large",
-          width: dl_large.width,
-          height: dl_large.height,
-          size: dl_large.size
-        )
-      end
+      options << DownloadOption.with_formatted_subhead("Medium JPG",
+        url: download_derivative_path(asset, :download_medium),
+        analyticsAction: "download_jpg_medium",
+        width: width_for(:medium),
+        height: height_for(:medium)
+      )
 
-      if dl_full = asset.derivative_for(:download_full)
-        options << DownloadOption.with_formatted_subhead("Full-sized JPG",
-          url: download_derivative_path(asset, :download_full),
-          analyticsAction: "download_jpg_full",
-          width: dl_full.width,
-          height: dl_full.height,
-          size: dl_full.size
-        )
-      end
+      options << DownloadOption.with_formatted_subhead("Large JPG",
+        url: download_derivative_path(asset, :download_large),
+        analyticsAction: "download_jpg_large",
+        width: width_for(:large),
+        height: height_for(:large)
+      )
+
+      options << DownloadOption.with_formatted_subhead("Full-sized JPG",
+        url: download_derivative_path(asset, :download_full),
+        analyticsAction: "download_jpg_full",
+        width: asset.width,
+        height: asset.height
+      )
 
       if asset.stored?
         options << DownloadOption.with_formatted_subhead("Original file",
@@ -74,5 +61,15 @@ module DownloadOptions
       return options
     end
 
+    private
+
+    def width_for(download_size)
+      Asset::IMAGE_DOWNLOAD_WIDTHS[download_size]
+    end
+
+    def height_for(download_size)
+      # calc from aspect ratio
+      ((asset.height.to_f / asset.width.to_f) * width_for(download_size)).round
+    end
   end
 end

--- a/spec/presenters/download_dropdown_display_spec.rb
+++ b/spec/presenters/download_dropdown_display_spec.rb
@@ -4,33 +4,6 @@ describe DownloadDropdownDisplay do
   let(:rendered) { Nokogiri::HTML.fragment(DownloadDropdownDisplay.new(asset, display_parent_work: asset.parent).display) }
   let(:div) { rendered.at_css("div.action-item.downloads") }
 
-  describe "no derivatives existing" do
-    let(:asset) do
-      create(:asset_with_faked_file,
-            faked_derivatives: [],
-            parent: build(:work, rights: "http://creativecommons.org/publicdomain/mark/1.0/")
-      )
-    end
-
-    it "renders" do
-      expect(div).to be_present
-
-      ul = div.at_css("div.dropdown-menu.download-menu")
-      expect(ul).to be_present
-
-      expect(ul).to have_selector("h3.dropdown-header", text: "Rights")
-      expect(ul).to have_selector("a.rights-statement.dropdown-item", text: /Public Domain/)
-
-      expect(div).to have_selector(".dropdown-header", text: "Download selected image")
-      expect(div).to have_selector("a.dropdown-item", text: /Original/)
-
-      expect(div).not_to have_selector("a.dropdown-item", text: /Small JPG/)
-      expect(div).not_to have_selector("a.dropdown-item", text: /Medium JPG/)
-      expect(div).not_to have_selector("a.dropdown-item", text: /Large JPG/)
-      expect(div).not_to have_selector("a.dropdown-item", text: /Full-sized JPG/)
-    end
-  end
-
   describe "with image file and derivatives" do
     let(:asset) do
       create(:asset_with_faked_file,
@@ -188,6 +161,35 @@ describe DownloadDropdownDisplay do
     let(:asset) { build(:asset) }
     it "renders without error" do
       expect(div).to be_present
+    end
+  end
+
+  # NOT currently supported, skipping tests. We stopped using fetched derivative records
+  # when deciding what download links to display.
+  xdescribe "no derivatives existing" do
+    let(:asset) do
+      create(:asset_with_faked_file,
+            faked_derivatives: [],
+            parent: build(:work, rights: "http://creativecommons.org/publicdomain/mark/1.0/")
+      )
+    end
+
+    it "renders" do
+      expect(div).to be_present
+
+      ul = div.at_css("div.dropdown-menu.download-menu")
+      expect(ul).to be_present
+
+      expect(ul).to have_selector("h3.dropdown-header", text: "Rights")
+      expect(ul).to have_selector("a.rights-statement.dropdown-item", text: /Public Domain/)
+
+      expect(div).to have_selector(".dropdown-header", text: "Download selected image")
+      expect(div).to have_selector("a.dropdown-item", text: /Original/)
+
+      expect(div).not_to have_selector("a.dropdown-item", text: /Small JPG/)
+      expect(div).not_to have_selector("a.dropdown-item", text: /Medium JPG/)
+      expect(div).not_to have_selector("a.dropdown-item", text: /Large JPG/)
+      expect(div).not_to have_selector("a.dropdown-item", text: /Full-sized JPG/)
     end
   end
 end


### PR DESCRIPTION
Instead it just creates blind links based on what derivatives it knows ought to exist for a given content type.

This means we can no longer supply file size of download to user with link (we would get that from deriv model). It also means we no longer check to make sure a derivative really exists before making download link -- if a user clicks on a download link for a deriv that doesn't actually exist, they'll just get a 404. These should be the only UI changes/degradatins.

This is an attempt at performance improvement. Accessing shrine json metadata (for file size, width, and height) seems to be a mysteriously expensive operation (may be fixed in shrine 2).

It also means that as far as DownloadDropdownDisplay is concerned, we COULD stop fetching/pre-loading derivative models at all. Which would be additional performance improvements. At present we are still preload fetching them for use as thumbnail src though. We will benchmark how much of an improvement we get from this step, without that.

ref: #296