### PR TITLE
Remove thumb URL from oai-pmh dc:identifier

### DIFF
--- a/app/serializers/work_oai_dc_serialization.rb
+++ b/app/serializers/work_oai_dc_serialization.rb
@@ -141,23 +141,17 @@ class WorkOaiDcSerialization
           xml["dc"].type genre.downcase
         end
 
-
-
         if appropriate_thumb_url.present?
-          # PA Digital wants the thumbnail in a repeated dc:identifier, okay then!
-          xml["dc"].send(:"identifier", appropriate_thumb_url)
+          xml["edm"].preview appropriate_thumb_url
         end
 
         ########################
         #
-        # PA Digital will probably throw these out and not forward them to DPLA, but they
-        # are tags DPLA MAP asks for, we might as well include them so they are there in the future
-        # if anyone wants em, without us having to code em then.
+        # These are tags the DPLA MAP asks for, we aren't certain if PA Digital are using these,
+        # but we might as well include them so they are there in the future  if anyone wants em,
+        # without us having to code em then.
 
         xml["dpla"].originalRecord in_our_app_url
-        if appropriate_thumb_url.present?
-          xml["edm"].preview appropriate_thumb_url
-        end
 
         if work.rights.present?
           xml["edm"].rights work.rights
@@ -170,7 +164,9 @@ class WorkOaiDcSerialization
         # "The URL of a suitable source object in the best resolution available on the website of the Data
         # "Provider from which edm:preview could be generated for use in available portal."
         #
-        # BEST resolution available? OK, we'll give them the full jpg.
+        # BEST resolution available? OK, we'll give them the full jpg. We could give them the
+        # actual original TIFFs, but that seems excessive. Unknown if anyone is using this
+        # on the PA Digital end.
         if full_jpg_url.present?
           xml["edm"].object full_jpg_url
         end

--- a/spec/serializers/work_oai_dc_serialization_spec.rb
+++ b/spec/serializers/work_oai_dc_serialization_spec.rb
@@ -33,10 +33,9 @@ describe WorkOaiDcSerialization do
     container = xml.at_xpath("./oai_dc:dc")
     expect(container).to be_present
 
-    # PA digital wants both URL and thumbnail URL in dc:identifiers
+    # PA digital wants both URL in dc:identifiers
     dc_identifiers = container.xpath("./dc:identifier").collect(&:text)
     expect(dc_identifiers).to include public_work_url
-    expect(dc_identifiers).to include work_thumb_url
 
     expect(container.at_xpath("./dc:title").text).to eq work.title
     expect(container.at_xpath("./dc:rights").text).to eq work.rights

--- a/spec/system/oai_pmh_spec.rb
+++ b/spec/system/oai_pmh_spec.rb
@@ -65,9 +65,8 @@ RSpec.feature "OAI-PMH feed", js: false do
 
     dc_identifiers = record.xpath("//dc:identifier", dc:"http://purl.org/dc/elements/1.1/").collect(&:text)
     expect(dc_identifiers).to include(public_work_url)
-    # PA digital wants the thumb in there too, I dunno.
-    expect(dc_identifiers).to include(work_thumb_url)
-    # But we're also putting it in edm:preview
+
+    # Thumb in edm:preview
     expect(record.xpath("//edm:preview", edm: "http://www.europeana.eu/schemas/edm/").collect(&:text)).to eq([work_thumb_url])
 
     expect(record.at_xpath("//edm:object", edm: "http://www.europeana.eu/schemas/edm/")&.text).to eq work_full_url


### PR DESCRIPTION
Leanne at PA Digital says they are not needing/using it there:

> And yup, I'm taking thumbnails from edm:preview rather than dc:identifier.

Was always pretty ugly, we only had it there cause PA Digital had told us they required it, if they don't, let's remove it.

Ref #572