### PR TITLE
update puma to 3.12.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,7 +382,7 @@ GEM
       byebug (~> 10.0)
       pry (~> 0.10)
     public_suffix (3.1.1)
-    puma (3.12.3)
+    puma (3.12.4)
     qa (5.0.0)
       activerecord-import
       deprecation


### PR DESCRIPTION
Previouslu updated to 3.12.3 to patch a security vuln, via dependabot. Looks like 3.12.3 did not in fact succesfully patch, and was yanked -- so a deploy won't actually work with 3.12.3 in the Gemfile.lock, oops\!