### PR TITLE
fix accordion open off-screen in OHMS ToC

### DIFF
--- a/app/javascript/src/js/simple_ohms_player.js
+++ b/app/javascript/src/js/simple_ohms_player.js
@@ -12,3 +12,23 @@ $(document).on("click", "*[data-ohms-timestamp-s]", function(event) {
   html5Audio.currentTime = seconds;
   html5Audio.play();
 });
+
+// After an accordion section change, sometimes the open section is scrolled out
+// of the viewport. This can happen occasionally even in an 'ordinary' situation
+// with bootstrap accordion, but our fixed navbar makes it even more likely that
+// the open section is hidden behind the navbar.
+//
+// We detect that condition, and scroll to reveal it. Only within
+// an .ohms-index-container, not affecting all bootstrap collapse/accordions.
+$(document).on("shown.bs.collapse", ".ohms-index-container", function(event) {
+  var indexSection = $(event.target).closest(".ohms-index-point").get(0);
+
+  if (!indexSection) { return; }
+
+  var targetViewportXPosition = indexSection.getBoundingClientRect().top;
+  var navbarBottom = $(".now-playing-container").get(0).getBoundingClientRect().bottom;
+
+  if (targetViewportXPosition <= navbarBottom) {
+    window.scrollTo({top: window.scrollY - (navbarBottom - targetViewportXPosition), behavior: "smooth"});
+  }
+});


### PR DESCRIPTION
This had already been done/fixed in the ohms-search branch, but we need to "back port" it to be in master while the unfortunately long-running ohms-search is still under construction. We'll have to deal with merge conflict over in ohms-search branch.

This is a little bit janky, it first opens the accordion, then repositions it to be at the right place. But this seems to be the best we can do with the bootstrap accordion stuff. I did notice similar "open then reposition" even in ohms standard viewer and other ohms-like viewers, it seems to be a common problem -- our fixed navbar makes it even worse. This is the best we can do, and hopefully good enough, we should ask stakeholders to verify it resolves problem reported in #689