### PR TITLE
Production log-level to :info instead of :debug

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,9 +50,9 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
+  # :info is one step less info than :debug, it's still a fairly large amount of info, including
+  # all requests. We're trying this in production for now.
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
Matching chf_sufia. Ref #480

Note "production" Rails environment is used by our staging server too, so applies to staging too. Just does not apply to test/development Rails envs.