### PR TITLE
update blacklight from 7.4.0 to 7.4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       i18n
     bcrypt (3.1.12)
     bindex (0.5.0)
-    blacklight (7.4.0)
+    blacklight (7.4.2)
       deprecation
       globalid
       jbuilder (~> 2.7)


### PR DESCRIPTION
I noticed there were some patch releases, so why not, I guess? Hopefully won't introduce any new bugs. We rely on our tests to pass I guess.

Updated just by running "bundle update blacklight --conservative" and committing resulting Gemfile.lock.

https://github.com/projectblacklight/blacklight/compare/v7.4.0...v7.4.2