### PR TITLE
Separate ActiveJob worker pools

### DIFF
--- a/app/jobs/on_demand_derivative_creator_job.rb
+++ b/app/jobs/on_demand_derivative_creator_job.rb
@@ -1,5 +1,7 @@
 # placeholder
 class OnDemandDerivativeCreatorJob < ApplicationJob
+  queue_as :on_demand_derivatives
+
   def perform(work, derivative_type)
     OnDemandDerivativeCreator.new(work, derivative_type: derivative_type).attach_derivative!
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,7 +62,12 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   config.active_job.queue_adapter     = :resque
-  config.active_job.queue_name_prefix = "scihist_digicoll_#{Rails.env}"
+
+  # We are not sharing a redis among multiple apps, seems no need to queue_name_prefix,
+  # and it makes it confusing when trying to set resque workers to work specific
+  # queues and getting it to match.
+  config.active_job.queue_name_prefix = nil
+  #config.active_job.queue_name_prefix = "scihist_digicoll_#{Rails.env}"
 
   # devise mailers require the `host` be set
   config.action_mailer.default_url_options = {

--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,4 +1,5 @@
 production:
-  "*": 10
+  "mailers,default": 10
+  "on_demand_derivatives": 2
 development:
   "*": 5


### PR DESCRIPTION
Instead of having 10 workers set up, we set up two pools of 10 and 2 workers each. Right now we have one jobs server, but if we had multiple this would be true on each of them.

The 2-worker pool is working ONLY the `on_demand_derivatives` queue -- which are on-demand derivatives job is now set to use.

The 1o-worker pool is working first priority `mailers` queue, then the `default` queue which includes all other work we know about -- mostly ingests. At the moment, we aren't actually sending any email using mailers in the bg, so the mailers queue won't have any work on it. But preemptively setting it up in case we do so it will keep working. Rails will use the `mailers` queue for any emails sent "later", and our workers will preferentially handle those (fairly quick) tasks when there are some waiting, before handling any other work such as (much slower) ingest-related work.

After deploying this, we should keep an eye on the resque admin, to make sure there isn't any work piling up in OTHER queues that we DON'T have workers working. Previously our workers were working "any" queue, but that is not possible with resque configuration options available and the desired two-separate-pool setup.

Ref #302