### PR TITLE
Unpublished items are included in public search results for logged in users.

### DIFF
--- a/app/models/search_builder/access_control_filter.rb
+++ b/app/models/search_builder/access_control_filter.rb
@@ -2,12 +2,8 @@ class SearchBuilder
   # An extension to Blacklight's SearchBuilder (which is locally generated in our app),
   # that provides access control for public non/public items.
   #
-  # For now, we just only allow published items to show up in search results. Later we
-  # could let logged in users see non-published items, but we're starting with public
-  # view for everyone.
-  #
-  # (We could also _not index_ non-published things, but kithe indexing routines might need
-  # more features to add/remove something from index if it's pubished status changes).
+  # Logged in users can see non-published items; the general public cannot.
+
   module AccessControlFilter
     extend ActiveSupport::Concern
 
@@ -16,8 +12,11 @@ class SearchBuilder
     end
 
     def access_control_filter(solr_params)
-      solr_params[:fq] ||= []
-      solr_params[:fq] << "{!term f=published_bsi}1"
+      if scope.context[:current_user].nil?
+        # Only apply this filter if the user is not logged in.
+        solr_params[:fq] ||= []
+        solr_params[:fq] << "{!term f=published_bsi}1"
+      end
     end
   end
 end


### PR DESCRIPTION
Logged-users can see unpublished items in the public-facing search results (e.g. at `/catalog`).
Includes tests.
Ref https://github.com/sciencehistory/scihist_digicoll/issues/432.