### PR TITLE
use thumb_large_2X for oai pmh thumbnail

### DIFF
--- a/app/serializers/work_oai_dc_serialization.rb
+++ b/app/serializers/work_oai_dc_serialization.rb
@@ -143,9 +143,9 @@ class WorkOaiDcSerialization
 
 
 
-        if medium_download_size_url.present?
+        if appropriate_thumb_url.present?
           # PA Digital wants the thumbnail in a repeated dc:identifier, okay then!
-          xml["dc"].send(:"identifier", medium_download_size_url)
+          xml["dc"].send(:"identifier", appropriate_thumb_url)
         end
 
         ########################
@@ -155,8 +155,8 @@ class WorkOaiDcSerialization
         # if anyone wants em, without us having to code em then.
 
         xml["dpla"].originalRecord in_our_app_url
-        if medium_download_size_url.present?
-          xml["edm"].preview medium_download_size_url
+        if appropriate_thumb_url.present?
+          xml["edm"].preview appropriate_thumb_url
         end
 
         if work.rights.present?
@@ -218,8 +218,11 @@ class WorkOaiDcSerialization
   # We are hand-building the URL instead of using Rails route helper to further improve
   # perfomrance and avoid the need to have rails route helpers here. Our tests
   # should still test with rails route helpers.
-  def medium_download_size_url
-    @medium_download_size_url ||= "#{ScihistDigicoll::Env.lookup!(:app_url_base)}/downloads/#{work.leaf_representative.friendlier_id}/download_medium?disposition=inline"
+  #
+  # We are using a pretty big URL, thumb_large_2X (1050px; facebook recommends 1200px upload!)
+  # our largest "thumb" type URL -- even PDFs get thumb-size derivatives.
+  def appropriate_thumb_url
+    @appropriate_thumb_url ||= "#{ScihistDigicoll::Env.lookup!(:app_url_base)}/downloads/#{work.leaf_representative.friendlier_id}/thumb_large_2X?disposition=inline"
   end
 
   def full_jpg_url

--- a/spec/serializers/work_oai_dc_serialization_spec.rb
+++ b/spec/serializers/work_oai_dc_serialization_spec.rb
@@ -15,7 +15,7 @@ describe WorkOaiDcSerialization do
   # hacky probably a better way to do this. :(
   let(:app_base) { "#{ScihistDigicoll::Env.app_url_base_parsed.scheme}://#{ScihistDigicoll::Env.app_url_base_parsed.host}" }
   let(:public_work_url) { app_base + Rails.application.routes.url_helpers.work_path(work) }
-  let(:work_thumb_url) { app_base + Rails.application.routes.url_helpers.download_derivative_path(work.representative, :download_medium, disposition: "inline") }
+  let(:work_thumb_url) { app_base + Rails.application.routes.url_helpers.download_derivative_path(work.representative, :thumb_large_2X, disposition: "inline") }
   let(:full_jpg_url) { app_base + Rails.application.routes.url_helpers.download_derivative_path(work.representative, :download_full, disposition: "inline") }
 
   let(:instance) { WorkOaiDcSerialization.new(work)}

--- a/spec/system/oai_pmh_spec.rb
+++ b/spec/system/oai_pmh_spec.rb
@@ -67,7 +67,14 @@ RSpec.feature "OAI-PMH feed", js: false do
     expect(dc_identifiers).to include(public_work_url)
     # PA digital wants the thumb in there too, I dunno.
     expect(dc_identifiers).to include(work_thumb_url)
+    # But we're also putting it in edm:preview
+    expect(record.xpath("//edm:preview", edm: "http://www.europeana.eu/schemas/edm/").collect(&:text)).to eq([work_thumb_url])
 
     expect(record.at_xpath("//edm:object", edm: "http://www.europeana.eu/schemas/edm/")&.text).to eq work_full_url
+
+    # And make sure thumb_url is actually visitable -- it may result in a redirect to S3 or underlying
+    # storage but should be 200 eventually. Also this may be different in test mock. :(
+    visit work_thumb_url
+    expect(page.status_code).to eq 200
   end
 end

--- a/spec/system/oai_pmh_spec.rb
+++ b/spec/system/oai_pmh_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "OAI-PMH feed", js: false do
   let(:oai_pmh_xsd_path) { Rails.root + "spec/fixtures/xsd/OAI-PMH.xsd" }
 
   let(:public_work_url) { work_url(work) }
-  let(:work_thumb_url) { download_derivative_url(work.leaf_representative, "download_medium", disposition: :inline) }
+  let(:work_thumb_url) { download_derivative_url(work.leaf_representative, "thumb_large_2X", disposition: :inline) }
   let(:work_full_url) { download_derivative_url(work.leaf_representative, "download_full", disposition: :inline) }
 
   it "renders feed with just work" do


### PR DESCRIPTION
PDFs didn't have a download_large. But should have thumb. It's only a bit smaller than download_large. Ref #572

Added tests in this PR, but they didn't actually go red to catch the bug. Oh well, good tests anyway, good enough.