### PR TITLE
Preserve parent represntative on asset/child work conversion

### DIFF
--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -102,6 +102,11 @@ class Admin::AssetsController < AdminController
     Kithe::Model.transaction do
       new_child.save!
       @asset.save! # to get new parent
+
+      if parent.representative_id == @asset.id
+        parent.representative = new_child
+        parent.save!
+      end
     end
 
     redirect_to edit_admin_work_path(new_child), notice: "Asset promoted to child work #{new_child.title}"

--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -183,10 +183,14 @@ class Admin::WorksController < AdminController
     asset = @work.members.reset.first
 
     asset.position = @work.position
-    @work.members
     asset.parent = @work.parent
 
     Kithe::Model.transaction do
+      if parent.representative_id == @work.id
+        parent.representative = asset
+        parent.save!
+      end
+
       asset.save!
       @work.destroy
     end

--- a/spec/system/asset/convert_to_child_work_spec.rb
+++ b/spec/system/asset/convert_to_child_work_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe "Convert asset to child work", :logged_in_user, type: :system, js
   let(:conversion_source) { work.members[2] }
 
   it "converts" do
+    work.update(representative_id: conversion_source.id)
+
     original_position = conversion_source.position
     visit admin_asset_path(conversion_source)
 
@@ -14,6 +16,7 @@ RSpec.describe "Convert asset to child work", :logged_in_user, type: :system, js
       expect(page).to have_content("Asset promoted to child work")
     end.to change { Work.count }.by(1).and change { Asset.count }.by(0)
 
+    work.reload
     expect(conversion_source.reload.persisted?).to be(true)
     new_work = Work.order(:created_at).last
 
@@ -21,6 +24,7 @@ RSpec.describe "Convert asset to child work", :logged_in_user, type: :system, js
     expect(new_work.parent).to eq(work)
     expect(new_work.contained_by).to eq(work.contained_by)
     expect(new_work.position).to eq(original_position)
+    expect(work.representative_id).to eq(new_work.id)
 
     # all attr_json attributes
     expect(new_work.json_attributes).to eq(work.json_attributes)

--- a/spec/system/work/demote_to_asset_spec.rb
+++ b/spec/system/work/demote_to_asset_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe "Convert child work to asset", :logged_in_user, type: :system, js
   let(:child_work) { FactoryBot.create(:work, :with_assets, parent: parent_work, position: 3) }
 
   it "demotes to asset" do
+    parent_work.update(representative: child_work)
+
     original_position = child_work.position
     asset = child_work.members.first
 
@@ -19,9 +21,11 @@ RSpec.describe "Convert child work to asset", :logged_in_user, type: :system, js
       expect(page).to have_current_path(admin_work_path(parent_work))
     end.to change { Work.count }.by(-1).and change { Asset.count }.by(0)
 
+    parent_work.reload
     asset.reload # not raise
     expect(asset.parent).to eq(parent_work)
     expect(asset.position).to eq(original_position)
+    expect(parent_work.representative_id).to eq(asset.id)
 
     expect { child_work.reload }.to raise_error(ActiveRecord::RecordNotFound)
   end


### PR DESCRIPTION
Both directions. 

Ref #482