### PR TITLE
improve collection show page test

### DIFF
--- a/spec/system/collection_show_spec.rb
+++ b/spec/system/collection_show_spec.rb
@@ -5,8 +5,16 @@ describe "Collection show page", solr: true, indexable_callbacks: true do
     let(:collection) do
       create(:collection,
         description: "some description",
-        related_url: ["http://othmerlib.sciencehistory.org/record=b1234567", "https://example.org/foo/bar"],
-        contains: [create(:public_work), create(:public_work), create(:private_work)])
+        related_url: ["http://othmerlib.sciencehistory.org/record=b1234567", "https://example.org/foo/bar"]
+      ).tap do |col|
+        # doing these as separate creates after collection exists necessary for them to have collection
+        # on save, so to get indexed properly
+        #
+        # Different dates to make sure we exersize blacklight_range_limit a bit.
+        create(:public_work, title: "public work one", date_of_work: Work::DateOfWork.new(start: "2019"), contained_by: [col])
+        create(:public_work, title: "public work two", date_of_work: Work::DateOfWork.new(start: "1900"), contained_by: [col])
+        create(:private_work, title: "private work", contained_by: [col])
+      end
     end
 
     it "displays" do
@@ -20,6 +28,10 @@ describe "Collection show page", solr: true, indexable_callbacks: true do
 
       expect(page).to have_link(href: "http://othmerlib.sciencehistory.org/record=b1234567", text: "View in library catalog")
       expect(page).to have_link(href: "https://example.org/foo/bar", text: "example.org/…")
+
+      expect(page).to have_content("public work one")
+      expect(page).to have_content("public work two")
+      expect(page).not_to have_content("private_work")
     end
   end
 end

--- a/spec/system/featured_topic_spec.rb
+++ b/spec/system/featured_topic_spec.rb
@@ -1,7 +1,15 @@
 require 'rails_helper'
 
-describe "Featured Topic show page", type: :system, js: false, solr:true do
-  it "displays" do
+describe "Featured Topic show page", type: :system, js: false, solr:true, indexable_callbacks: true do
+  let!(:three_sample_works ) do
+    [
+      create(:public_work, title: "artillery", subject: ["Artillery"]),
+      create(:public_work, title: "lithographs", genre: ["Lithographs"]),
+      create(:private_work, title: "machinery", subject: ["Machinery"])
+    ]
+  end
+
+  it "smoke tests" do
     fake_definition =  {
         instruments_and_innovation: {
         title: "Instruments & Innovation",
@@ -16,5 +24,8 @@ describe "Featured Topic show page", type: :system, js: false, solr:true do
     expect(page).to have_title "Instruments & Innovation"
     expect(page).to have_selector("h1", text: 'Instruments & Innovation')
     expect(page).to have_selector("p", text: 'Fireballs')
+    expect(page).to have_content("artillery")
+    expect(page).to have_content("lithographs")
+    expect(page).not_to have_content("machinery")
   end
 end


### PR DESCRIPTION
It wasn't actually succesfully testing that collection members were displayed on page -- they weren't actually being properly solr-indexed in test, and were not being displayed.

Also give them different dates, to exersize blacklight_range_limit a bit.

This improved test would have failed when updating blacklight_range_limit, so would have caught problem in #678, that was uncaught and let us deploy with a bug.