### PR TITLE
Fixity rake task fixes

### DIFF
--- a/lib/scihist_digicoll/assets_needing_fixity_checks.rb
+++ b/lib/scihist_digicoll/assets_needing_fixity_checks.rb
@@ -38,7 +38,7 @@ module ScihistDigicoll
     end
 
     def expected_num_to_check
-      @expected_num_to_check ||= Asset.count / cycle_length
+      @expected_num_to_check ||= (cycle_length == 0 ? Asset.count : Asset.count / cycle_length)
     end
 
     private

--- a/lib/tasks/check_fixity.rake
+++ b/lib/tasks/check_fixity.rake
@@ -5,19 +5,19 @@ namespace :scihist do
   Checks the fixity of some or all Assets in the database.
 
   To check only a subset today, checking all every 7 days:
-    bundle exec rake scihist_digicoll:check_and_prune_fixity
+    bundle exec rake scihist_digicoll:check_fixity
 
   To run a full check of all assets with stored files:
-    CYCLE_LENGTH=0 bundle exec rake scihist_digicoll:check_and_prune_fixity
+    CYCLE_LENGTH=0 bundle exec rake scihist_digicoll:check_fixity
 
   To check 1/30th today instea dof 1/7th, checking all every 30 days:
-    CYCLE_LENGTH=30 bundle exec rake scihist_digicoll:check_and_prune_fixity
+    CYCLE_LENGTH=30 bundle exec rake scihist_digicoll:check_fixity
 
   To run checks, but leave stale checks around without pruning them:
-    SKIP_PRUNE='true'  bundle exec rake scihist_digicoll:check_and_prune_fixity
+    SKIP_PRUNE='true'  bundle exec rake scihist_digicoll:check_fixity
 
   To just prune stale checks, without checking any assets:
-    SKIP_CHECK='true'  bundle exec rake scihist_digicoll:check_and_prune_fixity
+    SKIP_CHECK='true'  bundle exec rake scihist_digicoll:check_fixity
 
   For a progress bar, preface any of these with
     SHOW_PROGRESS_BAR='true'
@@ -25,7 +25,7 @@ namespace :scihist do
   """
 
   task :check_fixity => :environment do
-    cycle_length = ENV['CYCLE_LENGTH']|| 7
+    cycle_length = ENV['CYCLE_LENGTH'].nil? ? 7 : Integer(ENV['CYCLE_LENGTH'])
 
     check_lister = ScihistDigicoll::AssetsNeedingFixityChecks.new(cycle_length)
 


### PR DESCRIPTION
 - Convert `cycle_length` ENV argument to integer at the beginning of the rake task
 - fixed documentation to conform to renamed task name
 - expected_num_to_check shouldn't divide by zero