### PR TITLE
WIP Indexing blank values in Rights and Department

### DIFF
--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -26,10 +26,10 @@ class WorkIndexer < Kithe::Indexer
     to_field "text_no_boost_tesim", obj_extract("related_url")
     to_field ["text_no_boost_tesim", "place_facet"], obj_extract("place", "value")
     to_field "text_no_boost_tesim", obj_extract("related_url")
-    to_field ["text_no_boost_tesim", "department_facet"], obj_extract("department")
+    to_field ["text_no_boost_tesim", "department_facet"], obj_extract("department"), transform(->(v) { v.empty? ? "No Department" : v })
     to_field ["text_no_boost_tesim", "medium_facet"], obj_extract("medium")
     to_field ["text_no_boost_tesim", "format_facet"], obj_extract("format"), transform(->(v) { v.titleize })
-    to_field ["text_no_boost_tesim", "rights_facet"], obj_extract("rights") # URL id
+    to_field ["text_no_boost_tesim", "rights_facet"], obj_extract("rights"), transform(->(v) { v.empty? ? "http://rightsstatements.org/vocab/CNE/1.0/" : v }) # URL id
     to_field ["text_no_boost_tesim"], obj_extract("rights"), transform(->(v) { RightsTerms.label_for(v) }) # human label
     to_field "text_no_boost_tesim", obj_extract("rights_holder")
     to_field "text_no_boost_tesim", obj_extract("series_arrangement")

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -26,11 +26,29 @@ class WorkIndexer < Kithe::Indexer
     to_field "text_no_boost_tesim", obj_extract("related_url")
     to_field ["text_no_boost_tesim", "place_facet"], obj_extract("place", "value")
     to_field "text_no_boost_tesim", obj_extract("related_url")
-    to_field ["text_no_boost_tesim", "department_facet"], obj_extract("department"), transform(->(v) { v.empty? ? "No Department" : v })
+
+    # This still does not correctly index all records with nil department.
+    to_field ["text_no_boost_tesim", "department_facet"] do |record, acc|
+      if record.department.nil? || record.department.empty?
+        acc << "Missing"
+      else
+        acc << record.department
+      end
+    end
+
     to_field ["text_no_boost_tesim", "medium_facet"], obj_extract("medium")
     to_field ["text_no_boost_tesim", "format_facet"], obj_extract("format"), transform(->(v) { v.titleize })
-    to_field ["text_no_boost_tesim", "rights_facet"], obj_extract("rights"), transform(->(v) { v.empty? ? "http://rightsstatements.org/vocab/CNE/1.0/" : v }) # URL id
-    to_field ["text_no_boost_tesim"], obj_extract("rights"), transform(->(v) { RightsTerms.label_for(v) }) # human label
+
+    # This still does not correctly index all records with nil rights.
+    to_field ["text_no_boost_tesim", "rights_facet"] do |record, acc|
+      if record.department.nil? || record.department.empty?
+        acc << "Missing"
+      else
+        acc << RightsTerms.label_for(record.rights)
+      end
+    end
+
+
     to_field "text_no_boost_tesim", obj_extract("rights_holder")
     to_field "text_no_boost_tesim", obj_extract("series_arrangement")
 

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -41,7 +41,7 @@ class WorkIndexer < Kithe::Indexer
 
     # This still does not correctly index all records with nil rights.
     to_field ["text_no_boost_tesim", "rights_facet"] do |record, acc|
-      if record.department.nil? || record.department.empty?
+      if record.rights.nil? || record.rights.empty?
         acc << "Missing"
       else
         acc << RightsTerms.label_for(record.rights)

--- a/config/data/rights_terms.yml
+++ b/config/data/rights_terms.yml
@@ -76,3 +76,9 @@ terms:
     active: true
     category: no_copyright
     short_label_html: Public<br>Domain
+
+  - id: http://rightsstatements.org/vocab/CNE/1.0/
+    label: Copyright Not Evaluated
+    active: true
+    category: other
+    short_label_html: Not<br>Evaluated

--- a/config/data/rights_terms.yml
+++ b/config/data/rights_terms.yml
@@ -77,8 +77,8 @@ terms:
     category: no_copyright
     short_label_html: Public<br>Domain
 
-  - id: http://rightsstatements.org/vocab/CNE/1.0/
-    label: Copyright Not Evaluated
-    active: true
-    category: other
-    short_label_html: Not<br>Evaluated
+  # - id: http://rightsstatements.org/vocab/CNE/1.0/
+  #   label: Copyright Not Evaluated
+  #   active: true
+  #   category: other
+  #   short_label_html: Not<br>Evaluated

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -140,21 +140,6 @@
 
        <str name="facet">true</str>
        <str name="facet.mincount">1</str>
-       <!-- This should work
-
-        https://lucene.apache.org/solr/guide/8_0/faceting.html
-
-        Unless otherwise specified, all of the parameters below can be specified on a per-field basis with the syntax of f.<fieldname>.facet.<parameter>
-       -->
-
-       <str name="f.department_facet.facet.missing">true</str>
-       <str name="f.rights_facet.facet.missing">true</str>
-      <!--
-        <str name="f.department_facet.facet.missing">enum</str>
-        <str name="f.rights_facet.facet.method">enum</str>
-       -->
-
-       <!-- end eddie hacking -->
 
        <str name="spellcheck">false</str>
        <str name="spellcheck.dictionary">default</str>

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -140,6 +140,21 @@
 
        <str name="facet">true</str>
        <str name="facet.mincount">1</str>
+       <!-- This should work
+
+        https://lucene.apache.org/solr/guide/8_0/faceting.html
+
+        Unless otherwise specified, all of the parameters below can be specified on a per-field basis with the syntax of f.<fieldname>.facet.<parameter>
+       -->
+
+       <str name="f.department_facet.facet.missing">true</str>
+       <str name="f.rights_facet.facet.missing">true</str>
+      <!--
+        <str name="f.department_facet.facet.missing">enum</str>
+        <str name="f.rights_facet.facet.method">enum</str>
+       -->
+
+       <!-- end eddie hacking -->
 
        <str name="spellcheck">false</str>
        <str name="spellcheck.dictionary">default</str>


### PR DESCRIPTION
Changes to work_indexer.rb to account for (unlikely) blank values in fields that are a) not supposed to be blank in the first place and b) picked from a limited vocabulary. Practically speaking, this means "Department" and "Rights".

We still want to facet these so they can be easily found (ref #408 )

As a proof of concept, I'm indexing these, respectively, under:
`No Department` and `http://rightsstatements.org/vocab/CNE/1.0/` , which translates as `Copyright Not Evaluated` on the front end.

No tests yet.