### PR TITLE
less strict Gemfile requirements for ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby File.read(".ruby-version").chomp
+# Include just the major/minor version of whatever we find in .ruby-version,
+# ie `~> 2.5` or `~> 2.6`, not including additional that may be in 2.3
+ruby "~> #{File.read('.ruby-version').chomp.split('.').slice(0,3).join('.')}"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.1'


### PR DESCRIPTION
In our app we have a couple ways of specifying/requiring the ruby version to be used, that are automatically used by software. The goal is making sure we're all using the same version of ruby -- all developers are using the same version, which is the same version used in deploy/production, and multiple hosts involved in deploy/production are all using the same version too.

* The `.ruby-version` file has a specific ruby version in it (like "2.5.3", needs to be a full specific version). This is used by tools used by developers like rvm or rbenv or chruby to automatically switch to this version of ruby when you are in that directory. It's a convenience for developers; it is not used at all on our deploy/production machines, which don't use ruby version switchers.
* The `Gemfile` can have a `ruby` statement which specifies a ruby version or range of versions. This will result in an error being used and the app refuisng to run unless a version specified is being used; it won't automatically select it, it'll just complain if it's wrong. While this _can_ be expressed as a range of permissible versions, we had been putting some automated code in there to just take whetever was in `.ruby-version` and use it as the `ruby` specification insisting on that version. To keep this Gemfile-enforcement mechanism sync'd with the ruby version switcher `.ruby-version` mechanism.  This is used in both dev and deploy/production, and in production it ensures that the app won't even start unless correct version of ruby is used.

While very effective at ensuring everyone is using the same ruby version -- it makes _upgrading_ our ruby version in production cumbersome, cause the app will insist on using only a certain version, so that insistence has to be changed at _exactly_ the same time a version is changed on deploy servers, to avoid having a git 'master' that is not deployable.  As eg in  #327.

So, we've loosed up the Gemfile `ruby` statement a bit -- it still automatically reads from `.ruby-version`, but if eg "2.6.3" is in `.ruby-version.` it puts into Gemfile as a `~>` range restriction: `ruby "~> 2.6.3"`, so it will allow any 2.6.x >= 2.6.3.  This is a bit hacky, and doesn't totally solve the problem when we want to upgrade to 2.7, but lets us do what we need right now less cumbersomely.

I wonder how other people are handling this for deployment.