### PR TITLE
update rubyzip for CVE-2019-16892

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -594,7 +594,7 @@ GEM
     ruby-progressbar (1.10.1)
     ruby-rc4 (0.1.5)
     ruby_dep (1.5.0)
-    rubyzip (1.2.2)
+    rubyzip (1.3.0)
     safe_yaml (1.0.5)
     sassc (2.0.0)
       ffi (~> 1.9.6)


### PR DESCRIPTION
Just did `bundle update rubyzip`. 

Was alerted by Github security alert (Github analyzes our Gemfile/Gemfile.lock against known vulnerabilities). 