### PR TITLE
[WIP] Downloads for combined audio derivatives; show start times and durations.

### DIFF
--- a/app/assets/stylesheets/local/show_audio.scss
+++ b/app/assets/stylesheets/local/show_audio.scss
@@ -46,7 +46,7 @@
     margin-top: 0;
   }
 
-  .track-listings {
+  .track-listings, .combined-downloads {
     border-top: 3px solid $table-border-color;
 
    .track-listing {
@@ -76,6 +76,18 @@
       word-break: break-word;
     }
 
+  }
+
+
+  .combined-downloads {
+      margin-bottom: 1rem;
+  }
+
+  .combined-download {
+      border-top: $table-border-width solid $table-border-color;
+      padding: 0.5rem;
+      display: flex;
+      align-items: center;
   }
 
   .other-files {

--- a/app/javascript/src/js/simple_ohms_player.js
+++ b/app/javascript/src/js/simple_ohms_player.js
@@ -12,3 +12,20 @@ $(document).on("click", "*[data-ohms-timestamp-s]", function(event) {
   html5Audio.currentTime = seconds;
   html5Audio.play();
 });
+
+function showDuration() {
+    var startTime = parseFloat(this.dataset.ohmsTimestampS);
+    var nextTrack = jQuery(this).next('.track-listing')
+    var endTime = jQuery('audio')[0].duration;
+    if (nextTrack.length > 0) {
+        endTime = parseFloat(nextTrack[0].dataset.ohmsTimestampS);
+    }
+    durationInSeconds = endTime - startTime
+    durationInMinutes = durationInSeconds / 60.0
+    roundedDurationInMinutes = Math.round(durationInMinutes * 10.0) / 10.0
+    jQuery(this).find("*[data-role=track-duration]").html(roundedDurationInMinutes);
+}
+
+jQuery('audio')[0].onloadedmetadata = function () {
+    jQuery(".track-listing").each(showDuration);
+};

--- a/app/javascript/src/js/simple_ohms_player.js
+++ b/app/javascript/src/js/simple_ohms_player.js
@@ -13,19 +13,49 @@ $(document).on("click", "*[data-ohms-timestamp-s]", function(event) {
   html5Audio.play();
 });
 
+
+////////////
+////////////
+// START HACK
+//
+// Let's temporarily rig the front end to display the starting point
+// of each segment, as well as its duration.
+// The starting points are stored in the DB;
+// we can redily calculate the duration of each segment
+// by subtracting its start time from its end time.
+//
+// The way we get the end time of the last element is a hack that
+// we definitely won't want to keep in the long run:
+// loading the combined audio into the DOM and then asking the browser
+// to give us the length of the audio tag.
+//
+
 function showDuration() {
     var startTime = parseFloat(this.dataset.ohmsTimestampS);
-    var nextTrack = jQuery(this).next('.track-listing')
-    var endTime = jQuery('audio')[0].duration;
-    if (nextTrack.length > 0) {
+    var nextTrack = jQuery(this).next('.track-listing');
+    var endTime;
+    if (nextTrack.length) {
+        // this track ends when the next one begins
         endTime = parseFloat(nextTrack[0].dataset.ohmsTimestampS);
     }
-    durationInSeconds = endTime - startTime
-    durationInMinutes = durationInSeconds / 60.0
-    roundedDurationInMinutes = Math.round(durationInMinutes * 10.0) / 10.0
+    else {
+        // this track ends when the combined audio ends
+        endTime = jQuery('audio')[0].duration;
+    }
+    var durationInSeconds = endTime - startTime;
+    var durationInMinutes = durationInSeconds / 60.0;
+    var roundedDurationInMinutes = Math.round(durationInMinutes * 10.0) / 10.0;
     jQuery(this).find("*[data-role=track-duration]").html(roundedDurationInMinutes);
 }
 
+// Wait until we have the length metadata for the total play.
+// We're temporarily rigging the front end to display
 jQuery('audio')[0].onloadedmetadata = function () {
     jQuery(".track-listing").each(showDuration);
 };
+
+//
+//
+// END HACK
+////////////
+////////////

--- a/app/views/works/show_with_audio.html.erb
+++ b/app/views/works/show_with_audio.html.erb
@@ -70,7 +70,7 @@
 
         <div class="tab-pane" id="ohDownloads" role="tabpanel" aria-labelledby="oh-downloads-tab">
           <div>
-            <h2 class="attribute-sub-head sound-file-header"><%= pluralize(decorator.audio_members.count, 'sound file')%></h2>
+            <h2 class="attribute-sub-head sound-file-header"><%= pluralize(decorator.audio_members.count, 'separate interview segment')%></h2>
 
             <div class="sans-serif track-listings" data-role="track-listings" >
               <% decorator.audio_members.each do |track| %>
@@ -93,7 +93,7 @@
                   <div class="title">
                     <% if decorator.start_time_for(track) %>
                       <a class="title play-link" title="Listen to '<%= track.title%>'" aria-label="Listen to '<%= track.title%>'" href="#" data-role="play-link">
-                        <%= track.title %>
+                        <%= track.title %> (start: <%= (decorator.start_time_for(track) / 60).round(1) %> min., duration: <span data-role="track-duration"></span> min.)
                         <% unless track.published? %>
                           <span title="Private" class="badge badge-warning">Private</span>
                         <% end %>
@@ -111,6 +111,22 @@
                 </div>
               <% end %>
             </div>
+
+            <% if decorator.audio_members.count > 1 %>
+              <h2 class="attribute-sub-head sound-file-header">
+                <%= decorator.audio_members.count == 2 ? "Both" : "All #{decorator.audio_members.count}" %>
+                segments as a single file
+              </h2>
+              <div class="combined-downloads">
+
+                <div class="sans-serif combined-download" >
+                  <a href="decorator.combined_mp3_audio">Download mp3 format</a>
+                </div>
+                <div class="sans-serif combined-download">
+                  <a href="decorator.combined_webm_audio">Download webm format</a>
+                </div>
+              </div>
+            <% end %>
           </div>
 
 


### PR DESCRIPTION
**DO NOT MERGE**

For demo purposes, I'm combining two features into one PR, which can easily be broken into two PRs if and when we want the features. (We can also simply erase part of the changes via a commit.)

Feature 1: enable users to download combined derivatives.
Feature 2: display start time and duration on the Downloads tab.

NOTE:
Feature 2 is based on hacky front-end development; if we do need this functionality we will want to store some extra metadata in the DB and remove the extra front-end code in this PR.