### PR TITLE
honeybadger notify fixity failure, don't group

### DIFF
--- a/app/services/fixity_check_failure_service.rb
+++ b/app/services/fixity_check_failure_service.rb
@@ -25,11 +25,15 @@ class FixityCheckFailureService
     end
 
     if defined? Honeybadger
-      Honeybadger.notify("Fixity check failure", context: {
-        asset: @asset.inspect,
-        asset_url: asset_url,
-        fixity_check: @fixity_check.inspect
-        })
+      Honeybadger.notify("Fixity check failure: #{@asset.friendlier_id}",
+        context: {
+          asset: @asset.inspect,
+          asset_url: asset_url,
+          fixity_check: @fixity_check.inspect
+        },
+        fingerprint: "fixity_check_failure_#{@asset.friendlier_id}",
+        tags: "fixity"
+      )
     end
   end
 


### PR DESCRIPTION
Only group by asset id, so different failures become different honeybadger groups.

Also add a tag fixity in case we need to treat them differnetly in honeybadger UI or API.

https://docs.honeybadger.io/lib/ruby/getting-started/reporting-errors.html
https://docs.honeybadger.io/lib/ruby/getting-started/customizing-error-grouping.html
https://docs.honeybadger.io/lib/ruby/getting-started/tagging-errors.html