### PR TITLE
Proper logic for adding directly to 'storage' in shrine 2 or 3, with condition check

### DIFF
--- a/app/models/oral_history_content.rb
+++ b/app/models/oral_history_content.rb
@@ -79,8 +79,17 @@ class OralHistoryContent < ApplicationRecord
     # `attacher.attach(file, storage: :store)`  Or not sure if that should be `storage: :actual_name_of_store`
 
     original = shrine_attacher.get
-    stored_file = shrine_attacher.store!(io, metadata: {"mime_type" => mime_type, "filename" => "combined.#{file_suffix}"})
-    shrine_attacher.set(stored_file)
+    metadata = { "mime_type" => mime_type, "filename" => "combined.#{file_suffix}" }
+
+    if Shrine.version < Gem::Version.new("3.0")
+      # shrine 2.x way of writing directly to storage
+      stored_file = shrine_attacher.store!(io, metadata: metadata)
+      shrine_attacher.set(stored_file)
+    else
+      # shrine 3.x way of writing directly to storage
+      shrine_attacher.attach(io, metadata: metadata)
+    end
+
     self.save!
   rescue StandardError => e
     # clean up file if there was a problem


### PR DESCRIPTION
Part of attempt to get ready for shrine 3 with small changes that leave the app working in both shrine 2 and shrine 3.

This does pass tests (and is necessary to pass tests) when run directly against the in-progress branch of kithe I have that uses shrine 3. But that isn't demo'd by CI, and I think it's too much trouble to try to get CI running like that, too much is still up in the air. So it's a bit 'dangerous' that the branch of code for shrine 3 added here is not actually used by any regular tests; but I still think this is an overall helpful approach.