### PR TITLE
Add alternate OAI link to audio template

### DIFF
--- a/app/views/works/show_with_audio.html.erb
+++ b/app/views/works/show_with_audio.html.erb
@@ -2,6 +2,7 @@
 
 <% content_for :head do %>
   <%= render "meta_tags", work: @work  %>
+  <%= tag "link", rel: "alternate", type: "application/xml", title: "OAI-DC metadata in XML", href: work_path(@work, format: "xml") %>
 <% end %>
 
 <div class="show-page-layout work-show" itemscope itemtype="http://schema.org/CreativeWork" class="row">


### PR DESCRIPTION
Adding the link tag for auto-discovery of oai-dc representation to the parallel audio template.
( see https://github.com/sciencehistory/scihist_digicoll/commit/17543a77e640457a055585e22c868faf0d485a00 , which adds it to  `app/views/works/show.html.erb`  .)