### PR TITLE
We weren't actually properly creating faked/mocked/quicker Shrine::UploadedFiles in test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/sciencehistory/kithe.git
-  revision: 28b237e5cc77b0bd7a0d997b48ea0003b76c57c1
+  revision: d6c1c8654cc74cf3722ee358f5fdeb5853f63ed5
   specs:
     kithe (0.3.0)
       attr_json (< 2.0.0)
@@ -675,7 +675,7 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
-    traject (3.1.0)
+    traject (3.2.0)
       concurrent-ruby (>= 0.8.0)
       dot-properties (>= 0.1.1)
       hashie (~> 3.1)

--- a/spec/factories/asset_factory.rb
+++ b/spec/factories/asset_factory.rb
@@ -97,7 +97,7 @@ FactoryBot.define do
           md5: evaluator.faked_md5,
           sha512: evaluator.faked_sha512)
 
-        asset.file_data = uploaded_file.to_json
+        asset.file_data = uploaded_file.as_json
 
         # Now add derivatives for any that work for our faked file type
         if evaluator.faked_derivatives.nil?


### PR DESCRIPTION
Fixing that revealed a conflict with kithe, where we were trying to create derivatives in tests in a hacky but quicker way, but kithe was deciding to delete the derivatives attached pre-promotion after the file was promoted (on the theory that the original had changed, so derivatives were no longer applicable). Updated to a newer kithe that has a fix to allow us to do what we wanted: https://github.com/sciencehistory/kithe/pull/63