### PR TITLE
Lock csl-styles gem to 1.0.1.9 exactly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -168,4 +168,9 @@ gem 'aws-sdk-core'
 
 # we use for data structures for citation models, and for generating citations
  gem "citeproc-ruby", '~> 1.0'
- gem 'csl-styles', '~> 1.0' # Need to load the styles so we can use chicago
+# Need to load the styles so we can use chicago, we lock to 1.0.1.9 for now, because
+# future versions change rendering in ways we didn't want. This is probably
+# fine to leave locked as long as we only use chicago in the specific way we are now.
+#
+# https://github.com/inukshuk/csl-styles/issues/5
+ gem 'csl-styles', '1.0.1.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -637,7 +637,7 @@ DEPENDENCIES
   cocoon
   coffee-rails (~> 4.2)
   content_disposition (~> 1.0)
-  csl-styles (~> 1.0)
+  csl-styles (= 1.0.1.9)
   database_cleaner (~> 1.7)
   db-query-matchers (< 2.0)
   devise (~> 4.5)


### PR DESCRIPTION
Subsequent release causes our human-readable citations to be output in a way we do not prefer. For now, just lock it to the version that works. csl-styles being a separate gem with just style info is nice, cause we don't have to lock the actual csl logic gems.

See https://github.com/inukshuk/csl-styles/issues/5