### PR TITLE
Quick fix for the combined audio deriv maker.

### DIFF
--- a/app/services/combined_audio_derivative_creator.rb
+++ b/app/services/combined_audio_derivative_creator.rb
@@ -39,7 +39,7 @@ class CombinedAudioDerivativeCreator
     ['mp3', 'webm'].each do |format|
       output_files[format] = output_file(format)
       ffmpeg_args = args_for_ffmpeg(output_files[format].path)
-      cmd.run(*ffmpeg_args, binmode: true)
+      cmd.run(*ffmpeg_args, binmode: true, only_output_on_error: true)
     end
     resp = Response.new
     resp.webm_file   = output_files['webm']
@@ -53,7 +53,7 @@ class CombinedAudioDerivativeCreator
 
 
   def cmd
-     @cmd ||= TTY::Command.new()
+    @cmd ||= TTY::Command.new(output: Rails.logger)
   end
 
   def output_file(format)

--- a/spec/services/work_combined_audio_creator_spec.rb
+++ b/spec/services/work_combined_audio_creator_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe "Combined Audio" do
-  # We need to set the friendlier_id explicitly, because it's part of the fingerprint recipe.
   let!(:work) { FactoryBot.create(:work, title: "Oral history with two interview audio segments")}
 
   let!(:audio_asset_1)  { create(:asset, :inline_promoted_file,
@@ -66,7 +65,6 @@ describe "Combined Audio" do
     audio_asset_1.position = 2
     audio_asset_1.save!
     audio_asset_2.save!
-    #work.save!
 
     combined_audio_info = CombinedAudioDerivativeCreator.new(work).generate
     expect(combined_audio_info.start_times.count).to eq 2


### PR DESCRIPTION
Tweak error logging for combined audio deriv maker. Output to the Rails log, not to stdout, and that only if the command happens to fail.
Ref #658