### PR TITLE
Asset download filename fix

### DIFF
--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -24,7 +24,7 @@
 
     <% if @asset.file %>
       <%= link_to "Download Original",
-            @asset.file.url(response_content_disposition: ContentDisposition.format(disposition: :attachment, filename: @asset.title)),
+            download_path(@asset),
             class: "btn btn-outline-primary btn-lg mt-4" %>
       <% end %>
   </div>

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -24,7 +24,7 @@
 
     <% if @asset.file %>
       <%= link_to "Download Original",
-            download_path(@asset),
+            @asset.file.url(response_content_disposition: ContentDisposition.format(disposition: :attachment, filename: DownloadFilenameHelper.filename_for_asset(@asset))),
             class: "btn btn-outline-primary btn-lg mt-4" %>
       <% end %>
   </div>


### PR DESCRIPTION
Use `DownloadFilenameHelper.filename_for_asset` to calculate the proper download filename, and pass that to the `response_content_disposition` in the URL.
This means that e.g. `/admin/asset_files/0g354f48h` will result in a compact downloaded filename with the correct file extension on it instead of a rambling six-word title.
`Orig. Filename` metadata is still available for reference on the asset view page, by the way.

Ref #349