### PR TITLE
Log downloads of combined audio derivatives in Google Analytics

### DIFF
--- a/app/views/works/_show_with_audio_downloads.html.erb
+++ b/app/views/works/_show_with_audio_downloads.html.erb
@@ -51,7 +51,11 @@
   </h2>
   <div class="combined-audio-download-links">
     <div class="combined-audio-download-icon-container">
-      <a href="<%= decorator.combined_mp3_audio_download %>" download>
+      <a href="<%= decorator.combined_mp3_audio_download %>"
+        data-analytics-category="Work"
+        data-analytics-action="download_combined_audio_derivatives"
+        data-analytics-label="<%= @work.friendlier_id %>"
+        >
         <i class="fa fa-download" aria-hidden="true"></i>
         Web-quality MP3
       </a>


### PR DESCRIPTION
Ref #706 
I'm using as the `eventAction`:
```data-analytics-action="download_combined_audio_derivatives"```
which I assume does not have to be registered with the GA interface before it Just Works (tm).