### PR TITLE
remove superfluous target=_blank

### DIFF
--- a/app/presenters/social_share_display.rb
+++ b/app/presenters/social_share_display.rb
@@ -35,7 +35,6 @@ class SocialShareDisplay < ViewModel
 
     link_to "javascript:window.open('https://facebook.com/sharer/sharer.php?#{{u: share_url}.to_param}')",
         class: 'social-media-link facebook btn btn-brand-dark',
-        target: '_blank',
         rel: 'noopener noreferrer',
         data: {
           analytics_category: "Work",


### PR DESCRIPTION
We are doing a javascript window.open anyway (for convoluted purposes involving letting Facebook JS close the window itself), so the target blank was really superfluous. And for some reason we don't entirely understand, triggers browser blocking, causing #551, which this seems to resolve.