### PR TITLE
keep old query URLs working on new app

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -353,7 +353,6 @@ class CatalogController < ApplicationController
     "system_modified_dtsi asc" => "date_modified_asc"
   }
 
-  # TODO date?
   LEGACY_FACET_REDIRECTS = {
     "subject_sim" => "subject_facet",
     "maker_facet_sim" => "creator_facet",

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -353,10 +353,35 @@ class CatalogController < ApplicationController
     "system_modified_dtsi asc" => "date_modified_asc"
   }
 
+  # TODO date?
+  LEGACY_FACET_REDIRECTS = {
+    "subject_sim" => "subject_facet",
+    "maker_facet_sim" => "creator_facet",
+    "genre_string_sim" => "genre_facet",
+    "resource_type_sim" => "format_facet",
+    "medium_sim" => "medium_facet",
+    "place_facet_sim" => "place_facet",
+    "language_sim" => "language_facet",
+    "rights_sim" => "rights_facet",
+    "division_sim" => "department_facet",
+    "exhibition_sim" => "exhibition_facet"
+  }
+
 
   def redirect_legacy_query_urls
+    corrected_params = {}
+
+    if params[:f].respond_to?(:keys) && params[:f].keys.any? { |k| LEGACY_FACET_REDIRECTS.keys.include?(k.to_s) }
+      # to_unsafe_h should be fine here, arbitrary :f params for facet limiting are expected and not a vulnerability.
+      corrected_params[:f] = params[:f].transform_keys { |k| LEGACY_FACET_REDIRECTS[k.to_s] || k }.to_unsafe_h
+    end
+
     if new_sort = LEGACY_SORT_REDIRECTS[params[:sort]]
-      redirect_to helpers.safe_params_merge_url(sort: new_sort)
+      corrected_params[:sort] = new_sort
+    end
+
+    if corrected_params.present?
+      redirect_to helpers.safe_params_merge_url(corrected_params)
     end
   end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -3,6 +3,7 @@
 require 'kithe/blacklight_tools/bulk_loading_search_service'
 
 class CatalogController < ApplicationController
+  before_action :redirect_legacy_query_urls, only: :index
 
   include BlacklightRangeLimit::ControllerOverride
   # Blacklight wanted Blacklight::Controller included in ApplicationController,
@@ -340,5 +341,22 @@ class CatalogController < ApplicationController
     # if the name of the solr.SuggestComponent provided in your solrcongig.xml is not the
     # default 'mySuggester', uncomment and provide it below
     # config.autocomplete_suggester = 'mySuggester'
+  end
+
+  LEGACY_SORT_REDIRECTS = {
+    "latest_year desc" => "newest_date",
+    "earliest_year asc" => "oldest_date",
+    "score desc, system_create_dtsi desc" => "relevance",
+    "system_create_dtsi desc" => "recently_added",
+    "system_create_dtsi asc" => "oldest_added",
+    "system_modified_dtsi desc" => "date_modified_desc",
+    "system_modified_dtsi asc" => "date_modified_asc"
+  }
+
+
+  def redirect_legacy_query_urls
+    if new_sort = LEGACY_SORT_REDIRECTS[params[:sort]]
+      redirect_to helpers.safe_params_merge_url(sort: new_sort)
+    end
   end
 end

--- a/app/helpers/safe_params_merge_helper.rb
+++ b/app/helpers/safe_params_merge_helper.rb
@@ -1,0 +1,28 @@
+module SafeParamsMergeHelper
+
+  # sometimes we want to take the current Rails action, and change just a handful
+  # of params in it, to link or redirect.
+  #
+  # This is surprisingly hard to do in a secure way, because if the query params
+  # have, say, a `host` key, that can end up being an argument sent to `url_for`,
+  # allowing the user to change the hosts in your urls. Or if sending to `redirect_to`,
+  # a `notice` param in the query params could let the user set flash notice!
+  #
+  # For this reason, rails will warn you if you just try to do eg
+  # `redirect_to params.merge(something: "else"). Rails really wants
+  # you to _whitelist_ anything you want preserved from incoming params. But
+  # sometimes, especially with Blacklight, we really do want to safely take
+  # "all" the incoming params (including ones set from the path by routing!),
+  # but with some changed.
+  #
+  # This is an attempt to do so safely, by insisting on `only_path: true`
+  # so host/protocol/etc params will be ignored, and returning a String
+  # (So it can't have params interepted as args if passed to redirect_to).
+  # Hopefully it works.
+  #
+  # @example in view safe_params_merge_url(sort: "new_sort")
+  # @example in controller you can use helpers.safe_params_merge_url(sort: "new_sort")
+  def safe_params_merge_url(to_be_merged)
+    url_for(params.to_unsafe_h.merge(to_be_merged.merge(only_path: true)))
+  end
+end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -6,11 +6,24 @@ RSpec.describe CatalogController, solr: true, type: :controller do
       let(:legacy_sort) { "system_create_dtsi desc" }
       let(:new_sort) { "recently_added" }
 
-      let(:base_params) { { q: "some search", search_field: "all_fields" } }
+      let(:legacy_facets) do
+        {
+          subject_sim: ["subject"],
+          rights_sim: ["http://creativecommons.org/publicdomain/mark/1.0/"]
+        }
+      end
+      let(:new_facets) do
+        {
+          subject_facet: ["subject"],
+          rights_facet: ["http://creativecommons.org/publicdomain/mark/1.0/"]
+        }
+      end
+
+      let(:base_params) { { q: "some search", arbitrary_thing_to_preserve: "value", search_field: "all_fields" } }
 
       it "redirects" do
-        get :index, params: base_params.merge(sort: legacy_sort)
-        expect(response).to redirect_to(search_catalog_path(base_params.merge(sort: new_sort)))
+        get :index, params: base_params.merge(sort: legacy_sort, f: legacy_facets)
+        expect(response).to redirect_to(search_catalog_path(base_params.merge(sort: new_sort, f: new_facets)))
       end
     end
   end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe CatalogController, solr: true, type: :controller do
+  describe "redirects searches with legacy params", solr: false do
+    describe "sort" do
+      let(:legacy_sort) { "system_create_dtsi desc" }
+      let(:new_sort) { "recently_added" }
+
+      let(:base_params) { { q: "some search", search_field: "all_fields" } }
+
+      it "redirects" do
+        get :index, params: base_params.merge(sort: legacy_sort)
+        expect(response).to redirect_to(search_catalog_path(base_params.merge(sort: new_sort)))
+      end
+    end
+  end
+end

--- a/spec/controllers/collection_show_controller_spec.rb
+++ b/spec/controllers/collection_show_controller_spec.rb
@@ -21,4 +21,21 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
       end
     end
   end
+
+  describe "redirects searches with legacy params", solr: false do
+    let(:collection_id) { "faked" }
+    describe "sort" do
+      let(:legacy_sort) { "system_create_dtsi desc" }
+      let(:new_sort) { "recently_added" }
+
+      let(:base_params) { { collection_id: collection_id, q: "some search", search_field: "all_fields" } }
+
+      it "redirects" do
+        get :index, params: base_params.merge(sort: legacy_sort)
+        expect(response).to redirect_to(collection_path(base_params.merge(sort: new_sort)))
+      end
+    end
+  end
+
+
 end


### PR DESCRIPTION
Blacklight query URLs by default include literal solr field names in the URL for facet fields and sort fields. That ties your URLs to your Solr implementaton in a way that makes it hard to keep them working -- especially since Blacklight's solr field naming schema embeds the solr field type in the field name, but best practices for types change.

In the new app, they indeed changed. In this PR, we change BL configuration to keep solr field name out of URLs for sorting. For facets, the field names are still in the URLs, but we have chosen more 'generic' solr field names, like 'subject_facet'. 

And this PR also catches all the old URLs and redirects them with HTTP status 301 moved permanently.

[Cool URIs don't change](https://www.w3.org/Provider/Style/URI.html)

Bonus: Working for searches on a Collection page too (within a collection), by virtue of CollectionShowController inheriting from CatalogController. (Although the first implementation I had of transforming query params didn't work, didn't preserve the :collection_id that is in the URL _path_). 

Closes #135 