### PR TITLE
Encrypt patron data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # ie `~> 2.5` or `~> 2.6`, not including additional that may be in 2.3
 ruby "~> #{File.read('.ruby-version').chomp.split('.').slice(0,3).join('.')}"
 
+gem 'lockbox'
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.4'
 gem 'webpacker', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,6 +314,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    lockbox (0.3.1)
     loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -651,6 +652,7 @@ DEPENDENCIES
   kaminari (~> 1.0)
   kithe!
   listen (>= 3.0.5, < 3.2)
+  lockbox
   oai (~> 1.0, >= 1.0.1)
   pdf-reader (~> 2.2)
   pg (>= 0.18, < 2.0)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ Some other interesting/complicated sub-systems we've written documentation for:
 * [access-granted](https://github.com/chaps-io/access-granted) is used for some very simple authorization/permissions (right now just admins can do some things other logged in staff can not)
 * [blacklight](https://github.com/projectblacklight/blacklight) We are currently using Blacklight
   for the "end-user-facing" search, although we are using it in a very limited and customized fashion, not including a lot of things the BL generator wanted to include in our app, that we didn't plan on using.
-* [lockbox](https://github.com/ankane/lockbox) for encrypting our patron data.
+* [lockbox](https://github.com/ankane/lockbox) for encrypting our patron data in Admin::RAndRItem.
+  For rotating keys should private key need to be changed, see https://github.com/ankane/lockbox/issues/35
 
 ### Task to copy a Work from staging to your local dev instance
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Some other interesting/complicated sub-systems we've written documentation for:
 * [access-granted](https://github.com/chaps-io/access-granted) is used for some very simple authorization/permissions (right now just admins can do some things other logged in staff can not)
 * [blacklight](https://github.com/projectblacklight/blacklight) We are currently using Blacklight
   for the "end-user-facing" search, although we are using it in a very limited and customized fashion, not including a lot of things the BL generator wanted to include in our app, that we didn't plan on using.
+* [lockbox](https://github.com/ankane/lockbox) for encrypting our patron data.
 
 ### Task to copy a Work from staging to your local dev instance
 

--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -63,6 +63,8 @@ module ScihistDigicoll
     define_key :aws_access_key_id
     define_key :aws_secret_access_key
 
+    define_key :lockbox_master_key #default: lookup!(:lockbox_master_key)
+
     define_key :aws_region, default: "us-east-1"
 
     # eg "https://digital.sciencehistory.org", or "http://localhost:3000".

--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -63,7 +63,7 @@ module ScihistDigicoll
     define_key :aws_access_key_id
     define_key :aws_secret_access_key
 
-    define_key :lockbox_master_key #default: lookup!(:lockbox_master_key)
+    define_key :lockbox_master_key
 
     define_key :aws_region, default: "us-east-1"
 

--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -63,7 +63,15 @@ module ScihistDigicoll
     define_key :aws_access_key_id
     define_key :aws_secret_access_key
 
-    define_key :lockbox_master_key
+    define_key :lockbox_master_key, default: -> {
+      # In production, we insist that local_env.yml contain
+      # a real 64-bit key; if none is defined, we fail at
+      # deploy time (see config/initializers/lockbox.rb).
+      #
+      # However, we do provide a dummy key for dev and test
+      # environments, which is a string of 64 zeros.
+      "0" * 64 if Rails.env.test? || Rails.env.development?
+    }
 
     define_key :aws_region, default: "us-east-1"
 

--- a/app/models/admin/r_and_r_item.rb
+++ b/app/models/admin/r_and_r_item.rb
@@ -1,6 +1,9 @@
 # This model is based on the parallel Admin::DigitizationQueueItem.rb.
 
 class Admin::RAndRItem < ApplicationRecord
+  encrypts :patron_name
+  encrypts :patron_email
+
   has_many :digitization_queue_item, dependent: :nullify
   has_many :queue_item_comments, dependent: :destroy
 

--- a/app/models/admin/r_and_r_item.rb
+++ b/app/models/admin/r_and_r_item.rb
@@ -1,5 +1,10 @@
-# This model is based on the parallel Admin::DigitizationQueueItem.rb.
-
+ # "RAndR" is "Rights & Reproductions", and represents requests from specific patrons
+# for copies of things in our collection. We sometimes photograph things in response
+# to patron request, sometimes they will wind up also being processed for adding
+# to Digital Collections, other times not.
+#
+# This model is based on the parallel Admin::DigitizationQueueItem.rb, both are
+# adaptations of former google doc spreadsheet-based processes, and track workflow.
 class Admin::RAndRItem < ApplicationRecord
 
   # For more info about how to rotate a leaked Lockbox master key,

--- a/app/models/admin/r_and_r_item.rb
+++ b/app/models/admin/r_and_r_item.rb
@@ -1,8 +1,11 @@
 # This model is based on the parallel Admin::DigitizationQueueItem.rb.
 
 class Admin::RAndRItem < ApplicationRecord
-  encrypts :patron_name
-  encrypts :patron_email
+
+  # For more info about how to rotate a leaked Lockbox master key,
+  # see https://github.com/sciencehistory/scihist_digicoll/issues/629
+  # and https://github.com/ankane/lockbox/issues/35
+  encrypts :patron_name, :patron_email
 
   has_many :digitization_queue_item, dependent: :nullify
   has_many :queue_item_comments, dependent: :destroy

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -2,3 +2,6 @@
 
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += [:password]
+
+Rails.application.config.filter_parameters += [:patron_email]
+Rails.application.config.filter_parameters += [:patron_name]

--- a/config/initializers/lockbox.rb
+++ b/config/initializers/lockbox.rb
@@ -4,11 +4,11 @@ unless lockbox_master_key.present?
   raise RuntimeError,
     """
 
-    Lockbox master key is missing!
+    Lockbox master key is missing in production.
 
-    This application encrypts patron information using Lockbox.
-    For it to work, you need to make sure that local_env.yml
-    contains a line such as:
+    We encrypt our patron information using Lockbox.
+    For encryption to work in production, local_env.yml
+    must contain a line such as:
         lockbox_master_key: #{Lockbox.generate_key}
     A key can be generated in the Rails console by running:
         \"Lockbox.generate_key\".

--- a/config/initializers/lockbox.rb
+++ b/config/initializers/lockbox.rb
@@ -1,0 +1,1 @@
+Lockbox.master_key = ScihistDigicoll::Env.lookup(:lockbox_master_key)

--- a/config/initializers/lockbox.rb
+++ b/config/initializers/lockbox.rb
@@ -1,1 +1,21 @@
-Lockbox.master_key = ScihistDigicoll::Env.lookup(:lockbox_master_key)
+lockbox_master_key = ScihistDigicoll::Env.lookup(:lockbox_master_key)
+
+unless lockbox_master_key.present?
+  raise RuntimeError,
+    """
+
+    Lockbox master key is missing!
+
+    This application encrypts patron information using Lockbox.
+    For it to work, you need to make sure that local_env.yml
+    contains a line such as:
+        lockbox_master_key: #{Lockbox.generate_key}
+    A key can be generated in the Rails console by running:
+        \"Lockbox.generate_key\".
+
+    More details can be found at https://github.com/ankane/lockbox .
+
+    """
+end
+
+Lockbox.master_key = lockbox_master_key

--- a/db/migrate/20200206194219_add_patron_cyphertext_to_r_and_r_items.rb
+++ b/db/migrate/20200206194219_add_patron_cyphertext_to_r_and_r_items.rb
@@ -1,0 +1,9 @@
+class AddPatronCyphertextToRAndRItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :r_and_r_items, :patron_name_ciphertext,  :text
+    add_column :r_and_r_items, :patron_email_ciphertext, :text
+
+    remove_column :r_and_r_items, :patron_name
+    remove_column :r_and_r_items, :patron_email
+  end
+end

--- a/db/migrate/20200206194219_add_patron_cyphertext_to_r_and_r_items.rb
+++ b/db/migrate/20200206194219_add_patron_cyphertext_to_r_and_r_items.rb
@@ -3,7 +3,7 @@ class AddPatronCyphertextToRAndRItems < ActiveRecord::Migration[5.2]
     add_column :r_and_r_items, :patron_name_ciphertext,  :text
     add_column :r_and_r_items, :patron_email_ciphertext, :text
 
-    remove_column :r_and_r_items, :patron_name
-    remove_column :r_and_r_items, :patron_email
+    remove_column :r_and_r_items, :patron_name,   :string
+    remove_column :r_and_r_items, :patron_email,  :string
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -343,8 +343,6 @@ CREATE TABLE public.r_and_r_items (
     title character varying,
     curator character varying,
     collecting_area character varying,
-    patron_name character varying,
-    patron_email character varying,
     bib_number character varying,
     location character varying,
     accession_number character varying,

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -365,7 +365,9 @@ CREATE TABLE public.r_and_r_items (
     deadline timestamp without time zone,
     date_files_sent timestamp without time zone,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    patron_name_ciphertext text,
+    patron_email_ciphertext text
 );
 
 
@@ -893,6 +895,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191016134900'),
 ('20191112170956'),
 ('20191210210454'),
-('20200131161750');
+('20200131161750'),
+('20200206194219');
 
 

--- a/spec/controllers/admin/r_and_r_controller_spec.rb
+++ b/spec/controllers/admin/r_and_r_controller_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Admin::RAndRItemsController, :logged_in_user, type: :controller d
     it "can show the edit form for an item" do
       #item = FactoryBot.create(:r_and_r_item)
       get :edit, params: {"id"=> r_and_r_item.id}
+      byebug
       expect(response.code).to eq "200"
     end
 

--- a/spec/controllers/admin/r_and_r_controller_spec.rb
+++ b/spec/controllers/admin/r_and_r_controller_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe Admin::RAndRItemsController, :logged_in_user, type: :controller d
       expect(Admin::RAndRItem.count).to eq 1
       item = Admin::RAndRItem.last
       expect(item.title).to eq "Some Item"
+      # Just by way of making sure the patron and email are indeed
+      # encrypted in the DB. The length of the encrypted strings
+      # is arbitrary, but shouldn't change unless e.g. the master_key
+      # used for our test environment changes first.
+      expect(item.patron_name_ciphertext.length).to  eq 56
+      expect(item.patron_email_ciphertext.length).to eq 56
     end
 
     it "it can show a single item" do

--- a/spec/controllers/admin/r_and_r_controller_spec.rb
+++ b/spec/controllers/admin/r_and_r_controller_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe Admin::RAndRItemsController, :logged_in_user, type: :controller d
     it "can show the edit form for an item" do
       #item = FactoryBot.create(:r_and_r_item)
       get :edit, params: {"id"=> r_and_r_item.id}
-      byebug
       expect(response.code).to eq "200"
     end
 


### PR DESCRIPTION
For now, we're just encrypting patron_name and patron_email.
A 64-bit master key is present in `local_env.yml`, so this can be safely deployed whenever.