### PR TITLE
avoid double display of same link to opac

### DIFF
--- a/app/presenters/work_show_info.rb
+++ b/app/presenters/work_show_info.rb
@@ -44,10 +44,11 @@ class WorkShowInfo < ViewModel
         external_id.category == "bib"
       end.map(&:value)
 
-      (bib_ids + related_url_filter.opac_ids).map do |bib_id|
+      (bib_ids + related_url_filter.opac_ids).uniq.map do |bib_id|
         ScihistDigicoll::Util.opac_url(bib_id)
       end
     end
+    @links_to_opac
   end
 
   # Our creators are a list of Work::Creator object. We want to group them by

--- a/spec/presenters/work_show_info_spec.rb
+++ b/spec/presenters/work_show_info_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe WorkShowInfo do
+  let(:work) {  build(:work, external_id: {category: "bib", value: "b1075359"}, related_url: "https://othmerlib.sciencehistory.org/record=b1075359")}
+  context "with duplicate bibnum and related url" do
+    it "has only one links_to_opac" do
+      links = WorkShowInfo.new(work).links_to_opac
+      expect(links).to eq(["https://othmerlib.sciencehistory.org/record=b1075359"])
+    end
+  end
+end


### PR DESCRIPTION
When a bib number is entered as an identifier, PLUS a link to opac is included as a related_url (which happens in some of our older data), don't show the same link to opac twice. The solution is just putting a 'uniq' in the right place. With a unit test.

Ref #451