### PR TITLE
update kind-of npm dependency

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3895,9 +3895,9 @@ kind-of@^5.0.0:
   integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
 
 kind-of@^6.0.0, kind-of@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
-  integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
 last-call-webpack-plugin@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Github warned us about a security vuln to kind-of CVE-2019-20149, Vulnerable versions: = 6.0.2

We have LOTS of versions of kind-of in our yarn.lock, but only 6.x are relevant here.

Manually edited `yarn.lock` to delete the block for ` kind-of@^6.0.0, kind-of@^6.0.2:`, that had been using 6.0.2. ran `yarn-install`, it replaced it with 6.0.3 in yarn.lock, the diff you see here.