### PR TITLE
R&R adjustments

### DIFF
--- a/app/controllers/admin/digitization_queue_items_controller.rb
+++ b/app/controllers/admin/digitization_queue_items_controller.rb
@@ -19,7 +19,6 @@ class Admin::DigitizationQueueItemsController < AdminController
       r_and_r_item = Admin::RAndRItem.find(params[:r_and_r_item])
       @admin_digitization_queue_item.r_and_r_item_id = r_and_r_item.id
       r_and_r_item.fill_out_digitization_queue_item(@admin_digitization_queue_item)
-      @admin_digitization_queue_item.status = 'awaiting_dig_on_cart'
     end
   end
 

--- a/app/models/admin/r_and_r_item.rb
+++ b/app/models/admin/r_and_r_item.rb
@@ -37,20 +37,10 @@ class Admin::RAndRItem < ApplicationRecord
     STATUSES
   end
 
-
-  CURATORS = %w{ ashley hillary jim patrick molly }
-
   validates :status, inclusion: { in: STATUSES }
 
   validates :title, presence: true
-
-  # Note: We're choosing not to check that the curator is one of
-  # the existing list of CURATORS
-  # because if one of them is removed
-  # from the list... all their ex-R&R-items
-  # then fail to validate.
   validates :curator, presence: true
-
   validates :patron_name, presence: true
 
 

--- a/app/models/admin/r_and_r_item.rb
+++ b/app/models/admin/r_and_r_item.rb
@@ -60,19 +60,6 @@ class Admin::RAndRItem < ApplicationRecord
     end
   end
 
-  # Is this ready to make a DigitizationQueueItem out of?
-  def ready_to_move_to_digitization_queue?
-    return false unless self.is_destined_for_ingest
-    return false if self.copyright_research_still_needed
-    return false unless self.ready_to_move_to_digitization_queue_based_on_status?
-    return true
-  end
-
-  def ready_to_move_to_digitization_queue_based_on_status?
-    possible_statuses = %w{post_production_completed files_sent_to_patron closed}
-    possible_statuses.include?(self.status)
-  end
-
   # Fill out a DigitizationQueueItem with metadata in here. Does not save.
   #
   # Note:

--- a/app/models/admin/r_and_r_item.rb
+++ b/app/models/admin/r_and_r_item.rb
@@ -38,7 +38,7 @@ class Admin::RAndRItem < ApplicationRecord
   end
 
 
-  CURATORS = %w{ ashley hillary jim patrick molly other }
+  CURATORS = %w{ ashley hillary jim patrick molly }
 
   validates :status, inclusion: { in: STATUSES }
 
@@ -81,9 +81,11 @@ class Admin::RAndRItem < ApplicationRecord
         digitization_queue_item.send "#{key}=", value
       end
     end
+
+    digitization_queue_item.status = 'post_production_completed'
+
     digitization_queue_item.title = self.title
     # self.scope refers to the R&R request scope.
     digitization_queue_item.scope = self.additional_pages_to_ingest
-
   end
 end

--- a/app/views/admin/r_and_r_items/_form.html.erb
+++ b/app/views/admin/r_and_r_items/_form.html.erb
@@ -35,9 +35,8 @@
       <div class="col">
         <%= f.input :curator,
           label: "Curator",
-          hint: "Who is fielding this request?",
-          collection: Admin::RAndRItem::CURATORS.collect {|s| [s.humanize, s]},
-          include_blank: false %>
+          hint: "Who is fielding this request?"
+        %>
       </div>
       <div class="col">
         <%= f.input :patron_name,

--- a/app/views/admin/r_and_r_items/_show_first_column.html.erb
+++ b/app/views/admin/r_and_r_items/_show_first_column.html.erb
@@ -1,15 +1,16 @@
 <h2>About</h2>
 
 
+<dt>Status</dt>
+<dd>
+  <%= DigitizationQueueItemStatusForm.new(@admin_r_and_r_item).display %>
+</dd>
+
 <dt>Is this going into the Digital Collections?</dt>
 <dd>
   <%=  @admin_r_and_r_item.is_destined_for_ingest ? 'Yes' : "No" %>.
 </dd>
 
-<dt>Status</dt>
-<dd>
-  <%= @admin_r_and_r_item.status.humanize %> as of <%= l @admin_r_and_r_item.status_changed_at, format: :admin %>
-</dd>
 
 <% if @admin_r_and_r_item.deadline %>
   <dt>Deadline to send files to the patron</dt>

--- a/app/views/admin/r_and_r_items/_show_first_column.html.erb
+++ b/app/views/admin/r_and_r_items/_show_first_column.html.erb
@@ -3,15 +3,7 @@
 
 <dt>Is this going into the Digital Collections?</dt>
 <dd>
-  <%=  @admin_r_and_r_item.is_destined_for_ingest ? 'Yes' : "No (thus, it can't be moved to the digitization queue)" %>.
-  <% if @admin_r_and_r_item.is_destined_for_ingest %>
-    <% unless @admin_r_and_r_item.ready_to_move_to_digitization_queue_based_on_status? %>
-      <br />(although status is still "<%= @admin_r_and_r_item.status.humanize %>")
-    <% end %>
-    <% if @admin_r_and_r_item.copyright_research_still_needed %>
-      <br />(although copyright research still needed)
-    <%end %>
-  <% end %>
+  <%=  @admin_r_and_r_item.is_destined_for_ingest ? 'Yes' : "No" %>.
 </dd>
 
 <dt>Status</dt>

--- a/app/views/admin/r_and_r_items/index.html.erb
+++ b/app/views/admin/r_and_r_items/index.html.erb
@@ -74,7 +74,7 @@
   <table class="table">
     <thead>
       <tr>
-        <th>Title and notes</th>
+        <th scope="col" class="w-25 p-3">Title and notes</th>
         <th scope="col" class="d-none d-sm-table-cell" >Status</th>
         <th scope="col" class="d-none d-sm-table-cell" >Deadline</th>
         <th scope="col" class="d-none d-sm-table-cell" >Collecting area</th>
@@ -88,7 +88,7 @@
     <tbody>
       <%@admin_r_and_r_items.each do |admin_r_and_r_item| %>
         <tr>
-          <td>
+          <td class="w-25 p-3">
             <%= link_to admin_r_and_r_item.title, admin_r_and_r_item_path(admin_r_and_r_item)%>
 
             <% if admin_r_and_r_item.additional_notes.present? %>

--- a/app/views/admin/r_and_r_items/index.html.erb
+++ b/app/views/admin/r_and_r_items/index.html.erb
@@ -75,13 +75,13 @@
     <thead>
       <tr>
         <th scope="col" class="w-25 p-3">Title and notes</th>
-        <th scope="col" class="d-none d-sm-table-cell" >Status</th>
+        <th scope="col" class="d-none d-sm-table-cell  w-25 p-3" >Status</th>
         <th scope="col" class="d-none d-sm-table-cell" >Deadline</th>
         <th scope="col" class="d-none d-sm-table-cell" >Collecting area</th>
         <th scope="col" class="d-none d-md-table-cell" >Bib number</th>
         <th scope="col" class="d-none d-md-table-cell" >Accession number</th>
         <th scope="col" class="d-none d-md-table-cell" >Object ID</th>
-        <th scope="col" class="d-none d-md-table-cell" >Location </th>
+        <th scope="col" class="d-none d-md-table-cell mw-10" >Location </th>
       </tr>
     </thead>
 
@@ -97,7 +97,7 @@
               </small>
             <% end %>
           </td>
-          <td scope="col" class="d-none d-sm-table-cell">
+          <td scope="col" class="d-none d-sm-table-cell w-25 p-3">
              <%= DigitizationQueueItemStatusForm.new(admin_r_and_r_item).display %>
           </td>
           <td scope="col" class="d-none d-sm-table-cell" ><%= l(admin_r_and_r_item.deadline.to_date, format: :admin) if admin_r_and_r_item.deadline%></td>
@@ -110,7 +110,11 @@
           </td>
           <td scope="col" class="d-none d-md-table-cell" ><%= admin_r_and_r_item.accession_number %>  </td>
           <td scope="col" class="d-none d-md-table-cell" ><%= admin_r_and_r_item.museum_object_id %>  </td>
-          <td scope="col" class="d-none d-md-table-cell" ><%= admin_r_and_r_item.location %>  </td>
+          <td scope="col" class="d-none d-md-table-cell mw-10" >
+            <small class="text-muted">
+              <%= admin_r_and_r_item.location %>
+            </small>
+            </td>
 
         </tr>
       <% end %>

--- a/app/views/admin/r_and_r_items/index.html.erb
+++ b/app/views/admin/r_and_r_items/index.html.erb
@@ -81,6 +81,7 @@
         <th scope="col" class="d-none d-md-table-cell" >Bib number</th>
         <th scope="col" class="d-none d-md-table-cell" >Accession number</th>
         <th scope="col" class="d-none d-md-table-cell" >Object ID</th>
+        <th scope="col" class="d-none d-md-table-cell" >Location </th>
       </tr>
     </thead>
 
@@ -109,6 +110,7 @@
           </td>
           <td scope="col" class="d-none d-md-table-cell" ><%= admin_r_and_r_item.accession_number %>  </td>
           <td scope="col" class="d-none d-md-table-cell" ><%= admin_r_and_r_item.museum_object_id %>  </td>
+          <td scope="col" class="d-none d-md-table-cell" ><%= admin_r_and_r_item.location %>  </td>
 
         </tr>
       <% end %>

--- a/app/views/admin/r_and_r_items/show.html.erb
+++ b/app/views/admin/r_and_r_items/show.html.erb
@@ -15,7 +15,6 @@
 
 
     <div class="mb-2">
-      <% if @admin_r_and_r_item.ready_to_move_to_digitization_queue? %>
         <%# We can create a new digitization queue item based on this R&R item.  %>
         <% if @admin_r_and_r_item.digitization_queue_item.count > 0 %>
           <%# This R&R item *already* has at least one DQ item associated with it. Most likely, the user will *not* want to proceed with creating a new one. %>
@@ -29,10 +28,6 @@
           <%# This R&R item has *no* DQ items associated with it.%>
           <%= link_to "Send to Digitization Queue", new_admin_digitization_queue_items_path(r_and_r_item: @admin_r_and_r_item.id, collecting_area: @admin_r_and_r_item.collecting_area), class: "btn btn-primary" %>
         <% end %>
-      <% else %>
-        <%# Show a disabled button, since this is not ready to send to the digitization queue. %>
-        <button type="button" class="btn btn-primary" disabled>Send to Digitization Queue</button>
-      <% end %>
     </div>
 
     <% if @admin_r_and_r_item.digitization_queue_item.count > 0 %>

--- a/spec/models/admin/r_and_r_item_spec.rb
+++ b/spec/models/admin/r_and_r_item_spec.rb
@@ -15,37 +15,6 @@ describe Admin::RAndRItem, type: :model do
       }
     end
 
-    it "checks whether item has the right status" do
-      item = FactoryBot.create(:r_and_r_item,
-          is_destined_for_ingest: true,
-          copyright_research_still_needed: false,
-          status: 'awaiting_dig_on_cart')
-      expect(item.ready_to_move_to_digitization_queue?).to be false
-      item.status = 'files_sent_to_patron'
-      expect(item.ready_to_move_to_digitization_queue?).to be true
-    end
-
-    it "checks whether item is destined for ingest" do
-      item = FactoryBot.create(:r_and_r_item,
-          is_destined_for_ingest: false,
-          copyright_research_still_needed: false,
-          status: 'files_sent_to_patron')
-      expect(item.ready_to_move_to_digitization_queue?).to be false
-      item.is_destined_for_ingest = true
-      expect(item.ready_to_move_to_digitization_queue?).to be true
-    end
-
-    it "checks whether copyright_research_still_needed" do
-      item = FactoryBot.create(:r_and_r_item,
-          is_destined_for_ingest: true,
-          copyright_research_still_needed: true,
-          status: 'files_sent_to_patron')
-      expect(item.ready_to_move_to_digitization_queue?).to be false
-      item.copyright_research_still_needed = false
-      expect(item.ready_to_move_to_digitization_queue?).to be true
-    end
-
-
     it "can fill out new DigitizationQueueItem with its own metadata" do
       item = FactoryBot.create(:r_and_r_item)
       new_item = Admin::DigitizationQueueItem.new()

--- a/spec/models/admin/r_and_r_item_spec.rb
+++ b/spec/models/admin/r_and_r_item_spec.rb
@@ -33,6 +33,8 @@ describe Admin::RAndRItem, type: :model do
       end
       # self.scope refers to the R&R request scope.
       expect(new_item.scope).to eq item.additional_pages_to_ingest
+      # self.scope refers to the R&R request scope.
+      expect(new_item.status).to eq 'post_production_completed'
     end
   end
 end


### PR DESCRIPTION
Adding some more tweaks based on feedback from Hillary and Nicole:

- Add "location" to the list view 

- Drop-down menu for "Curator" field on R&R edit form: Remove "Other." R&R requests always involve a named curator who is responsible for managing a specific collection.

- On the show page : add status menu/save feature

- When an R&R item is sent to the Digitization Queue: set status to "post production completed?"

- Removing too-clever functionality to hide or disable the button to send items to the DQ. It wasn't helping that much and conflicted with the new dropdown menu above.