### PR TITLE
Stop using tzinfo gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -141,7 +141,8 @@ group :test do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+# Not using any of these platforms, so commented out to avoid bundler warning.
+# gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 
 # Used for Cap deployment

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -688,7 +688,6 @@ DEPENDENCIES
   solr_wrapper (~> 2.1)
   sprockets (~> 4.0)
   sprockets-rails (>= 2.3.2)
-  tzinfo-data
   uglifier (>= 1.3.0)
   uppy-s3_multipart
   web-console (>= 3.3.0)


### PR DESCRIPTION
It is only needed on Windows or JRuby, which we don't use. Having it in the Gemfile results in the confusing error message:

> The dependency tzinfo-data (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`

Every time you do a bundler thing.

Trying to follow it's `--add-platform` directions just seems to result in other problems. I don't think we need it, let's just comment it out.