### PR TITLE
Change "Museum Object" label to "Object ID (Past Perfect)"

### DIFF
--- a/app/helpers/digitization_queue_items_helper.rb
+++ b/app/helpers/digitization_queue_items_helper.rb
@@ -2,7 +2,7 @@ module DigitizationQueueItemsHelper
   # just a hacky helper to show a dt/dd for a given Admin::DigitizationQueueItem field,
   # if present, we could be using presenters, or something else. This gets us started
   # with a basic show view.
-  def queue_item_show_field(item, field, humanize_value: false, paragraphs: false)
+  def queue_item_show_field(item, field, humanize_value: false, paragraphs: false, override_label: nil)
     value = item.send(field)
     if value.present?
       if humanize_value
@@ -12,7 +12,7 @@ module DigitizationQueueItemsHelper
         value = simple_format(value)
       end
 
-      content_tag("dt", field.to_s.titleize) +
+      content_tag("dt", (override_label || field.to_s.titleize)) +
         content_tag("dd", value)
     end
   end

--- a/app/views/admin/digitization_queue_items/show.html.erb
+++ b/app/views/admin/digitization_queue_items/show.html.erb
@@ -42,7 +42,7 @@
       <%= queue_item_show_field(@admin_digitization_queue_item, :bib_number) %>
       <%= queue_item_show_field(@admin_digitization_queue_item, :location) %>
       <%= queue_item_show_field(@admin_digitization_queue_item, :accession_number) %>
-      <%= queue_item_show_field(@admin_digitization_queue_item, :museum_object_id) %>
+      <%= queue_item_show_field(@admin_digitization_queue_item, :museum_object_id, override_label: "Object ID (Past Perfect)") %>
       <%= queue_item_show_field(@admin_digitization_queue_item, :box) %>
       <%= queue_item_show_field(@admin_digitization_queue_item, :folder) %>
 


### PR DESCRIPTION
Did this the quick and dirty way, adding a param for caller to just specify label override, instead of deriving it from db column name.

The DB column name is still the somewhat incorrect :museum_object_id, decided it wasn't worth the more difficult task of changing for now.

Ref #473