### PR TITLE
Recognize weird Sierra URLs with eg b1069527~S5 on end mean bibID b1069527

### DIFF
--- a/app/presenters/related_url_filter.rb
+++ b/app/presenters/related_url_filter.rb
@@ -30,8 +30,15 @@ class RelatedUrlFilter
     @related_work_friendlier_ids ||= related_work_urls.collect {|u| u.sub(RELATED_WORK_PREFIX_RE, '') }
   end
 
+  # Look through related urls for URLs matching OPAC link pattern, extract
+  # bib number out of them. Limit bib number to first 8 chars, to normalize
+  # ones that have been entered as EG `http://othmerlib.sciencehistory.org/record=b1069527~S5`,
+  # where the `~S5` is a weird extra thing sometimes in Sierra OPAC urls that is not
+  # part of the bib number.
   def opac_ids
-    @opac_ids ||= opac_urls.collect {|u| u.sub(OPAC_PREFIX_RE, '') }
+    @opac_ids ||= opac_urls.
+      collect { |u| u.sub(OPAC_PREFIX_RE, '') }.
+      collect { |id| id.slice(0,8) }
   end
 
   private

--- a/spec/presenters/related_url_filter_spec.rb
+++ b/spec/presenters/related_url_filter_spec.rb
@@ -33,6 +33,13 @@ describe RelatedUrlFilter do
     expect(filter.opac_ids).to eq(["b1", "b2", "b3"])
   end
 
+  describe "weird sierra extra url" do
+    let(:opac_urls) {["http://othmerlib.sciencehistory.org/record=b1069527~S5"]}
+
+    it "ignores weird suffix" do
+      expect(filter.opac_ids).to eq(["b1069527"])
+    end
+  end
 
   describe "nil input" do
     let(:filter) { RelatedUrlFilter.new(nil) }


### PR DESCRIPTION
Ref #451, solves PART of it