### PR TITLE
On audio pages, make PDFs downloadable; all other non-audio files should not be linked.

### DIFF
--- a/app/decorators/audio_work_show_decorator.rb
+++ b/app/decorators/audio_work_show_decorator.rb
@@ -56,7 +56,7 @@ class AudioWorkShowDecorator < Draper::Decorator
   # and we want to link to pdf "view" link -- just direct delivery of the PDF
   # to the browser, using download controller same as MemberImagePresentation does.
   #
-  # If it's an image type, we don't expect it here, and don't know what to do with it
+  # If it's not a PDF, we don't expect it here, and don't know what to do with it
   # here (we're not supporting the Viewer here at present), so just punt and don't make it
   # a link.
   #
@@ -67,13 +67,12 @@ class AudioWorkShowDecorator < Draper::Decorator
   #        contents of link
   #     <% end %>
   def link_to_non_audio_member(member)
-    if member.content_type.start_with?("image/")
-      yield
-    else
+    if member.content_type == 'application/pdf'
       link_to download_path(member.leaf_representative, disposition: :inline) do
         yield
       end
+    else
+      yield
     end
   end
-
 end

--- a/app/decorators/audio_work_show_decorator.rb
+++ b/app/decorators/audio_work_show_decorator.rb
@@ -56,7 +56,7 @@ class AudioWorkShowDecorator < Draper::Decorator
   # and we want to link to pdf "view" link -- just direct delivery of the PDF
   # to the browser, using download controller same as MemberImagePresentation does.
   #
-  # If it's not a PDF, we don't expect it here, and don't know what to do with it
+  # If it's an image type, we don't expect it here, and don't know what to do with it
   # here (we're not supporting the Viewer here at present), so just punt and don't make it
   # a link.
   #
@@ -67,12 +67,13 @@ class AudioWorkShowDecorator < Draper::Decorator
   #        contents of link
   #     <% end %>
   def link_to_non_audio_member(member)
-    if member.content_type == 'application/pdf'
+    if member.content_type&.start_with?("image/")
+      yield
+    else
       link_to download_path(member.leaf_representative, disposition: :inline) do
         yield
       end
-    else
-      yield
     end
   end
+
 end


### PR DESCRIPTION
Instead of testing for an image, let's just explicitly check to see if the file is a PDF when deciding whether to create a link or not should fix ref #580 .  If it's not (or we don't have a content_type), don't link to it.