### PR TITLE
tweak 'Technical Summary'

### DIFF
--- a/app/views/static/about.html.erb
+++ b/app/views/static/about.html.erb
@@ -13,7 +13,7 @@
   <p>The U.S. Copyright Law contains an exception for the so-called fair use of copyrighted materials for the purposes of teaching, scholarship, research, criticism, commentary, and news reporting. Patrons are solely responsible for determining whether their intended use of a copyrighted work is fair and for responding to any claims of copyright infringement that may arise from use of the material. For more information on copyright and fair use, please refer to the <a href="https://www.copyright.gov/" target="_blank">U.S. Copyright Office website</a>.</p>
 
   <h2 class="brand-alt-h2">Technical Summary</h2>
-  <p>The Digital Collections are built on open-source technology such as Ruby on Rails, Solr, and Blacklight. All of <a href="https://github.com/sciencehistory/scihist_digicoll" target="_blank">our code is freely available</a> on GitHub via an Apache 2.0 license.</p>
+  <p>The Digital Collections are built on an open-source technology stack based on Ruby on Rails, postgres, Solr, and blacklight. All of <a href="https://github.com/sciencehistory/scihist_digicoll" target="_blank">our code is freely available</a> on GitHub via an Apache 2.0 license. We have also created the <a href="https://github.com/sciencehistory/kithe">kithe</a> gem as shareable toolkit for Rails apps that would like to take a similar architectural approach.</p>
 
   <h2 class="brand-alt-h2">Acknowledgments</h2>
   <p>We would like to acknowledge the generous support of the Arnold and Mabel Beckman Foundation and Robert W. Gore. This project was made possible in part by the Institute of Museum and Library Services grant SP-02-16-0014-16.</p>


### PR DESCRIPTION
Ref #396

Had already been tweaked slightly since chf_sufia, but current live chf_sufia is:

> The Digital Collections are built on the open-source technology stack Samvera (formerly Project Hydra), composed of Ruby on Rails, Solr, Blacklight, and Fedora 4. All of our code is freely available on GitHub via an Apache 2.0 license.

-- https://digital.sciencehistory.org/about

New as of this PR:

> The Digital Collections are built on an open-source technology stack based on Ruby on Rails, postgres, Solr, and blacklight. All of our code is freely available on GitHub via an Apache 2.0 license. We have also created the kithe gem as shareable toolkit for Rails apps that would like to take a similar architectural approach.

@HKativa I'm not sure if you want to sign off on this language or just leave it to us.