### PR TITLE
Access control has to be set to true or false

### DIFF
--- a/app/importers/importers/importer.rb
+++ b/app/importers/importers/importer.rb
@@ -176,6 +176,8 @@ module Importers
         add_error("missing 'access_control'")
       elsif metadata["access_control"] == "public"
         target_item.published = true
+      else
+        target_item.published = false
       end
     end
 


### PR DESCRIPTION
Nulls are no longer allowed in the DB.
This sets items' `published` flag explicitly to either true or false.