### PR TITLE
Handle either shrine 2.x or shrine 3.x file not found exception classes

### DIFF
--- a/app/services/combined_audio_derivative_creator.rb
+++ b/app/services/combined_audio_derivative_creator.rb
@@ -73,15 +73,11 @@ class CombinedAudioDerivativeCreator
     @components ||= begin
       result = []
       audio_member_files.each do |original_file|
-        begin
-          new_temp_file = Tempfile.new(['temp_', original_file.metadata['filename'].downcase], :encoding => 'binary')
-          original_file.open(rewindable:false) do |input_audio_io|
-            new_temp_file.write input_audio_io.read until input_audio_io.eof?
-          end
-          result << new_temp_file
-        rescue Aws::S3::Errors::NotFound
-          return []
+        new_temp_file = Tempfile.new(['temp_', original_file.metadata['filename'].downcase], :encoding => 'binary')
+        original_file.open(rewindable:false) do |input_audio_io|
+          new_temp_file.write input_audio_io.read until input_audio_io.eof?
         end
+        result << new_temp_file
       end
       result
     end

--- a/lib/tasks/scihist.rake
+++ b/lib/tasks/scihist.rake
@@ -26,7 +26,7 @@ namespace :scihist do
 
       progress_bar.title = asset.friendlier_id
       asset.dzi_file.create
-    rescue Aws::S3::Errors::NotFound
+    rescue *FixityChecker::SHRINE_NOT_FOUND_ERRORS
       progress_bar.log("Missing original for #{asset.friendlier_id}")
     ensure
       progress_bar.increment


### PR DESCRIPTION
Shrine 3 helpfully standardizes the exception raised from storage when a file is not found. But that is a backwards compat.

In order to safely and easily get ready for shrine 3, we're making some changes such that tests will pass and the app will work on either shrine 2 OR shrine 3, make our app ambidextrous, with some tiny easily comprehended non-dangerous changes.

This is one of them.