### PR TITLE
break out the IDs into separate columns on dig queue index list

### DIFF
--- a/app/views/admin/digitization_queue_items/index.html.erb
+++ b/app/views/admin/digitization_queue_items/index.html.erb
@@ -48,12 +48,14 @@
 
 
 <div class="table-responsive">
-  <table class="table" style="table-layout: fixed; font-size: 90%; min-width: 700px;">
+  <table class="table" style="table-layout: fixed; font-size: 90%; min-width: 55rem; word-break: break-word;">
     <thead>
       <tr>
-        <th style="width: 4rem;"></th>
+        <th style="width: 4.5rem;"></th>
         <th>title</th>
-        <th style="width: 7rem;">IDs</th>
+        <th style="width: 6rem;">bib #</th>
+        <th style="width: 6rem;">acc. #</th>
+        <th style="width: 8rem;">object id</th>
         <th style="width: 11rem;">status</th>
         <th style="width: 8rem;">status changed</th>
       </tr>
@@ -73,7 +75,9 @@
               </p>
             <% end %>
           </td>
-          <td><%= [admin_digitization_queue_item.bib_number, admin_digitization_queue_item.accession_number, admin_digitization_queue_item.museum_object_id].collect(&:presence).compact.join(", ") %>  </td>
+          <td><%= admin_digitization_queue_item.bib_number %></td>
+          <td><%= admin_digitization_queue_item.accession_number %></td>
+          <td><%= admin_digitization_queue_item.museum_object_id %></td>
           <td>
              <%= DigitizationQueueItemStatusForm.new(admin_digitization_queue_item).display %>
           </td>


### PR DESCRIPTION
ref #603 https://github.com/sciencehistory/scihist_digicoll/issues/603#issuecomment-581512956

Tried to size the columns such that there would be enough space for each, based on trying to find sample data for each type of ID from production.

No fancy getting rid of columns on small screen, you'll just get horizontal scroll when too small.