### PR TITLE
Updating capistrano version in capfile lock

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -11,7 +11,7 @@
 # the local_env.yml file.
 
 # config valid only for current version of Capistrano
-lock '3.11.0'
+lock '3.11.2'
 
 # Make our EC2 server autodiscover available
 include CapServerAutodiscover


### PR DESCRIPTION
#586 updated the version of Capistrano from 3.11.0 to 3.11.2, but left the lock in deploy.rb unchanged.