### PR TITLE
Update simple_form to 5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem 'kithe', git: "https://github.com/sciencehistory/kithe.git"
 # temporary git master, we should get on an attr_json release once we're settled down
 gem "attr_json", git: "https://github.com/jrochkind/attr_json" #path: "../attr_json"
 
-gem 'simple_form', "~> 4.0"
+gem 'simple_form', "~> 5.0"
 gem "cocoon"
 
 gem "browse-everything", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/sciencehistory/kithe.git
-  revision: d6c1c8654cc74cf3722ee358f5fdeb5853f63ed5
+  revision: 2fae484ef600ab5a6b4d99b29f7edef9241dbb5a
   specs:
     kithe (0.3.0)
       attr_json (< 2.0.0)
@@ -20,7 +20,7 @@ GIT
       ruby-progressbar (~> 1.0)
       shrine (~> 2.14)
       shrine-url (~> 2.0)
-      simple_form (~> 4.0)
+      simple_form (>= 4.0, < 6.0)
       traject (~> 3.0, >= 3.1.0.rc1)
       tty-command (>= 0.8.2, < 2)
 
@@ -620,16 +620,16 @@ GEM
     shrine (2.19.3)
       content_disposition (~> 1.0)
       down (~> 4.1)
-    shrine-url (2.2.1)
+    shrine-url (2.3.0)
       down (~> 4.4)
       http (>= 3.2, < 5)
-      shrine (>= 2.0)
+      shrine (>= 2.0, < 4)
     signet (0.11.0)
       addressable (~> 2.3)
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    simple_form (4.1.0)
+    simple_form (5.0.1)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
     sinatra (2.0.5)
@@ -687,7 +687,7 @@ GEM
       yell
     ttfunk (1.5.1)
     tty-color (0.5.0)
-    tty-command (0.8.2)
+    tty-command (0.9.0)
       pastel (~> 0.7.0)
     typhoeus (1.3.1)
       ethon (>= 0.9.0)
@@ -792,7 +792,7 @@ DEPENDENCIES
   sassc-rails (~> 2.0)
   selenium-webdriver
   shrine (~> 2.0)
-  simple_form (~> 4.0)
+  simple_form (~> 5.0)
   sitemap_generator (~> 6.0)
   slackistrano (~> 4.0)
   solr_wrapper (~> 2.1)


### PR DESCRIPTION
To get a minor security patch. http://blog.plataformatec.com.br/2019/09/incorrect-access-control-in-simple-form-cve-2019-16676/

Also updates to a new kithe from github that will allow simple_form 5.0.

Edited Gemfile to insist on simple_form 5.0, then ran:

    $ bundle update --conservative kithe simple_form