### PR TITLE
Fix asset_with_faked_file factory to actually use faked_file argument appropriately

### DIFF
--- a/spec/factories/asset_factory.rb
+++ b/spec/factories/asset_factory.rb
@@ -91,6 +91,7 @@ FactoryBot.define do
         # Set our uploaded file
 
         uploaded_file = create(:stored_uploaded_file,
+          file: evaluator.faked_file,
           content_type: evaluator.faked_content_type,
           width: evaluator.faked_width,
           height: evaluator.faked_height,

--- a/spec/models/dzi_files_spec.rb
+++ b/spec/models/dzi_files_spec.rb
@@ -84,18 +84,20 @@ describe DziFiles do
     describe "non-image file" do
       describe "asset creation" do
         let(:asset) {
-          create(:asset_with_faked_file, faked_file: File.open((Rails.root + "spec/test_support/pdf/sample.pdf").to_s)).
-          tap {|a| a.dzi_file.create }
+          create(:asset_with_faked_file, faked_content_type: "audio/mpeg", faked_file: File.open((Rails.root + "spec/test_support/audio/5-seconds-of-silence.mp3").to_s))
         }
 
         it "does not queue dzi creation" do
-          asset
+          expect {
+            asset.dzi_file.create
+          }.to raise_error(ArgumentError)
+
           expect(CreateDziJob).not_to have_been_enqueued.with(asset)
         end
       end
 
       describe "asset deletion" do
-        let(:asset) { create(:asset_with_faked_file, faked_file: File.open((Rails.root + "spec/test_support/pdf/sample.pdf").to_s)) }
+        let(:asset) { create(:asset_with_faked_file, faked_content_type: "audio/mpeg", faked_file: File.open((Rails.root + "spec/test_support/audio/5-seconds-of-silence.mp3").to_s)) }
 
         it "does not raise" do
           asset.set_promotion_directives(delete: :inline)


### PR DESCRIPTION
Which then revealed that some tests weren't testing what they thought, and were broken once they were. Fixed also.