### PR TITLE
Adding a link to the file in the s3 interface.

### DIFF
--- a/app/services/s3_console_uri.rb
+++ b/app/services/s3_console_uri.rb
@@ -1,0 +1,60 @@
+# S3ConsoleUri.new(asset.file.url(public: true)).console_uri
+# S3ConsoleUri.new(some_uri).console_uri
+#
+#
+# This will return a link that takes admins
+# directly to a AWS S3 console containing the file
+# and various s3 bells and whistles.
+# Initially written as part of the fixity checking code,
+# but useful in other contexts as well.
+class S3ConsoleUri
+
+  # Kind of hacky and fragile, will break
+  # if AWS changes their console URLs, or if our
+  # assumptions weren't quite right in other ways.
+  def console_uri
+    @checked_uri_in_s3_console ||= begin
+      region = ScihistDigicoll::Env.lookup(:aws_region)
+      parts = uri_components
+      if parts
+        "https://s3.console.aws.amazon.com/s3/buckets/#{parts[:bucket]}/#{parts[:key_path]}/?region=#{region}&tab=overview&prefixSearch=#{parts[:end_key]}"
+      else
+        nil
+      end
+    end
+  end
+
+  def initialize(uri)
+    raise ArgumentError.new("Please pass in a public S3 URI.") if uri.nil?
+    @uri = uri
+  end
+
+  # returns false if we do not think @uri looks like S3.
+  # returns a hash with keys :bucket, :key_path, :end_path
+  #
+  # If we later use a custom CNAME for S3 buckets,
+  # may have to adjust this, it assumes
+  # it can recognize S3 as *.s3.amazonaws.com)
+  def uri_components
+    parsed = URI.parse(@uri)
+
+    return false unless parsed.host
+
+    host_parts = parsed.host.split(".")
+    if host_parts.slice(1, host_parts.length) != %w{s3 amazonaws com}
+      return false
+    end
+
+    path_components = parsed.path.split("/")
+    key_path = path_components.slice(1, path_components.length - 2)&.join("/")
+    end_key = path_components.last
+
+    {
+      bucket: host_parts.first,
+      key_path: key_path,
+      end_key: end_key
+    }
+  rescue URI::InvalidURIError
+    false
+  end
+end

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -40,9 +40,13 @@
       <dt class="col-sm-4">Orig. Filename</dt>
       <dd class="col-sm-8"><%= @asset&.file&.metadata.try { |h| h["filename"]} %></dd>
 
-      <% if @asset.stored? && @asset&.file&.url %><%# are these equivalent ? %>
+      <% if @asset.stored? && @asset&.file&.url %>
         <dt class="col-sm-4">Direct link to file in storage</dt>
-        <dd class="col-sm-8"><%= link_to @asset.file.url.split('/').last, @asset.file.url %></dd>
+        <dd class="col-sm-8"><%= link_to @asset.file.url.split('/').last.split('?').first, @asset.file.url %></dd>
+      <%end %>
+      <%if Shrine.storages[:store].try('bucket').try('name') %>
+        <dt class="col-sm-4">Stored in S3 bucket</dt>
+        <dd class="col-sm-8"><%= Shrine.storages[:store].bucket.name %></dd>
       <% end %>
 
       <dt class="col-sm-4">Content-type</dt>

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -41,8 +41,8 @@
       <dd class="col-sm-8"><%= @asset&.file&.metadata.try { |h| h["filename"]} %></dd>
 
       <%if @asset.stored? && Shrine.storages[:store].try('bucket').try('name') %>
-        <dt class="col-sm-4">File in s3 (requires s3 login)</dt>
-        <dd class="col-sm-8"><%= link_to "File in S3", S3ConsoleUri.new(@asset.file.url(public: true)).console_uri %></dd>
+        <dt class="col-sm-4">File in s3</dt>
+        <dd class="col-sm-8"><%= link_to @asset.file.url(public: true).split('/').last, S3ConsoleUri.new(@asset.file.url(public: true)).console_uri %></dd>
 
         <dt class="col-sm-4">Stored in S3 bucket</dt>
         <dd class="col-sm-8"><%= Shrine.storages[:store].bucket.name %></dd>

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -40,11 +40,10 @@
       <dt class="col-sm-4">Orig. Filename</dt>
       <dd class="col-sm-8"><%= @asset&.file&.metadata.try { |h| h["filename"]} %></dd>
 
-      <% if @asset.stored? && @asset&.file&.url %>
-        <dt class="col-sm-4">Direct link to file in storage</dt>
-        <dd class="col-sm-8"><%= link_to @asset.file.url.split('/').last.split('?').first, @asset.file.url %></dd>
-      <%end %>
-      <%if Shrine.storages[:store].try('bucket').try('name') %>
+      <%if @asset.stored? && Shrine.storages[:store].try('bucket').try('name') %>
+        <dt class="col-sm-4">File in s3 (requires s3 login)</dt>
+        <dd class="col-sm-8"><%= link_to "File in S3", S3ConsoleUri.new(@asset.file.url(public: true)).console_uri %></dd>
+
         <dt class="col-sm-4">Stored in S3 bucket</dt>
         <dd class="col-sm-8"><%= Shrine.storages[:store].bucket.name %></dd>
       <% end %>


### PR DESCRIPTION
I broke Jonathan's recipe for determining a file's URL *within* the s3 interface (basically a link to the bucket with a canned search to the file itself.) out of the `fixity_check` object, where it had lived before, and moved it into a service object.
The link is now available for all assets.
Does not display if the file doesn't exist, or if (like me) you're storing files locally.
Ref #518