### PR TITLE
Additional search filters for Admin Work search

### DIFF
--- a/app/assets/stylesheets/local/admin/admin.scss
+++ b/app/assets/stylesheets/local/admin/admin.scss
@@ -3,3 +3,17 @@ dl.admin-metadata {
     @extend .ml-3;
   }
 }
+
+.admin-filter {
+  display: inline-block;
+  margin-right: 1rem;
+  margin-bottom: 1rem;
+
+  label {
+    display: block;
+  }
+  .custom-select {
+    max-width: 10em;
+    width: auto;
+  }
+}

--- a/app/views/admin/works/index.html.erb
+++ b/app/views/admin/works/index.html.erb
@@ -13,16 +13,54 @@
         <%= f.label :title_or_friendlier_id_cont, "In Title or ID", class: "input-group-text" %>
       </div>
       <%= f.search_field :title_or_friendlier_id_cont, class: "form-control" %>
-      <%= select_tag "q[parent_id_null]",
-            options_for_select({"All" => "", "No Children" => true}, params[:q][:parent_id_null]),
-            class: "custom-select col-3"
-      %>
       <div class="input-group-append">
         <%= f.button "Search", class: "btn btn-primary" %>
       </div>
     </div>
   </div>
 
+  <div class="admin-filters">
+    <div class="admin-filter">
+      <label for="q_published">Published</label>
+      <%= select_tag "q[published_eq]",
+            options_for_select({"Yes" => true, "No" => false}, params[:q][:published_eq]),
+            include_blank: "Any",
+            class: "custom-select" %>
+    </div>
+
+    <div class="admin-filter">
+      <label for="q_genre">Genre</label>
+      <%= select_tag "q[genre]",
+            options_for_select(Work::ControlledLists::GENRE, params[:q][:genre]),
+            include_blank: "Any",
+            class: "custom-select" %>
+    </div>
+
+
+    <div class="admin-filter">
+        <label for="q_format">Format</label>
+        <%= select_tag "q[format]",
+              options_for_select(Work::ControlledLists::FORMAT.collect {|t| [t.titleize, t]}, params[:q][:format]),
+              include_blank: "Any",
+              class: "custom-select" %>
+    </div>
+
+    <div class="admin-filter">
+        <label for="q_department">Department</label>
+        <%= select_tag "q[department]",
+              options_for_select(Work::ControlledLists::DEPARTMENT, params[:q][:department]),
+              include_blank: "Any",
+              class: "custom-select" %>
+    </div>
+
+    <div class="admin-filter">
+      <label for="q_parent_id_null">Child Works In Results</label>
+      <%= select_tag "q[parent_id_null]",
+            options_for_select({"Yes" => "", "No" => true}, params[:q][:parent_id_null]),
+            class: "custom-select"
+      %>
+    </div>
+  </div>
 <% end %>
 
 

--- a/db/migrate/20190910160148_sane_published_boolean.rb
+++ b/db/migrate/20190910160148_sane_published_boolean.rb
@@ -1,0 +1,12 @@
+# https://thoughtbot.com/blog/avoid-the-threestate-boolean-problem
+# Make pubilished column default false and not accept null
+class SanePublishedBoolean < ActiveRecord::Migration[5.2]
+  def up
+    change_column_default :kithe_models, :published, false
+    change_column_null :kithe_models, :published, false, false
+  end
+  def down
+   change_column_default :kithe_models, :published, nil
+   change_column_null :kithe_models, :published, true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -202,7 +202,7 @@ CREATE TABLE public.kithe_models (
     representative_id uuid,
     leaf_representative_id uuid,
     digitization_queue_item_id bigint,
-    published boolean,
+    published boolean DEFAULT false NOT NULL,
     kithe_model_type integer NOT NULL
 );
 
@@ -679,6 +679,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190305202051'),
 ('20190404155001'),
 ('20190422201311'),
-('20190716180327');
+('20190716180327'),
+('20190910160148');
 
 


### PR DESCRIPTION
1. I noticed that while our 'published' column is a postgres boolean, we were allowing SQL "null" values, so it was actually a tri-valued field. Which made things confusing in querying. Added a migration to not allow nulls, and default false. (Changing any existing nulls in db to false). 

2. Add on UI elements and logic for limiting by additional fields. Since some of the additional fields are inside our JSON, we use specialty postgres json operators in constructing our SQL conditions. (Especially odd for things like genre, where we're looking for one field in a JSON _array_ at a certain path). We had been using a gem called "ransack" to construct the query based on UI choices with little code (including supporting the sort-by-column-of-choice controls really easily), but it doesn't do custom JSON operators well. So now it's a weird frankenstein combo, but it owrks. (Looked at removing ransack entirely, wasn't worth rewriting everything that would have to be rewritten I don't think). 

3. I am not sure if these postgres JSON-operartor queries are actually using PG indexes, or just scanning all rows. I think probably scanning. There are ways to set up PG indexes for such queries, but I don't think we've done them. However, with the actual size of our db, the searches still tested quite fast enough on staging, so good enough for now. 

4. Not sure if this UI will end up confusing for staff users, we'll have to see.

![Screenshot 2019-09-10 16 33 53](https://user-images.githubusercontent.com/149304/64648396-cdcabc80-d3e8-11e9-819c-150c5d4bd45a.png)

Closes #342 