### PR TITLE
Bug fix for broken audio file download links

### DIFF
--- a/app/views/works/show_with_audio.html.erb
+++ b/app/views/works/show_with_audio.html.erb
@@ -77,13 +77,18 @@
                 <div  class="track-listing" data-role="track-listing"
                       data-title="<%= track.title %>"
                       data-member-id="<%= track.id %>"
-                      data-original-url="<%= main_app.download_path(track.id)    %>"
-                      data-ohms-timestamp-s="<%= decorator.start_time_for(track) %>"
+                      data-original-url="<%= main_app.download_path(track.id) %>"
                   >
 
                   <% if decorator.start_time_for(track) %>
                     <div class="icon">
-                      <a class="title play-link" title="Listen to '<%= track.title%>'" aria-label="Listen to '<%= track.title%>'" href="#" data-role="play-link">
+                      <a
+                        class="title play-link"
+                        title="Listen to '<%= track.title%>'"
+                        aria-label="Listen to '<%= track.title%>'"
+                        href="#" data-role="play-link"
+                        data-ohms-timestamp-s="<%= decorator.start_time_for(track) %>"
+                      >
                         <i class="fa fa-play-circle" aria-hidden="true"></i>
                       </a>
                     </div>
@@ -92,7 +97,14 @@
 
                   <div class="title">
                     <% if decorator.start_time_for(track) %>
-                      <a class="title play-link" title="Listen to '<%= track.title%>'" aria-label="Listen to '<%= track.title%>'" href="#" data-role="play-link">
+                      <a
+                        class="title play-link"
+                        title="Listen to '<%= track.title%>'"
+                        aria-label="Listen to '<%= track.title%>'"
+                        href="#"
+                        data-role="play-link"
+                        data-ohms-timestamp-s="<%= decorator.start_time_for(track) %>"
+                      >
                         <%= track.title %>
                         <% unless track.published? %>
                           <span title="Private" class="badge badge-warning">Private</span>

--- a/spec/system/audio_front_end_spec.rb
+++ b/spec/system/audio_front_end_spec.rb
@@ -117,16 +117,25 @@ describe "Audio front end", type: :system, js: true do
       # No we should see audio.
       expect(page).not_to have_css("*[data-role='no-audio-alert']")
       expect(page).to have_selector('audio')
-      expect(page).to have_selector(".track-listing[data-ohms-timestamp-s=\"0\"]" , visible: false)
-      expect(page).to have_selector(".track-listing[data-ohms-timestamp-s=\"0.5\"]" , visible: false)
-      expect(page).to have_selector(".track-listing[data-ohms-timestamp-s=\"1\"]" , visible: false)
 
       click_on "Downloads"
+
+      # click on icons to play
+      expect(page).to have_selector(".track-listing div.title a.play-link[data-ohms-timestamp-s=\"0\"]" )
+      expect(page).to have_selector(".track-listing div.title a.play-link[data-ohms-timestamp-s=\"0.5\"]")
+      expect(page).to have_selector(".track-listing div.title a.play-link[data-ohms-timestamp-s=\"1\"]")
+
+      # click on titles to play
+      expect(page).to have_selector(".track-listing div.icon a.play-link[data-ohms-timestamp-s=\"0\"]")
+      expect(page).to have_selector(".track-listing div.icon a.play-link[data-ohms-timestamp-s=\"0.5\"]")
+      expect(page).to have_selector(".track-listing div.icon a.play-link[data-ohms-timestamp-s=\"1\"]")
+
+      current_time_js = "document.getElementsByTagName('audio')[0].currentTime"
       scrubber_times = []
-      scrubber_times << evaluate_script("document.getElementsByTagName('audio')[0].currentTime")
+      scrubber_times << evaluate_script(current_time_js)
       [1, 3, 4].each do |track_number|
         click_on "Track #{track_number}"
-        scrubber_times << evaluate_script("document.getElementsByTagName('audio')[0].currentTime")
+        scrubber_times << evaluate_script(current_time_js)
       end
       # This doesn't need to be super precise.
       # We just want a general reassurance


### PR DESCRIPTION
Only add the data-ohms-timestamp-s to links that are actually supposed to play audio.

This should fix #687.