### PR TITLE
Tweaks to individual-asset fixity check report

### DIFF
--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -3,9 +3,9 @@ class Admin::AssetsController < AdminController
   def show
     @asset = Asset.find_by_friendlier_id!(params[:id])
     if @asset.stored?
-      @checks = @asset.fixity_checks.order('created_at desc')
-      @latest_check   = @checks.first
-      @earliest_check = @checks.last
+      @checks = @asset.fixity_checks.order('created_at asc')
+      @latest_check   = @checks.last
+      @earliest_check = @checks.first
     end
   end
 

--- a/app/models/fixity_check.rb
+++ b/app/models/fixity_check.rb
@@ -38,13 +38,15 @@ class FixityCheck < ApplicationRecord
   private
 
   # returns false if we do not think checked_uri looks like S3.
-  # (If we later use a custon CNAME for S3 buckets, may have to adjust this!)
+  # (NOTE If we later use a custon CNAME for S3 buckets, may have to adjust this, it assumes
+  # it can recognize S3 as *.s3.amazonaws.com)
   #
   # returns a hash with keys :bucket, :key_path, :end_path
   # Used for #checked_uri_in_s3_console to link admins directly to a AWS S3 console.
-  #
   def checked_uri_on_s3_components
     parsed = URI.parse(checked_uri)
+
+    return false unless parsed.host
 
     host_parts = parsed.host.split(".")
     if host_parts.slice(1, host_parts.length) != %w{s3 amazonaws com}

--- a/app/models/fixity_check.rb
+++ b/app/models/fixity_check.rb
@@ -20,4 +20,28 @@ class FixityCheck < ApplicationRecord
     passed
   end
 
+  # A link to the checked_uri in the AWS S3 Console. Kind of hacky and fragile, will break
+  # if AWS changes their console URLs, or if our assumptions weren't quite right in other
+  # ways, but it's so clever and useful when it works!
+  def checked_uri_in_s3_console
+    @checked_uri_in_s3_console ||= begin
+      original_storage = Shrine.storages[:store]
+      uri = URI.parse(checked_uri)
+
+      if original_storage.kind_of?(Shrine::Storage::S3)
+        region = ScihistDigicoll::Env.lookup(:aws_region)
+        bucket = original_storage.bucket.name
+        path_components = uri.path.split("/")
+        key_path = path_components.slice(1, path_components.length - 2)&.join("/")
+        end_key = path_components.last
+
+        "https://s3.console.aws.amazon.com/s3/buckets/#{bucket}/#{key_path}/?region=#{region}&tab=overview&prefixSearch=#{end_key}"
+      else
+        # Can't do it, sorry
+        nil
+      end
+    rescue URI::InvalidURIError
+      nil
+    end
+  end
 end

--- a/app/services/fixity_checker.rb
+++ b/app/services/fixity_checker.rb
@@ -1,10 +1,14 @@
+# Checks the SHA512 of _current_ stored file, compares against stored expected sha512,
+# records the results of the check in FixityCheck ActiveRecord object. Also prunes old
+# FixityCheck log records to keep only the interesting/useful ones, not complete history.
+#
 # FixityChecker.new(asset).check
 #   This will check the asset, and log the results to the database.
 #
 # FixityChecker.new(asset).prune_checks
 #   This will remove all the excess checks for the object so the database table
 #   doesn't get too large.
-
+#
 class FixityChecker
   attr_reader :asset
 
@@ -32,7 +36,7 @@ class FixityChecker
   def check
     FixityCheck.create!(
       asset: @asset,
-      hash_function: 'SHA-512',
+      hash_function: 'SHA512',
       checked_uri: permanent_url,
       expected_result: expected_result,
       actual_result: actual_result,

--- a/app/views/admin/assets/_fixity.html.erb
+++ b/app/views/admin/assets/_fixity.html.erb
@@ -45,6 +45,9 @@
               <i class="fa fa-times text-danger" aria-hidden="true" class="text-danger"></i> <span class="sr-only">Failed</span>
             <% end %>
             <%= l ch.created_at, format: :admin %>
+            <%= content_tag "span", class: "badge badge-light" do %>
+              <%= ch.hash_function %>:<%= ch.actual_result.slice(0, 10) %>
+            <% end %>
           </div>
         <% end %>
       </dd>

--- a/app/views/admin/assets/_fixity.html.erb
+++ b/app/views/admin/assets/_fixity.html.erb
@@ -64,7 +64,7 @@
       <dt class="text-danger">Actual</dt> <dd><%= @latest_check.hash_function %>: <%= text_field_tag "", @latest_check.actual_result, readonly: true %></dd>
 
       <dt class="text-danger">Checked file location</dt>
-      <dd><%= link_to @latest_check.checked_uri, @latest_check.checked_uri_in_s3_console, target: "_blank" %></dd>
+      <dd><%= link_to_if @latest_check.checked_uri_in_s3_console, @latest_check.checked_uri, @latest_check.checked_uri_in_s3_console, target: "_blank" %></dd>
     </dl>
   <% end %>
 

--- a/app/views/admin/assets/_fixity.html.erb
+++ b/app/views/admin/assets/_fixity.html.erb
@@ -20,59 +20,58 @@
   </dl>
 
 
-    <% if @latest_check.present? && !@latest_check.passed? %>
-      <dl>
-        <dt class="text-danger">Failing FixityCheck id</dt> <dd><%= @latest_check.id %></dd>
+  <%# Details with assets with actual checks to report about: %>
+  <% if @asset.stored? && @checks.present? %>
+    <dl class="row">
+      <dt class="col-sm-2">Latest</dt>
+      <dd class="col-sm-10 text-truncate">
+        <%= "#{time_ago_in_words(@latest_check.created_at)} ago" %>
+      </dd>
+      <dt class="col-sm-2">Earliest</dt>
+      <dd class="col-sm-10 text-truncate">
+        <%= "#{time_ago_in_words(@earliest_check.created_at)} ago" %>
+      </dd>
+      <dt class="col-sm-12">
+        <a data-toggle="collapse" href="#collapseFixityDetails"
+          role="button" aria-expanded="false"
+          aria-controls="collapseProvenanceNotes">Fixity Check History</a>
+      </dt>
+      <dd class="col-sm-12 collapse" id="collapseFixityDetails">
+        <% @checks.each do | ch | %>
+          <div>
+            <%if ch.passed? %>
+              <i class="fa fa-check text-success" aria-hidden="true" class="text-success"></i> <span class="sr-only">Passed</span>
+            <% else %>
+              <i class="fa fa-times text-danger" aria-hidden="true" class="text-danger"></i> <span class="sr-only">Failed</span>
+            <% end %>
+            <%= l ch.created_at, format: :admin %>
+          </div>
+        <% end %>
+      </dd>
+    </dl>
+  <% end %>
 
-        <dt class="text-danger">Time</dt><dd><%= l @latest_check.created_at, format: :admin %></dd>
+  <% if @latest_check.present? && !@latest_check.passed? %>
+    <dl>
+      <dt class="text-danger">Current Failing FixityCheck id</dt> <dd><%= @latest_check.id %></dd>
 
-        <dt class="text-danger">Expected</dt>
-        <dd><%= @latest_check.hash_function %>: <%= text_field_tag "", @latest_check.expected_result, readonly: true %></dd>
+      <dt class="text-danger">Time</dt><dd><%= l @latest_check.created_at, format: :admin %></dd>
 
-
-        <dt class="text-danger">Actual</dt> <dd><%= @latest_check.hash_function %>: <%= text_field_tag "", @latest_check.actual_result, readonly: true %></dd>
-
-        <dt class="text-danger">Checked file location</dt>
-        <dd><%= link_to @latest_check.checked_uri, @latest_check.checked_uri_in_s3_console, target: "_blank" %></dd>
-      </dl>
-    <% end %>
+      <dt class="text-danger">Expected</dt>
+      <dd><%= @latest_check.hash_function %>: <%= text_field_tag "", @latest_check.expected_result, readonly: true %></dd>
 
 
-    <%# Details with assets with actual checks to report about: %>
-    <% if @asset.stored? && @checks.present? %>
-      <dl class="row">
-        <dt class="col-sm-2">Latest</dt>
-        <dd class="col-sm-10 text-truncate">
-          <%= "#{time_ago_in_words(@latest_check.created_at)} ago" %>
-        </dd>
-        <dt class="col-sm-2">Earliest</dt>
-        <dd class="col-sm-10 text-truncate">
-          <%= "#{time_ago_in_words(@earliest_check.created_at)} ago" %>
-        </dd>
-        <dt class="col-sm-12">
-          <a data-toggle="collapse" href="#collapseFixityDetails"
-            role="button" aria-expanded="false"
-            aria-controls="collapseProvenanceNotes">Details</a>
-        </dt>
-        <dd class="col-sm-12 collapse" id="collapseFixityDetails">
-          <% @checks.each do | ch | %>
-            <div>
-              <%if ch.passed? %>
-                <i class="fa fa-check text-success" aria-hidden="true" class="text-success"></i> <span class="sr-only">Passed</span>
-              <% else %>
-                <i class="fa fa-times text-danger" aria-hidden="true" class="text-danger"></i> <span class="sr-only">Failed</span>
-              <% end %>
-              <%= l ch.created_at, format: :admin %>
-            </div>
-          <% end %>
-        </dd>
-      </dl>
-    <% end %>
+      <dt class="text-danger">Actual</dt> <dd><%= @latest_check.hash_function %>: <%= text_field_tag "", @latest_check.actual_result, readonly: true %></dd>
 
-    <%# Check the asset now: %>
-    <% if @asset.stored? %>
-      <div class="row col-sm-12">
-        <%= link_to "Schedule a check now", admin_check_fixity_path(@asset.friendlier_id), method: "post", class: "btn btn-primary mt-3 mb-3"%>
-      </div>
-    <% end %>
+      <dt class="text-danger">Checked file location</dt>
+      <dd><%= link_to @latest_check.checked_uri, @latest_check.checked_uri_in_s3_console, target: "_blank" %></dd>
+    </dl>
+  <% end %>
+
+  <%# Check the asset now: %>
+  <% if @asset.stored? %>
+    <div class="row col-sm-12">
+      <%= link_to "Schedule a check now", admin_check_fixity_path(@asset.friendlier_id), method: "post", class: "btn btn-primary mt-3 mb-3"%>
+    </div>
+  <% end %>
 </dd>

--- a/app/views/admin/assets/_fixity.html.erb
+++ b/app/views/admin/assets/_fixity.html.erb
@@ -32,7 +32,8 @@
 
         <dt class="text-danger">Actual</dt> <dd><%= @latest_check.hash_function %>: <%= text_field_tag "", @latest_check.actual_result, readonly: true %></dd>
 
-        <dt class="text-danger">Checked file location</dt> <dd><%= @latest_check.checked_uri %></dd>
+        <dt class="text-danger">Checked file location</dt>
+        <dd><%= link_to @latest_check.checked_uri, @latest_check.checked_uri_in_s3_console, target: "_blank" %></dd>
       </dl>
     <% end %>
 

--- a/app/views/admin/assets/_fixity.html.erb
+++ b/app/views/admin/assets/_fixity.html.erb
@@ -6,29 +6,9 @@
       <% if @asset.stored? %>
         <% if  @checks.present? %>
           <% if @latest_check.passed?  %>
-            <i class="fa fa-check" aria-hidden="true" style="color:green;"></i> OK
+            <i class="fa fa-check text-success" aria-hidden="true"></i> OK
           <% else %>
-            <ul style="list-style: none;">
-              <li>
-                <i class="fa fa-times" aria-hidden="true" style="color:red;"></i>
-                <strong>FAILURE</strong>
-              </li>
-              <li>
-                Check ID: <code><%= @latest_check.id %></code>
-              </li>
-              <li>
-                Time: <code><%= @latest_check.created_at %></code>
-              </li>
-              <li>
-                Expected: <code><%= @latest_check.expected_result %></code>
-              </li>
-              <li>
-                Actual: <code><%= @latest_check.actual_result %></code>
-              </li>
-              <li>
-                Checked URI: <code><%= @latest_check.checked_uri %></code>
-              </li>
-            </ul>
+            <i class="fa fa-times text-danger" aria-hidden="true"></i> <strong class="text-danger">FAILING</strong>
           <% end %>
         <% else %>
           No fixity checks yet.
@@ -37,42 +17,61 @@
         This file is still being ingested.
       <% end %>
     </dd>
+  </dl>
+
+
+    <% if @latest_check.present? && !@latest_check.passed? %>
+      <dl>
+        <dt class="text-danger">Failing FixityCheck id</dt> <dd><%= @latest_check.id %></dd>
+
+        <dt class="text-danger">Time</dt><dd><%= l @latest_check.created_at, format: :admin %></dd>
+
+        <dt class="text-danger">Expected</dt>
+        <dd><%= @latest_check.hash_function %>: <%= text_field_tag "", @latest_check.expected_result, readonly: true %></dd>
+
+
+        <dt class="text-danger">Actual</dt> <dd><%= @latest_check.hash_function %>: <%= text_field_tag "", @latest_check.actual_result, readonly: true %></dd>
+
+        <dt class="text-danger">Checked file location</dt> <dd><%= @latest_check.checked_uri %></dd>
+      </dl>
+    <% end %>
+
 
     <%# Details with assets with actual checks to report about: %>
     <% if @asset.stored? && @checks.present? %>
-      <dt class="col-sm-2">Latest</dt>
-      <dd class="col-sm-10 text-truncate">
-        <%= "#{time_ago_in_words(@latest_check.created_at)} ago" %>
-      </dd>
-      <dt class="col-sm-2">Earliest</dt>
-      <dd class="col-sm-10 text-truncate">
-        <%= "#{time_ago_in_words(@earliest_check.created_at)} ago" %>
-      </dd>
-      <dt class="col-sm-12">
-        <a data-toggle="collapse" href="#collapseFixityDetails"
-          role="button" aria-expanded="false"
-          aria-controls="collapseProvenanceNotes">Details</a>
-      </dt>
-      <dd class="col-sm-12 collapse" id="collapseFixityDetails">
-        <% @checks.each do | ch | %>
-          <div>
-            <%if ch.passed? %>
-              <i class="fa fa-check" aria-hidden="true" style="color:green;"></i> <span class="sr-only">Passed</span>
-            <% else %>
-              <i class="fa fa-times" aria-hidden="true" style="color:red;"></i> <span class="sr-only">Failed</span>
-            <% end %>
-            <%= l ch.created_at, format: :admin %>
-          </div>
-        <% end %>
-      </dd>
+      <dl class="row">
+        <dt class="col-sm-2">Latest</dt>
+        <dd class="col-sm-10 text-truncate">
+          <%= "#{time_ago_in_words(@latest_check.created_at)} ago" %>
+        </dd>
+        <dt class="col-sm-2">Earliest</dt>
+        <dd class="col-sm-10 text-truncate">
+          <%= "#{time_ago_in_words(@earliest_check.created_at)} ago" %>
+        </dd>
+        <dt class="col-sm-12">
+          <a data-toggle="collapse" href="#collapseFixityDetails"
+            role="button" aria-expanded="false"
+            aria-controls="collapseProvenanceNotes">Details</a>
+        </dt>
+        <dd class="col-sm-12 collapse" id="collapseFixityDetails">
+          <% @checks.each do | ch | %>
+            <div>
+              <%if ch.passed? %>
+                <i class="fa fa-check text-success" aria-hidden="true" class="text-success"></i> <span class="sr-only">Passed</span>
+              <% else %>
+                <i class="fa fa-times text-danger" aria-hidden="true" class="text-danger"></i> <span class="sr-only">Failed</span>
+              <% end %>
+              <%= l ch.created_at, format: :admin %>
+            </div>
+          <% end %>
+        </dd>
+      </dl>
     <% end %>
 
     <%# Check the asset now: %>
     <% if @asset.stored? %>
-      <dt class="col-sm-12">
-        <%= link_to "Schedule a check now", admin_check_fixity_path(@asset.friendlier_id), method: "post", class: "btn btn-primary mt-3"%>
-      </dt>
+      <div class="row col-sm-12">
+        <%= link_to "Schedule a check now", admin_check_fixity_path(@asset.friendlier_id), method: "post", class: "btn btn-primary mt-3 mb-3"%>
+      </div>
     <% end %>
-
-  </dl>
 </dd>

--- a/spec/models/fixity_check_spec.rb
+++ b/spec/models/fixity_check_spec.rb
@@ -24,7 +24,7 @@ describe FixityCheck do
     expect(FixityCheck.count).to eq 2
     expect(FixityCheck.all[0].passed?).to be true
     expect(FixityCheck.all[1].failed?).to be true
-    expect(FixityCheck.all[1].hash_function).to eq 'SHA-512'
+    expect(FixityCheck.all[1].hash_function).to eq 'SHA512'
 
     expect { FixityChecker.new(nil).check }.
       to raise_error(ArgumentError)

--- a/spec/models/fixity_check_spec.rb
+++ b/spec/models/fixity_check_spec.rb
@@ -88,6 +88,41 @@ describe FixityCheck do
       expect(count_of_good_checks_kept).to eq n_to_keep + 1
     end
   end
+
+  describe "#checked_uri_in_s3_console" do
+    before do
+      FixityChecker.new(corrupt_asset).check
+    end
+    let(:fixity_check) { corrupt_asset.fixity_checks.order(:created_at).last }
+
+    describe "for local path not url" do
+      it "returns nil" do
+        expect(fixity_check.checked_uri_in_s3_console).to be nil
+      end
+    end
+
+    describe "for S3 storage" do
+      # fake the checked-uri to look like an S3 uri, cheesy but hopefully good
+      # enough for a reliable test.
+      let(:s3_url) { "https://some-bucket.s3.amazonaws.com/asset/b2c64027-7124-4388-9a32-57dba88156ba/f9a99647faa471f5b34b77316c0fbda5.tif" }
+      before do
+        fixity_check.checked_uri = s3_url
+      end
+
+      it "returns what we think is a good direct link to AWS console" do
+        expect(fixity_check.checked_uri_in_s3_console).to eq "https://s3.console.aws.amazon.com/s3/buckets/some-bucket/asset/b2c64027-7124-4388-9a32-57dba88156ba/?region=us-east-1&tab=overview&prefixSearch=f9a99647faa471f5b34b77316c0fbda5.tif"
+      end
+    end
+
+    describe "for some other non-S3 host" do
+      before do
+        fixity_check.checked_uri = "http://example.com/foo/bar"
+      end
+      it "returns nil" do
+        expect(fixity_check.checked_uri_in_s3_console).to be nil
+      end
+    end
+  end
 end
 
 


### PR DESCRIPTION
1. Clean up display a bit, hopefully to make it more readable. 

Before:

![Screenshot 2019-09-19 11 42 23](https://user-images.githubusercontent.com/149304/65278971-31e13500-dafb-11e9-85bd-3bb3612f8424.png)


After:

![Screenshot 2019-09-19 16 34 50](https://user-images.githubusercontent.com/149304/65279089-72d94980-dafb-11e9-8edf-0a8afc0c8a9c.png)

(Fixity check history is now in ASC order, among other more obvious graphic design changes)


2. The "checked file URI" in a "currently failing details" read out. is now a _link_ to the object in AWS S3 Console for further debugging. A bit hacky and subject to breakage if Amazon changes their URLs, but handy enough to give it a try. 

I'm still not totally sure about the `checked_file_uri` thing -- what if it _doesn't_ match the presently expected file URI? That could happen in a historical FixityCheck if the file has changed... or a current one if it also changed after FixityCheck was done?  

I guess maybe we should at least warn people if they don't match? Maybe I'll go add that. 