### PR TITLE
Make sure DZI lifecycle doesn't get in the way of dealing with Assets without attached files

### DIFF
--- a/app/models/dzi_files/active_record_callbacks.rb
+++ b/app/models/dzi_files/active_record_callbacks.rb
@@ -20,6 +20,11 @@ class DziFiles
 
     def self.after_commit(asset)
       if asset.destroyed?
+        if asset.md5.blank?
+          Rails.logger.warn("Deleting file without an md5, can't find/delete DZI: #{asset.friendlier_id || asset.id}")
+          return
+        end
+
         # we're gonna use the same kithe promotion_directives for :delete to
         # control how we do dzi deletion too.
         Kithe::TimingPromotionDirective.new(

--- a/spec/models/dzi_files_spec.rb
+++ b/spec/models/dzi_files_spec.rb
@@ -112,5 +112,12 @@ describe DziFiles do
       asset.destroy!
       expect(asset.destroyed?).to be(true)
     end
+
+    it "can have a file assigned, and get DZI's, without complaining" do
+      asset.file = File.open(Rails.root + "spec/test_support/images/20x20.png")
+      asset.save!
+      asset.reload
+      expect(dzi_management.exists?).to eq true
+    end
   end
 end

--- a/spec/models/dzi_files_spec.rb
+++ b/spec/models/dzi_files_spec.rb
@@ -104,4 +104,13 @@ describe DziFiles do
       end
     end
   end
+
+  # normally shouldn't happen
+  describe "without attached file", queue_adapter: :inline do
+    let(:asset) { create(:asset) }
+    it "can be deleted without complaining about missing DZI/md5" do
+      asset.destroy!
+      expect(asset.destroyed?).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
Our app doesn't mean to allow for an asset without an attached file, but it can happen in odd edge cases. The DZI lifecycle was getting confused not taking accoun this could happen, and raising trying to delete DZI's when there was no attached file so no md5 so couldn't figure out where associated DZI's might be. Ref #401