### PR TITLE
Auto-submitting digitization queue item select menu, in a couple more places

### DIFF
--- a/app/javascript/packs/admin.js
+++ b/app/javascript/packs/admin.js
@@ -11,3 +11,4 @@ import '../src/js/admin/tab_selection_in_anchor';
 import '../src/js/admin/simple_uppy_file_input';
 import '../src/js/admin/uppy_dashboard.js';
 import '../src/js/admin/qa_autocomplete.js';
+import '../src/js/admin/queue_status_submit.js';

--- a/app/javascript/src/js/admin/queue_status_submit.js
+++ b/app/javascript/src/js/admin/queue_status_submit.js
@@ -23,8 +23,19 @@ domready(function() {
   }
 
 
-  // The "ajax:" events are custom events from rails-ujs
+  // On digitization queue item status select menu change, auto-submit form
+  document.body.addEventListener("input", function(event) {
+    var changed = event.target;
+    var form = changed.closest("form")
+    if (changed.tagName != "SELECT" || notOurForm(form))  {
+      return;
+    }
 
+    Rails.fire(form, 'submit');
+  });
+
+
+  // The "ajax:" events are custom events from rails-ujs
 
   document.body.addEventListener('ajax:error', function(event) {
     var form = event.target;

--- a/app/javascript/src/js/admin/queue_status_submit.js
+++ b/app/javascript/src/js/admin/queue_status_submit.js
@@ -1,0 +1,62 @@
+// We have Digitiation Queue Item "status" forms that consist only of
+// a select menu (and submit button), and use rails-ujs remote=true
+// to do a remote form.
+//
+// We make them auto-submit on select menu selection, and also add some
+// things to show progress spinner and handle errors.
+//
+// The rails-ujs stuff we're using here is kind of poorly documented.
+// We could rewrite it to not use at all? But here are some references
+//
+// https://guides.rubyonrails.org/working_with_javascript_in_rails.html#remote-elements
+// https://guides.rubyonrails.org/working_with_javascript_in_rails.html#rails-ujs-event-handlers
+// https://github.com/rails/rails/issues/29546#issuecomment-313981539
+//
+// Our actual HTML uses the poorly documented rails-ujs "data-disable-with" feature to
+// have a progress spinner and disable form when in proress.
+
+import domready from 'domready';
+
+domready(function() {
+  function notOurForm(form) {
+    !(form && form["data-auto-submit"] == "true");
+  }
+
+
+  // The "ajax:" events are custom events from rails-ujs
+
+
+  document.body.addEventListener('ajax:error', function(event) {
+    var form = event.target;
+
+    if (notOurForm(form)) {
+      return;
+    }
+
+    // Make it show what we actually think is saved, not updated value.
+    form.reset();
+    //debugger;
+    // And warn the user, with info for developer in console
+    var detail = event.detail;
+    var data = detail[0], status = detail[1], xhr = detail[2];
+    console.error("DigitizationQueueItem AJAX status change failed\n\n" + status + " " + data);
+    alert("Uh oh, digitization Queue Item status change failed!");
+  });
+
+
+  document.body.addEventListener('ajax:success', function(event) {
+    var form = event.target;
+
+    if (notOurForm(form)) {
+      return;
+    }
+
+    // Fix the select value to record this is what we think it is, so if
+    // we need to rollback on error in future, it's to this.
+    var select = form.querySelector("select");
+    var updatedValue = select.value;
+    select.querySelector("option[selected]").removeAttribute("selected");
+    select.querySelector("option[value='" + updatedValue + "']").setAttribute('selected', true);
+  })
+
+});

--- a/app/presenters/digitization_queue_item_status_form.rb
+++ b/app/presenters/digitization_queue_item_status_form.rb
@@ -1,0 +1,17 @@
+# Displays a little self-contained auto-submitting form for a DigitizationQueueItem. Uses rails-ujs,
+# with customization in queue_status_submit.js.
+#
+# For admins, to let them see and change a queue item status without any clicks beyond the select menu,
+# using AJAX, with progress spinner and error handling.
+#
+# Renders it's own form, NOT meant for use within an existing form!
+#
+#     <%= DigitizationQueueItemStatusForm.new(queue_item).display %>
+#
+class DigitizationQueueItemStatusForm < ViewModel
+  valid_model_type_names 'Admin::DigitizationQueueItem'
+
+  def display
+    render "/presenters/digitization_queue_item_status_form", model: model, view: self
+  end
+end

--- a/app/views/admin/digitization_queue_items/index.html.erb
+++ b/app/views/admin/digitization_queue_items/index.html.erb
@@ -68,23 +68,7 @@
           <td><%= link_to admin_digitization_queue_item.title, admin_digitization_queue_item_path(admin_digitization_queue_item) %></td>
           <td><%= [admin_digitization_queue_item.bib_number, admin_digitization_queue_item.accession_number, admin_digitization_queue_item.museum_object_id].collect(&:presence).compact.join(", ") %>  </td>
           <td>
-            <%= simple_form_for(admin_digitization_queue_item, data: {remote: true, auto_submit: true}) do |f| %>
-              <div class="input-group input-group-sm flex-nowrap">
-                <%= f.collection_select :status,
-                      Admin::DigitizationQueueItem::STATUSES.collect {|s| [s.humanize, s]}, :second, :first, {},
-                      class: "form-control custom-select"
-                %>
-                <div class="input-group-append">
-                  <%= f.button_button '<i class="fa fa-floppy-o fa-fw" aria-hidden="true" title="Save"></i><span class="sr-only">Save</span>'.html_safe,
-                    type: :submit,
-                    class: "btn btn-outline-secondary",
-                    data: {
-                      "disable-with": '<i class="fa fa-spinner fa-spin fa-fw" title="Saving..."></i><span class="sr-only">Saving...</span>',
-                      "submit-button": "true"
-                    } %>
-                </div>
-              </div>
-            <% end %>
+             <%= DigitizationQueueItemStatusForm.new(admin_digitization_queue_item).display %>
           </td>
           <td><%= l(admin_digitization_queue_item.status_changed_at.to_date, format: :admin) %></td>
         </tr>

--- a/app/views/admin/digitization_queue_items/index.html.erb
+++ b/app/views/admin/digitization_queue_items/index.html.erb
@@ -68,14 +68,21 @@
           <td><%= link_to admin_digitization_queue_item.title, admin_digitization_queue_item_path(admin_digitization_queue_item) %></td>
           <td><%= [admin_digitization_queue_item.bib_number, admin_digitization_queue_item.accession_number, admin_digitization_queue_item.museum_object_id].collect(&:presence).compact.join(", ") %>  </td>
           <td>
-            <%= simple_form_for(admin_digitization_queue_item, data: {remote: true}) do |f| %>
+            <%= simple_form_for(admin_digitization_queue_item, data: {remote: true, auto_submit: true}) do |f| %>
               <div class="input-group input-group-sm flex-nowrap">
                 <%= f.collection_select :status,
                       Admin::DigitizationQueueItem::STATUSES.collect {|s| [s.humanize, s]}, :second, :first, {},
                       class: "form-control custom-select"
                 %>
                 <div class="input-group-append">
-                  <%= f.submit value: "Save", class: "btn btn-outline-secondary", data: { "disable-with": "saving" } %>
+                  <%= f.button :button,
+                    '<i class="fa fa-floppy-o fa-fw" aria-hidden="true" title="Save"></i><span class="sr-only">Save</span>'.html_safe,
+                    type: :submit,
+                    class: "btn btn-outline-secondary",
+                    data: {
+                      "disable-with": '<i class="fa fa-spinner fa-spin fa-fw" title="Saving..."></i><span class="sr-only">Saving...</span>',
+                      "submit-button": "true"
+                    } %>
                 </div>
               </div>
             <% end %>

--- a/app/views/admin/digitization_queue_items/index.html.erb
+++ b/app/views/admin/digitization_queue_items/index.html.erb
@@ -75,8 +75,7 @@
                       class: "form-control custom-select"
                 %>
                 <div class="input-group-append">
-                  <%= f.button :button,
-                    '<i class="fa fa-floppy-o fa-fw" aria-hidden="true" title="Save"></i><span class="sr-only">Save</span>'.html_safe,
+                  <%= f.button_button '<i class="fa fa-floppy-o fa-fw" aria-hidden="true" title="Save"></i><span class="sr-only">Save</span>'.html_safe,
                     type: :submit,
                     class: "btn btn-outline-secondary",
                     data: {

--- a/app/views/admin/digitization_queue_items/show.html.erb
+++ b/app/views/admin/digitization_queue_items/show.html.erb
@@ -1,7 +1,12 @@
-<div class="mb-4">
+<div class="mb-2">
   <div>Digitization Queue: <%= link_to @admin_digitization_queue_item.collecting_area.humanize, admin_digitization_queue_items_url(@admin_digitization_queue_item.collecting_area) %></div>
   <h1><%= @admin_digitization_queue_item.title %></h1>
-  <p class="text-muted"><%= @admin_digitization_queue_item.status.humanize %></p>
+</div>
+
+<div class="row">
+  <div class="col-lg-5 pr-4 mb-4">
+    <%= DigitizationQueueItemStatusForm.new(@admin_digitization_queue_item).display %>
+  </div>
 </div>
 
 <div class="row">

--- a/app/views/admin/works/_metadata.html.erb
+++ b/app/views/admin/works/_metadata.html.erb
@@ -17,20 +17,18 @@
       <dd>
         <table class="w-100">
           <tr>
-            <td>
+            <td class="w-50">
               <%= link_to @work.digitization_queue_item.title, admin_digitization_queue_item_path(@work.digitization_queue_item) %>
             </td>
-            <td>
+            <td class="w-50">
               <%= l @work.digitization_queue_item.created_at.to_date, format: :admin %>
             </td>
           </tr>
           <tr>
             <td>
-              <%= @work.digitization_queue_item.status.humanize %>
+               <%= DigitizationQueueItemStatusForm.new(@work.digitization_queue_item).display %>
             </td>
-            <td>
-              <%= l @work.digitization_queue_item.status_changed_at.to_date, format: :admin %>
-            </td>
+            <td></td>
           </tr>
         </table>
       </dd>

--- a/app/views/presenters/_digitization_queue_item_status_form.html.erb
+++ b/app/views/presenters/_digitization_queue_item_status_form.html.erb
@@ -1,0 +1,17 @@
+<%= simple_form_for(view.model, data: {remote: true, auto_submit: true}) do |f| %>
+  <div class="input-group input-group-sm flex-nowrap">
+    <%= f.collection_select :status,
+          Admin::DigitizationQueueItem::STATUSES.collect {|s| [s.humanize, s]}, :second, :first, {},
+          class: "form-control custom-select"
+    %>
+    <div class="input-group-append">
+      <%= f.button_button '<i class="fa fa-floppy-o fa-fw" aria-hidden="true" title="Save"></i><span class="sr-only">Save</span>'.html_safe,
+        type: :submit,
+        class: "btn btn-outline-secondary",
+        data: {
+          "disable-with": '<i class="fa fa-spinner fa-spin fa-fw" title="Saving..."></i><span class="sr-only">Saving...</span>',
+          "submit-button": "true"
+        } %>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
The Queue List (index) page already had a select menu for item status for each item listed. It was in it's own form (one per item), and used the very poorly documented rails-ujs `date-remote`-triggered JS functions to do an "AJAX" submit, so when you saved the form, it was done via AJAX, didn't create a page reload. 

Previously, the results of the AJAX form submit were pretty much ignored. 

This PR adds some features to the JS. Still building off rails-ujs, which is again very poorly documented, and I had to google to figure out how to do a lot of things. But for now, seems better than rewriting from scratch, it does take care of a lot of things for us. 

* Auto-submit the form on change of select menu, so you don't actually need to press save ==> user-testing revealed this is what people expected, they were highly likely to not know/forget to submit the form as a separate click. 
* Better "in progress" spinner, using a fontawesome spinner icon that replaces a "floppy save" icon, and disables the form while in progress. This uses the `data-disable-with` attribute feature of rails-ujs remote forms. 
* Catch errors -- if the back-end app says there is an error, print out diagnostics to console, warn the user with an ugly JS alert, and revert the select menu back to what it was before the save, since the changed didn't actually get persisted (or at least we don't know if it did). 

Additionally, the HTML code for the auto-submitting-form-with-select was extracted to a "ViewModel". AND then this auto-submitting form was put in a couple other places where observation of staff users led me to think it would be convenient and save clicks. 

I tried to write a capybara JS test to test that all this fancy JS actually works -- but I couldn't get it to work, changing the select menu with Capybara/Chromekit JS somehow does not trigger the JS "change" event.  After spending some non-trivial time on it, I gave up, sorry no tests. 🤷‍♂ 