### PR TITLE
update minimist npm dependency

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4262,9 +4262,9 @@ minimist@0.0.8:
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
 minimist@^1.1.3, minimist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
 minipass-collect@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Github was warning us that some versions of minimist were effected by CVE CVE-2020-7598; Vulnerable versions: >= 1.0.0, < 1.2.3

We have something in our dep tree using minimist 0.0.8, but that's not a problem. But other parts were using 1.2.0, that was a problem.

To get this fixed, I manually edited the `yarn.lock` file. I _deleted_ the section that looked like:

```
 minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
```

Then I ran `yarn install` again. It added that section back to the `yarn.lock`, but now using version 1.2.5.

This seems to be the only way to get the yarn tool to update an indirect dependency to a more recent version that resolves in your dependency tree.

fyi @sanfordd