### PR TITLE
Strip footnotes out of OHMS transcript

### DIFF
--- a/app/models/oral_history_content/ohms_xml.rb
+++ b/app/models/oral_history_content/ohms_xml.rb
@@ -43,6 +43,16 @@ class OralHistoryContent
       end
     end
 
+    # Returns an ordered array of transcript lines
+    #
+    # TBD: filters footnotes out (later, does something... else with them)
+    #
+    def transcript_lines
+      @transcript_lines ||= begin
+        parsed.at_xpath("//ohms:transcript", ohms: OHMS_NS).text.split("\n")
+      end
+    end
+
     # Represents an ohms //index/point element, what ohms calls an index we might
     # really call a Table of Contents. We're not currently using all the elements,
     # only providing access to those we are.

--- a/app/presenters/ohms_transcript_display.rb
+++ b/app/presenters/ohms_transcript_display.rb
@@ -22,7 +22,7 @@ class OhmsTranscriptDisplay < ViewModel
   def display
     paragraphs = []
     current_paragraph = []
-    model.parsed.at_xpath("//ohms:transcript", ohms: OHMS_NS).text.split("\n").each_with_index do |line, index|
+    model.transcript_lines.each_with_index do |line, index|
       current_paragraph << { text: line, line_num: index + 1}
 
       if line.empty?

--- a/spec/models/oral_history_content_spec.rb
+++ b/spec/models/oral_history_content_spec.rb
@@ -114,5 +114,21 @@ describe OralHistoryContent do
       end
     end
 
+    describe "#transcript_lines" do
+      # an XML with footnotes so we can test them being stripped
+      let(:ohms_xml_path) { Rails.root + "spec/test_support/ohms_xml/hanford_OH0139.xml"}
+
+      it "strips footnotes" do
+        expect(ohms_xml.transcript_lines).to be_present
+
+        all_text = ohms_xml.transcript_lines.join("\n")
+
+        expect(all_text).not_to match(%r{\[\[/?footnote\]\]})
+        expect(all_text).not_to match(%r{\[\[/?footnotes\]\]})
+
+        # with footnote omitted:
+        expect(all_text).to include("mail them to get a patent.\n")
+      end
+    end
   end
 end

--- a/spec/test_support/ohms_xml/hanford_OH0139.xml
+++ b/spec/test_support/ohms_xml/hanford_OH0139.xml
@@ -1,0 +1,1674 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ROOT xmlns="https://www.weareavp.com/nunncenter/ohms" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.weareavp.com/nunncenter/ohms/ohms.xsd"><record id="00089281" dt="2020-04-07"><version>5.4</version><date value="" format="yyyy-mm-dd"/><date_nonpreferred_format>Unknown Date</date_nonpreferred_format><cms_record_id></cms_record_id><title>Oral history interview with William E. Hanford</title><accession>OH0139</accession><duration></duration><collection_id></collection_id><collection_name></collection_name><series_id></series_id><series_name></series_name><repository>Science History Institute</repository><funding></funding><repository_url /><file_name></file_name><sync>1:|25(2)|40(7)|50(8)|64(2)|69(8)|81(1)|93(9)|101(6)|113(14)|123(18)|132(7)|143(10)|153(11)|161(10)|171(2)|182(5)|193(12)|206(8)|221(3)|233(12)|245(15)|259(1)|271(11)|288(9)|298(13)|312(1)|326(2)|339(11)|353(6)|370(13)|388(14)|398(5)|409(10)|425(3)|438(1)|449(5)|462(1)|473(6)|485(13)|497(11)|508(10)|523(6)|535(2)|549(1)|558(8)|568(5)|578(7)|592(2)|602(13)|616(10)|626(14)|638(13)|648(10)|665(14)|677(3)|691(1)|703(2)|714(8)|724(12)|735(1)|746(9)|757(6)|768(1)|776(11)|789(9)|800(7)|812(9)|822(13)|836(3)|847(5)|858(10)|868(3)|879(2)|890(5)|899(13)|912(9)|926(2)|935(13)|944(12)|955(8)|965(10)|974(5)|981(8)|989(10)|998(2)|1008(11)|1017(9)|1027(2)|1037(9)|1045(1)|1052(12)|1062(9)|1071(3)|1089(1)|1097(15)|1106(5)|1113(11)|1117(3)|1127(11)|1138(13)|1148(10)|1153(2)|1161(11)|1173(2)|1183(9)|1197(2)|1207(5)|1216(17)|1226(10)|1234(1)|1239(11)|1248(1)|1251(4)|1260(12)|1267(10)|1272(9)|1285(11)|1294(4)|1302(2)|1311(4)|1320(7)|1330(8)|1338(3)|1347(1)|1355(8)|1367(5)|1379(6)|1388(19)|1394(1)|1403(6)|1415(2)|1428(11)|1437(6)|1447(7)|1457(1)|1466(2)|1477(3)|1487(4)|1497(5)|1506(2)|1515(1)</sync><sync_alt></sync_alt><transcript_alt_lang></transcript_alt_lang><translate>0</translate><media_id></media_id><media_url>https://scihist-digicoll-production-derivatives.s3.amazonaws.com/combined_audio_derivatives/0e84c870-0307-4714-99a0-1bde3134cf6f/combined_9e5906e9d445cc1b58683723e1665211.mp3</media_url><mediafile><host>Other</host><avalon_target_domain></avalon_target_domain><host_account_id></host_account_id><host_player_id></host_player_id><host_clip_id></host_clip_id><clip_format>audio</clip_format></mediafile><kembed></kembed><language></language><user_notes></user_notes><index><point><time>0</time><title>Pre-Interview Discussion</title><title_alt></title_alt><partial_transcript>BOHNING:  Let me just see if this is working all right. It looks like it is. And I think there were—</partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis></synopsis><synopsis_alt></synopsis_alt><keywords></keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink></hyperlink><hyperlink_text></hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point><point><time>82</time><title>Early Career</title><title_alt></title_alt><partial_transcript>HANFORD:  The only thing I didn’t quite understand was question number six, about the award. </partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis>Experience at DuPont.  Importance of teamwork.  Influence of Roger Adams.</synopsis><synopsis_alt></synopsis_alt><keywords>Adams, Roger;E. I. DuPont de Nemours &amp; Co.;Experimental Station;GAF;General Aniline &amp; Film Company;Tanberg, Arthur P.;University of Illinois;wife (Lorraine)</keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink></hyperlink><hyperlink_text></hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point><point><time>479</time><title>Family Background and Education</title><title_alt></title_alt><partial_transcript>BOHNING:  I know you were born on December 9, 1908, in Bristol, Pennsylvania. Could you tell me something about your father and mother and your family background?</partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis>Parents.  Growing up in Bristol, Pennsylvania.  Financial situation.  High school science.  Encouragement of uncle.  Decision to attend Philadelphia College of Pharmacy and Science.  First job at Rohm and Haas.  Decision to pursue graduate studies.
+</synopsis><synopsis_alt></synopsis_alt><keywords>Bridesburg, Pennsylvania;Bristol High School;Bristol, Pennsylvania;brothers;father (Thomas Cook Hanford);First World War;Hollander, Charles Samuel;Insecticides;mother (Irene Laing Hanford);Muhlenberg College;Pennsylvania State University;Philadelphia College of Pharmacy and Science;Philadelphia, Pennsylvania;Potassium;Rohm and Haas Company;Snyder, --;Sodium;uncle;University of Illinois;Whitmore, Frank C.;World War I</keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink></hyperlink><hyperlink_text></hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point><point><time>1076</time><title>Graduate School</title><title_alt></title_alt><partial_transcript>HANFORD: Anyhow, I applied, and I was accepted temporarily at Illinois and Penn State.</partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis>Choosing the University of Illinois. Working with Roger Adams. Laboratory research. Interactions with Carl Marvel, Reynold Fuson, and Ralph Shriner. Language studies.
+</synopsis><synopsis_alt></synopsis_alt><keywords>Adams, Roger;Amherst College;E. I. DuPont de Nemours &amp; Co.;Evans, --;Fuson, Reynold C.;Great Depression;Holmes, Donald F.;Marvel, Carl S.;mother (Irene Laing Hanford);National Inventors Hall of Fame;Pennsylvania State University;Philadelphia College of Pharmacy and Science;Rohm and Haas Company;Shriner, Ralph Lloyd;University of Illinois;wife (Lorraine);Wilmington, Delaware</keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink>https://digital.sciencehistory.org/works/fj236304x</hyperlink><hyperlink_text>Oral history interview with Carl S. Marvel</hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point><point><time>1614</time><title>E.I. DuPont de Nemours &amp; Company</title><title_alt></title_alt><partial_transcript>HANFORD: When I got to DuPont, I was assigned to work for a man by the name of Paul [Lawrence] Salzberg.
+
+</partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis>Working in Experimental Station. Isolthiocyanate. Becoming group leader. Polymerizing caprolactam. Polymerizing polyethylene.  Teflon. Fluorochemistry. Polyesters and polyamides. Decision to leave.
+</synopsis><synopsis_alt></synopsis_alt><keywords>Adams, Roger;Allan, --;Ammonia;Asbestos;Atomic Energy Commission;Bolton, Elmer K.;Brubaker, Merlin;Calcium carbonate;Caprolactam;Carbon tetrachloride;Carboxyl;Carothers, Wallace Hume;Christ, Robert E.;Diisocyanates;E. I. DuPont de Nemours &amp; Co.;Ester;Ethylene;Experimental Station;Fluorochemistry;GAF;General Aniline &amp; Film Company;Greenewalt, Crawford H.;Harmon, Jesse;Harvard University;Hill, Julian W.;Holmes, Donald F.;ICI Americas, Inc.;IG Farben;Insecticides;Isothiocyanate;Joyce, Robert M.;Lactam;M. W. Kellogg Company;National Inventors Hall of Fame;New York City, New York;Northwestern University;Nylon;Peterson, Wesley R.;Plunkett, Roy;Polyamides;Polyester polyamides;Polyesters;Polyethylene;Polymers;Polyols;Polyurethanes;Reid, Emmet;Rohm and Haas Company;Salzberg, Paul L.;Second World War;Teflon;Telomers;Terephthalic acid;Tetrafluorethylene;Thiocyanates;University of Illinois;Urethane;Wiley, Richard H.;World War II;Young, Howard</keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink>https://digital.sciencehistory.org/works/0g354g32</hyperlink><hyperlink_text>Oral history interview with Roy J. Plunkett</hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point><point><time>3166</time><title>General Aniline and Film Corporation</title><title_alt></title_alt><partial_transcript>HANFORD: At GAF, I was made the Director of Research, reported to one of the presidents. </partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis>Becoming Director of Research. Administrative challenges. Developing Glim.  </synopsis><synopsis_alt></synopsis_alt><keywords>Acetylene;Adams, Roger;Alkali;Cross, James M.;E. I. DuPont de Nemours &amp; Co.;Ethylene;Fluorocarbons;GAF;General Aniline &amp; Film Company;Kellogg, --;M. W. Kellogg Company;Methylvinyl ethers;Petroleum;Phenol;Polymers;Propylene;Pullman Company;Trifluorochloroethylene;World War II;Zimmerli, William F.</keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink></hyperlink><hyperlink_text></hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point><point><time>3605</time><title>M. W. Kellogg Company</title><title_alt></title_alt><partial_transcript>HANFORD: Anyhow, Kellogg hired me to do what I could with Bob Kearns of Cornell [University]. </partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis>Synthol. Developing KEL-F. Relationship with Pullman Company. Selling KEL-F to 3M.
+</synopsis><synopsis_alt></synopsis_alt><keywords>Acetamides;Acetic acid;Carey, James;Carothers, Wallace Hume;Catalytic cracking;Cornell University;Cummish, E.;E. I. DuPont de Nemours &amp; Co.;Ethylene oxide;Fluid beds;Fluorocarbons;GAF;General Aniline &amp; Film Company;Hydrocarbon;IG Farben;Kearns, Bob;KEL-F;Kellogg, --;M. W. Kellogg Company;Minnesota Mining and Manufacturing Company;Nylon;Peterson, W. R.;Polymers;Pullman Company;Rohm and Haas Company;Schwarzenbek, Eugene Frederick;Synthol</keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink></hyperlink><hyperlink_text></hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point><point><time>4188</time><title>Olin Corporation</title><title_alt></title_alt><partial_transcript>HANFORD: John [M.] Olin, who was another one of the old, old inventors in money--made the Olin Corporation--heard of me, and I met him. </partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis>Moving to Olin Corporation. Influence of John M. Olin. Introducing Head and Shoulders. Work on plastic shotgun shells and spiral-wound lightweight shotgun. Composite metal coinage. Production of polyurethanes.
+</synopsis><synopsis_alt></synopsis_alt><keywords>Benzene;Chlorine;Churchill, John Wilbur;Copenhaver, John W.;Diaminotoluene;Dinitrotoluene;DNT;E. I. DuPont de Nemours &amp; Co.;E.R. Squibb &amp; Sons, Inc.;Errede, Louis A.;Ethylene oxide;Fluorocarbons;Head and Shoulders;Hofrichter, Charles H.;Minnesota Mining and Manufacturing Company;Olin Corporation;Olin, John M.;Plastic;Polymers;Polyols;Polyurethanes;Pullman Company;Toluene;U.S. Mint;Winchester-Western</keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink></hyperlink><hyperlink_text></hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point><point><time>4858</time><title>Conclusion</title><title_alt></title_alt><partial_transcript>HANFORD: It was there that I learned another great thing, which is so important--that all research is a team effort. </partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis>Importance of teamwork. Shift to administration. Winning the Chemical Industry Medal.  Leaving Olin.  Working with son in World Water Resources, Inc.  Role of Nature.  Relationship with Wallace Carothers and Julian Hill. Family. Induction into National Inventors Hall of Fame.
+</synopsis><synopsis_alt></synopsis_alt><keywords>Acetic acid;Acetone;Acetylene;Agassi, Andre K.;Akron, Ohio;American Institute of Chemists;Amino acid;Ammonia;aunt;Bailey, --;Barnes, Carl Edmund;Bolton, Elmer K.;Bristol, Pennsylvania;brothers;Brubaker, Merlin;Camden, New Jersey;Campbell’s Soup Company;Caprolactam;Carboxyl;Carothers, Wallace Hume;Chilton, Thomas Hamilton;Clathrates;Cobalt;Creosote;daughter-in-law;Dorrance, Arthur C.;E. I. DuPont de Nemours &amp; Co.;E.R. Squibb &amp; Sons, Inc.;East Alton, Illinois;Eastman Kodak Company;Ethanol;Ethyl glycenate;GAF;General Aniline &amp; Film Company;granddaughter;grandfather;Great Lakes;Greenewalt, Crawford H.;Harvard University;Haught, John William;Hexamethylene-diamene;Hill, Julian W.;Hydrocarbon;IG Farben;Isocyanate;Kellogg, M.W.;Lazier, Wilbur A.;Lobo, Walter E.;M. W. Kellogg Company;Mercury;Methane;Methanol;Methanol-ethylene-glycol;Minnesota Mining and Manufacturing Company;National Institutes of Health;National Inventors Hall of Fame;Northwestern University;Nylon;nylon 10-10;nylon 6-6;Olin Corporation;Olin, John M.;Perkin Medal;Peterson, W. R.;Petroleum;Polyamides;Polyesters;Polyethylene;Polymers;Pullman Company;Simpers, Tommy;Sloane, Howard N.;Sloane, Lucille L.;son (William E. Hanford, Jr.);Teflon;Tensometer;Tishler, Max;uncle;University of Akron;University of Illinois;Urethane;Western Cartridge Company;wife (Lorraine);Winchester Repeating Arms Company;Winchester-Western;World War I;World Water Resources, Inc.</keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink>https://digital.sciencehistory.org/works/td96k3858</hyperlink><hyperlink_text>Oral history interview with Max Tishler.</hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point></index><type></type><description></description><rel /><transcript>BOHNING: Let me just see if this is working all right. It looks like it is. And
+I think there were--hmm.
+
+HANFORD: Well, let&#039;s, before we start recording, let&#039;s get a picture of what
+type of stuff you want.
+
+BOHNING: All right. Let me just check something here.
+
+HANFORD: In other words, I looked at that outline. And--that&#039;s easy.
+
+BOHNING: Well that&#039;s basically what I would like to do. I&#039;m just going to ask
+you some questions and--you can respond, and, you can respond and --
+
+HANFORD: Well let&#039;s try a few of the questions before we start with (concert?),
+get my mind ordered.
+
+BOHNING: Well, I&#039;m going to edit this, and I&#039;ll cut out all kinds of things.
+
+HANFORD: OK.
+
+BOHNING: --I just don&#039;t want to miss something, so--I&#039;m going to send you a
+transcript, but I will edit the transcript.
+
+HANFORD: Whatever you write--do it. I&#039;m a poor editor, and I am a great believer
+in a man&#039;s work&#039;s a man&#039;s work.
+
+BOHNING: Well, I appreciate that. Why don&#039;t--oh, there&#039;s just one other thing I
+needed yet.
+
+HANFORD: Well, you just go ahead and do what you want! I&#039;ll answer any questions!
+
+BOHNING: OK. I just wanted to get one other thing out of the file.
+
+HANFORD: The only thing I didn&#039;t quite understand was question number six, about
+the award. I don&#039;t believe you earn those, in a sense. I don&#039;t think you set out
+and say, &quot;I&#039;m going to win that.&quot; You work, and then your peers decide whether
+you get something. In this connection, I&#039;ve been very, very lucky. I&#039;m an
+extremely lucky man. I&#039;ve had good men.
+
+The other thing that bothers me about something like this--I don&#039;t know where to
+start; let me tell you this. I started work. I went to DuPont [E. I. DuPont de
+Nemours &amp; Co.]. I got there and I found that there were a lot of us. I found out
+that the boss liked to call everybody, &quot;Dr.&quot; so-and-so. I said to myself one
+day, after I&#039;d been there about two weeks, &quot;That&#039;s not for me.&quot;
+
+Here, doctors are two cents a dozen. At [University of] Illinois, I had been
+christened &quot;Butch.&quot; We had a lot of Illinois men at DuPont at that time, at the
+Experimental Station, and soon nobody ever called me anything but &quot;Butch.&quot;
+
+Dr. [Arthur P.] Tanberg, who was the head of the station, called me up one day
+and said, &quot;We don&#039;t like that. We don&#039;t think that&#039;s dignified enough!&quot;
+[laughter] I said, &quot;Doctor, let&#039;s get it straight. Nobody&#039;ll remember me except
+as Butch.&quot; He said, &quot;Okay.&quot;
+
+I&#039;ll give you one more story. My wife knew Dr. Tanberg. After I&#039;d been there a
+little while--she knew that he didn&#039;t like it--we went there to dinner. At the
+dinner, everything went fine. Finally, we were standing at the door and I was
+talking, and she said, &quot;Come on, Butch! Let&#039;s go!&quot; [laughter] Tanberg called me
+in the next day and said, &quot;Well, I guess there&#039;s no use in trying to change it;
+that&#039;s it!&quot; [laughter]
+
+I think that that&#039;s been one of my greatest assets. I really do.
+
+The other thing I want to make sure we understand before we get started is that
+I was nothing without good men! It&#039;s people. By people, I mean all kinds of
+people--secretaries, dishwashers, whoever they are! They are important in the
+team operation. Sure, somebody has to be a part of the team, and even who gets a
+patent is kind of a roll of the dice. I want you to understand that anything I
+say is basically in part what the team did, not me--because that&#039;s so important.
+
+Just one more thing to orient you. Roger Adams was my greatest friend and
+advisor. I got into Illinois by the roll of the dice. I applied for it, and
+according to the stories that went around, they were reviewing the people who
+were going to get in. The chief came to my application and looked at it, and
+said, &quot;We&#039;re not going to let this guy in!&quot; Somebody said, &quot;Why not?&quot; He said,
+&quot;Hell, that&#039;s a school of pill rollers!&quot; [laughter]
+
+Somebody said, &quot;Well, look at his grades!&quot; He did and they were good, and he
+said, &quot;All right, give him a chance.&quot; That&#039;s why I got into Illinois.
+
+That&#039;s what I mean; I was lucky. Yet when I left, and as long as he lived, Adams
+was my greatest friend. Many of the things that I did were the results of
+conversations with the chief.
+
+Just as an orientation, one of your questions is, why did I change jobs? I went
+to DuPont; I did very well and I was lucky. We&#039;ll come to that as we go ahead.
+
+The war started. When it started, there was a German company, GAF [General
+Aniline &amp; Film Company], and they were looking for somebody. They went to the
+chief and talked to him.
+
+He came to DuPont then one day and said, &quot;Butch, you want that job?&quot; I said, &quot;I
+don&#039;t know.&quot; He said, &quot;Let me tell you. Chemistry--there&#039;s no doubt you can do
+it.&quot; He said, &quot;What we don&#039;t know is how you can manage people.&quot; He said, &quot;At
+your age, there won&#039;t be many chances; but you can get this job. Why don&#039;t you
+take it?&quot; I took it. That&#039;s how I left DuPont.
+
+That&#039;s been characteristic of most of the things I&#039;ve been involved in. We can
+go ahead if you want. That&#039;s what made my life.
+
+BOHNING: I know you were born on December 9, 1908, in Bristol, Pennsylvania.
+Could you tell me something about your father and mother and your family background?
+
+HANFORD: My mother [Irene Laing Hanford], to me, was the greatest woman who ever
+lived. My father [Thomas Cook Hanford] was a Philadelphian and he came from,
+&quot;out of the 1900s, an aristocratic family.&quot; My mother came from &quot;an aristocratic
+family&quot; in Bristol. They were married in Bristol.
+
+My father was a bookkeeper and, like all bookkeepers, a beautiful penman. He
+couldn&#039;t do much because as a young man, he lifted some bags and had a rupture.
+In those days, that meant you were half capacitated.
+
+The net result was that my mother, who was practically born with a silver spoon,
+took over. She ran everything, and she was the hardest worker who ever lived. No
+job was too menial for her as long as she got paid.
+
+There were three of us; I was the middle one. My oldest brother was two years
+older, and my youngest brother was two years younger. She raised us. During
+World War I, she ran a dining room of fifty people by herself and with people
+like me. I carried the dishes out to the dining room. That&#039;s the way she lived.
+She was a very religious woman and reared us the right way. She was great!
+
+I think one of the things that was my asset was, I never had too much money. The
+net result is that my whole life has depended on slight modifications. I was a
+student. I had no money, but on the other hand, I never wanted for anything. But
+we were told not to want too much.
+
+I graduated from Bristol High School. I was no star. I was a good student, but
+not par excellence. When I graduated from there, I decided I wanted to go to
+college. My uncle was a druggist and a graduate of the Philadelphia College of
+Pharmacy and Science [University of the Sciences in Philadelphia]. He thought it
+was a great school. In 1926, they had just started a new division in chemistry.
+He told me that if I wanted to go to college, I&#039;d go there and he&#039;d pay my way.
+That was in Philadelphia. I said, &quot;Okay, that&#039;s a good deal.&quot; He was a power in
+the school; he had been very successful. He got me in, and I went to school there.
+
+BOHNING: Had you had any science in high school?
+
+HANFORD: Yes, I did. I had a science teacher by the name of Mr. Snyder, who was
+a graduate of Muhlenberg College. He taught chemistry. He was a good teacher. I
+also had another teacher who was from Muhlenberg.
+
+The ones who really got me interested in science were my uncle and Snyder. Now,
+we had in Bristol, as you probably know, a chemical business, which was Rohm and
+Haas [Company]. Therefore, we were a little bit acquainted with that.
+
+Anyhow, I did like it, and Snyder was a promoter. My uncle thought that was a
+good job and I ought to take it because of Rohm and Haas. The net result was
+that I did go there. I commuted by train between Bristol and Philadelphia, and
+then walked to Tenth Street where the school was.
+
+The class was very small; I think it had seven people in it--that&#039;s all. All the
+students had a pharmacy background in the sense that their parents ran a
+drugstore or something like that. Anyhow, I went there. The thing was that the
+chemistry that I was taught at PCP was very, very experimental and very
+basic--no fancy-pants stuff. We had a very good teacher who had been in pharmacy
+for a long while. The teachers were sound, but they were not--I use the word--fancy-pants.
+
+Anyhow, I went there, and I did well. I graduated--I don&#039;t know whether top of
+the class--but it doesn&#039;t make any difference. I had good grades. When I
+graduated in 1930, I had to find a job. Again, my uncle said, &quot;Well, if you
+can&#039;t find a job, I&#039;ll help you.&quot; So that was fine. I applied at some schools.
+
+Just about this time of the year, Rohm and Haas had an analytical chemist who
+had died, a young man. They called up my uncle and said, &quot;We know you&#039;ve got a
+nephew who&#039;s a chemist. We wanted to tell you, we&#039;ve got an opening. If he&#039;s
+interested and you are, send him down and we&#039;ll talk to him.&quot; My uncle said,
+&quot;Well, there it is. You go down there.&quot;
+
+That was within a few miles of my home, so I went down there and met the
+superintendent. He said, &quot;Okay, are you a chemist?&quot; I said, &quot;Yes.&quot; He said,
+&quot;Well, that&#039;s fine.&quot; He looked at my transcript--&quot;Never heard of the school.&quot; I
+said, &quot;That&#039;s all right.&quot; He said, &quot;The vice president of Rohm and Haas is here,
+a Dr. [Charles Samuel] Hollander. We don&#039;t hire anybody without his talking to you.&quot;
+
+He said, &quot;He&#039;s waiting for you.&quot; He took me across the road and into his office,
+and he pulled up a chair and I sat there, and I didn&#039;t know what was going to
+happen! I stayed there three hours, and I took the most difficult chemistry exam
+I ever took. He was an old chemist and as such, he thought chemistry is
+chemistry. [laughter] He asked me a lot of questions. I knew all the answers
+except two. I didn&#039;t know an insoluble salt of potassium, nor did I know an
+insoluble salt of sodium; I didn&#039;t recall either one of them. But the net result
+of the three hours was that those were the only questions I couldn&#039;t answer to
+his satisfaction, so he stood up and shook hands, and he said, &quot;You&#039;re hired!&quot; [laughter]
+
+That&#039;s how I got the job. I went to work in the Rohm and Haas analytical
+laboratory. At that time, Bristol was one of the research areas for Rohm and
+Haas. The other was in Bridesburg. We had in the company a number of Ph.D.&#039;s all
+over the country. They were working mainly on insecticides--the laboratory was
+routine--and research samples.
+
+We had a fellow that had been there a long time, and he was more experienced
+than I, but he didn&#039;t like to do this experimental section because it was
+always, always different. So I started to do that. After being there for about
+six or eight months, I decided this was not for me. I wanted to go elsewhere.
+
+These fellows-- who were all graduates of Illinois and Penn State, and places
+like that--said, &quot;Well, if you want to go to Penn State, you ought to go.&quot; I
+said, &quot;I&#039;ll see.&quot;
+
+Again, I talked to my uncle and said, &quot;I&#039;m going to go to graduate school.&quot; He
+said, &quot;Go ahead, see if you can make it.&quot; I applied to some schools--Illinois
+was one, Penn State was another one. In those days, I had good contacts at
+those. I knew F. C. [Frank Clifford] Whitmore; he was a consultant for Rohm and Haas.
+
+Anyhow, I applied, and I was accepted temporarily at Illinois and Penn State. In
+the Rohm and Haas laboratory at that time, there was one from Penn State and
+there was one from Illinois. The Illinois fellow said, &quot;Look, you don&#039;t want to
+go to Penn State. All you do there is distill. That&#039;s all that&#039;s happening at
+Penn State now; they give you distilling and stuff. If you want to learn
+chemistry, go to Illinois.&quot; [laughter]
+
+It was mostly on that basis that I decided to go to Illinois. I packed up my
+clothes and I went to Illinois. I had no scholarship, no nothing.
+
+BOHNING: This was the Depression.
+
+HANFORD: I just went there. I paid my tuition at the grand total of seventy-five
+dollars in those days, which may not be much money even then, but it was a lot
+of money to me. My mother bought my ticket to Illinois, and they agreed to send
+me some money for my room and board while I was there.
+
+I went, and I matriculated and started. In the first year, I didn&#039;t do anything,
+and I&#039;d been there a little while when the question came up, &quot;Who are you going
+to do your work under?&quot; I said, &quot;Well, I&#039;d like to work for the chief [Roger
+Adams], if he&#039;ll have me.&quot; I went down and saw him, and then he said, &quot;Yes,
+that&#039;s all right. You&#039;ll work?&quot; I said, &quot;Sure.&quot;
+
+He gave me a problem, and I went to work on it. Again, it goes back to the fact
+that money was not very plentiful. There was nothing to do but work in the lab,
+so I worked seven days a week in the lab, fifteen hours a day. It was no trouble.
+
+In those days, the chief came to see you. He came around the building, and he&#039;d
+drop in at odd times. No matter when he was there, I was there! He gave me a
+problem and it was relatively easy; I solved it. In about the first year, I had
+enough for my Ph.D. degree, but that was not enough!
+
+I went down and said, &quot;How about a scholarship or something?&quot; &quot;Now, Butch, you
+could make it on seventy-five dollars a semester. You don&#039;t need any more than
+that.&quot; He never gave me an assistantship. He said, &quot;You&#039;re going to work in the laboratory.&quot;
+
+After I completed the first problem, the chief would travel all over the country
+and he&#039;d hear all kinds of problems, and he&#039;d bring them back and give them to
+me--oh, a piece of wood or something--and he&#039;d say, &quot;What can you extract from
+this?&quot; All this kind of junk, I did, and I did them for him. This gave me a
+tremendous breadth of operation, because I was in all kinds of stuff.
+
+I had a good thing with him, and we made out fine. A typical example of that
+period was, Illinois had a pretty good football team one year. We wanted to get
+a radio in the lab. There wasn&#039;t any, so the question came up, &quot;Let&#039;s get a
+radio. Illinois is playing a big game and we&#039;d like to go.&quot; Someone said, &quot;Well,
+you go down and ask the chief.&quot;
+
+I went down and Mrs. Evans, who was the secretary and a very good friend of
+mine, said, &quot;What do you want?&quot; I told her, and she said, &quot;Well, you go talk to
+the chief,&quot; so I did. He thought a minute and he said, &quot;Okay, one condition,
+Butch.&quot; &quot;What&#039;s that?&quot; &quot;That you continue to work while it&#039;s on!&quot; [laughter]
+
+I said, &quot;Fine.&quot; [laughter] I got to the laboratory, told the boys, and just in
+the middle of the game--it was very exciting--who walks in but Roger Adams!
+[laughter] The whole group of people ran, but fortunately, I was at the lab. I
+was working. [laughter] He looked over and said, &quot;Hmm! Okay, Butch!&quot; We talked
+about the problem, he kidded the rest of them and went out. That was Illinois.
+That&#039;s the type of work I did.
+
+BOHNING: Did you interact with Carl [Shipp] Marvel at all?
+
+HANFORD: Oh, yes. I knew all of them, because I was a good student and I did a
+lot of experimental work.
+
+One of the things that I&#039;ve mentioned to you that I still thought was very
+important was people, so I made Marvel one of my friends. In fact, I finally
+came to the conclusion that Marvel was the one who said, &quot;Let&#039;s give him a
+chance!&quot; [laughter]
+
+Anyhow, Speed Marvel, [Reynold Clayton] Fuson, and all those, I knew very, very
+well--and knew them all personally as Speed, and Butch, and [Ralph Lloyd]
+Shriner, and the rest of them. I circulated through all the laboratories, and I
+knew what most of the people were working on. It wasn&#039;t unusual that somebody
+would come to me and say, &quot;Butch, how do you do this?&quot;
+
+Finally I graduated, and the question was, &quot;Where do I go to work?&quot;
+
+BOHNING: That was in 1935.
+
+HANFORD: It was 1935, yes.
+
+Oh, I had one problem, too. I was probably, and still am, the poorest linguist
+who ever lived. In those days, as you know, a Ph.D. required a reasonable
+knowledge of French and German. I had had practically no German but one semester
+at PCP, and high school French. I knew none; I was terrible. The chief, he&#039;d
+come in and he&#039;d say, &quot;Butch! When are you going to take them damn languages
+there? You can&#039;t get out of here without them!&quot;
+
+I said &quot;Okay,&quot; and I started. I learned both French and German in Butch&#039;s way. I
+had a French chemistry book there and a translation of it over here. I would
+look at this and then I would look at that, I would look at this and look at
+that, look at this and look at that. I couldn&#039;t pronounce anything. I didn&#039;t
+know any structure, but I could get the sense of what it was. Adams said, &quot;You
+ready?&quot; I said, &quot;Sure! Let&#039;s go!&quot;
+
+In those days at Illinois, it took three passages--one without a dictionary in
+the language, one with the dictionary in the language, and one in a popular
+thought--so you had three things to translate. I did that, and I got them, and I passed.
+
+That has always been one of my bugaboos. My wife used to kid me because I met
+her in Wilmington and I married her in Wilmington, and I always had chemistry
+with me. We&#039;d sit on the porch, and I&#039;d have a chemistry book, and it was in
+German! [laughter] She said, &quot;How in the hell can you read that?&quot; I said, &quot;Don&#039;t
+worry about it, I know what it&#039;s about.&quot;
+
+It so happened that the friend I got the award from, the Inventors Hall of Fame,
+was Don [Donald F.] Holmes, who was a classmate of mine at Illinois. That&#039;s how
+we got together. Don&#039;s father was the vice president of DuPont. Don never should
+have been a chemist, but his father wanted him to be one. Don was a very, very
+smart fellow. He was a graduate of Amherst [College], and he was really
+smart--languages and all that.
+
+Anyhow, he and I became good friends. I met my wife through him, and that&#039;s
+where that came out. Don used to say, &quot;Well, what are we going to do?&quot; That&#039;s
+how I met them.
+
+When I got to DuPont, I was assigned to work for a man by the name of Paul
+[Lawrence] Salzberg.
+
+BOHNING: It was Holmes who got you to DuPont?
+
+HANFORD: Yes.
+
+BOHNING: Had you thought about going back to Rohm and Haas?
+
+HANFORD: No. I was offered a job at Rohm and Haas, but again, Adams said DuPont,
+so I went, and he said, &quot;In DuPont, you go to the Experimental Station! I&#039;ll
+take care of that, but you&#039;re going to the Experimental Station. [Elmer K.]
+Bolton and I were classmates at Harvard [University], and you&#039;ll be there.&quot; So I went.
+
+Again, how things played was, I walked into Paul Salzberg&#039;s office one morning
+as I went to work. He said to me, &quot;Butch, what do you do?&quot; I said, &quot;I don&#039;t
+care; I&#039;m a chemist.&quot; He said, &quot;I&#039;ve got a problem. We have just developed a
+commercial method for making long-chain amines by the hydrogenation of ammonia.
+So we&#039;ve got some long-chain amines. Now, you probably know that Rohm and Haas
+has made a job out of the long-chain thiocyanates as an insecticide.&quot; I said,
+&quot;Yes, I&#039;ve analyzed hundreds of them.&quot; [laughter] He said, &quot;I want the
+isothiocyanate.&quot; He said, &quot;I don&#039;t know whether it will work or not, but I don&#039;t
+feel comfortable without it.&quot;
+
+He said, &quot;I have two men who have worked on it, and I knew them both. They were
+good friends of mine, but they couldn&#039;t make it. Do you think you could make
+it?&quot; I said, &quot;Sure!&quot; He said, &quot;That&#039;s your problem. It&#039;ll give you a chance to
+meet the people and do all of this.&quot;
+
+Then he said, &quot;One other thing I want to tell you.&quot; He said, &quot;I don&#039;t want to
+ever hear you wrote a paper longhand. Here, we don&#039;t do that. You start tomorrow
+to dictate, and you don&#039;t give up!&quot; I said, &quot;I never did it, sir.&quot; He said, &quot;I
+didn&#039;t ask you that, I told you.&quot;
+
+ [laughter]
+
+[END OF AUDIO FILE 1.1]
+
+HANFORD: Well, anyhow, from that I got the isothiocyanate. I read over Allan,
+and I knew he used the standard method and there was no use in messing around,
+so I went down to the library and looked around a little bit and found an
+alternate reaction.
+
+Instead of using the old lead salt and heating it, I didn&#039;t use any but calcium
+carbonate. I went upstairs and mixed them up and in ten days, just took them
+down and said, &quot;Here they are, both of them.&quot;
+
+I had finished because it was simple organic chemistry, but he said, &quot;Well,
+you&#039;d better learn the people around here,&quot; so I did. Then I said, &quot;What do I do
+now?&quot; He said, &quot;Do what you want.&quot;
+
+He literally left me alone from then on. The net result is, I worked through the
+thiocyanates and made God knows how many derivatives and all that jazz, and
+tested them for everything. That was good because it was insecticides,
+lubricants, and all kinds of stuff.
+
+Then I got kind of tired of it. One day old Pop Reid, who was at [Johns] Hopkins
+[University]--you probably knew about him?
+
+BOHNING: Oh, yes. [E.] Emmet Reid.
+
+HANFORD: He was a consultant for us. He came to the laboratory. I said to Pop
+Reid, &quot;Look, I&#039;m getting tired of these thiocyanates; I can&#039;t find anyone to do
+them. I think I&#039;ll make just the oxygen compounds.&quot; He said, &quot;That&#039;s a good
+idea.&quot; I said, &quot;I haven&#039;t got any hood.&quot; He said, &quot;Oh, hell, what difference
+does that make, Butch? Just get a tube and put it out the window!&quot; [laughter]
+
+That&#039;s 1935-1936 chemistry. I did it. I made a bunch of them. Then, since they
+were all new compounds, I&#039;d take them around and try to find uses for them.
+
+I was only at DuPont for about six months when I was made a group leader. I was
+given two men to work for me. From that, I then got groups of people, and I was
+assigned projects or I picked them out myself. I did pretty much whatever I
+wanted. I reported to the steering committee, which was a method of telling them
+how you&#039;re doing. It included [Crawford Hallock] Greenewalt, who was the vice
+president of the corporation and a fine guy, and four or five other men. You
+stood up there and you told them what you did, and they either liked it or they
+didn&#039;t like it, and then you heard about it. Anyhow, I went around and did that,
+and I got into various other problems.
+
+One day Paul Salzberg called me downstairs. He said, &quot;Butch, we&#039;ve got a
+problem!&quot; I said, &quot;What&#039;s your problem?&quot; He said, &quot;Well, we&#039;re just working up
+the patent situation, and we&#039;ve seen that we&#039;ve got one hold on the patent.
+[Wallace Hume] Carothers said he can&#039;t polymerize caprolactam. It won&#039;t go; you
+try to heat it and it&#039;s going to cyclize. That&#039;s all that you get out of it.&quot; He
+said, &quot;They&#039;ve tried it! [Wesley R.] Peterson has proved that. He made it, he
+put it in a still, put it on a high vacuum, and distilled it and got nothing but
+caprolactam. Do you think you can make it?&quot; I said, &quot;Sure.&quot; I didn&#039;t know what
+the hell I was talking about! [laughter] That was characteristic of everything I
+ever did.
+
+I went back upstairs, and I had a new chemist, an Illinois graduate named Bob
+[Robert Michael] Joyce [Jr.]. I said, &quot;Bob, we&#039;re going to work on caprolactam
+polymer.&quot; He said, &quot;Hell, Carothers says it won&#039;t work.&quot; I said, &quot;I didn&#039;t ask
+you that, I said we&#039;re going to do it.&quot;
+
+I said, &quot;You go down to the shop, get yourself a piece of pipe, about 6 inches
+long, maybe 2 inches wide. Put a cap on each end of it and bring it up.&quot; I said,
+&quot;Then you load that with caprolactam. Then you add just a little bit of water,
+not too much--a few cc&#039;s of water.&quot;
+
+He said, &quot;Well, what else?&quot; I said, &quot;Spit in it if you want, I don&#039;t care! Seal
+it up, put it in a lead bath, and heat it at 250 to 265 degrees for a week.&quot;
+[laughter] &quot;Okay.&quot;
+
+We did it. The end of the week, we took it apart, and the caprolactam had all
+gone; it was all polymer. We dissolved it, and we found that the equilibrium was
+96 percent polymer, 4 percent lactam.
+
+With that, that was the end. That finished the polymer patent situation for
+DuPont. That got me into the polyamides deal, and I did a lot of work on
+polyamides and polyesters and what have you.
+
+Then about that time, ICI [Americas, Inc.] had had very great success in high
+pressure work. DuPont had an agreement with ICI. Bolton one day decided that
+DuPont needed a high-pressure lab, so he would build one. What&#039;s he going to do
+in it? Well, he and Salzberg and a man by the name of [Merlin Martin] Brubaker
+got me together and said, &quot;Butch, we&#039;re going to build a high-pressure lab.&quot; I
+said, &quot;What am I going to do?&quot; &quot;That&#039;s your job!&quot; [laughter]
+
+They said, &quot;It&#039;s going to take us six months to build it. In that six months,
+you&#039;re to write a new program every month. You submit it to us and we&#039;ll
+indicate what we like and cross out what we don&#039;t like, and then you can do it
+from there.&quot; So I did.
+
+Anyhow, I got the laboratory. Of course, the first problem was the
+polymerization of ethylene at lower pressures, so that&#039;s what we did. That work
+was done by a fellow by the name of Bob [Robert Edward] Christ, who was a
+Northwestern graduate. We tried all kinds of stuff and we didn&#039;t get anywhere,
+so finally I got back to say, &quot;Now let&#039;s take all that fancy stuff out and just
+put water in.&quot; We did it.
+
+That again is the reason I think it&#039;s important--water has been always been an
+important factor in my life. Caprolactam, now poly. We ran an experiment one day
+in high pressure with ethylene. When we opened it up, we had some polymer, so we
+coded that polymer &quot;TG&quot;--&quot;Thank God, Number One!&quot; [laughter] That was what then
+got me into the high-pressure work. I had maybe five or six people working in
+there all the time.
+
+That work was going along fine. We&#039;d found that polyethylene worked best if we
+didn&#039;t have any solvent in it! Our original theory was that we should put a
+solvent in it and that the ethylene would dissolve in the solvent, and then that
+would be dispersed in the water, and that would give us the concentration; but
+then later, we found that the water was all we needed.
+
+Anyhow, one day, Bob Joyce was still working on polymers. We were talking about
+what were we going to do, and I said to him, &quot;Bob, let&#039;s get the worst solvent
+for polyethylene and see what happens.&quot; I called up the guy who was working on
+it, and he said, &quot;Carbon tetrachloride.&quot; I said, &quot;What?&quot; He said, &quot;Carbon
+tetrachloride.&quot; I said, &quot;Okay. Let&#039;s try it!&quot; We put water, ethylene, and carbon
+tetrachloride in the system, and--boom. We blew the disk out. Fastest reaction
+we ever had!
+
+We went back and looked at it some more and finally, we decided we didn&#039;t make
+much polymer. We didn&#039;t get polymer; we got a liquid. The liquid was there
+instead of the carbon tetrachloride. We looked at it. I had a man that I&#039;d taken
+some of my doctor&#039;s degree with by the name of Jesse Harmon. He was working for
+me. He was ten years older than I am. He said, &quot;Let me have it.&quot; He took this
+liquid we had in there and put it in the still and fractionated it. We had the
+C1, C3, C4, and so forth.
+
+That was the basis for the discovery of telomers, so then we had a whole series
+of research. We did a whole lot of research. It was important not only from that
+point of view, but because it was the first time that anyone had ever proven
+what the end group was at a bonded polymer, and why certain groups inhibited the
+high molecular weight, and so forth. It became a very important program, and I
+lectured all over the country about it, and had patents.
+
+That&#039;s how I got into that. Then the next one, which was an outgrowth of that,
+probably, is that I had a problem. We had a lot of work on polyamides, but the
+question was, how high a melting point could you make them? Could you make them
+out of aromatics like terephthalic acid and stuff like that? That was given to me.
+
+I said, &quot;Okay, let&#039;s go to work.&quot; I had a fellow by the name of Dick [Richard
+Haven] Wiley. Dick and I started to work on it. We made them, but then we didn&#039;t
+have too good luck with them--so high a melting point, and so forth.
+
+In the course of that we had a little press. In order to keep the oil from
+getting heated, we kept putting thicker and thicker pieces of insulating
+material. We were able to fiber-fabricate some of these materials enough for an
+operation and mail them to get a patent [[footnote]]1[[/footnote]].
+
+Then one day--this is the time of World War II, we were just in the
+war--Brubaker came up to me. He said, &quot;Butch, I&#039;ve got a problem for you.&quot; I
+said, &quot;Oh, really?&quot; He said, &quot;You know that organic chem has been working on
+tetrafluorethylene.&quot; &quot;Yes,&quot; I said. &quot;Sure, it&#039;s interesting.&quot; He said, &quot;They
+can&#039;t make it worth a damn. The only way they know how to make it is to put it
+in a tube, put a little silver salt in it--they don&#039;t know why--and seal it up.
+Then after a while, they cut the cylinder apart and they dig the stuff out.&quot;
+
+He said, &quot;That material has unusual properties, and the Atomic Energy Commission
+is interested in it, but nobody&#039;ll get interested in that.&quot; He said, &quot;The other
+thing, nobody can shape the damn thing! It won&#039;t dissolve in anything. What do
+you think? Do you think you could do it?&quot; I said, &quot;Sure.&quot;
+
+I called my two men in and went into the high-pressure lab--I think it was Bob
+Joyce, but maybe it was Wiley--anyhow, they had come, and he had left me a
+sample of polymer, which had come out. He said, &quot;Can you shape it?&quot; I said,
+&quot;Sure.&quot; He said, &quot;How?&quot; I said, &quot;Don&#039;t ask me, just give it to me!&quot;
+
+He just put in great big sections of asbestos in this thing so that we could
+burn them. I said, &quot;We&#039;ve got a new one in there, let&#039;s try it.&quot; I said, &quot;Dick,
+how&#039;s the press working?&quot; &quot;Oh,&quot; he said, &quot;it&#039;s working fine!&quot; I said, &quot;Are you
+going to the seminar tonight?&quot; He said, &quot;Yes, why?&quot; I said, &quot;You go down and get
+all the asbestos floss you can. Before you go to the seminar, you wrap that damn
+thing up with the asbestos and get it as hot as you possibly can.&quot; He said, &quot;Oh,
+Butch, it&#039;ll boil all over that stuff!&quot; I said, &quot;I didn&#039;t ask you that, I said
+get it hot.&quot; He said, &quot;What are we going to do?&quot; I said, &quot;When it comes time to
+do it, we&#039;ll do it.&quot;
+
+We went to the seminar. After the seminar we got two little plates and put a
+little of this polymer on and poured it between the plates, and first, smoke&#039;s
+coming out! [laughter] We pulled it and pulled it, because the oil wouldn&#039;t
+hold. We pulled it and pulled it, and after a while, we said, &quot;Let&#039;s take it
+out.&quot; We took out the thing and threw it in a bucket of water. That was the
+first Teflon sheet. We weren&#039;t impressed! [laughter]
+
+We took that down to Brubaker and told him, &quot;Here&#039;s the sheet.&quot; Then, of course,
+having known it could be done, real engineers went to work--but it didn&#039;t have a synthesis.
+
+It only took us, I guess, six weeks to reorient our polymers so we could run a
+high-pressure polymerization. It was so simple. You looked at the physical
+properties of ethylene, you looked at physical properties of
+tetrafluorethylene--they&#039;re the same. We said, &quot;Simple! All we do is take the
+ethylene out and put the tetrafluorethylene in, the same catalyst everybody else needs.&quot;
+
+Howard Young, who was the engineer running the damn equipment, and Bob Joyce,
+who was the chemist, and I, we said, &quot;Let&#039;s go!&quot; So we did. I don&#039;t know what
+time of the day it was, but all of a sudden, it was an explosion! Our high
+pressure lab had lost some of its valuable equipment. That&#039;s the best explosion
+I ever had. It ruined the place. It was filled with carbon. Why? We hit it too
+hard! Anyhow, that was the first experiment.
+
+Then we said, &quot;Let&#039;s get a tack hammer instead of the sledge.&quot; We went back, and
+again, in maybe a month&#039;s time we had enough stuff made, and good enough, that
+we transferred the process to Or Chem and they carried it on. Roy [J.] Plunkett,
+the man who discovered Teflon, got the Inventors Hall of Fame, too.
+
+That work put me into the next field endeavor, which was fluorochemistry, and
+many, many things that you could make. Here the telomer was an actual, because I
+could polymerize, I could make all kinds of derivatives with tetrafluorethylene
+and so many inert materials, and we made dozens of them. Everybody got a lot of patents.
+
+That was that. That&#039;s what got me into that field. I did a lot of other things,
+but those are the best stories from that. The next thing that came up was, the
+war was now over, and I had transferred. I said, &quot;Okay, I&#039;ll go.&quot; I&#039;ll go on
+back to my first story now.
+
+Seven years had gone by since I started at DuPont, until the war was over.
+Adams, he said, &quot;Butch, you better take that job with GAF.&quot; That&#039;s how I moved.
+The other work was in the period up to that.
+
+I wanted to go back to one other thing, because that led to the Inventors Hall
+of Fame. I had Bob Christ working, who was a Northwestern man. He was working on
+polyester polyamides, because when we were looking at the high-molecular-weight
+stuff, we wanted things that would handle lower melting. We decided, &quot;Oh hell,
+that&#039;s obvious. We&#039;ll just put polyester groups in it, and we&#039;ll have this
+linkage between the two.&quot;
+
+We started to make copolymers of polyesters and polyamides. They&#039;d give these to
+Christ, and he&#039;d make one, and I&#039;d say, &quot;Well, let&#039;s put 10 percent in, let&#039;s
+try 20 percent,&quot; and we made them.
+
+Then I got discouraged because I couldn&#039;t make them fast enough. They didn&#039;t
+mate, because the polyamide work was over, but the ester work was not started!
+You had to get the water down or the ester off.
+
+Bob Christ was working along and we were making a bunch of them; it wasn&#039;t going
+very well. I said to Bob, &quot;Look, this is too damn slow. Let&#039;s button it
+together. Let&#039;s make the best we can. Get the water down to half a percent or
+something like that, and then let&#039;s put the damn thing together.&quot; He said, &quot;How
+the hell are you going to button it together?&quot; I said, &quot;Oh, that&#039;s easy! We&#039;ll
+get some of my diisocyanates!&quot; I said, &quot;Reactions with hydroxyl, carboxyl,
+amides, and amines. Here, look, tie them all together. The only thing is, let&#039;s
+not have any free ester groups in there. When we work, let&#039;s work with the fatty
+acid instead.&quot; So we did. We had this thing going, and we added half a percent
+of diisocyanate and up goes viscosity, and the whole thing was done. We made a
+lot of them! We made a lot of good work. That&#039;s where I started that.
+
+Then I went back to Holmes. Holmes and I were good friends. As I said, Holmes
+was bright, but he wasn&#039;t thinking in chemistry. Anyhow, Julian [Werner] Hill
+gave him a problem. The problem was, he had a bunch of polyols and he wanted to
+tie them all together.
+
+Now Julian Hill had been essentially a cellulose chemist, so he was thinking in
+polyols. Holmes and I had lunch one day together, and I said, &quot;How are you
+coming, Donnie?&quot; He said, &quot;I&#039;m not getting to first base.&quot; I said, &quot;Hell, I&#039;ll
+tell you how to do it!&quot; He said, &quot;How&#039;s that?&quot; I said, &quot;Take those polyols and
+calculate them out and add diisocyanate to them; they&#039;ll button together faster
+than hell.&quot; He said, &quot;You mean it?&quot; I said, &quot;Yes!&quot; He said, &quot;Where do I get the
+diisocyanate?&quot; I said, &quot;I&#039;ve got some in the lab.&quot; I gave Holmes some
+diisocyanate and he took the thing. That&#039;s who invented polyurethanes.
+
+I&#039;d say that that invention took me seventeen minutes. I didn&#039;t pay any
+attention to it. The patent was filed in 1939; it was issued in 1940. DuPont
+never really paid any attention to it. Before it got to be a big business, I had
+moved. In fact, I was in my third job. I was now with the [M. W.] Kellogg Company.
+
+Again, Paul Salzberg came up to New York one day and said, &quot;Butch, I&#039;ve got a
+question for you.&quot; I said, &quot;What&#039;s that?&quot; He said, &quot;We&#039;ve just learned that IG
+[Farben] has been doing a hell of a lot of work on polyurethanes. They entered
+this field because when they studied our nylon field--polyester polyamides and
+that kind of stuff--they found there was no room for them, so they had to find
+some field that they could develop, in which there was no prior art.&quot; He said,
+&quot;They picked the urethane field, and they&#039;ve been doing some wonderful work.&quot; I
+said, &quot;That&#039;s interesting.&quot; He said, &quot;I think we&#039;re going to have to challenge
+them on your patent.&quot;
+
+&quot;Oh,&quot; I said. &quot;Okay.&quot; He said, &quot;You don&#039;t work for us any more. I just want to
+make sure that if we need your assistance, you&#039;ll cooperate.&quot; I said, &quot;Sure,
+that&#039;s fine. Just do what you want, and that&#039;s the way it&#039;ll go.&quot; I said, &quot;By
+the way, I&#039;m working on polyamides myself now.&quot;
+
+He said, &quot;All right.&quot; I didn&#039;t hear anything more about it, except by the
+grapevine. I later heard that IG and DuPont had made a deal. The patent had, I
+guess, quite a while to run; I guess it was 1942, 1943, something like that, and
+the patent was relatively new. That was how I got that one.
+
+It was just good chemists. A question on the mind of the management was, &quot;Can
+you do something?&quot; I had started with the thing; nobody is ever going to say
+&quot;Can you do it?&quot; until I say yes. That&#039;s the reason I got into the high polymer field.
+
+Anyhow, that was the end of all the stories basically on DuPont.
+
+At GAF, I was made the Director of Research, reported to one of the presidents.
+My main job there was to hold their position in the acetylene field.
+
+BOHNING: You were quite young to be a Director of Research.
+
+HANFORD: Yes, I was.
+
+BOHNING: You were thirty-four.
+
+HANFORD: That was 1942. I was Director of Research. That&#039;s when Adams said to
+me, &quot;Butch, you can do the chemistry. You can stay here and you know you can do
+it. But,&quot; he said, &quot;that&#039;s not going to challenge you.&quot; He said to me, &quot;You take
+this GAF job, you don&#039;t know a damn thing about anybody! You don&#039;t know anybody,
+anything, you don&#039;t even speak the language, but you do know the chemistry.&quot; He
+said, &quot;So, acetylene, you can learn that, because you get a book and read it.
+Dye work, and that kind of stuff--why, that&#039;s no problem. They want you, mainly,
+not to lose their position.&quot;
+
+Of course, the Germans were thinking they were going to win the war, but they
+didn&#039;t want to lose their position; so I was there five years as a taskmaster.
+
+In that time I had another problem I had never done. I&#039;d never hired a man in my
+life; I&#039;d never picked a salary in my life! I had to decide, how do you pick a
+good man? I had been around long enough, and I had college professors like
+yourself; they were old friends of mine. I said, &quot;I&#039;m looking for a good man,&quot;
+and they said, &quot;Well, look, here&#039;s one, here&#039;s one.&quot; I had a hell of a time
+hiring them, because nobody wanted to go to work for a German company at that
+time. Anyhow, I had a good enough record that people worked for me.
+
+At GAF, I was mainly a custodian of property, and held it. I did a lot of work
+on acetylene, methylvinyl ethers, and stuff like that, but nothing really great.
+Then the war ended.
+
+BOHNING: Hadn&#039;t GAF been taken over by the government?
+
+HANFORD: Yes. It was taken over by the government, but it was a government
+property at that time, and it was then a private company. I got that job in part
+because the government had to hire somebody to manage it, and I was not that type.
+
+They hired a man by the name of Bill [William Frederick] Zimmerli, who was in
+DuPont. Bill Zimmerli was a commercial development man, an old-timer, but he
+knew everybody, and he took the job. He&#039;s the one that told GAF to hire me, so
+Zimmerli hired me on my record at DuPont.
+
+[END OF AUDIO FILE 1.2]
+
+HANFORD: --Very spectacular. I traveled a lot, I lectured a lot, and I built my
+reputation as a leader of research up pretty well.
+
+Then the M. W. Kellogg Company was sold by &quot;Old Man&quot; [Morris W.] Kellogg to the
+Pullman Company to make cars! The M.W. Kellogg Company was the finest chemical
+engineering and petroleum company in the world. &quot;Old Man&quot; Kellogg was as proud
+of it as anybody in the possibility.
+
+Then, he got the idea that he&#039;d have to expand his company, so he joined Pullman
+because they had money; they wanted to invest. They wanted a research director,
+so I got that job.
+
+I got that job because Kellogg had hired a man who had been working on the
+polymers of trifluorochloroethylene. He was doing a lot of stuff, but he sold
+his stuff to Pullman. Pullman wanted somebody who had fluorocarbon business, and
+general business, and all of this. Anyhow, they hired me. I went there as Vice
+President of Research and Development of Pullman and the Kellogg Company.
+
+BOHNING: Before we go to Kellogg, though, one of the things you did at GAF was
+to come up with the first liquid detergent. Isn&#039;t that correct?
+
+HANFORD: Yes, GAF was the detergent company. They were dye people. We called it &quot;Glim.&quot;
+
+We ended up straightforward. It was simple stuff. What&#039;s the cheapest hydroxyl
+compound you can make? [laughter] Where do you get the cheapest R-group on it?
+Then, how did you balance the stuff? You took phenol, or something like that,
+alkylated it, then took the alcohol and reduced them in five mixes of ethylene,
+alkali, and propylene. Anyhow, that was a simple problem. No problem.
+
+You see, he had another thing going at that time. Detergents were a relatively
+new area because the petroleum people had gotten into it, and there were some
+needs for new functions. You wanted one that was soluble in hard water, all that
+kind of jazz. We did that. I had a very good man by the name of [James M.] Cross
+who&#039;d been in the field for a long while. I had a little trouble with him, but
+we got along. We made a lot of them.
+
+Then Zimmerli, he was a commercial development man. He picked them up, started
+to push them. That gave us a thing to hand out, like my old Kellogg ration.
+
+That was, you called it &quot;surefire&quot;. It was just a question of whether you could
+package it. That led me into the field of packaging. I got very much interested
+in packaging; in fact, I have one problem I&#039;ve been working on for thirty years.
+Maybe before you get this published I&#039;ll have an answer to you.
+
+Anyhow, Kellogg hired me to do what I could with Bob Kearns of Cornell
+[University]. He invented this product and did a lot with E. Cummish.
+
+I went to work on it. I worked with Kearns on that, and then I worked on
+Synthol, which was the big project in those days. I was going to make gasoline
+from CO and hydrogen and coal, so I ran a big group on the synthesis of liquid
+hydrocarbons from CO and hydrogen, which we called &quot;Synthol&quot;.
+
+We were the ones who first introduced the use of fluid beds in that type of
+reaction. Kellogg had been the company that developed fluid beds in cracking, so
+it was a natural extension that we should try an exothermic reaction to control
+it with the fluid bed. I had a very good man by the name of Gene [Eugene
+Frederick] Schwarzenbek, who worked for me in the laboratory. There I worked on
+the trifluorochloro compound; I made a lot of the same old chemistry.
+
+The ethylene oxide was a big project in GAF. That was a big development of IG.
+It was timed right. So we did that.
+
+BOHNING: KEL-F was also a polymer you developed at Kellogg.
+
+HANFORD: Yes. The Pullman Company had a lot of money, and the Pullman Company
+was looking for things to do, so a year before I went there, old man Kellogg
+was--I say an old man, maybe not as old as I am now! [laughter]
+
+He was a great man, and he was very proud of his company, so he convinced Jim
+[James] Carey of Pullman to buy his company. With it he said, &quot;You&#039;re going to
+do more research.&quot; Pullman then hired me to lead the research in the company in
+the hydrocarbon field and to do what else we could in the polymer field. That I
+did. Then of course more oil was discovered, and synthetic oil dropped into the
+back burner.
+
+We were going fine in the KEL-F field, and I had an excellent staff, because I
+had my total right to whom I wanted. I was fortunate because I didn&#039;t leave a
+company, one to the other, that men didn&#039;t want to leave with me. When I left
+GAF, I told them, &quot;These fellows are coming to me! I&#039;m not going to them!&quot;
+
+It ended up that my Kellogg staff was partly DuPont, some of it from Rohm and
+Haas, some of it from this and that company. [laughter] I built up a very, very
+competent laboratory. I didn&#039;t have anything. The barn we had was a barn. It had
+been used to make Pullman cars. It didn&#039;t have anything. Anyhow, it didn&#039;t
+bother me; hell, we just put it together.
+
+It went along fine for about five years--we were making good progress when the
+catastrophe happened. Mr. Kellogg died. When Mr. Kellogg died, the Pullman
+Company lost interest in anything like that.
+
+Champ Carey called me up one day and said, &quot;Butch, we&#039;re going to have to
+curtail the research. That&#039;s not in Pullman&#039;s interest any more. It&#039;s up to you
+to disperse the staff as you see fit.&quot; I said, &quot;What do you want me to do?&quot; He
+said, &quot;Sell it, do anything you can; that&#039;s your business.&quot; That gave me a new job.
+
+In the surface-active area and all, I got to know the people in 3M [Minnesota
+Mining and Manufacturing Company] pretty well. I knew people in most of the
+chemical companies very well, because I made a real effort to get known. You
+see, I was still pitching; I had to get people, and I had to get people working
+for me, so the &quot;Butch&quot; was the key to many of those.
+
+Anyhow, 3M was going fire, and they decided that they were in the fluorocarbon
+business because of their work on the electrolysis of HF and the making of
+fluorocarbons. They wanted more. I went out and talked to them. I said, &quot;Why
+don&#039;t you buy the whole thing?&quot; &quot;Well, I don&#039;t know whether we want to.&quot; &quot;How
+about the staff?&quot; I said, &quot;If you can sell them, you can have the whole staff!&quot;
+
+They said, &quot;Okay, how much?&quot; I said, &quot;Let&#039;s not worry about that; let&#039;s worry
+about whether you want to buy it so that the staff will go with you.&quot; I said,
+&quot;You come up and you talk to all the staff you want to, and do what you want.&quot;
+
+After some little negotiation, I went to Champ and I said, &quot;I can sell the whole
+operation, I think, to 3M. I don&#039;t know how much money they&#039;ll give you, but
+that&#039;s your business, not mine; I&#039;m not going to negotiate the selling price.&quot;
+He said, &quot;That&#039;s fair enough.&quot;
+
+He went out, and he negotiated with them the selling price and the deal that the
+chemists would go with them. They took all the men I wanted them to take except
+one; they didn&#039;t want him. I said, &quot;Look, you take him, or there&#039;s no deal.&quot; &quot;W.
+R. Peterson ? He&#039;s an old man!&quot; I said, &quot;Yes, but he&#039;s a hell of a good patent
+man and he knows his field. He&#039;s a good inventor.&quot; He&#039;s the one who invented
+stabilization of nylon. He&#039;s the one Carothers told that DuPont would never make
+nylon unless it could be melt-spun. Carothers said, &quot;That&#039;s impossible, because
+the molecular weight&#039;s going to go up as you melt it; it can&#039;t be done!&quot;
+
+This guy Peterson worked for him, and he was a nice guy, so Peterson went to
+Carothers one day and said, &quot;Dr. Carothers, I want you to see this.&quot; He said,
+&quot;What did you do?&quot; Peterson said, &quot;I just spun it melt.&quot; &quot;How&#039;d you do that?&quot; He
+said, &quot;Very simple. I just put a little acetic acid in the nylon.&quot; He said,
+&quot;That did the trick, because that bedded up the free nitrogen groups to
+acetamides so the molecule couldn&#039;t grow any more! The only way it can go up is
+to have an interchange, and that doesn&#039;t go very fast.&quot; Carothers said, &quot;I don&#039;t
+believe it.&quot; &quot;Oh,&quot; he said, &quot;there it is.&quot;
+
+It was that type of thing that was characteristic of Carothers. He was a
+brilliant man, but he didn&#039;t fit the industrial side well.
+
+Anyhow, Peterson did that. Then when I left DuPont, Peterson wanted to come with
+me. He did, and he came in my path. He came with me to GAF, and then he came
+with me to Kellogg. At this time he was about sixty-two or sixty-three, and I
+couldn&#039;t do anything, so I told 3M that was part of the deal, and they took him.
+He earned his money, and he was a good man.
+
+When I decided to leave Kellogg, having sold the KEL-F, the next problem was,
+what do I do now?
+
+BOHNING: Why didn&#039;t you go to 3M with everybody else?
+
+HANFORD: I&#039;m coming to that right now. 3M at one time said, &quot;Unless you come,
+it&#039;s no deal.&quot; I said, &quot;I&#039;ve got to look around first and see what else is
+available.&quot; I said, again, &quot;I&#039;m still not versatile enough! Maybe I&#039;d better
+look elsewhere.&quot;
+
+John [M.] Olin, who was another one of the old, old inventors in money--made the
+Olin Corporation--heard of me, and I met him. He had bought Winchester-Western.
+He bought the cellophane business, he bought Squibb [E. R. Squibb &amp; Sons, Inc.].
+He had other things--very wide. He said, &quot;I want a good, broad man to head up my
+research. From all I hear, you&#039;re the man.&quot;
+
+I said, &quot;Oh, no.&quot; Again, what kind of a laboratory did they have? &quot;Oh, don&#039;t
+worry about that. You just say what you want, we&#039;ll get it.&quot;
+
+Then I went to 3M. I had two choices, honestly. I could have gone with 3M, but
+3M was a company that didn&#039;t have very rigid stepladders. They just said, &quot;You
+come here. We&#039;ll fit you in.&quot; That didn&#039;t seem to me to be too good; there were
+too many brains out there, maybe. He said, &quot;We&#039;ll guarantee to take care of
+you.&quot; When I went to John Olin and I told him, &quot;Well, I&#039;m thinking about it,
+John,&quot; he said, &quot;We&#039;ll make you an offer. You&#039;ll be Vice President of Research
+of the Pullman Company. You&#039;ll be in charge of all research in the entire
+corporation. That&#039;s what you&#039;re here for.&quot; I said, &quot;Well, that&#039;s interesting.
+I&#039;ve got a question of money.&quot; He said, &quot;I didn&#039;t ask you that. How much do you
+want?&quot; I said, &quot;Nobody ever asked me that before.&quot; Anyhow, John Olin and I made
+a deal, and I went to work for them.
+
+I never really regret that I didn&#039;t go with 3M, because it was a gold mine to my
+men. They took my men, and they became the leaders in 3M. John [W.] Copenhaver
+became the leader of their exploratory research. This man and that man, they all
+did very well. Lou [Louis A.] Errede is one the best-known physical chemists in
+the business today--he was my man. He went there and he did polymer
+thermodynamics. They were all good men.
+
+It later developed that 3M called me one time and said, &quot;Butch, if you have any
+men you don&#039;t want, let us know!&quot; [laughter]
+
+Anyhow, I went to Olin. That was a hodgepodge. I made out fine as long as John
+Olin lived. When John Olin died, the new people decided to split the company up.
+[laughter] It ended up that they sold Squibb. I had been in Squibb.
+
+At Squibb I was responsible for the introduction of Head and Shoulders, which
+put them into the over-the-counter business. Not that I did much, but John Olin
+and the other people wouldn&#039;t believe Squibb. They said, &quot;Butch, you go look at
+it. If you sign it, we ought to do it, we&#039;ll do it.&quot; I said, &quot;Okay,&quot; so I did. I
+thought it was what we were looking for, a dandruff control agent, and it was. I
+went back, and I said, &quot;Sure! Go ahead.&quot; It&#039;s still on the market today. That&#039;s
+a long time.
+
+Then at Winchester-Western I got involved in plastic shot shells, which was an
+important business. I got involved in a spiral-wound lightweight shotgun.
+
+You know that if you wrap plastic wire around steel, you can increase the
+strength of steel. We could make a shotgun with a very thin barrel. We wrapped
+it with plastic and set it, and we sold it. It became very popular for field
+shooting because you carried 4 or 5 pounds less on your back with this gun than
+the other one. That was something we&#039;d done. Then I got into cellophane,
+plasticizers, and I got in the paper business.
+
+There, I was mainly a carrier of the technology to the management. I was never
+on the board. I was a Pullman; I was a vice president of about three divisions,
+but I was never on the board. I was the technical brains.
+
+Not that I continued much to Squibb, for instance. They didn&#039;t like me; they
+didn&#039;t want me. They said, &quot;Leave us alone.&quot; I said, &quot;Look, never mind that. You
+tell me so I can sell it to John Olin! That&#039;s what counts.&quot;
+
+That was that one. The same thing was true with Winchester, the same thing was
+true with the paper business. I was the carrier of the technical skill of the
+people. It was that way until I retired.
+
+BOHNING: A few other things I have here that you did at Olin include the
+composite metal coinage that&#039;s used by the U.S. Mint.
+
+HANFORD: Yes. That was an outgrowth of some of Winchester&#039;s work. I never played
+too much of a role in that. I was involved in it, but I couldn&#039;t take many
+brownie points on that. It was, again, another project, and it was worthwhile.
+They did a good job, but I don&#039;t know whether it&#039;s even made today. Is it?
+
+BOHNING: I don&#039;t know.
+
+HANFORD: I don&#039;t know either, but it was a good project and it filled the bill
+at that time.
+
+BOHNING: You also worked to develop a carpet backing or foundation.
+
+HANFORD: That was at Olin.
+
+When I went to Olin, you see, they had Winchester. One of the things they made
+was explosives, so the one thing that Olin knew something about was how to make
+explosives. Olin knew a lot about nitrating benzene and other systems--toluene
+was one we knew a lot about nitrating. When I got there and found out that Olin
+knew how to make dinitrotoluene, it was simple that we made diaminotoluene. From
+diaminotoluene, we made polyurethanes.
+
+This put the chemical division into a new operation. It fit perfectly. Why?
+First of all, they had the dinitrotoluene. Second, they had chlorine. Third,
+they had a plastic interest, so that was a natural. They had ethylene oxide, and
+that was polyols for modification. So, in a very short time after I was there,
+we were making DNT. That wasn&#039;t the one I had done the original work on, but we
+made DNT. It is today, I think, Olin&#039;s chemical business&#039; biggest asset.
+
+They&#039;ve expanded the plant three or four times, and it&#039;s a good thing. I had
+some very good men there. John [Wilbur] Churchill and [Charles Henry] Hofrichter
+and those--they took right hold of it and ran. That was where my background did
+lead me into a new business.
+
+BOHNING: At this point, you weren&#039;t doing much yourself in the laboratory.
+
+HANFORD: I worked in the laboratory alone, as the only one, for about six
+months; maybe it was a year. After that time, I was assigned some chemists and I
+was promoted to what they called a Group Leader. That is the position I held,
+Group Leader, as long as I was there. I had groups, when I first started, of
+two, and I think I ended up with fifteen, something like that.
+
+I had at DuPont all of the new stuff. I was responsible for breaking the way.
+The main ways we had then were the high-pressure system, high-pressure work, and
+the fluorocarbons; but they were natural operations.
+
+BOHNING: By the time you got to Olin, you were directing, but you weren&#039;t participating.
+
+HANFORD: Yes. Going in the laboratory, I had a laboratory assistant--probably at
+DuPont--for about a year. After that, I was told that it wasn&#039;t my job any more;
+I was to supervise the people and spend more time at that.
+
+It was there that I learned another great thing, which is so important--that all
+research is a team effort. To think that we should have so many Ph.D.&#039;s is a
+mistake. Give me a good amateur plumber as an assistant to a Ph.D., and he&#039;s a
+hell of a lot better than giving me a new Ph.D. [laughter] I&#039;ve always felt that
+the thing that&#039;s not emphasized enough is the importance of teamwork in the
+commercial development of product. Teamwork. How do you get the engineers to
+work with the chemists? How do you get the secretaries to work with the
+chemists? How do you get a team?
+
+From my Kellogg days, even my GAF days and my Pullman days, my whole effort was
+a team. In fact, the only notes I remember were, &quot;What do I talk to you about?&quot;
+I listed the people. They should be mentioned anytime I&#039;m mentioned, because I
+was nothing without them. Sure, I could encourage them. I could take them when
+they were down in the dumps and nothing working, and say, &quot;Let&#039;s do this!&quot; I was
+lucky--very lucky. Many times I would find the key to the problem.
+
+Usually, it was something as simple as water--too much water, not enough water,
+what have you. [laughter] I was just looking over a folder that I had. I was
+trying to get something to write on if you wanted me to do something, and in it
+I found a scheme that I had written in 1984. It said, &quot;The trouble with
+industrial research today is, you give too much credit to the inventor and not
+enough credit to the team.&quot; That is true. You cannot do anything without a team.
+
+It&#039;s very important to have the transformation from one type of man to another.
+I, as a chemist, was probably best in starting things, but I knew very early, I
+had to have other people who were better technicians than I was. I had to be
+sure that those technicians stayed in the laboratory and got paid, that they had
+good help! When I say good pay, I&#039;m talking two hundred fifty dollars a month.
+It didn&#039;t pay to have these people watching the distillation or the temperature
+that I wanted when I could probably get a guy for thirty cents.
+
+That&#039;s what&#039;s not done enough today. There isn&#039;t enough emphasis on the team. We
+ought to be able to work out a system like football. Football has the Most
+Valuable Player [Award]. That&#039;s fine.
+
+[END OF AUDIO FILE 1.3]
+
+HANFORD: You won&#039;t win the championship with the Most Valuable Player. You win
+the championship with a team of people--each one who is able to do his job
+better than I could do it and better than the inventor could do it, because the
+inventor gets tired. He doesn&#039;t want to spend the time necessary to develop the
+yield. He doesn&#039;t want to spend the time on what material his construction&#039;s
+going to be. He doesn&#039;t want to spend the time on, &quot;What are you going to do
+with the HCl that you make when you make the isocyanate? What are you to do with
+it? How are you going to get it back? Can you electrolyze it or what, or can you
+just sell it or what?&quot; These things are important, because the field of urethane
+would not be as great as it is if we had not found uses for HCl in pickling
+steel and all these things! You have to have this team.
+
+If anything goes in the book, that&#039;s what&#039;s needed! To tell you the truth,
+that&#039;s what was wrong with the Germans&#039; chemistry as compared to U.S. science.
+The Germans never had any good chemical engineers. We have chemical engineers
+because of the petroleum business; it wasn&#039;t that the chemical business learned
+to steal their chemical engineers from the petroleum business. That&#039;s the reason
+the petrocarbon business came along. It was a big scale, and what to do with
+byproducts, see?
+
+These things are not rewarded enough. The salesmen are just as important. You
+made something and you said, &quot;What&#039;s it good for?&quot; Somebody said, &quot;Hell, it&#039;s
+good for so-and-so.&quot; I talked to a friend the other day as an illustration of
+it. He works for 3M. What do you think one of 3M&#039;s best products is now?
+
+BOHNING: It&#039;s tape and adhesives, things like that.
+
+HANFORD: Let&#039;s see. It&#039;s a mixture of Teflon and a porous substance. Why?
+Because the porosity you want to keep. If you put it into most powders, the damn
+powder gets in the pores. He said, &quot;Fine. Teflon won&#039;t wet the pores.&quot; They have
+a whole class now of absorbent systems, which are Teflon and an absorbent
+material. [laughter]
+
+That&#039;s what you call teamwork. If there&#039;s any company in the world that&#039;s been
+able to do that, it&#039;s 3M. They have that unique ability to take and put Teflon
+and absorbent together and say, &quot;I&#039;ll make a super absorbent,&quot; and they make a
+sheet--and it&#039;s a beauty! [laughter]
+
+Again, the thing that is so important in my operation is the recognition of the
+team. That is the reason why, even in Kellogg, I got along with Walter [Eder]
+Lobo. Walter Lobo is probably one of the best chemical engineers in the business
+of petroleum.
+
+This was the thing that bothered me in going with 3M. I had no doubt that I
+could lead them in doing research. I don&#039;t have any doubt that it&#039;d been equally
+as good or better if I&#039;d have been there. But I didn&#039;t have any way to work
+myself into it.
+
+At Olin, I had it perfect. They&#039;d just spent a lot of money in buying a lot of
+stuff, and it was buying shotguns and pharmaceuticals--but you have to find some
+way to use them! That&#039;s the thing that I worried about, quite frankly, and still
+do. How do we set up?
+
+Here&#039;s a good problem for you to work on. How do you set up, in the chemical
+business, so you could have an all-star football game? You would have on the
+team an inventor. You would have some salespeople. You would have this and that;
+and your team would challenge my team.
+
+That would make a lot of difference in the business. We would be competitive;
+you&#039;d get a ring if you&#039;re on the winning football team. That ring would be just
+as highly prized as the quarterback who got the Most Valuable Player Award.
+Sure, the rest of the teams wouldn&#039;t have him, but if he didn&#039;t have that guard
+to keep the other guy off his neck, he&#039;d have been in the hospital! [laughter]
+
+That&#039;s the thing that we don&#039;t emphasize enough in this business. We don&#039;t have
+enough emphasis on team play and awarding teams. I see that myself. I&#039;ve been
+fortunate. To get the Most Valuable award is just like being put in the
+Inventors Hall of Fame. That&#039;s not what I did. I didn&#039;t do a damn thing, but
+somebody--I never knew who--had enough interest in it to put my name up. When my
+name came up, there were enough people in it to say, &quot;Yes, that is an important field.&quot;
+
+There&#039;s one other interesting thing, too, just to show what happened. Many
+people think I&#039;m a millionaire because I had the urethane patent. Do you know
+how much I got for the urethane patent?
+
+BOHNING: I was going to ask you that; I was curious.
+
+HANFORD: Nothing.
+
+BOHNING: Nothing?
+
+HANFORD: Nothing. My son [William E. Hanford, Jr.] said I got a dollar, because
+DuPont gives everybody who is issued a patent a dollar. I don&#039;t remember that. I
+never got a single thing out of DuPont. When I won the award, DuPont sent one
+man out to be present when I was honored.
+
+Fine! They said, &quot;It&#039;s not important! The important thing is that that invention
+made millions of dollars for somebody else who was in the investment business,
+offered good sales jobs, offered opportunity to develop new products.&quot; It just
+happens that that reaction is one of the easiest ones to use to make a new
+product. It&#039;s just about equal to spitting in it! It is that thing.
+
+Talk about the coinage. Sure, I was involved in that, but I didn&#039;t contribute
+much, except I&#039;d go to the management and say to the management, &quot;Look, we&#039;re in
+the aluminum business. We want new uses for it. Let&#039;s get the government to pay
+for it.&quot; We would do the work, and it was good work--it was good! We spent a lot
+of hours. I think that some day, our coinage will be probably more aluminum than
+it is silver or nickel, because those are too rare. [laughter]
+
+That&#039;s what is important. If I gain anything for me, in this operation, I think
+in terms of how could we get in a team operation.
+
+I don&#039;t know the answer. As I said, I still have one problem. I have a problem
+that I have been interested in for thirty years. I haven&#039;t solved it yet. I am
+probably on my twenty-ninth alternative of how to solve it. I now have a new
+system, which I won&#039;t go into right now, but I&#039;ll tell you how I got there.
+
+Again, I was interested in this deal--how do you get there? Why can&#039;t you get
+the things together? Why can&#039;t you get methane in my automobile? I know it must
+be there. We&#039;ve got to get it. There&#039;s too much in a whirl. Why can&#039;t we get it in?
+
+As I said, many men, many years ago, worked on acetylene at night. We were
+working on acetylene. I knew something. I knew how to package acetylene. It is
+as old as the hills. How did I do it? I took an absorbent material, and on that
+absorbent material I put a solvent. I was fortunate, it was cheap. It was
+acetone. Then they could pump acetylene onto that absorbent material with
+acetone, and they could make a very safe acetone-acetylene system. After all,
+that was the basis for putting it in your automobile years ago. Why couldn&#039;t
+they do that?
+
+I can tell you this, don&#039;t look for acetylenes for a solvent for methane. I
+didn&#039;t read German very well, but I looked in a lot of German books. In fact--I
+have to complete my time--I went to a major oil company. I told them I had an
+idea of how we could put methane in your automobile. They said, &quot;We&#039;re not
+interested in that. That&#039;s competition. I&#039;ll tell you what we&#039;ll do, Butch. You
+give us the idea, we&#039;ll take a look at it, and tell you whether it&#039;s any good.&quot;
+
+I said, &quot;Thanks!&quot; The oil company did do it. I estimated they spent somewhere
+between twenty-five and fifty thousand dollars on a literature search, a volume.
+[laughter] After about six months to a year, they called me in and they said,
+&quot;Butch, we&#039;ve looked at your stuff, and there are two things. One, we&#039;re not in
+the methane business; and two, we don&#039;t think your idea&#039;s worth a damn!
+[laughter] Here&#039;s the literature search!&quot; I said, &quot;Can I look at the literature
+search?&quot; They said, &quot;Sure.&quot; They gave me a copy of it.
+
+About two weeks later, I called them up and I said, &quot;I agree with you. It&#039;s not
+worth a damn!&quot; [laughter] That doesn&#039;t mean I&#039;m stopped! That doesn&#039;t mean I&#039;m
+not still working at it.
+
+This same company had said at the time that if I ever had an idea that I thought
+was novel, they&#039;d give me a little money to try it. Within the last few years,
+they did. I told them I had an idea. They gave me five thousand dollars. In my
+day, that was a lot of money.
+
+We tried it. I don&#039;t know whether I got it or not. I know this, that the first
+experiment with that money was a bellwether. I can&#039;t duplicate it. I have run
+literally hundreds of experiments, and I can&#039;t come close. Something was in the
+system that I didn&#039;t realize. I have come to the conclusion I know what that
+something was--water. In some way, that was not apparent to me. I still don&#039;t
+know that that&#039;s the answer. But I still think that I know how to do it. My wife
+said I&#039;m crazy and maybe I am, but I can&#039;t give up. That one has stuck me for
+nearly forty years.
+
+It is the one thing, that if you had your choice in this country today to solve
+a problem, what would you solve? Methane powering a combustion engine. Don&#039;t go
+to me and talk to me about an electric engine. Why? Because we know that the
+largest supply of hydrocarbon in the world--we&#039;d never use it up--is methane.
+The one thing that&#039;s interesting is, the people who have done the most work are
+the Germans. There&#039;s one field that been worked over and over, and that is how
+to get it out of the earth! We don&#039;t know that yet. But there&#039;s an amount of
+work that we&#039;ve done at the mines on how to get it out. Look at the work the
+Germans have done as to how to get it out.
+
+Just think, what&#039;s the reason you can&#039;t get it out? It&#039;s water. It forms a
+classic compound. If they plug up the pipe, and if you heat the pipe a little
+bit, you can break it up. Or you can do what the government&#039;s doing. They add
+methanol-ethylene-glycol. Why? Simple. They just want to drop the melting point
+of ice and then they can go ahead, because the water doesn&#039;t hurt you. In fact,
+the water with methane would probably be a good thing, because the methane alone
+might be too high a temperature in the pressure-condensation engine. You&#039;d have
+to use stainless steel. If you could get a little water and methane in the
+system, and not plug it up--it&#039;s the only one--and just put the methanol in to
+get rid of it, or use methanol as an antidote; it stinks. It&#039;s poisonous. It&#039;d
+kill you. No mother&#039;s going to want methanol in her automobile.
+
+Ethanol? Where the hell&#039;s that good grain to make ethanol with? The question is,
+how can I get the methanol in my car?
+
+It&#039;s going in the bus. There is a group on which the government is now spending
+money on using cylinders. Those cylinders are 3,000 pounds pressure, and those
+cylinders are made by winding drums in order to get their weight down. You
+couldn&#039;t put that in your car; you wouldn&#039;t have any room for you! [laughter]
+Now, in a truck it&#039;s different, but you can&#039;t in an automobile.
+
+If you could do that, you would solve the biggest health problem in the United
+States--better than all the other things. My wife wouldn&#039;t be sick back there
+now with an allergy type of reaction.
+
+With that, I guess I&#039;ve shot my load.
+
+BOHNING: No, I have a few more questions yet. I&#039;m not clear on how you left
+Olin. Was that when Mr. Olin died?
+
+HANFORD: Yes. It was John Olin. John Olin was the Olin who founded the Olin
+Corporation in East Alton, Illinois. John Olin got into the explosives business
+in World War I, and he made explosives. Winchester [Repeating Arms Company] and
+Western Cartridge [Company] were his big businesses. He had big ammunition all
+over. He was a very brilliant man; he was a very wealthy man; he was a very
+inquisitive man.
+
+He bought the Olin Corporation and put it together, because it had a lot of
+things! It wasn&#039;t just making explosives and things. He wanted to package. He
+had the right concept of package, but when he died, the package fell apart.
+Squibb didn&#039;t want to have anything to do with Winchester, and the paper
+business didn&#039;t want anything to do with cellophane. Each one wanted his own
+way. They couldn&#039;t see, any of them--but Mr. Olin could see the advantages of
+tying them together.
+
+Polyethylene shot shells is a good example. That&#039;s burned out. In fact, now
+they&#039;re all recycled.
+
+So you see, it takes people. That&#039;s where I&#039;ve been very lucky. I&#039;ve gotten to
+know people like Elmer K. Bolton, who was head of DuPont research. Bolton had a
+concept of research. He had a team of advisors; he had a steering committee.
+Bolton was not the only one. He had himself. He had a man out of the cellophane
+division who was assistant to him, and then he had a chemical engineer,
+Greenewalt. He had Brubaker, a damn good organic chemist. He had [Thomas
+Hamilton] Chilton, a chemical engineer. He had a team of about seven people.
+They met once every week come hell or high water, and nobody on that steering
+committee dared miss--not even the vice president of the company, Crawford
+Greenewalt. That was his job. Bolton sat at the end of the table, and the guys
+who were brought into that team of people were young men like me!
+
+That had a tremendous effect on me because it gave me a confidence that I
+couldn&#039;t have gotten any other way. I knew that when I walked into that room,
+they were going to be better at tearing me apart than Bailey is tearing the
+people apart today. On the other hand, I knew that if I could hold up--if the
+next day Brubaker called me and said, &quot;Butch, we want you to write a little
+project in this direction,&quot; I&#039;d succeeded.
+
+You have to excuse me for crying, but I&#039;m a very sentimental man.
+
+I guess that was some way to get prestige, through the people down along the
+line. I have several awards--and I really earned them. There was this one; I
+think it said something about &quot;The Utilization of Research in Industry.&quot; It is
+the Chemical Industry Medal, I think.
+
+I say Max Tishler, he&#039;s a good friend of mine--Max Tishler got a lot of awards,
+and Max Tishler got them as a man who made a classic compound. But Max Tishler,
+with all his making his compounds, wasn&#039;t worth a tinker&#039;s damn without somebody
+in the plant who could scale it up, somebody who could tell me how to put it in
+a capsule, somebody who could get it through the NIH [National Institutes of
+Health] up here. That is the team!
+
+That&#039;s not recognized enough in industry. I just feel so positive of that.
+
+[END OF AUDIO FILE 1.4]
+
+HANFORD: I have one son. Who is an eng(ineer)--is a chemist--he&#039;s a lawyer! His
+work now is dealing with inventions in science. In fact, the AIC [American
+Institute of Chemists] is going to put out a new paper, and it&#039;s &quot;Fathers and
+Sons in Chemistry.&quot; He and I are the first candidates.
+
+We discuss a lot of things. He has a business; we built a plant. Another thing I
+was in was water purification.
+
+BOHNING: That was after you left Olin. That was World Water Resources, Inc.
+
+HANFORD: That was my son&#039;s business. Our son has traveled literally around the
+world putting in systems for sterilization of water. He is one of the
+best-traveled men in the company. [laughter]
+
+It has never really taken off. He still makes them, but it didn&#039;t take off. We
+couldn&#039;t gel it right. It&#039;s still a big business. I was just reading, I guess it
+was the other day, where one of the biggest supplies of fresh water is in the
+world. It&#039;s the Great Lakes. Now it&#039;s being contaminated. Strangely enough,
+what&#039;s contaminated it is mercury. To contaminate that is a crime. How are you
+going to purify it? The best way is, never let the water you&#039;ve used back into
+it that&#039;s not pure. That was the type of thing we were looking at.
+
+That one didn&#039;t hit. We couldn&#039;t gel it. The other thing is, we couldn&#039;t raise
+enough money. Don&#039;t underestimate, in anything like this you do, the importance
+of the money man--the John Olins, the M.W. Kellogg--Mr. Kellogg, [Arthur C.]
+Dorrance. Do you know who Dorrance is? Did you ever hear the name?
+
+BOHNING: No.
+
+HANFORD: He invented one of the biggest businesses in the world; it makes a lot
+of money. He&#039;s the starter of Campbell&#039;s Soup [Company].
+
+BOHNING: Oh, sure. In Camden.
+
+HANFORD: Dorrance came from Bristol, too; in fact, he lived within two blocks of
+my grandfather. He went to France as a young man and learned to cook. When he
+came back, he started the Campbell&#039;s Soup business. He must have been awfully good.
+
+Now, the ones that are really good--not me--are those like Dorrance who would
+take an idea like cooking--learned to cook it--and then learned how to package
+it and put it through. Somehow he learned the importance of building a team, and
+he built a team.
+
+The Coke bottle&#039;s another example. Those are simple things. Yet who would&#039;ve
+ever thought that I&#039;d package Coke in polyethylene?
+
+We used to sit around the drugstore when I was a young kid. My uncle ran a
+drugstore. In those days a drugstore had a soda fountain. In the soda fountain,
+he had to have soda, so in the basement of my uncle&#039;s drugstore, he had a big
+high-pressure cylinder--not big, maybe twenty-five gallons--that sat on a
+rocker. Alongside of that he had a tank of carbon dioxide. Every once in a
+while, my uncle would say, &quot;We haven&#039;t got enough soda water. Go down and get
+started. I&#039;ll come down and hook you up.&quot; He would come down and fill the tank
+with water out of the spigot. Then he would connect the CO2--let out the air and
+connect it. Then he&#039;d say, &quot;Sit there and rock,&quot; and I&#039;d sit there and rock it.
+
+It&#039;s things like that, how unquestioned they are. I say I&#039;ve got a new idea,
+which I have, but the idea comes back to rocking. I think I know what happened
+in that good experiment--I was too impatient, because one of the things you
+learn from nature is that nature takes time.
+
+If you look up in the mining engineering book by Howard and Lucille Sloane,
+which I&#039;ve read three times, you find two things that they tell you
+[[footnote]]2[[/footnote]]. The first thing is that clathrates can take a
+century to make, under lots of conditions. Just think of that; you can make it
+in a few minutes, or you can take a long time. The difference is agitation,
+water conditions. If you don&#039;t shake it enough, it&#039;s just mixed.
+
+The other thing is that nature had to find some way to keep it. You and I make
+plenty of it. I get rid of a lot of it every day, but it has to keep it. How did
+nature decide to keep it? He decided to set it with water. When they get a leak
+in a field down in the earth, if he didn&#039;t have some way to pluck it, it
+wouldn&#039;t be there long. Nature said, &quot;I&#039;ll fix that.&quot; He said, &quot;I&#039;ll make a
+clathrate.&quot; The clathrate is that the methane comes up with the water, it drops
+in velocity, the temperature drops a few degrees, and it freezes. All of the
+methane you&#039;ve got in the world is there because nature is able to make a
+clathrate when a rupture occurs. Have an earthquake, you could blow the damn
+world up, but nature has a way to plug it up. The question is, how do we use it?
+
+The question with this field right now is this: there have been oodles and
+oodles of dollars spent on how to get the methane out of the clathrate, but
+there is no good method of making a clathrate in a tank. That&#039;s the
+question--can I do it?
+
+What we don&#039;t use enough is to think in terms of, how does nature solve a
+problem? Then, how can I use that same thing to solve the problem? The best
+example of that was Carothers&#039; nylon. He wanted a polyamide; he knew that they
+would be good. All he did is very simple. He put five carbon atoms between the
+carboxyl and an H2 group, and took amino acid and stretched them apart. His
+theory was simple, &quot;If I get them far enough apart, I won&#039;t find the former
+ring.&quot; That&#039;s what he did. That&#039;s the total concept that led to nylon--the total concept.
+
+Now, I have a man who worked for me, who made the five-member ring polymerize.
+That&#039;s Carl [Edmund] Barnes. I told him he couldn&#039;t do it. But Carl Barnes
+worked for me at GAF. We worked in acetylene, and one of the things we tried to
+do was acetylate everything. Barnes decided to acetylate ethyl glycenate.
+
+In GAF, he had to wait in line to get a position to get at the acetylene to do
+his experiments. In fact, most of us thought so poorly of him--he was last in
+the line. He didn&#039;t care, he did it. Then one day he decided that if he got a
+line quick, he got the product he wanted. If he had to wait a week, he didn&#039;t
+get that; he got a polymer.
+
+He spent, I would guess, fifteen years to get that polymer where he could take
+an amino acid and polymerize it through a high molecular weight polymer with
+enough stability that he could melt-spin it. This is where timing comes in. He
+was unfortunate. He was just about twenty years too late, because man had
+circumvented that problem by the nylon problem instead of going from the amino
+acid. If he&#039;d have run his experiment prior to Carothers, nylon may never have
+come about.
+
+BOHNING: That&#039;s interesting.
+
+HANFORD: Yes, that&#039;s right. That&#039;s true.
+
+He is one of the early inventors in color photography. He was a photographer as
+an amateur. He&#039;s a graduate chemist from Harvard University. He got into color
+photography. He was the IG color photography man in this country long before
+Eastman Kodak [Company] was in the picture.
+
+That&#039;s how I met him. [laughter] He was interested in polymers and I was
+interested in polymers. We were interested in acetylene. While I was at GAF, I
+supported his work. He later got some of the other people to support it, but it
+was too slow.
+
+Again, going back to Carothers and them, one of the things was that if Carothers
+had been left alone, nylon would have been a secondary product. Why? Because he
+would have had to have spun it from solution. The only thing that will dissolve
+it is creosote. But there was a chemical engineer on that steering committee;
+his name was Crawford Greenewalt. Crawford Greenewalt said, &quot;As long as I&#039;m on
+this committee, we will never commercialize that project until you can melt-spin
+it!&quot; Carothers said, &quot;It&#039;s impossible.&quot; It was another man, Peterson, who added
+the key--which was nothing but a few percent of acetic acid--that made that
+polymer spinning.
+
+I don&#039;t know what the hell they&#039;re doing today, but that was the original one.
+When you did that, you could melt it, you could spin it, and you could draw it.
+
+Now the other guy who was important was Julian Hill. Julian Hill was working on polyesters with Carothers. One day he
+did this--just this way--and he had enough imagination to know that when he did
+this, it necked down. In necking down, he put it in the tensometer, and the
+strength was ten times as strong, but not useful because the polyesters had
+melted too long. That didn&#039;t come for a long time.
+
+There&#039;s so many people. There&#039;s another thing. You couldn&#039;t make
+hexamethylene-diamene today if you had to. If you said, &quot;Well hell, the obvious
+way to do that is to make a diponitryl and a lot of ammonia and then hydrogenate
+it with nickel,&quot; it doesn&#039;t work. You know why? It ring forms, and you get
+amine. It wasn&#039;t until [John William] Haught and [Wilbur Arthur] Lazier decided
+to switch from nickel to cobalt that the yield went from maybe 10 percent to 99 percent.
+
+Those are the things that make it! Carothers wanted to make the
+ten-polymer--ten-ten--for two reasons. One, it was easier to make; two, it was
+easier to spin because it was lower melting, and he couldn&#039;t melt-spin it. But
+DuPont said, &quot;No, no. We don&#039;t want that.&quot;
+
+Then it went to the six-six. It wasn&#039;t until Haught and Lazier--and one other
+fellow&#039;s name, I&#039;ve forgotten--switched to cobalt. Just think, that was the only
+change! The hydrogen was the same, the dinitryl was the same, the ammonia was
+the same, but he switched to cobalt. They made Rainey cobalt instead of Rainey nickel.
+
+Well, I&#039;m sorry, sir. I don&#039;t know whether I&#039;ve given you what you wanted.
+
+BOHNING: Oh, you have. It&#039;s been very good.
+
+HANFORD: Now, any specific questions I&#039;ll be glad to answer.
+
+BOHNING: I did have one other question. You said that you didn&#039;t receive any
+award for the DuPont patents, but what about the other places where you worked?
+Did they reward you more for patents?
+
+HANFORD: No.
+
+BOHNING: It was the same all the way through.
+
+HANFORD: It was the same way all along. I never made any money out of patents,
+because once I left DuPont, I was in management. My job then was to make sure
+that the guy who ran the experiments got the patents. I was not interested,
+truly, that I should get the patent. The idea alone is not enough. It takes
+experimental skill.
+
+When I was in the laboratory, I had an assistant; we called him a lab assistant.
+His name was Tommy Simpers. When Tommy Simpers came to the DuPont Company, he
+couldn&#039;t read or write, but he was the best assistant anybody ever had because
+he did learn to read. He did learn to do, and he learned a lot of stuff. He was
+a man who looks like [Andre K.] Agassi now looks when he plays tennis--a bum!
+[laughter] I don&#039;t go with that kind of tennis player. Anyhow, that was him.
+When he worked for me, I would say, &quot;Tommy, do this; put 55 cc of that and 20 cc
+of this on the thing and heat it to 80 degrees,&quot; and he heated it to 80 degrees.
+It wasn&#039;t 90 degrees; it wasn&#039;t up and back and all. He did what he was told.
+The trouble today with too much experimental work is, they don&#039;t have the
+patience to do it. I told you I missed one, too.
+
+I missed the clathrate. I didn&#039;t have the patience to think that that thing
+nature formed wouldn&#039;t form like that. Then when I got to read the mining
+engineering work and found that they said that it can take anywhere from a few
+minutes to a century to make a clathrate, I knew I&#039;d missed the boat. That again
+is the reason that the team is so important.
+
+BOHNING: We&#039;ve covered this list of questions. Let me ask you this: what do you
+think is the future for chemical research and development in this country? Do
+you think it&#039;s as vital as it was when you were involved?
+
+HANFORD: Oh, yes, probably more so, because of this; we have more reason to get
+rid of stuff. We&#039;ve got to find some way that when the maid turns that water on
+and gets a lot of stuff in it, it doesn&#039;t go back in the sewer contaminated.
+It&#039;s even worse with that toilet; when that toilet flushes, you&#039;ve got to find
+some way to recycle that water. Where synthetic detergents come in is, they have
+to be biodegradable. If they&#039;re biodegradable, then nature will clean them up
+provided we put them in the right environment. I think that&#039;s just as important
+as ever. The human body is such that, the way we live, it&#039;s got to be kept
+clean, and the clothes have got to be kept clean, and the dishes have got to get clean.
+
+Now, of course, there&#039;s another area that&#039;s been very important, which I got
+involved in, too. That&#039;s the nonfoaming. You&#039;ve got a dishwasher in the kitchen
+there. I built my first house when I was first married. I&#039;ve been married sixty
+years or something. Anyhow, I decided that I would build a house. My wife wanted
+a house; she didn&#039;t want an apartment. She wanted to build it. My brother was a builder.
+
+Again, going back to the things getting done, I had an aunt who was interested
+in building. She supported my brother in his building trade. When I wanted a
+house, my brother built it; my aunt put in the money. I was a good enough risk
+for her to take it. [laughter]
+
+Anyhow, the story is this. When it was built, I wanted a modern kitchen, and I
+wanted a dishwasher in it. My brother said, &quot;That&#039;s a waste of money. Nobody
+uses those damn things! They&#039;re no good! I&#039;ve put them in a lot of houses, they
+don&#039;t work!&quot; Lorraine said, &quot;It doesn&#039;t make any difference; we want one.&quot;
+
+We built it. We put a dishwasher in it. When I was at DuPont, and even at GAF, I
+did a hell of a lot of dishwashing in my dishwasher to test out those foamy
+characteristics. That&#039;s the secret. It wasn&#039;t any trouble to get something to
+wash; the question was, how to get it so it would reduce the fat, and put it in
+this emulsion somehow, or whatever you want to call it, and not contaminate the
+water--and know, when I opened the door, there&#039;s no foam?
+
+As far as I&#039;m concerned, yes, that&#039;s going to be an important thing. I don&#039;t
+quite think we&#039;ll get to the point where we&#039;ll have shirts to throw away, but
+it&#039;s getting close to it now. I think that&#039;s still an important field. Of
+course, the source of the hydrocarbon, and all those things, have to be balanced.
+
+BOHNING: Well, I think at this point I&#039;m going to thank you very much for
+spending the morning with me. I don&#039;t have any more questions. Is there anything
+you&#039;d like to add?
+
+HANFORD: You know, you do raise one question in there which bothered me. That
+was, how did the Chemical Industry Medal influence me? I think the fact that it
+was available influenced me. Not that winning it influenced me, but that my
+friends won it. Therefore, it was a goal; how could I win it?
+
+I think in that respect, don&#039;t lose sight of the importance of giving the MVP,
+the Most Valuable Player Award. On the other hand, don&#039;t lose sight that you&#039;ve
+got to have the other team members. Today, I think we are putting too much money
+on emphasizing the MVPs, and not the guards and those people.
+
+I end up by telling you a story. I&#039;ve got lots of stories. We moved here. Over
+the years, the world&#039;s been very good to me. I&#039;ve never been paid for patents,
+never got any royalty on a patent. I have been paid, at times, some pretty good
+salaries. I have been in companies in which I was the highest paid man, then.
+What I&#039;ve been paid as my highest then, you couldn&#039;t hire a Ph.D. for today.
+That&#039;s all right; I lived in the day. Anyway, I&#039;ll tell you this story.
+
+I went to work for DuPont. When I went to work, the salary was two hundred
+fifteen dollars a month.
+
+[END OF AUDIO FILE 1.5]
+
+[AUDIO FILE 1.6 IS NOT ON FILE]
+
+HANFORD: I was fortunate. I had only been there about a month when DuPont raised
+the salary to two hundred fifty dollars a month. Just think of that--I got a
+thirty-five dollar raise and hadn&#039;t started to work yet.
+
+I have been involved in salaries, and I have had many a fight to get a chemist
+paid what I thought he was due. I think I could truthfully say I was probably
+one of the first men to get men paid fifteen hundred dollars a month. That&#039;s
+chicken feed now! Anyhow, I&#039;ll tell you my story.
+
+We moved here. Because of my way of doing things, I&#039;ve always lived well. I&#039;ve
+always had some help in the house. I always have had visitors. If men came from
+Europe to see me, I always had them in my home. Why? Because I knew what they
+were interested in. They wanted to know how the hell these damn Americans live!
+It didn&#039;t make any difference what country they were from.
+
+I had another thing that I did--I sent Christmas cards. We sent Christmas cards
+to everybody. If I met them, they got a Christmas card. We have stopped. What do
+you think the number was we stopped at? Three thousand. My wife said, &quot;You can&#039;t
+do it any more!&quot; [laughter] But they were important. We haven&#039;t done it now in
+probably over ten years; we can&#039;t do it. But the maximum we had was three
+thousand. We bought them; I paid for them, I sent them. I wrote something on a
+high percentage of them. Why? I wanted them personal! I didn&#039;t want them to
+forget me! That&#039;s important to me still. I didn&#039;t want to be forgotten.
+
+I started to tell you a story and got lost. I&#039;ll go back to this story.
+
+We came here to live. This is a very nice apartment; it is very comfortable,
+nice. My wife has always traveled with me. My wife&#039;s been as well known as I am,
+as Toots Hanford. She used to travel with me. When the people came to my house,
+they knew her and all.
+
+Anyhow, we came here, and I&#039;ll get back to the story. We wanted some part-time
+help. No place for them to live here, so they have to be part time. We&#039;ve
+changed our habits. We now eat our main meal at 1:30 p.m. because I can&#039;t keep a
+girl till eight o&#039;clock at night. We changed everything, so we had to find a
+part-time help--the one we&#039;ve gotten.
+
+I interviewed her and asked her if she&#039;d cook, and she said, &quot;Yes.&quot; We found she
+couldn&#039;t, but my wife taught her. Then the question was, &quot;How much money do you
+want?&quot; She thought for a minute, and she said, &quot;I want five hundred dollars.&quot;
+Whew! Gee, five hundred dollars! I said, &quot;Okay,&quot; but I missed the point. The
+five hundred dollars, I thought she was talking a month. Honestly, as soon as I
+heard it, I thought that&#039;s what she was talking about. She wasn&#039;t; she was
+talking a week. Five days a week. That&#039;s what I pay her, and I find that that&#039;s
+the going rate.
+
+You see how you can get out of perspective. Now, if I offered a chemist
+two-fifty--and I&#039;ve offered many of them three hundred dollars. [laughter]
+
+BOHNING: Well, I&#039;ll thank you again.
+
+HANFORD: I don&#039;t know whether I did what you wanted or not.
+
+BOHNING: Oh, yes. We got a lot of good information, and I appreciate it very much.
+
+HANFORD: My wife&#039;s got a volume back there that&#039;s that high. She pointed them
+out to you. That is called &quot;That&#039;s My Life.&quot; Now my wife has been very, very
+diligent in clipping records--all kinds of things that I have done, and we have
+done. That&#039;s in those volumes back there. When the people from the Inventors
+Hall of Fame came and wanted some pictures of things--they&#039;ve got some kind of a
+new exhibit, I haven&#039;t seen it yet--she got those books out and she and my
+daughter-in-law sat down and picked them out. They picked the picture out that&#039;s
+going to be there. I had no words talking about it, except they said it looked
+like me.
+
+What it is is a picture of me leaning over a melting point in the laboratory
+with a dirty laboratory coat on. [laughter] That&#039;s what gave me the name of
+Butch. I wore a dirty laboratory coat; I cut the sleeves off here and here, and
+it was always covered with chemicals.
+
+When I went to Illinois and the people were looking for a name, they said, &quot;The
+only thing that will satisfy him is &#039;Butch.&#039; He looks like a butcher.&quot;
+[laughter] That&#039;s how I got the name of &quot;Butcher.&quot; The picture, I think, that&#039;s
+going to be used down there is me in that laboratory looking at a melting point.
+You can&#039;t see anything but me except the back.
+
+BOHNING: That&#039;s at the University of Akron; isn&#039;t the Inventors Hall of Fame in Akron?
+
+Yes, Akron. Apparently, they&#039;re really going to have a showplace.
+
+BOHNING: I haven&#039;t seen it.
+
+HANFORD: When I got mine, which was in 1991, they had just accumulated the money
+to build it, and they were building it. I think I can say, for one thing, that
+the money has been current to build it, and to equip it, and to put the exhibits
+in it. It was this thing that they wanted here from me. I think now there&#039;s
+going to be another good change, and that is that the classes admitted to the
+National Inventors Hall of Fame are going to be bigger, which they should be.
+When I got mine--I think I&#039;m right--there were seventeen million patents. How
+they ever picked mine out of them, I don&#039;t know, but that&#039;s true. [laughter]
+From what they&#039;re doing now, I think it&#039;s going to be a much broader thing,
+which it should be. In other words, I was the ninety-first recipient. There were
+that many patents.
+
+One of the stories is that DuPont got three members to the National Inventors
+Hall of Fame in the period I was there. I have given you the experiment that
+made it possible to keep the invention. The nylon patent, they had to get the
+caprolactam. The Teflon patent, they had to find the process to make it, and I
+did that. Those three men had been admitted to the National Inventors Hall of
+Fame because I added something--not a great deal maybe, but something to it. I&#039;m
+not taking anything away from them, but this is what I mean by team. I was on
+the nylon team, and I was on the Teflon team. They deserved the patents, but
+there were a lot of other people in those fields.
+
+For instance, to me, Julian Hill deserves a place because in polymer science at
+that time, that was a real invention! [laughter] Everybody knew you could dry
+rubber, but nobody ever thought it would stay there.
+
+I think they&#039;re going to have a good show. You ought to get them to send you out there.
+
+BOHNING: When I get to Ohio, I have relatives who live near Akron. I&#039;ll have to
+make a stop.
+
+HANFORD: I have a couple of letters from them now, urging me to come, because I
+don&#039;t think there are many of us living. [laughter] I have to do some talking to
+get my wife to let me go, because she doesn&#039;t think that I should get out of the house.
+
+BOHNING: It would be nice for you to get out there.
+
+HANFORD: Oh, I&#039;m going to go this time. My son will take me, and my
+granddaughter. They&#039;re the ones who are in the picture there; they&#039;re the ones
+who were with me when I got it before. My granddaughter is now working at
+Northwestern University to get her Ph.D. in computers.
+
+BOHNING: That&#039;s great. That&#039;s marvelous.
+
+HANFORD: Well, it&#039;s been a real pleasure to meet you.
+
+BOHNING: Yes. I&#039;ll turn this off.
+
+[END OF AUDIO FILE 1.6]
+
+[END OF INTERVIEW]
+
+ [[footnotes]]
+
+[[note]]William E. Hanford (to E.I. DuPont de Nemours &amp; Co.), &quot;Polyamides,&quot; U.S.
+Patent 2,281,576, issued 5 May 1942.[[/note]]
+
+[[note]]Howard N. and Lucille L. Sloane, A Pictorial History of American Mining:
+The adventure and drama of finding and extracting nature&#039;s wealth from the
+earth, from pre-Columbian times to the present (New York: Crown Publishers,
+Inc., 1970).[[/note]]
+
+ [[/footnotes]]
+
+</transcript><transcript_alt></transcript_alt><rights></rights><fmt>audio</fmt><usage></usage><userestrict>0</userestrict><xmllocation></xmllocation><xmlfilename></xmlfilename><collection_link></collection_link><series_link></series_link></record></ROOT>


### PR DESCRIPTION
We don't have the feature to display them yet, so instead of the markup for footnotes showing up 'raw', we want to just strip them out before display,for now. 

Ref #691