### PR TITLE
Try fixing date range rendering with hacky event to resize on load

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -20,3 +20,4 @@ import '../src/js/scihist_search_slideout.js';
 import '../src/js/scihist_on_demand_downloader.js';
 import '../src/js/scihist_viewer.js';
 import '../src/js/custom_google_analytics_events.js';
+import '../src/js/date_range_render_workaround.js';

--- a/app/javascript/src/js/date_range_render_workaround.js
+++ b/app/javascript/src/js/date_range_render_workaround.js
@@ -1,0 +1,20 @@
+// There is a problem with blacklight_range_limit rendered chart (that we use for date range
+// facet), where it sometimes doesn't wind up with the right size.
+//
+// In at least some cases, it looks like the size is being calculated before load,
+// and if we force it to be reiszed on `load` event (not to be confused with earlier DOMContentLoaded),
+// it can get fixed.
+//
+// We don't have an explicit wait to tell blacklight_range_limit "resize the chart", but
+// we can trick it into doing so by sending a fake `shown.bs.collapse`. We do on the 'load'
+// event.
+//
+// https://github.com/sciencehistory/scihist_digicoll/issues/270
+// https://github.com/projectblacklight/blacklight_range_limit/issues/111
+//
+// This isn't necessary if the facet didn't start out open. It's unclear if this
+// actually resolves the problem entirely.
+
+window.addEventListener('load', function(event) {
+  $("#facet-year_facet_isim:visible").trigger("shown.bs.collapse");
+});


### PR DESCRIPTION
Hacky attempt to deal with #270 

Hook into the `load` event (which happens AFTER the DOMContentLoaded event blacklight_range_limit is trying to hook into).  If there is a visible date-range-facet area, send a fake `shown.bs.collapse` event, which tricks `blacklight_range_limit` into doing a chart re-size/re-display operation. 

VERY hacky. In my testing, fixed the cases i was able to reproduce -- however, I'm no longer able to reproduce any cases! This is a mysterious timing-related problem. 

It doesn't appear to cause any other problems. We'll give it a try. 

Long-term, blacklight_range_limit probably has to be entirely rewritten. Based on a recent version of `flot` (or an alternative to flot). Maybe with a different design that doesn't rely on trying to detect size of container at all, or finds a way to get reliable hooks into 'element has been resized' events to re-draw. 