### PR TITLE
Remove reference to outdated 'scih-uploads' bucket name

### DIFF
--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -107,17 +107,14 @@ module ScihistDigicoll
     define_key :s3_bucket_dzi
 
     define_key :ingest_bucket, default: -> {
-      if Rails.env.production?
-        # This bucket is mounted on some staff Windows workstations
-        # We use it in both production and staging environments.
-        # But dev AWS key does not currently have access to it.
-        "scih-uploads"
-      else
+      if !Rails.env.production?
         # This bucket isn't actually mounted on workstations, but you can
         # add files to it in AWS console if you want files to test ingest
         # with in a dev environment.
         "scih-uploads-dev"
       end
+      # In production we rely on local_env.yml to provide value, no default,
+      # it'll just get out of sync.
     }
 
     define_key :s3_sitemap_bucket, default: -> {


### PR DESCRIPTION
That is no longer a bucket we use. Don't try to guess what buckets we're using as a 'default' in our Env.rb, just count on local_env.yml to provide it, no reason to try to keep an additional source of information that has to be kept sync'd as a default in ruby code.

There is still a default for non-production environments, so when you're in dev you don't need to have a local_env.yml, we want dev to work out of the box. The dev default is a bucket not actually mounted anywhere.