### PR TITLE
Upgrade to Sprockets 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'honeybadger', '~> 4.0'
 
 # Until we get things working under sprockets 4, lock to sprockets 3
 # https://github.com/sciencehistory/scihist_digicoll/issues/458
-gem "sprockets", "~> 3.0"
+gem "sprockets", "~> 4.0"
 
 # Use SCSS for stylesheets
 gem 'sassc-rails', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -658,7 +658,7 @@ GEM
     sparql-client (3.0.1)
       net-http-persistent (>= 2.9, < 4)
       rdf (~> 3.0)
-    sprockets (3.7.2)
+    sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -796,7 +796,7 @@ DEPENDENCIES
   sitemap_generator (~> 6.0)
   slackistrano (~> 4.0)
   solr_wrapper (~> 2.1)
-  sprockets (~> 3.0)
+  sprockets (~> 4.0)
   sprockets-rails (>= 2.3.2)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,8 @@
+// https://github.com/rails/sprockets/blob/c4b191e70d89e9d70f19ade5faf0692054a3bd1b/UPGRADING.md
+//
+//
 //= link_tree ../images
-//= link_directory ../javascripts .js
-//= link_directory ../stylesheets .css
+//= link_directory ../html .html
+//
+//= link application.css
+//= link application.js


### PR DESCRIPTION
Ref #458

See https://github.com/rails/sprockets/blob/c4b191e70d89e9d70f19ade5faf0692054a3bd1b/UPGRADING.md

We have edited the config/manifest.js to be more targetted in what it compiles. So it does NOT get our stuff at eg app/assets/stylesheets/_mixins.scss that was not treated as a top-level component in sprockets 3, and raises errors in 4 unless properly excluded.

The files output by `rake assets:precompile` after this upgrade are NOT exactly the same as the files that were output under sprockets 3. There are some in sprockets 3 that are not included here -- but I think all those were ERRONEOUSLY being output and unused in sprockets 3. Eg:

```
I, [2019-11-19T11:32:31.884627 #94915]  INFO -- : Writing /Users/jrochkind/code/scihist_digicoll/public/assets/local/admin/README-fdd0747847051df4c4d266a4235feca9b0527ae74bc6278a3247e2e2e860eb34.md
I, [2019-11-19T11:32:31.905769 #94915]  INFO -- : Writing /Users/jrochkind/code/scihist_digicoll/public/assets/qa/application-fed7594354f41c527f9e8dab7f766cd780129ed1fd04e8c0646a72b825ad8e8b.js
I, [2019-11-19T11:32:31.906028 #94915]  INFO -- : Writing /Users/jrochkind/code/scihist_digicoll/public/assets/qa/application-fed7594354f41c527f9e8dab7f766cd780129ed1fd04e8c0646a72b825ad8e8b.js.gz
I, [2019-11-19T11:32:31.926141 #94915]  INFO -- : Writing /Users/jrochkind/code/scihist_digicoll/public/assets/qa/application-f9e7c1541e1b8783561468c59162bd896007380f5a3799ef2169d3a3fdf40bed.css
I, [2019-11-19T11:32:31.926983 #94915]  INFO -- : Writing /Users/jrochkind/code/scihist_digicoll/public/assets/qa/application-f9e7c1541e1b8783561468c59162bd896007380f5a3799ef2169d3a3fdf40bed.css.gz
I, [2019-11-19T11:32:33.113657 #94915]  INFO -- : Writing /Users/jrochkind/code/scihist_digicoll/public/assets/express/lib/application-9232ebdb20ad39572e70fb9e29810e63dbb63b58f5f18617c7c2bc8bd28321b5.js
I, [2019-11-19T11:32:33.115169 #94915]  INFO -- : Writing /Users/jrochkind/code/scihist_digicoll/public/assets/express/lib/application-9232ebdb20ad39572e70fb9e29810e63dbb63b58f5f18617c7c2bc8bd28321b5.js.gz
```

I'm not even sure what the "express" one is from (I think `qa` gem), but I think that one and the others above were actually being compiled/output *erroneously* in sprockets 3.

But it's hard to be entirely sure what's going on, or absolutely rule out problems that could be caused by this switch. I think we are good though. There may STILL be some top-level assets being compiled unnecessarily that were also compiled unnecessarily in sprockcets 3, but that's okay.

I did do some manual tests of qa (subject autocomplete) and browse-everything func to make sure it was still working and styled correctly. It seemed to be.