### PR TITLE
update slackistrano gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem "uppy-s3_multipart"
 gem "content_disposition", "~> 1.0"
 
 # slack notifications on capistrano deploys
-gem 'slackistrano', "~> 3.8"
+gem 'slackistrano', "~> 4.0"
 gem "whenever" # automatic crontob maintenance, on capistrano deploys
 
 gem "ransack", "~> 2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -640,7 +640,7 @@ GEM
       tilt (~> 2.0)
     sitemap_generator (6.0.2)
       builder (~> 3.0)
-    slackistrano (3.8.3)
+    slackistrano (4.0.1)
       capistrano (>= 3.8.1)
     slop (3.6.0)
     solr_wrapper (2.1.0)
@@ -795,7 +795,7 @@ DEPENDENCIES
   shrine (~> 2.0)
   simple_form (~> 4.0)
   sitemap_generator (~> 6.0)
-  slackistrano (~> 3.8)
+  slackistrano (~> 4.0)
   solr_wrapper (~> 2.1)
   sprockets-rails (>= 2.3.2)
   tzinfo-data

--- a/lib/scihist_digicoll/slackistrano_messaging.rb
+++ b/lib/scihist_digicoll/slackistrano_messaging.rb
@@ -27,7 +27,7 @@ if defined?(Slackistrano::Messaging)
             payload[:attachments] ||= []
             payload[:attachments] << {
                 title: "Github Diff",
-                title_link: "https://github.com/chemheritage/chf-sufia/compare/#{CGI.escape previous}...#{CGI.escape current}",
+                title_link: "https://github.com/sciencehistory/scihist_digicoll/compare/#{CGI.escape previous}...#{CGI.escape current}",
                 short: false
               }
           end


### PR DESCRIPTION
Slack updates from capistrano. Just because why not, and we had a mysterious warning message from the old version we're hoping to be rid of.

And fix URL for github diff compare. It was old chf_sufia url.