### PR TITLE
Fix attribute value lists at some smaller responsive sizes

### DIFF
--- a/app/assets/stylesheets/local/attribute_table.scss
+++ b/app/assets/stylesheets/local/attribute_table.scss
@@ -42,6 +42,7 @@ $attribute-table-max-tabular: 22.5em;
       }
       ul {
         padding-left: 0;
+        list-style: none;
       }
     }
     & > tbody > tr  td {

--- a/app/assets/stylesheets/local/attribute_table.scss
+++ b/app/assets/stylesheets/local/attribute_table.scss
@@ -31,7 +31,7 @@ $attribute-table-max-tabular: 22.5em;
     word-break: break-word;
     hyphens: auto;
 
-    table, tbody, thead, td, th {
+    table, tbody, thead, tr, td, th {
       display: block;
       width: 100%;
     }

--- a/app/assets/stylesheets/local/attribute_table.scss
+++ b/app/assets/stylesheets/local/attribute_table.scss
@@ -51,7 +51,11 @@ $attribute-table-max-tabular: 22.5em;
   }
 
   // At larger sizes, a table for real.
-  @media (min-width: $attribute-table-max-tabular + 1) {
+  //
+  // $attribute-table-max-tabular may be in "ems", this is a hakcy way to do it
+  // combining max-width above with min-width here to take over, but it's what
+  // we got for now.
+  @media (min-width: $attribute-table-max-tabular + 0.01) {
     //table-layout: fixed;
     overflow: hidden;
 


### PR DESCRIPTION
One part of #584 

At certain sizes attribute list <uls> were looking weird, with bullet characters showing up that were not intended. 

-----

![Screenshot 2020-01-21 15 04 32](https://user-images.githubusercontent.com/149304/72841255-0070a580-3c64-11ea-93aa-b18e7d02266b.png)
![Screenshot 2020-01-21 14 53 35](https://user-images.githubusercontent.com/149304/72841257-0070a580-3c64-11ea-940e-9da035dd79bb.png)

-------

This fixes em, see code and individual commit messages. 