### PR TITLE
Lock to sprockets 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,10 @@ gem "resque-pool"
 
 gem 'honeybadger', '~> 4.0'
 
+# Until we get things working under sprockets 4, lock to sprockets 3
+# https://github.com/sciencehistory/scihist_digicoll/issues/458
+gem "sprockets", "~> 3.0"
+
 # Use SCSS for stylesheets
 gem 'sassc-rails', '~> 2.0'
 # Use Uglifier as compressor for JavaScript assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -796,6 +796,7 @@ DEPENDENCIES
   sitemap_generator (~> 6.0)
   slackistrano (~> 4.0)
   solr_wrapper (~> 2.1)
+  sprockets (~> 3.0)
   sprockets-rails (>= 2.3.2)
   tzinfo-data
   uglifier (>= 1.3.0)


### PR DESCRIPTION
Upgrading to sprockets 4 breaks our app until we tweak it to work. Putting this in Gemfile will keep any 'bundle update's of other dependencies from accidentally updating sprockets 4 too, before we're ready. When we're ready, we change or removee this line in Gemfile. We did create an issue to upgrade to sprockets 4 eventually, #458