### PR TITLE
fix DZI deletion when shrine S3 storage has no prefix

### DIFF
--- a/app/models/dzi_files.rb
+++ b/app/models/dzi_files.rb
@@ -195,7 +195,7 @@ class DziFiles
 
       @storage = storage
       @prefix = prefix
-      @total_prefix = File.join(storage.prefix || "", clear_prefix).to_s
+      @total_prefix = File.join([storage.prefix, clear_prefix].compact).to_s
     end
 
     # copy/pasted/modifed from Shrine::Storage::S3#clear!, to let us


### PR DESCRIPTION
In dev, even with S3, we usually use prefixes set on shrine S3 storage. In production, we do not. Our code for figuring out the prefix to delete to clean up DZI tiles for a deleted asset was broken if no prefix.

One of the downsides of using even slightly different config in dev and prod, alas. but we don't want all those buckets in dev, one per each dev too. Oh well.

Probably should be tested, but can't figure out a good way to test it, so just fixing without a test sorry.

Closes #341 thanks to @sanfordd for finding the bug.