### PR TITLE
WIP Avoid empty string in department facet

### DIFF
--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -26,7 +26,7 @@ class WorkIndexer < Kithe::Indexer
     to_field "text_no_boost_tesim", obj_extract("related_url")
     to_field ["text_no_boost_tesim", "place_facet"], obj_extract("place", "value")
     to_field "text_no_boost_tesim", obj_extract("related_url")
-    to_field ["text_no_boost_tesim", "department_facet"], obj_extract("department")
+    to_field ["text_no_boost_tesim", "department_facet"], obj_extract("department"), transform( ->(v) { v.blank? ? nil : v })
     to_field ["text_no_boost_tesim", "medium_facet"], obj_extract("medium")
     to_field ["text_no_boost_tesim", "format_facet"], obj_extract("format"), transform(->(v) { v.titleize })
     to_field ["text_no_boost_tesim", "rights_facet"], obj_extract("rights") # URL id

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -22,4 +22,13 @@ describe WorkIndexer do
       expect(output_hash["collection_id_ssim"]).to match [collection1.id, collection2.id]
     end
   end
+
+  describe "empty string department" do
+    let(:work) { create(:work, department: "") }
+    it "indexes as nil" do
+      output_hash = WorkIndexer.new.map_record(work)
+      expect(output_hash).not_to include("department_facet")
+    end
+  end
+
 end


### PR DESCRIPTION
Ref #408

Just because it was getting so confusing, I decided to start with the simplest possible demo of avoiding the empty string in the department facet (solr field `department_facet`). 

The test written here was written first, and started out failing. It tests that the output of the WorkIndexer, for a work wtih empty string in departmet, doesn't even have a `department_facet` key in it at all. It started out failing, then I added the simple `transform` to the WorkIndexer to change empty strings to nil, and then the test passed. 

I confirmed on staging -- on master, when logged in the Department facet had a count of 13 next to the "empty string" facet you could not click on. After deploying this, AND reindexing (log into server, run ./bin/rake scihist:solr:reindex), there is no "empty string" facet in Department. 

So this demonstrates that it is straightforward to treat the empty string like nil in indexing, for a specific indexing rule with a "transform" -- and avoid the "empty string facet". 

However, this may not be what we want to commit. Possible enhancements:

* We could clean up the code slightly by doing "value.presence" in the transform instead of `value.blank? ? nil : value`. Rails #presence is basically a shortcut for that. https://api.rubyonrails.org/classes/Object.html#method-i-presence

But also, instead of handing this with explicit config on every field you want ot ignore empty strings -- we probably _always_ want to ignore empty strings, they don't do anything too useful in Solr generally. How might we do that?

Can we do it with traject config? Hypothetically we could do it with an `each_record` traject config that eliminated empty strings from the traject collector hash. But the `each_record` directive would need to be after _all_ traject directives, to make sure it happened after all index rules were executed. This is error-prone, and also makes it hard to build in as a default/automatic thing in the kithe indexer, which we might want to do. Traject could possibly use an `after_record` hook in addition to `each_record`. Or maybe it should be called `each_record_before_write` or something -- but a hook that's like each_record, but guaranteed to run _after_ all indexing rules. 

Alternately, the kithe `obj_extract` method could/should be enhanced to just ignore empty strings, turn them into nils (and leave them out of arrays). I don't think they are ever useful, but Rails and kithe patterns mean they can easily wind up in your DB records, and then in your solr index via obj_extract. obj_extract should probably normalize them to nils. In general, empty strings are not useful in Solr -- for "text" fields they end up being tokenized to nothing, for facet-type fields they do this weird thing.