### PR TITLE
increase worker count to 10

### DIFF
--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,4 +1,4 @@
 production:
-  "*": 5
+  "*": 10
 development:
   "*": 5


### PR DESCRIPTION
Increases workers to 10, we'll want to finish #302 before we launch to avoid potential crashes if we get too many on-demand creation requests.