### PR TITLE
Tweak to member visibility rules on public work view.

### DIFF
--- a/app/decorators/audio_work_show_decorator.rb
+++ b/app/decorators/audio_work_show_decorator.rb
@@ -1,5 +1,6 @@
 class AudioWorkShowDecorator < Draper::Decorator
   delegate_all
+  include Draper::LazyHelpers
 
   # This is called by works_controller#show.
   def view_template

--- a/app/decorators/audio_work_show_decorator.rb
+++ b/app/decorators/audio_work_show_decorator.rb
@@ -11,11 +11,9 @@ class AudioWorkShowDecorator < Draper::Decorator
   # The list of tracks for the playlist.
   def all_members
     @all_members ||= begin
-      model.members.
-        with_representative_derivatives.
-        where(published: true).
-        order(:position).
-        to_a
+      members = model.members.with_representative_derivatives
+      members = members.where(published: true) if current_user.nil?
+      members.order(:position).to_a
     end
   end
 
@@ -23,7 +21,7 @@ class AudioWorkShowDecorator < Draper::Decorator
   # to pass to MemberImagePresenter. But instead of following the `representative`
   # association, let's find it from the `members`, to avoid an extra fetch.
   #
-  # Does assume your represnetative is one of your members, otherwise it won't find it.
+  # Does assume your representative is one of your members, otherwise it won't find it.
   def representative_member
     @representative_member ||= model.members.find { |m| m.id == model.representative_id }
   end

--- a/app/decorators/work_show_decorator.rb
+++ b/app/decorators/work_show_decorator.rb
@@ -15,12 +15,9 @@ class WorkShowDecorator < Draper::Decorator
 
   def member_list_for_display
     @member_list_display ||= begin
-      members = model.members.
-        with_representative_derivatives.
-        where(published: true).
-        order(:position).
-        to_a
-
+      members = model.members.with_representative_derivatives
+      members = members.where(published: true) if current_user.nil?
+      members = members.order(:position).to_a
       # If the representative image is the first item in the list, don't show it twice.
       members.delete_at(0) if members[0] == representative_member
       members

--- a/spec/system/audio_front_end_spec.rb
+++ b/spec/system/audio_front_end_spec.rb
@@ -6,14 +6,17 @@ describe "Audio front end", type: :system, js: true do # , solr:true do
   end
   let(:audio_file_path) { Rails.root.join("spec/test_support/audio/ice_cubes.mp3")}
   let(:audio_file_sha512) { Digest::SHA512.hexdigest(File.read(audio_file_path)) }
-  #let!(:audio_asset) { FactoryBot.create(:asset, file: File.open(audio_file_path)) }
 
   let!(:audio_assets) {
-    (1..3).to_a.map do |i|
+    (1..4).to_a.map do |i|
       create(:asset_with_faked_file, :mp3,
         title: "Track #{i}",
         position: i - 1,
         parent: parent_work,
+
+        # All of these are published except for the second one.
+        published: i != 2,
+
         faked_derivatives: [
             build(:faked_derivative, key: 'small_mp3', uploaded_file: build(:stored_uploaded_file, content_type: "audio/mpeg")),
             build(:faked_derivative, key: 'webm',      uploaded_file: build(:stored_uploaded_file, content_type: "audio/webm"))
@@ -21,12 +24,21 @@ describe "Audio front end", type: :system, js: true do # , solr:true do
       )
     end
   }
+
+  let!(:published_audio_assets) {
+    audio_assets.select {|a| a.published }
+  }
+
   let!(:regular_assets) {
-    (4..6).to_a.map do |i|
+    (5..8).to_a.map do |i|
       create(:asset_with_faked_file,
         title: "Regular file #{i}",
         faked_derivatives: [],
         position: i - 1,
+
+        #5, #7 and #8 are published, but not #6:
+        published: i != 6,
+
         parent: parent_work
       )
     end
@@ -44,20 +56,23 @@ describe "Audio front end", type: :system, js: true do # , solr:true do
         expect(page).to have_css(".current-track-label", :text => "Track 1")
         audio_element = page.find('.show-page-audio-playlist-wrapper audio')
         track_listings = page.find_all('.track-listing')
-        expect(track_listings.map {|x| x['data-title'] }).to contain_exactly("Track 1", "Track 2", "Track 3")
-        expect(track_listings.map {|x| x['data-member-id'] }).to eq audio_assets.map {|x| x.id}
+        # The user is not logged in, and Track 2 is not published yet.
+        # Thus, Track 2 should not be shown.
+        expect(track_listings.map {|x| x['data-title'] }).to contain_exactly("Track 1", "Track 3", "Track 4")
+        expect(track_listings.map {|x| x['data-member-id'] }).to eq published_audio_assets.map {|x| x.id}
         download_links = page.find_all('.dropdown-item:not(.dropdown-header)', :visible => false).map { |x| x['href'] }
         (0..2).to_a.map do |i|
-          expect(download_links.any? { |x| x.include? "#{audio_assets[i].friendlier_id}/small_mp3" }).to be true
+          expect(download_links.any? { |x| x.include? "#{published_audio_assets[i].friendlier_id}/small_mp3" }).to be true
         end
         # Original file + two derivatives:
-        expect(download_links.count).to eq audio_assets.count * ( 1 + 2)
+        expect(download_links.count).to eq published_audio_assets.count * ( 1 + 2)
         # The two derivatives are served by the downloads controller:
-        expect(download_links.select{ |x| x.include? 'downloads'}.count).to eq audio_assets.count * 2
+        expect(download_links.select{ |x| x.include? 'downloads'}.count).to eq published_audio_assets.count * 2
       end
-
       other_thumbs = page.find_all('.member-image-presentation')
-      expect(other_thumbs.count). to eq regular_assets.count
+
+      # Don't show the unpublished non-audio asset (# 6) to the not-logged-in user.
+      expect(other_thumbs.count). to eq regular_assets.count {|a| a.published }
     end
   end
 end

--- a/spec/system/work_show_spec.rb
+++ b/spec/system/work_show_spec.rb
@@ -130,11 +130,11 @@ describe "Public work show page", :logged_in_user, type: :system, js: false do
   let(:work) {
     create( :work, members:
       [
-        create( :asset_with_faked_file, title: "Published asset", published: true  ),
-        create( :work, title: "First child work", published: true  ),
-        create( :work, title: "Second child work", published: false ),
-        create( :work, title: "Third child work", published: true  ),
-        create( :asset_with_faked_file, title: "Private asset",  published: false )
+        create( :asset_with_faked_file, position: 0, title: "Published asset", published: true  ),
+        create( :work,  position: 1, title: "First child work", published: true  ),
+        create( :work,  position: 2, title: "Second child work", published: false ),
+        create( :work,  position: 3, title: "Third child work", published: true  ),
+        create( :asset_with_faked_file,  position: 4, title: "Private asset",  published: false )
       ]
     )
   }
@@ -149,7 +149,7 @@ describe "Public work show page", :logged_in_user, type: :system, js: false do
       visit work_path(work)
       expect(page.find(:css, 'a[text()="Edit"]').visible?).to be true
       thumbnails = page.find_all('.member-image-presentation')
-      expect(thumbnails.count). to eq work.members.count
+      expect(thumbnails.count).to eq work.members.count
     end
   end
 end

--- a/spec/system/work_show_spec.rb
+++ b/spec/system/work_show_spec.rb
@@ -30,7 +30,12 @@ describe "Public work show page", type: :system, js: false do
           create(:asset_with_faked_file,
             title: "Second asset",
             faked_derivatives: [],
-            position: 1)
+            position: 1),
+          create(:asset_with_faked_file,
+            title: "Third asset (private)",
+            faked_derivatives: [],
+            published: false,
+            position: 2)
           ]
       )
     }
@@ -52,7 +57,7 @@ describe "Public work show page", type: :system, js: false do
       expect(page.find_all(".show-page-audio-playlist-wrapper").count). to eq 0
 
       thumbnails = page.find_all('.member-image-presentation')
-      expect(thumbnails.count). to eq work.members.count
+      expect(thumbnails.count). to eq work.members.select {|m| m.published }.count
 
 
       within(".show-genre") do
@@ -123,12 +128,28 @@ end
 
 describe "Public work show page", :logged_in_user, type: :system, js: false do
   let(:work) {
-    create( :work)
+    create( :work, members:
+      [
+        create( :asset_with_faked_file, title: "Published asset", published: true  ),
+        create( :work, title: "First child work", published: true  ),
+        create( :work, title: "Second child work", published: false ),
+        create( :work, title: "Third child work", published: true  ),
+        create( :asset_with_faked_file, title: "Private asset",  published: false )
+      ]
+    )
   }
+
+  before do
+    work.representative = work.members.first
+    work.save!
+  end
+
   describe "Logged in user" do
-    it "shows the edit button" do
+    it "shows the edit button, and all child items, including unpublished ones." do
       visit work_path(work)
       expect(page.find(:css, 'a[text()="Edit"]').visible?).to be true
+      thumbnails = page.find_all('.member-image-presentation')
+      expect(thumbnails.count). to eq work.members.count
     end
   end
 end


### PR DESCRIPTION
If a user is logged in, it's OK to show non-published member items on the public view of the work.
Includes tests for both audio and regular decorators.

Ref #432
Ref #449

Note: PR #489 depends on this one. #489 adds "Private" labels to the non-published member items now being displayed to logged-in users, to make the interface less confusing. Please merge this PR first, as it will simplify #489.