### PR TITLE
Show all items to logged-in users on featured-items and collections pages.

### DIFF
--- a/app/controllers/collection_show_controller.rb
+++ b/app/controllers/collection_show_controller.rb
@@ -44,7 +44,7 @@ class CollectionShowController < CatalogController
 
   # Our custom SearchBuilder needs to know collection id (UUID)
   def search_service_context
-    { collection_id: collection.id }
+    super.merge!(collection_id: collection.id)
   end
 
   def check_auth

--- a/app/controllers/featured_topic_controller.rb
+++ b/app/controllers/featured_topic_controller.rb
@@ -30,7 +30,7 @@ class FeaturedTopicController < CatalogController
   private
 
   def search_service_context
-    { slug: params[:slug] }
+    super.merge!(slug: params[:slug])
   end
 
   def set_featured_topic


### PR DESCRIPTION
Fixes #509 .

`current_user` wasn't being provided to the `AccessControlFilter` because the two search controllers were clobbering the superclass' `search_service_context` instead of extending it.

Better now.

