### PR TITLE
AssetsNeedingFixityChecks avoid find_each

### DIFF
--- a/app/lib/scihist_digicoll/assets_needing_fixity_checks.rb
+++ b/app/lib/scihist_digicoll/assets_needing_fixity_checks.rb
@@ -19,6 +19,7 @@ module ScihistDigicoll
   # Note: if you pass in 0 as the cycle length, you just get all the assets.
   #
   class AssetsNeedingFixityChecks
+    BATCH_FETCH_SIZE = 1000
     DEFAULT_PERIOD_IN_DAYS  = 7 # in days
     attr_reader :cycle_length
 
@@ -31,10 +32,42 @@ module ScihistDigicoll
       @cycle_length = cycle_length
     end
 
+    # Gives you a way to iterate over all assets to check. You can call it with a block:
+    #
+    #     assets_needing.assets_to_check { |asset_model| ... }
+    #
+    # But using some ruby Enumerator cleverness, you can call it without a block to get an
+    # Enumerator back, which lets you chain methods like `each_slice` onto it, which is actually
+    # what our intended caller does.
+    #
+    # The implementation fetches 1000 (BATCH_FETCH_SIZE) of the Assets with stalest
+    # fixity checks in; and keeps doing that in batches of 1000 until all the assets
+    # we desire to fetch (based on total number of assets divide by CYCLE_LENGTH) have
+    # been fetched.
+    #
+    # This weird implementation is needed to avoid fetching everything into memory at once,
+    # without using ActiveRecord's `find_each` batching, becuase previous attempts
+    # to use `find_each` seemed to run into trouble with race-conditions caused by editing the database
+    # to add fixity checks records, in a way that affected the conditions of the `find_each`,
+    # and may have resulted in ending up checking everything. The trick here is to avoid
+    # fetching everything into memory, including huge lists of IDs, or making SQL involving
+    # lists of hundreds/thousands of IDs, while still batching fetching multipe objects
+    # per SQL select.
     def assets_to_check
-      # We need to use sub-query, cause find_each needs it's own ORDER BY, to
-      # be able to fetch in batches reliably.
-      Asset.where(id: selected_assets_scope).find_each
+      # Clever way to return an enumerator that can be chained
+      # https://blog.arkency.com/2014/01/ruby-to-enum-for-enumerator
+      return to_enum(:assets_to_check) unless block_given?
+
+
+      fetched = 0
+      while (fetched < expected_num_to_check)
+        num_to_fetch = ((expected_num_to_check - fetched) >= BATCH_FETCH_SIZE) ? BATCH_FETCH_SIZE : (expected_num_to_check - fetched)
+
+        selected_assets_scope(limit: num_to_fetch).each do |record|
+          yield record
+        end
+        fetched += num_to_fetch
+      end
     end
 
     def expected_num_to_check
@@ -43,13 +76,19 @@ module ScihistDigicoll
 
     private
 
-    def selected_assets_scope
+    # ActiveRecord scope for those Assets most in need of fixity checks -- either
+    # they don't have a fixity check on record, or their most recent fixity check
+    # is among the oldest in the database.
+    #
+    # Applying this sort is a bit tricky because of the one-to-many relationship
+    # between Asset and fixity check, and need to order by _most recent_ fixity
+    # check recorded.
+    def selected_assets_scope(limit:)
       Asset.
-        select("kithe_models.id").
         left_outer_joins(:fixity_checks).
         group(:id).
         order(Arel.sql "max(fixity_checks.created_at) nulls first").
-        limit(expected_num_to_check)
+        limit(limit)
     end
   end
 end

--- a/spec/models/assets_needing_fixity_checks_spec.rb
+++ b/spec/models/assets_needing_fixity_checks_spec.rb
@@ -16,8 +16,7 @@ describe ScihistDigicoll::AssetsNeedingFixityChecks do
     end
 
     it "is constructed sensibly" do
-      expected = """
-        SELECT kithe_models.id
+      expected_ending = """
         FROM \"kithe_models\"
         LEFT OUTER JOIN \"fixity_checks\"
         ON \"fixity_checks\".\"asset_id\" = \"kithe_models\".\"id\"
@@ -27,9 +26,9 @@ describe ScihistDigicoll::AssetsNeedingFixityChecks do
         LIMIT 1
       """.gsub(/\s+/, ' ').strip
 
-      actual = checker.send(:selected_assets_scope).to_sql.gsub(/\s+/, ' ').strip
+      actual = checker.send(:selected_assets_scope, limit: 1).to_sql.gsub(/\s+/, ' ').strip
 
-      expect(actual).to eq(expected), "\nexpected: #{expected}\n     got: #{actual}\n"
+      expect(actual).to end_with(expected_ending)
     end
   end
 


### PR DESCRIPTION
Accomplish the same thing more manually -- fetching in batches of 1000, but still yielding in a single stream.

We think find_each race condition may have been responsible for #498, and this may solve it.

@eddierubeiz 's debugging in #583 was crucial for figuring out what was going wrong and coming up with possible solution. Possibly we're still being too clever -- but I just didn't want to give up on avoiding fetching al objects or IDs into memory, to have an implementation that should be able to scale to orders of magnitude more assets no problem.