### PR TITLE
Adjustments to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,12 @@ scripts/import/fedora_creds.sh
 # Ignore the aws credential file
 /cap_aws_credentials.yml
 
-/public/sitemap
+public/__sitemaps/
+/public/downloads
+/public/packs
+/public/packs-test
+/public/shrine_storage_development
+/public/shrine_storage_test
+
+#A spot for developers to put miscellaneous scripts.
+/personal_bin/*


### PR DESCRIPTION
Per our discussion in Slack:
`personal_bin` is a great place to put temporary developer scripts that can be used with `watch` to monitor the output of a command in response to changes in the code (a test, a grep or find command, or a simple rake task)
`public` contains a variety of files don't belong in the codebase, but also a few that do.