### PR TITLE
[WIP] Comments for r and r items

### DIFF
--- a/app/controllers/admin/r_and_r_items_controller.rb
+++ b/app/controllers/admin/r_and_r_items_controller.rb
@@ -1,6 +1,6 @@
 # This controller is based on Admin::DigitizationQueueItemsController.rb
 class Admin::RAndRItemsController < AdminController
-  before_action :set_admin_r_and_r_item, only: [:show, :edit, :update, :destroy]
+  before_action :set_admin_r_and_r_item, only: [:show, :edit, :update, :destroy, :add_comment, :delete_comment]
 
   # GET /admin/r_and_r_items
   # GET /admin/r_and_r_items.json
@@ -42,7 +42,8 @@ class Admin::RAndRItemsController < AdminController
   # PATCH/PUT /admin/r_and_r_items/1.json
   def update
     respond_to do |format|
-      if @admin_r_and_r_item.update(admin_r_and_r_item_params)
+      if update_with_action_comments(@admin_r_and_r_item, admin_r_and_r_item_params)
+      #if @admin_r_and_r_item.update(admin_r_and_r_item_params)
         format.html { redirect_to @admin_r_and_r_item, notice: 'R&R item updated.' }
         format.json { render text: "Something" }
       else
@@ -67,74 +68,115 @@ class Admin::RAndRItemsController < AdminController
   end
   helper_method :collecting_area
 
-  private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_admin_r_and_r_item
-      @admin_r_and_r_item = Admin::RAndRItem.find(params[:id])
-    end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def admin_r_and_r_item_params
-      params.require(:admin_r_and_r_item).permit(
-        :title, :status, :accession_number, :museum_object_id, :bib_number, :location,
-        :box, :folder, :dimensions, :materials, :copyright_status,
-        :scope, :instructions, :additional_notes, :collecting_area,
-        :is_destined_for_ingest, :copyright_research_still_needed, :curator, :patron_name,
-        :patron_email, :deadline, :date_files_sent,
-        :additional_pages_to_ingest, :status_changed_at
+
+  # POST /admin/r_and_r_item/1/add_comment
+  def add_comment
+    if params["comment"].present?
+      Admin::QueueItemComment.create!(
+        user: current_user,
+        r_and_r_item: @admin_r_and_r_item,
+        text: params["comment"]
       )
     end
+    redirect_to @admin_r_and_r_item
+  end
 
-    def filtered_index_items
-      scope = Admin::RAndRItem.order(deadline: :asc)
+  # admin_delete_comment
+  # DELETE
+  # /admin/r_and_r_items/:id/delete_comment/:comment_id(.:format)
+  # admin/digitization_queue_items#delete_comment
+  def delete_comment
+    comment = Admin::QueueItemComment.find_by_id(params['comment_id'])
+    raise ArgumentError.new( 'Could not find this comment.') if comment.nil?
+    if can?(:destroy, comment)
+      comment.delete
+      notice = 'Comment deleted.'
+    else
+      notice = 'You may not delete this comment.'
+    end
+    redirect_to @admin_r_and_r_item,
+      notice: notice
+  end
 
-      if (q = params.dig(:query, :q)).present?
-        scope = scope.where("title like ? OR bib_number = ? or accession_number = ? OR museum_object_id = ?", "%#{q}%", q, q, q)
-      end
+private
+  # Use callbacks to share common setup or constraints between actions.
+  def set_admin_r_and_r_item
+    @admin_r_and_r_item = Admin::RAndRItem.find(params[:id])
+  end
 
-      status = params.dig(:query, :status)
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def admin_r_and_r_item_params
+    params.require(:admin_r_and_r_item).permit(
+      :title, :status, :accession_number, :museum_object_id, :bib_number, :location,
+      :box, :folder, :dimensions, :materials, :copyright_status,
+      :scope, :instructions, :additional_notes, :collecting_area,
+      :is_destined_for_ingest, :copyright_research_still_needed, :curator, :patron_name,
+      :patron_email, :deadline, :date_files_sent,
+      :additional_pages_to_ingest, :status_changed_at
+    )
+  end
 
-      if status == "ANY"
-        # no-op, no filter
-      elsif status.blank? # default, "open"
-        scope = scope.open_status
-      else
-        scope = scope.where(status: status)
-      end
+  def filtered_index_items
+    scope = Admin::RAndRItem.order(deadline: :asc)
 
-      collecting_area = params.dig(:query, :collecting_area)
-      unless collecting_area.blank? || collecting_area == "ANY"
-        scope = scope.where(collecting_area: collecting_area)
-      end
-
-      scope.page(params[:page]).per(100)
+    if (q = params.dig(:query, :q)).present?
+      scope = scope.where("title like ? OR bib_number = ? or accession_number = ? OR museum_object_id = ?", "%#{q}%", q, q, q)
     end
 
-    # hacky helper to give us select menu options for status filter
-    #
-    # The 'nil' option is actually 'closed', that we want to be default
-    def status_filter_options
-      helpers.options_for_select([["Any", "ANY"]], params.dig(:query, :status)) +
-      helpers.grouped_options_for_select(
-        { "open/closed" => [["Open", ""], ["Closed", "closed"]],
-          "status" =>  Admin::RAndRItem::STATUSES.
-            find_all {|s| s != "closed" }.
-            collect {|s| [s.humanize, s]}
-        },
-        params.dig(:query, :status) || ""
-      )
-    end
-    helper_method :status_filter_options
+    status = params.dig(:query, :status)
 
-    def collecting_area_filter_options
-      helpers.options_for_select([["Any", "ANY"]], params.dig(:query, :status)) +
-      helpers.grouped_options_for_select(
-        { "collecting area" =>  Admin::RAndRItem::COLLECTING_AREAS.
-            collect {|s| [s.humanize, s]}
-        },
-        params.dig(:query, :collecting_area) || ""
-      )
+    if status == "ANY"
+      # no-op, no filter
+    elsif status.blank? # default, "open"
+      scope = scope.open_status
+    else
+      scope = scope.where(status: status)
     end
-    helper_method :collecting_area_filter_options
 
+    collecting_area = params.dig(:query, :collecting_area)
+    unless collecting_area.blank? || collecting_area == "ANY"
+      scope = scope.where(collecting_area: collecting_area)
+    end
+
+    scope.page(params[:page]).per(100)
+  end
+
+  # hacky helper to give us select menu options for status filter
+  #
+  # The 'nil' option is actually 'closed', that we want to be default
+  def status_filter_options
+    helpers.options_for_select([["Any", "ANY"]], params.dig(:query, :status)) +
+    helpers.grouped_options_for_select(
+      { "open/closed" => [["Open", ""], ["Closed", "closed"]],
+        "status" =>  Admin::RAndRItem::STATUSES.
+          find_all {|s| s != "closed" }.
+          collect {|s| [s.humanize, s]}
+      },
+      params.dig(:query, :status) || ""
+    )
+  end
+  helper_method :status_filter_options
+
+  def collecting_area_filter_options
+    helpers.options_for_select([["Any", "ANY"]], params.dig(:query, :status)) +
+    helpers.grouped_options_for_select(
+      { "collecting area" =>  Admin::RAndRItem::COLLECTING_AREAS.
+          collect {|s| [s.humanize, s]}
+      },
+      params.dig(:query, :collecting_area) || ""
+    )
+  end
+  helper_method :collecting_area_filter_options
+
+  def update_with_action_comments(queue_item, params)
+    result = nil
+    queue_item.class.transaction do
+      result = queue_item.update(params)
+      if result && queue_item.saved_change_to_status?
+        queue_item.queue_item_comments.create!(system_action: true, user: current_user, text: "marked: #{queue_item.status.humanize.downcase}")
+      end
+    end
+    result
+  end
 end

--- a/app/models/admin/queue_item_comment.rb
+++ b/app/models/admin/queue_item_comment.rb
@@ -1,4 +1,5 @@
 # A comment attached to a particular Admin::DigitizationQueueItem
+# or Admin::RAndRItem.
 # They are displayed kind of "facebook timeline"-style
 #
 # Text is in #text attribute.
@@ -10,5 +11,12 @@
 # stick the user-displayable text in #text.
 class Admin::QueueItemComment < ApplicationRecord
   belongs_to :user, optional: true
-  belongs_to :digitization_queue_item
+  belongs_to :digitization_queue_item, optional:true
+  belongs_to :r_and_r_item, optional:true
+
+  # A comment must be EITHER on an r_and_r_item,
+  # XOR on a digitization_queue_item
+  # (but can't and shouldn't be on both).
+  validates :digitization_queue_item_id, presence: true, unless: :r_and_r_item_id
+  validates :r_and_r_item_id, presence: true, unless: :digitization_queue_item_id
 end

--- a/app/models/admin/r_and_r_item.rb
+++ b/app/models/admin/r_and_r_item.rb
@@ -2,6 +2,7 @@
 
 class Admin::RAndRItem < ApplicationRecord
   has_many :digitization_queue_item, dependent: :nullify
+  has_many :queue_item_comments, dependent: :destroy
 
   scope :open_status,   -> { where.not(status: "closed") }
   scope :closed_status, -> { where(    status: "closed") }

--- a/app/views/admin/digitization_queue_items/show.html.erb
+++ b/app/views/admin/digitization_queue_items/show.html.erb
@@ -107,7 +107,7 @@
             <% if can?(:destroy, comment) %>
               <div class="text-right">
                 <%= link_to "Delete",
-                  admin_delete_comment_path(id: @admin_digitization_queue_item.id, comment_id: comment.id),
+                  admin_delete_digitization_queue_item_comment_path(id: @admin_digitization_queue_item.id, comment_id: comment.id),
                   class: "btn btn-primary mb-1",
                   method: 'delete',
                   data: { confirm: "Delete your comment?" }

--- a/app/views/admin/r_and_r_items/_show_first_column.html.erb
+++ b/app/views/admin/r_and_r_items/_show_first_column.html.erb
@@ -1,5 +1,19 @@
 <h2>About</h2>
 
+
+<dt>Is this going into the Digital Collections?</dt>
+<dd>
+  <%=  @admin_r_and_r_item.is_destined_for_ingest ? 'Yes' : "No (thus, it can't be moved to the digitization queue)" %>.
+  <% if @admin_r_and_r_item.is_destined_for_ingest %>
+    <% unless @admin_r_and_r_item.ready_to_move_to_digitization_queue_based_on_status? %>
+      <br />(although status is still "<%= @admin_r_and_r_item.status.humanize %>")
+    <% end %>
+    <% if @admin_r_and_r_item.copyright_research_still_needed %>
+      <br />(although copyright research still needed)
+    <%end %>
+  <% end %>
+</dd>
+
 <dt>Status</dt>
 <dd>
   <%= @admin_r_and_r_item.status.humanize %> as of <%= l @admin_r_and_r_item.status_changed_at, format: :admin %>
@@ -24,18 +38,6 @@
   </dd>
 <% end %>
 
-<dt>Is this going into the Digital Collections?</dt>
-<dd>
-  <%=  @admin_r_and_r_item.is_destined_for_ingest ? 'Yes' : "No (thus, it can't be moved to the digitization queue)" %>.
-  <% if @admin_r_and_r_item.is_destined_for_ingest %>
-    <% unless @admin_r_and_r_item.ready_to_move_to_digitization_queue_based_on_status? %>
-      <br />(although status is still "<%= @admin_r_and_r_item.status.humanize %>")
-    <% end %>
-    <% if @admin_r_and_r_item.copyright_research_still_needed %>
-      <br />(although copyright research still needed)
-    <%end %>
-  <% end %>
-</dd>
 
 <dt>Is copyright research still needed for this item?</dt>
 <dd>

--- a/app/views/admin/r_and_r_items/_show_first_column.html.erb
+++ b/app/views/admin/r_and_r_items/_show_first_column.html.erb
@@ -1,0 +1,89 @@
+<% if @admin_r_and_r_item.digitization_queue_item.count > 0 %>
+  <dt><%= pluralize(@admin_r_and_r_item.digitization_queue_item.count, 'corresponding item') %> in the digitization queue</dt>
+  <dd>
+    <ul class="list-group">
+    <% @admin_r_and_r_item.digitization_queue_item.each do |dq_item| %>
+      <%= link_to dq_item.title, admin_digitization_queue_items_path(dq_item),
+      class: "list-group-item list-group-item-action" %>
+    <% end %>
+    </ul>
+  </dd>
+<% end%>
+
+<dt>Status</dt>
+<dd>
+  <%= @admin_r_and_r_item.status.humanize %> as of <%= l @admin_r_and_r_item.status_changed_at, format: :admin %>
+</dd>
+
+<% if @admin_r_and_r_item.deadline %>
+  <dt>Deadline to send files to the patron</dt>
+  <dd>
+    <%= l(@admin_r_and_r_item.deadline, format: "%F") %>
+  </dd>
+<% end %>
+
+<% if @admin_r_and_r_item.date_files_sent %>
+  <dt>When files were sent</dt>
+  <dd>
+    <%= l(@admin_r_and_r_item.date_files_sent, format: "%F") %>
+  </dd>
+<% else %>
+  <dt>Have files been sent to the patron?</dt>
+  <dd>
+    Not yet.
+  </dd>
+<% end %>
+
+<dt>Is this going into the Digital Collections?</dt>
+<dd>
+  <%=  @admin_r_and_r_item.is_destined_for_ingest ? 'Yes' : "No (thus, it can't be moved to the digitization queue)" %>.
+  <% if @admin_r_and_r_item.is_destined_for_ingest %>
+    <% unless @admin_r_and_r_item.ready_to_move_to_digitization_queue_based_on_status? %>
+      <br />(although status is still "<%= @admin_r_and_r_item.status.humanize %>")
+    <% end %>
+    <% if @admin_r_and_r_item.copyright_research_still_needed %>
+      <br />(although copyright research still needed)
+    <%end %>
+  <% end %>
+</dd>
+
+<dt>Is copyright research still needed for this item?</dt>
+<dd>
+  <%=  @admin_r_and_r_item.copyright_research_still_needed ? 'Yes' : 'No' %>.
+</dd>
+
+<dt>Collecting area</dt>
+<dd><%= @admin_r_and_r_item.collecting_area.humanize%></dd>
+
+<dt>Curator</dt>
+<dd>
+  <%=   @admin_r_and_r_item.curator ? @admin_r_and_r_item.curator.capitalize : "None" %>
+</dd>
+
+<%= queue_item_show_field(@admin_r_and_r_item, :patron_name) %>
+<%= queue_item_show_field(@admin_r_and_r_item, :patron_email) %>
+
+<% if @admin_r_and_r_item.bib_number.present? %>
+  <p>
+    <%= link_to "OPAC link (#{@admin_r_and_r_item.bib_number})", ScihistDigicoll::Util.opac_url(@admin_r_and_r_item.bib_number), target: "_blank" %>
+  </p>
+<% end %>
+
+<dt>Created at</dt>
+<dd>
+  <%= l @admin_r_and_r_item.created_at, format: :admin %>
+</dd>
+
+<%= queue_item_show_field(@admin_r_and_r_item, :bib_number) %>
+<%= queue_item_show_field(@admin_r_and_r_item, :scope, paragraphs: true, override_label: "Pages to scan for this patron") %>
+<%= queue_item_show_field(@admin_r_and_r_item, :additional_pages_to_ingest, override_label: "Additional pages to ingest into the Digital Collections") %>
+<%= queue_item_show_field(@admin_r_and_r_item, :location) %>
+<%= queue_item_show_field(@admin_r_and_r_item, :accession_number) %>
+<%= queue_item_show_field(@admin_r_and_r_item, :museum_object_id, override_label: "Object ID (Past Perfect)") %>
+<%= queue_item_show_field(@admin_r_and_r_item, :box) %>
+<%= queue_item_show_field(@admin_r_and_r_item, :folder) %>
+<%= queue_item_show_field(@admin_r_and_r_item, :dimensions) %>
+<%= queue_item_show_field(@admin_r_and_r_item, :materials) %>
+<%= queue_item_show_field(@admin_r_and_r_item, :instructions, paragraphs: true) %>
+<%= queue_item_show_field(@admin_r_and_r_item, :additional_notes, paragraphs: true) %>
+<%= queue_item_show_field(@admin_r_and_r_item, :copyright_status, paragraphs: true) %>

--- a/app/views/admin/r_and_r_items/_show_first_column.html.erb
+++ b/app/views/admin/r_and_r_items/_show_first_column.html.erb
@@ -1,14 +1,4 @@
-<% if @admin_r_and_r_item.digitization_queue_item.count > 0 %>
-  <dt><%= pluralize(@admin_r_and_r_item.digitization_queue_item.count, 'corresponding item') %> in the digitization queue</dt>
-  <dd>
-    <ul class="list-group">
-    <% @admin_r_and_r_item.digitization_queue_item.each do |dq_item| %>
-      <%= link_to dq_item.title, admin_digitization_queue_items_path(dq_item),
-      class: "list-group-item list-group-item-action" %>
-    <% end %>
-    </ul>
-  </dd>
-<% end%>
+<h2>About</h2>
 
 <dt>Status</dt>
 <dd>

--- a/app/views/admin/r_and_r_items/_show_second_column.html.erb
+++ b/app/views/admin/r_and_r_items/_show_second_column.html.erb
@@ -1,0 +1,35 @@
+<h2>Comments</h2>
+
+<%= form_tag add_comment_admin_r_and_r_item_path do %>
+  <div class="mb-4 text-right">
+    <h3 class="h5"><label for="addComment">Add Comment</label></h3>
+    <textarea class="form-control" name="comment" id="addComment" rows="3"></textarea>
+    <button class="btn btn-primary mt-1">Submit comment</button>
+  </div>
+<% end %>
+
+<% @admin_r_and_r_item.queue_item_comments.includes(:user).order(created_at: :desc).each do |comment| %>
+  <div>
+    <div class="card queue-comment mb-3 d-inline-flex <% if comment.system_action? %>text-white bg-info<% end %>">
+      <div class="card-header">
+        <% if comment.user %>
+          <%= comment.user&.name || comment.user&.email %>,
+        <% end %>
+        <%= time_ago_in_words comment.created_at %> ago
+      </div>
+      <div class="card-body pb-0">
+        <%= simple_format(comment.text) %>
+        <% if can?(:destroy, comment) %>
+          <div class="text-right">
+            <%= link_to "Delete",
+              admin_delete_r_and_r_comment_path(id: @admin_r_and_r_item.id, comment_id: comment.id),
+              class: "btn btn-primary mb-1",
+              method: 'delete',
+              data: { confirm: "Delete your comment?" }
+            %>
+          </div>
+        <%end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/r_and_r_items/_show_second_column.html.erb
+++ b/app/views/admin/r_and_r_items/_show_second_column.html.erb
@@ -1,8 +1,8 @@
 <h2>Comments</h2>
 
 <%= form_tag add_comment_admin_r_and_r_item_path do %>
+  <h3 class="h5"><label for="addComment">Add Comment:</label></h3>
   <div class="mb-4 text-right">
-    <h3 class="h5"><label for="addComment">Add Comment</label></h3>
     <textarea class="form-control" name="comment" id="addComment" rows="3"></textarea>
     <button class="btn btn-primary mt-1">Submit comment</button>
   </div>

--- a/app/views/admin/r_and_r_items/show.html.erb
+++ b/app/views/admin/r_and_r_items/show.html.erb
@@ -12,15 +12,41 @@
     <div class="mb-2">
       <%= link_to 'Edit this R & R request', edit_admin_r_and_r_item_path(@admin_r_and_r_item), class: "btn btn-primary" %>
     </div>
+
+
     <div class="mb-2">
       <% if @admin_r_and_r_item.ready_to_move_to_digitization_queue? %>
-        <%= link_to "Send to Digitization Queue", new_admin_digitization_queue_items_path(r_and_r_item: @admin_r_and_r_item.id, collecting_area: @admin_r_and_r_item.collecting_area), class: "btn btn-primary" %>
+        <% if @admin_r_and_r_item.digitization_queue_item.count > 0 %>
+          <%= link_to "Create a new Digitization Queue item",
+            new_admin_digitization_queue_items_path(r_and_r_item: @admin_r_and_r_item.id,
+            collecting_area: @admin_r_and_r_item.collecting_area),
+            class: "btn btn-primary",
+            data: { confirm: "This R&R item has already been used to create a digitization queue item. Really continue?" }
+          %>
+        <% else %>
+          <%= link_to "Send to Digitization Queue", new_admin_digitization_queue_items_path(r_and_r_item: @admin_r_and_r_item.id, collecting_area: @admin_r_and_r_item.collecting_area), class: "btn btn-primary" %>
+        <% end %>
       <% else %>
         <button type="button" class="btn btn-primary" disabled>Send to Digitization Queue</button>
       <% end %>
     </div>
+
+    <% if @admin_r_and_r_item.digitization_queue_item.count > 0 %>
+      <dt>This R&R item already has <%= pluralize(@admin_r_and_r_item.digitization_queue_item.count, 'corresponding item') %> in the digitization queue:</dt>
+      <dd>
+        <ul class="list-group">
+        <% @admin_r_and_r_item.digitization_queue_item.each do |dq_item| %>
+          <%= link_to dq_item.title, admin_digitization_queue_items_path(dq_item),
+          class: "list-group-item list-group-item-action" %>
+        <% end %>
+        </ul>
+      </dd>
+    <% end%>
   </div>
 </div>
+
+
+<hr/>
 
 <div class="row">
   <div class="col-md-7 order-md-2">
@@ -28,5 +54,16 @@
   </div>
   <div class="col-md-5 order-md-1 pr-4">
     <%= render 'admin/r_and_r_items/show_second_column' %>
+  </div>
+</div>
+
+<hr/>
+
+<div class="row mb-2">
+  <div class="col">
+    <%= link_to "Delete \"#{@admin_r_and_r_item.title}\"", admin_r_and_r_item_path(r_and_r_item: @admin_r_and_r_item.id),
+      class: "btn btn-primary btn-danger",
+      method: 'delete',
+      data: { confirm: "Do you really want to delete \"#{@admin_r_and_r_item.title}?\"" } %>
   </div>
 </div>

--- a/app/views/admin/r_and_r_items/show.html.erb
+++ b/app/views/admin/r_and_r_items/show.html.erb
@@ -16,17 +16,21 @@
 
     <div class="mb-2">
       <% if @admin_r_and_r_item.ready_to_move_to_digitization_queue? %>
+        <%# We can create a new digitization queue item based on this R&R item.  %>
         <% if @admin_r_and_r_item.digitization_queue_item.count > 0 %>
+          <%# This R&R item *already* has at least one DQ item associated with it. Most likely, the user will *not* want to proceed with creating a new one. %>
           <%= link_to "Create a new Digitization Queue item",
             new_admin_digitization_queue_items_path(r_and_r_item: @admin_r_and_r_item.id,
             collecting_area: @admin_r_and_r_item.collecting_area),
-            class: "btn btn-primary",
+            class: "btn btn-secondary",
             data: { confirm: "This R&R item has already been used to create a digitization queue item. Really continue?" }
           %>
         <% else %>
+          <%# This R&R item has *no* DQ items associated with it.%>
           <%= link_to "Send to Digitization Queue", new_admin_digitization_queue_items_path(r_and_r_item: @admin_r_and_r_item.id, collecting_area: @admin_r_and_r_item.collecting_area), class: "btn btn-primary" %>
         <% end %>
       <% else %>
+        <%# Show a disabled button, since this is not ready to send to the digitization queue. %>
         <button type="button" class="btn btn-primary" disabled>Send to Digitization Queue</button>
       <% end %>
     </div>

--- a/app/views/admin/r_and_r_items/show.html.erb
+++ b/app/views/admin/r_and_r_items/show.html.erb
@@ -1,151 +1,32 @@
-<div class="mb-2">
-  <h1>R&R request: <%= @admin_r_and_r_item.title %> </h1>
-</div>
-
-
 <div class="row mb-2">
   <div class="col">
-    <%= link_to 'Back to R & R list', admin_r_and_r_items_path, class: "btn btn-primary" %>
+    <h1>R&R request: <%= @admin_r_and_r_item.title %></h1>
   </div>
 </div>
-
-<div class="row mb-2">
-  <div class="col">
-    <%= link_to 'Edit this R & R request', edit_admin_r_and_r_item_path(@admin_r_and_r_item), class: "btn btn-primary" %>
-  </div>
-</div>
-
-
-<% if @admin_r_and_r_item.ready_to_move_to_digitization_queue? %>
-  <div class="row mb-2">
-    <div class="col">
-      <%= link_to "Send to Digitization Queue", new_admin_digitization_queue_items_path(r_and_r_item: @admin_r_and_r_item.id, collecting_area: @admin_r_and_r_item.collecting_area), class: "btn btn-primary" %>
-    </div>
-  </div>
-<% end %>
-
-<% if @admin_r_and_r_item.digitization_queue_item.count > 0 %>
-    <dt><%= pluralize(@admin_r_and_r_item.digitization_queue_item.count, 'corresponding item') %> in the digitization queue</dt>
-    <dd>
-      <ul class="list-group">
-      <% @admin_r_and_r_item.digitization_queue_item.each do |dq_item| %>
-        <%= link_to dq_item.title, admin_digitization_queue_items_path(dq_item),
-        class: "list-group-item list-group-item-action" %>
-      <% end %>
-      </ul>
-    </dd>
-<% end%>
-
-<dt>Status</dt>
-<dd>
-  <%= @admin_r_and_r_item.status.humanize %> as of <%= l @admin_r_and_r_item.status_changed_at, format: :admin %>
-</dd>
-
-<% if @admin_r_and_r_item.deadline %>
-  <dt>Deadline to send files to the patron</dt>
-  <dd>
-    <%= l(@admin_r_and_r_item.deadline, format: "%F") %>
-  </dd>
-<% end %>
-
-
-
-<% if @admin_r_and_r_item.date_files_sent %>
-  <dt>When files were sent</dt>
-  <dd>
-    <%= l(@admin_r_and_r_item.date_files_sent, format: "%F") %>
-  </dd>
-  <% else %>
-    <dt>Have files been sent to the patron?</dt>
-    <dd>
-      Not yet.
-    </dd>
-<% end %>
-
-<%= queue_item_show_field(@admin_r_and_r_item, :date_files_sent) %>
 
 <div class="row">
-
-  <div class="col-md-7 order-md-2">
-      <dt>Is this going into the Digital Collections?</dt>
-      <dd>
-        <%=  @admin_r_and_r_item.is_destined_for_ingest ? 'Yes' : "No (thus, it can't be moved to the digitization queue)" %>.
-        <% if @admin_r_and_r_item.is_destined_for_ingest %>
-          <% unless @admin_r_and_r_item.ready_to_move_to_digitization_queue_based_on_status? %>
-            <br />(although status is still "<%= @admin_r_and_r_item.status.humanize %>")
-          <% end %>
-          <% if @admin_r_and_r_item.copyright_research_still_needed %>
-            <br />(although copyright research still needed)
-          <%end %>
-        <% end %>
-      </dd>
-
-      <dt>Is copyright research still needed for this item?</dt>
-      <dd>
-        <%=  @admin_r_and_r_item.copyright_research_still_needed ? 'Yes' : 'No' %>.
-      </dd>
-
-      <dt>Collecting area</dt>
-      <dd><%= @admin_r_and_r_item.collecting_area.humanize%></dd>
-
-      <dt>Curator</dt>
-      <dd>
-        <%=   @admin_r_and_r_item.curator ? @admin_r_and_r_item.curator.capitalize : "None" %>
-      </dd>
-
-      <%= queue_item_show_field(@admin_r_and_r_item, :patron_name) %>
-      <%= queue_item_show_field(@admin_r_and_r_item, :patron_email) %>
-
-
-
-
-    <% if @admin_r_and_r_item.bib_number.present? %>
-      <p>
-        <%= link_to "OPAC link (#{@admin_r_and_r_item.bib_number})", ScihistDigicoll::Util.opac_url(@admin_r_and_r_item.bib_number), target: "_blank" %>
-      </p>
-    <% end %>
-
-    <dl>
-
-
-
-      <dt>Created at</dt>
-      <dd>
-        <%= l @admin_r_and_r_item.created_at, format: :admin %>
-      </dd>
-
-
-
-      <%= queue_item_show_field(@admin_r_and_r_item, :bib_number) %>
-
-
-      <%= queue_item_show_field(@admin_r_and_r_item, :scope, paragraphs: true, override_label: "Pages to scan for this patron") %>
-      <%= queue_item_show_field(@admin_r_and_r_item, :additional_pages_to_ingest, override_label: "Additional pages to ingest into the Digital Collections") %>
-
-
-      <%= queue_item_show_field(@admin_r_and_r_item, :location) %>
-      <%= queue_item_show_field(@admin_r_and_r_item, :accession_number) %>
-      <%= queue_item_show_field(@admin_r_and_r_item, :museum_object_id, override_label: "Object ID (Past Perfect)") %>
-      <%= queue_item_show_field(@admin_r_and_r_item, :box) %>
-      <%= queue_item_show_field(@admin_r_and_r_item, :folder) %>
-
-      <%= queue_item_show_field(@admin_r_and_r_item, :dimensions) %>
-      <%= queue_item_show_field(@admin_r_and_r_item, :materials) %>
-
-
-      <%= queue_item_show_field(@admin_r_and_r_item, :instructions, paragraphs: true) %>
-      <%= queue_item_show_field(@admin_r_and_r_item, :additional_notes, paragraphs: true) %>
-      <%= queue_item_show_field(@admin_r_and_r_item, :copyright_status, paragraphs: true) %>
-
-    </dl>
+  <div class="col">
+    <div class="mb-2">
+      <%= link_to 'Back to R & R list', admin_r_and_r_items_path, class: "btn btn-primary" %>
+    </div>
+    <div class="mb-2">
+      <%= link_to 'Edit this R & R request', edit_admin_r_and_r_item_path(@admin_r_and_r_item), class: "btn btn-primary" %>
+    </div>
+    <div class="mb-2">
+      <% if @admin_r_and_r_item.ready_to_move_to_digitization_queue? %>
+        <%= link_to "Send to Digitization Queue", new_admin_digitization_queue_items_path(r_and_r_item: @admin_r_and_r_item.id, collecting_area: @admin_r_and_r_item.collecting_area), class: "btn btn-primary" %>
+      <% else %>
+        <button type="button" class="btn btn-primary" disabled>Send to Digitization Queue</button>
+      <% end %>
+    </div>
   </div>
 </div>
 
-<div class="row mb-2">
-  <div class="col">
-    <%= link_to "Delete \"#{@admin_r_and_r_item.title}\"", admin_r_and_r_item_path(r_and_r_item: @admin_r_and_r_item.id),
-      class: "btn btn-primary btn-danger",
-      method: 'delete',
-      data: { confirm: "Do you really want to delete \"#{@admin_r_and_r_item.title}?\"" } %>
+<div class="row">
+  <div class="col-md-7 order-md-2">
+    <%= render 'admin/r_and_r_items/show_first_column' %>
+  </div>
+  <div class="col-md-5 order-md-1 pr-4">
+    <%= render 'admin/r_and_r_items/show_second_column' %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -173,16 +173,22 @@ Rails.application.routes.draw do
       end
       member do
         post :add_comment
-        # not sure how to do this implicitly.
-        # delete :delete_comment
+      end
+    end
+
+    resources :r_and_r_items do
+      member do
+        post :add_comment
       end
     end
 
     delete  "digitization_queue_items/:id/delete_comment/:comment_id",
       to: "digitization_queue_items#delete_comment",
-      as: "delete_comment"
+      as: "delete_digitization_queue_item_comment"
 
-    resources :r_and_r_items
+    delete  "r_and_r_items/:id/delete_comment/:comment_id",
+      to: "r_and_r_items#delete_comment",
+      as: "delete_r_and_r_comment"
 
     resources :cart_items, param: :work_friendlier_id, only: [:index, :update, :destroy] do
       collection do

--- a/db/migrate/20200131161750_add_r_and_r_item_ref_to_queue_item_comments.rb
+++ b/db/migrate/20200131161750_add_r_and_r_item_ref_to_queue_item_comments.rb
@@ -1,0 +1,7 @@
+class AddRAndRItemRefToQueueItemComments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :queue_item_comments, :r_and_r_item_id, :bigint, null:true
+    add_foreign_key :queue_item_comments, :r_and_r_items, null: true
+    change_column_null :queue_item_comments, :digitization_queue_item_id, true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -305,12 +305,13 @@ ALTER SEQUENCE public.on_demand_derivatives_id_seq OWNED BY public.on_demand_der
 
 CREATE TABLE public.queue_item_comments (
     id bigint NOT NULL,
-    digitization_queue_item_id bigint NOT NULL,
+    digitization_queue_item_id bigint,
     user_id bigint,
     text text,
     system_action boolean,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    r_and_r_item_id bigint
 );
 
 
@@ -847,6 +848,14 @@ ALTER TABLE ONLY public.kithe_models
 
 
 --
+-- Name: queue_item_comments fk_rails_d9dfe21716; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.queue_item_comments
+    ADD CONSTRAINT fk_rails_d9dfe21716 FOREIGN KEY (r_and_r_item_id) REFERENCES public.r_and_r_items(id);
+
+
+--
 -- Name: queue_item_comments fk_rails_faa45a6d5b; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -883,6 +892,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190912200533'),
 ('20191016134900'),
 ('20191112170956'),
-('20191210210454');
+('20191210210454'),
+('20200131161750');
 
 


### PR DESCRIPTION
Allow comments for R & R items. This will closely follow the pattern of the existing comments on digitization queue items. A new table will not be necessary; we will just allow comments to be attached to *either* R&R items *or* dq items.