### PR TITLE
Lock style generation to csl chicago-note-bibliography-16th-edition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -168,9 +168,4 @@ gem 'aws-sdk-core'
 
 # we use for data structures for citation models, and for generating citations
  gem "citeproc-ruby", '~> 1.0'
-# Need to load the styles so we can use chicago, we lock to 1.0.1.9 for now, because
-# future versions change rendering in ways we didn't want. This is probably
-# fine to leave locked as long as we only use chicago in the specific way we are now.
-#
-# https://github.com/inukshuk/csl-styles/issues/5
- gem 'csl-styles', '1.0.1.9'
+ gem 'csl-styles', '~> 1.0' # Need to load the styles so we can use chicago

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,7 +187,7 @@ GEM
     crass (1.0.6)
     csl (1.5.0)
       namae (~> 1.0)
-    csl-styles (1.0.1.9)
+    csl-styles (1.0.1.10)
       csl (~> 1.0)
     database_cleaner (1.7.0)
     db-query-matchers (0.9.0)
@@ -637,7 +637,7 @@ DEPENDENCIES
   cocoon
   coffee-rails (~> 4.2)
   content_disposition (~> 1.0)
-  csl-styles (= 1.0.1.9)
+  csl-styles (~> 1.0)
   database_cleaner (~> 1.7)
   db-query-matchers (< 2.0)
   devise (~> 4.5)

--- a/app/presenters/citation_display.rb
+++ b/app/presenters/citation_display.rb
@@ -31,7 +31,14 @@ class CitationDisplay
 
   # reuse this style cause it's expensive to load. It appears to be concurrency-safe.
   def self.csl_chicago_style
-    @csl_chicago_style ||= ::CSL::Style.load("chicago-note-bibliography")
+    # We lock to the older styles for "16th edition", because the newer 17th edition styles,
+    # while improved, change things in ways we may have to change some of our code to accomodate,
+    # for now we'll just lock to style version that we originally developed with.
+    #
+    # See: https://github.com/inukshuk/csl-styles/issues/5
+    #
+    # You could say just `chicago-note-bibliography` to mean latest version available.
+    @csl_chicago_style ||= ::CSL::Style.load("chicago-note-bibliography-16th-edition")
   end
 
   # similar to csl_chicago_style


### PR DESCRIPTION
Instead of leaving it `chicago-note-bibliography`, meaning latest version of the chicago style in the csl-styles gem.

We developed our func for the 16th edition styles, and when csl-styles updated to a 17th ed one, it changed some things, that interacted oddly with some of our workarounds. Rather than deal with it, we'll just lock to the style version we developed under for now, so our app behavior remains consistent.

This is an alternative to locking csl-styles gem itself, now we can allow updates to the gem, but keep using the locked stylesheet.

See https://github.com/inukshuk/csl-styles/issues/5