### PR TITLE
Revert "upgrade the yarn dependency serialize_javascript"

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   "resolutions": {
     "lodash": ">= 4.17.13",
     "lodash.template": ">= 4.5.0",
-    "js-yaml": ">= 3.13.1",
-    "serialize-javascript": ">= 2.1.1"
+    "js-yaml": ">= 3.13.1"
   },
   "browserslist": [
     "defaults"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6416,10 +6416,20 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-"serialize-javascript@>= 2.1.1", serialize-javascript@^1.4.0, serialize-javascript@^1.7.0, serialize-javascript@^2.1.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
-  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
+serialize-javascript@^1.4.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.7.0.tgz#d6e0dfb2a3832a8c94468e6eb1db97e55a192a65"
+  integrity sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==
+
+serialize-javascript@^1.7.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
+  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
+
+serialize-javascript@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.0.tgz#9310276819efd0eb128258bb341957f6eb2fc570"
+  integrity sha512-a/mxFfU00QT88umAJQsNWOnUKckhNCqOl028N48e7wFmo2/EHpTo9Wso+iJJCMrQnmFvcjto5RJdAHEvVhcyUQ==
 
 serve-index@^1.9.1:
   version "1.9.1"


### PR DESCRIPTION
This reverts commit 8e18a8cc01447b0cd70569babb995840dd928c72 and PR #553

533 did *not* work!

Now my local app is in the condition where it refuses to start, cause yarn complains:

```
yarn check v1.19.1
success Folder in sync.
Done in 0.11s.
yarn check v1.19.1
error "@rails/webpacker#compression-webpack-plugin#serialize-javascript" is wrong version: expected "^1.4.0", got "2.1.2"
error "@rails/webpacker#webpack#terser-webpack-plugin#serialize-javascript" is wrong version: expected "^1.7.0", got "2.1.2"
error Found 2 errors.
```

Not sure how we upgrade the vulnerable dependency, but apparently it wasn't that. yarn is driving me crazy!