### PR TITLE
"capistrano tasks for ssh to a jobs server

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -86,6 +86,31 @@ desc "list auto-disocvered EC2 servers"
 task :list_ec2_servers
 
 
+# https://stuff-things.net/2017/03/22/capistrano-ssh/
+desc "ssh to a jobs server"
+task :jobs_ssh do
+  on primary(:jobs) do |host|
+    command = "cd #{fetch(:deploy_to)}/current && exec $SHELL -l"
+    ssh_command = "ssh -l #{host.user} #{host.hostname} -p #{host.port || 22} -t '#{command}'"
+    puts ssh_command # if fetch(:log_level) == :debug
+    exec ssh_command
+  end
+end
+
+namespace :jobs_ssh do
+  desc "ssh to a jobs server and open up a rails console"
+  task :console do
+    on primary(:jobs) do |host|
+      command = "hostname && echo && cd #{fetch(:deploy_to)}/current && bundle exec rails console -e #{fetch(:rails_env)}"
+      ssh_command = "ssh -l #{host.user} #{host.hostname} -p #{host.port || 22} -t '#{command}'"
+      puts ssh_command
+      puts
+      exec ssh_command
+    end
+  end
+end
+
+
 namespace :deploy do
 
   # For cap deploy to notify slack:


### PR DESCRIPTION
    $ cap staging jobs_ssh

Opens up an ssh session on a jobs server (an arbitrary one if there are more than one, in our current setup. Technically the "first" one listed, but that's arbitrary. Or one listed to cap with "primary: true" but we don't do that. `cd`s into app `current` dir.

    $ cap production jobs_ssh:console

Opens up an ssh session which has you cd'd into app current dir AND drop you right into `rails console`. (Exiting rails console will immediately exit your ssh session). Also outputs the hostname to terminal before opening up rails console, since you won't get the hostname in the shell prompt, to try and avoid confusion on wrong host staging/production.

This is convenient with our "auto-discover" EC2 hostnames that have only numeric IPs, cause it avoids you having to look up "Wait, what's the IP of a current jobs server" to ssh there.

In an ideal world, we wouldn't manually ssh to deploy servers much/at all, but we still do plenty at present so don't need to pretend we don't. :)

Both of these tasks ssh in as `digcol` user (ie, the ordinary capistrano deploy user). Rather than using our personal accounts. I think that's actually fine? But if we wanted to, we could make it take an arg (actually an ENV variable) for specifying user, and or automatically trying the same user as your local `username`.

Curious to have @sanfordd's review of this approach.

Implementation taken from hints at https://stuff-things.net/2017/03/22/capistrano-ssh/

May make #367 irrelevant, if we mostly end up using this instead of manual ssh.