### PR TITLE
Report assets without stored files.

### DIFF
--- a/app/importers/importers/file_set_auditor.rb
+++ b/app/importers/importers/file_set_auditor.rb
@@ -10,6 +10,14 @@ class Importers::FileSetAuditor < Importers::Auditor
     confirm(@item.sha1 == @metadata['sha_1'], "sha_1")
     confirm(@item.title == @metadata["title_for_export"], 'title')
     confirm(@item.file.metadata['filename'] == @metadata['filename_for_export'], 'file data filename') unless @item.file.nil?
+    unless @item.stored?
+      report_line("Does not have a stored file.")
+      if @metadata['sha_1'].nil?
+        report_line("Expected sha1 is not in the exported file.")
+      else
+        report_line("Expected sha1 is: #{@metadata['sha_1']}.")
+      end
+    end
   end
 
   def self.importee()


### PR DESCRIPTION
If an asset doesn't have a stored file, the audit should report it:

```
Audit problems:

Asset hh63sx05h: Does not have a stored file.
Asset hh63sx05h: Expected sha1 is not in the exported file.
Asset bz60cw92w: Does not have a stored file.
Asset bz60cw92w: Expected sha1 is not in the exported file.
Asset bn999759h: Does not have a stored file.
Asset bn999759h: Expected sha1 is not in the exported file.
```

Fixes #397, ** as long as ** there are no more deletes in Sufia production between now and launch.

On a related note: the check against Fedora (currently being developed) is designed to catch items that are in Kithe but not Sufia.

See also #399 for an account of all assets without stored files in Kithe prod as of October 3.