### PR TITLE
btn-group necessary in download-dropdown-display after all

### DIFF
--- a/app/presenters/download_dropdown_display.rb
+++ b/app/presenters/download_dropdown_display.rb
@@ -76,8 +76,8 @@ class DownloadDropdownDisplay < ViewModel
 
   def display
     # https://getbootstrap.com/docs/4.0/components/dropdowns/
-    # viewer-navbar-btn necessary for it to style correctly when embedded in viewer. :(
-    content_tag("div", class: "action-item viewer-navbar-btn downloads #{@use_link ? "dropdown" : "dropup"}") do
+    # viewer-navbar-btn and btn-group necessary for it to style correctly when embedded in viewer. :(
+    content_tag("div", class: "action-item viewer-navbar-btn btn-group downloads #{@use_link ? "dropdown" : "dropup"}") do
       link_or_button +
       content_tag("div", class: "dropdown-menu download-menu", "aria-labelledby" => menu_button_id) do
         menu_items


### PR DESCRIPTION
Tried to remove it in 6ea353eb. But that messed up viewer display, not just in small screens but in all screens.

![Screenshot 2020-01-21 15 41 06](https://user-images.githubusercontent.com/149304/72842731-fef4ac80-3c66-11ea-84f8-0fd2ea2ec9ae.png)


Hopefully putting it back won't break popper positioning as suggested in the commit log for 6ea353eb -- i think we're good.

Ref #584 although it turns out it wasn't just small screens!