### PR TITLE
Require zip (fixes rubyzip NameError)

### DIFF
--- a/app/services/work_zip_creator.rb
+++ b/app/services/work_zip_creator.rb
@@ -1,4 +1,5 @@
 require 'open-uri'
+require 'zip'
 
 # Create a ZIP of full-size JPGs of all images in a work.
 #

--- a/spec/services/work_zip_creator_spec.rb
+++ b/spec/services/work_zip_creator_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'zip'
 
 describe WorkZipCreator do
   let(:work) do


### PR DESCRIPTION
We now need to explicitly require the rubyzip gem before invoking it.
#721