### PR TITLE
Send fixity failure emails to digital@sciencehistory.org as well.

### DIFF
--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -258,10 +258,11 @@ module ScihistDigicoll
     # bytestreams from fedora.
     define_key :import_fedora_auth
 
-    # Used as the from (no_reply) and to (digital_tech) email addresses
+    # Used as the from (no_reply) and to (digital_tech, digital) email addresses
     # when sending notices about failed fixity check.
     define_key :no_reply_email_address
     define_key :digital_tech_email_address
+    define_key :digital_email_address
 
     define_key :smtp_host
 

--- a/app/mailers/fixity_failure_mailer.rb
+++ b/app/mailers/fixity_failure_mailer.rb
@@ -6,9 +6,13 @@ class FixityFailureMailer < ApplicationMailer
     @fixity_check = params[:fixity_check]
     @asset = @fixity_check.asset
     from_address = ScihistDigicoll::Env.lookup(:no_reply_email_address)
-    to_address   = ScihistDigicoll::Env.lookup(:digital_tech_email_address)
-    if from_address.nil? || to_address.nil?
-      raise RuntimeError, 'Cannot send fixity error email; no email address is defined.'
+    to_address = [
+        ScihistDigicoll::Env.lookup(:digital_tech_email_address),
+        ScihistDigicoll::Env.lookup(:digital_email_address)
+      ].compact.join(',')
+
+    unless from_address.present? || to_address.present?
+      raise RuntimeError, 'Cannot send fixity error email; specify at least a "from" and a "to" address.'
     end
     mail(
       from:         from_address,

--- a/app/mailers/fixity_failure_mailer.rb
+++ b/app/mailers/fixity_failure_mailer.rb
@@ -11,7 +11,7 @@ class FixityFailureMailer < ApplicationMailer
         ScihistDigicoll::Env.lookup(:digital_email_address)
       ].compact.join(',')
 
-    unless from_address.present? || to_address.present?
+    unless from_address.present? && to_address.present?
       raise RuntimeError, 'Cannot send fixity error email; specify at least a "from" and a "to" address.'
     end
     mail(


### PR DESCRIPTION
If a `digital_email_address` is present in the local_env, send fixity failure emails to that email as well.
Otherwise, behave as before.
Ref #537 