### PR TITLE
Remove audio asset derivatives

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -47,20 +47,6 @@ class Asset < Kithe::Asset
     end
   end
 
-  # mono and 64k bitrate, nice and small, good enough for our voice-only
-  # Oral History interviews we're targetting. Our original might have been FLAC
-  # or might have been a probably larger MP3.
-  define_derivative('small_mp3', content_type: "audio") do |original_file|
-    Kithe::FfmpegTransformer.new(
-      bitrate: '64k', force_mono: true, output_suffix: 'mp3',
-    ).call(original_file)
-  end
-  define_derivative('webm', content_type: "audio") do |original_file|
-    Kithe::FfmpegTransformer.new(
-      bitrate: '64k',  force_mono: true, output_suffix: 'webm'
-    ).call(original_file)
-  end
-
   # Our DziFiles object to manage associated DZI (deep zoom, for OpenSeadragon
   # panning/zooming) file(s).
   #

--- a/app/presenters/download_options/audio_download_options.rb
+++ b/app/presenters/download_options/audio_download_options.rb
@@ -13,14 +13,6 @@ module DownloadOptions
       # We don't use content_type in derivative option subheads,
       # cause it's in the main label. But do use it for original.
 
-      if mp3_deriv = asset.derivative_for(:small_mp3)
-        options << DownloadOption.with_formatted_subhead("Optimized MP3",
-          url: download_derivative_path(asset, :small_mp3),
-          analyticsAction: "download_optimized_mp3",
-          size: mp3_deriv.size
-        )
-      end
-
       if asset.stored?
         options << DownloadOption.with_formatted_subhead("Original file",
           url: download_path(asset),

--- a/app/views/works/show_with_audio.html.erb
+++ b/app/views/works/show_with_audio.html.erb
@@ -78,8 +78,6 @@
                       data-title="<%= track.title %>"
                       data-member-id="<%= track.id %>"
                       data-original-url="<%= main_app.download_path(track.id)    %>"
-                      data-mp3-url="<%=  track.derivative_for('small_mp3')&.url  %>"
-                      data-webm-url="<%= track.derivative_for('webm')&.url       %>"
                       data-ohms-timestamp-s="<%= decorator.start_time_for(track) %>"
                   >
 

--- a/lib/tasks/remove_audio_asset_derivatives.rake
+++ b/lib/tasks/remove_audio_asset_derivatives.rake
@@ -1,7 +1,7 @@
 namespace :scihist do
   desc """
-    Goes through all the derivatives and if they are audio, removes them.
-
+    Goes through all derivatives of assets where key is either 'webm' or 'small_mp3', and removes them.
+    NOTE: Remove this file once the task has been run in production; it won't be needed after that.
     bundle exec rake scihist:remove_audio_asset_derivatives
   """
 

--- a/lib/tasks/remove_audio_asset_derivatives.rake
+++ b/lib/tasks/remove_audio_asset_derivatives.rake
@@ -6,7 +6,7 @@ namespace :scihist do
   """
 
   task :remove_audio_asset_derivatives => :environment do
-    progress_bar = ProgressBar.create(total: Work.where("json_attributes -> 'genre' ?  'Oral histories'").count, format: "%a %t: |%B| %R/s %c/%u %p%% %e")
+    progress_bar = ProgressBar.create(total: Kithe::Derivative.where(key: ['webm', 'small_mp3']).count, format: "%a %t: |%B| %R/s %c/%u %p%% %e")
     Kithe::Derivative.where(key: ['webm', 'small_mp3']).find_each(batch_size: 10) do |derivative|
       #Delete the derivative using ActiveRecord `destroy`:
       # shrine will take care of making sure

--- a/lib/tasks/remove_audio_asset_derivatives.rake
+++ b/lib/tasks/remove_audio_asset_derivatives.rake
@@ -1,0 +1,20 @@
+namespace :scihist do
+  desc """
+    Goes through all the derivatives and if they are audio, removes them.
+
+    bundle exec rake scihist:remove_audio_asset_derivatives
+  """
+
+  task :remove_audio_asset_derivatives => :environment do
+    progress_bar = ProgressBar.create(total: Work.where("json_attributes -> 'genre' ?  'Oral histories'").count, format: "%a %t: |%B| %R/s %c/%u %p%% %e")
+    Kithe::Derivative.where(key: ['webm', 'small_mp3']).find_each(batch_size: 10) do |derivative|
+      #Delete the derivative using ActiveRecord `destroy`:
+      # shrine will take care of making sure
+      # the actual bytestream in storage is deleted too.
+      derivative.destroy
+      progress_bar.increment
+      Rails.logger.info(" Deleted #{derivative.key} for asset #{derivative.asset.friendlier_id} in '#{derivative.asset.parent.title}'")
+    end
+  end
+
+end

--- a/spec/models/asset/derivatives.rb
+++ b/spec/models/asset/derivatives.rb
@@ -1,35 +1,9 @@
 require 'rails_helper'
 
 describe "derivative creation" do
-
-  let(:audio_file_path) { Rails.root.join("spec/test_support/audio/ice_cubes.mp3")}
-  let(:audio_file_sha512) { Digest::SHA512.hexdigest(File.read(audio_file_path)) }
-  let!(:audio_asset) { FactoryBot.create(:asset, file: File.open(audio_file_path)) }
-
   let(:pdf_file_path) { Rails.root.join("spec/test_support/pdf/sample.pdf")}
   let(:pdf_file_sha512) { Digest::SHA512.hexdigest(File.read(pdf_file_path)) }
   let!(:pdf_asset) { FactoryBot.create(:asset, file: File.open(pdf_file_path)) }
-
-
-  it "creates audio derivatives" do
-    # The derivative creation process expects the file object
-    # to have persisted sha512 data on the UploadedFile.
-    audio_asset.file.metadata['sha512'] = audio_file_sha512
-    audio_asset.save!
-    audio_asset.create_derivatives
-
-    mp3_deriv  = audio_asset.derivatives.find { |x| x.key == 'mp3'  }
-    webm_deriv = audio_asset.derivatives.find { |x| x.key == 'webm' }
-    expect(mp3_deriv).not_to be_nil
-    expect(webm_deriv).not_to be_nil
-    expect(mp3_deriv.file_data['id']).to match(/mp3$/)
-    expect(mp3_deriv.file_data['metadata']['mime_type']).to eq('audio/mpeg')
-    expect(mp3_deriv.file_data['metadata']['kithe_derivative_key']).to eq('mp3')
-    expect(webm_deriv.file_data['id']).to match(/webm$/)
-    expect(webm_deriv.file_data['metadata']['mime_type']).to match(/webm$/)
-    expect(webm_deriv.file_data['metadata']['kithe_derivative_key']).to eq('webm')
-  end
-
   it "creates pdf derivatives" do
     pdf_asset.file.metadata['sha512'] = pdf_file_sha512
     pdf_asset.save!
@@ -45,8 +19,4 @@ describe "derivative creation" do
     expect(widths[:thumb_mini]).to eq(54)
     expect(widths[:thumb_large_2X]).to eq(1050)
   end
-
-
-
-
 end

--- a/spec/presenters/download_dropdown_display_spec.rb
+++ b/spec/presenters/download_dropdown_display_spec.rb
@@ -89,18 +89,12 @@ describe DownloadDropdownDisplay do
         faked_content_type: "audio/x-flac",
         faked_height: nil,
         faked_width: nil,
-        faked_derivatives: [build(:faked_derivative, key: "small_mp3", uploaded_file: build(:stored_uploaded_file, content_type: "audio/mpeg"))],
         parent: build(:work, rights: "http://creativecommons.org/publicdomain/mark/1.0/")
       )
     end
 
     it "renders just original option" do
       expect(div).to be_present
-
-      expect(div).to have_selector(".dropdown-header", text: "Download selected file")
-      expect(div).to have_selector("a.dropdown-item", text: /Original file.*FLAC/)
-      expect(div).to have_selector("a.dropdown-item", text: /Optimized MP3/)
-
       expect(div).not_to have_selector("a.dropdown-item", text: /Small JPG/)
       expect(div).not_to have_selector("a.dropdown-item", text: /Medium JPG/)
       expect(div).not_to have_selector("a.dropdown-item", text: /Large JPG/)

--- a/spec/presenters/download_filename_helper_spec.rb
+++ b/spec/presenters/download_filename_helper_spec.rb
@@ -69,16 +69,6 @@ describe DownloadFilenameHelper, type: :model do
     end
   end
 
-  describe "#suffix_for_content_type" do
-    it "audio/x-flac" do
-      expect(DownloadFilenameHelper.suffix_for_content_type("audio/x-flac")).to eq("flac")
-    end
-
-    it "audio/mpeg" do
-      expect(DownloadFilenameHelper.suffix_for_content_type("audio/mpeg")).to eq("mp3")
-    end
-  end
-
   describe "#filename_for_asset" do
     let(:derivative_key) { :thumb_mini }
     let(:asset) do
@@ -95,26 +85,6 @@ describe DownloadFilenameHelper, type: :model do
     it "can create for derivative" do
       # note ends with jpeg, not png, cause it's a jpeg derivative
       expect(DownloadFilenameHelper.filename_for_asset(asset, derivative: derivative)).to eq "plastics_make_the_#{asset.parent.friendlier_id}_12_#{asset.friendlier_id}_#{derivative.key}.jpeg"
-    end
-
-    describe "audio file" do
-      let(:derivative_key) { :small_mp3 }
-      let(:asset) do
-        create(:asset_with_faked_file,
-               title: "mark_h_0030_1-1.flac",
-               faked_content_type: "audio/x-flac",
-               faked_derivatives: [ build(:faked_derivative, key: derivative_key, uploaded_file: build(:stored_uploaded_file, content_type: "audio/mpeg")) ],
-               position: 12,
-               parent: create(:work, title: "Plastics make the package Dow makes the plastics"))
-      end
-
-      it "can create for original" do
-        expect(DownloadFilenameHelper.filename_for_asset(asset)).to eq "mark_h_0030_1-1.flac"
-      end
-
-      it "can create for derivative" do
-        expect(DownloadFilenameHelper.filename_for_asset(asset, derivative: derivative)).to eq "mark_h_0030_1-1.mp3"
-      end
     end
   end
 

--- a/spec/system/audio_front_end_spec.rb
+++ b/spec/system/audio_front_end_spec.rb
@@ -20,12 +20,7 @@ describe "Audio front end", type: :system, js: true do
         parent: parent_work,
 
         # All of these are published except for the second one.
-        published: i != 2,
-
-        faked_derivatives: [
-            build(:faked_derivative, key: 'small_mp3', uploaded_file: build(:stored_uploaded_file, content_type: "audio/mpeg")),
-            build(:faked_derivative, key: 'webm',      uploaded_file: build(:stored_uploaded_file, content_type: "audio/webm"))
-        ]
+        published: i != 2
       )
     end
   }
@@ -75,13 +70,10 @@ describe "Audio front end", type: :system, js: true do
 
         download_links = page.find_all('.track-listing .dropdown-item', :visible => false).map { |x| x['href'] }
 
-        (0..2).to_a.map do |i|
-          expect(download_links.any? { |x| x.include? "#{published_audio_assets[i].friendlier_id}/small_mp3" }).to be true
-        end
-        # Original file + one derivatives + rights link:
-        expect(download_links.count).to eq published_audio_assets.count * ( 1 + 2)
-        # original and derivatives are served by the downloads controller:
-        expect(download_links.select{ |x| x.include? 'downloads'}.count).to eq published_audio_assets.count * 2
+        # Original file + rights link:
+        expect(download_links.count).to eq published_audio_assets.count * 2
+        # original is served by the downloads controller:
+        expect(download_links.select{ |x| x.include? 'downloads'}.count).to eq published_audio_assets.count
       end
 
       non_audio = page.find_all('.other-files .show-member-list-item')
@@ -160,12 +152,7 @@ describe "Audio front end", type: :system, js: true do
           parent: parent_work,
 
           # All of these are published except for the second one.
-          published: i != 2,
-
-          faked_derivatives: [
-              build(:faked_derivative, key: 'small_mp3', uploaded_file: build(:stored_uploaded_file, content_type: "audio/mpeg")),
-              build(:faked_derivative, key: 'webm',      uploaded_file: build(:stored_uploaded_file, content_type: "audio/webm"))
-          ]
+          published: i != 2
         )
       end
     }


### PR DESCRIPTION
Ref #664 .
Audio asset derivatives, now replaced by work-level audio derivatives:
 - Are no longer generated on ingest
 - Aren't available for download
 - Aren't referred to in any of the tests.

This PR includes a simple Rake task to get rid of all the now-obsolete derivatives.