### PR TITLE
WIP fix WorkZipCreator returning Tempfile with empty content

### DIFF
--- a/app/services/work_zip_creator.rb
+++ b/app/services/work_zip_creator.rb
@@ -69,6 +69,9 @@ class WorkZipCreator
       end
     end
 
+    # tell the Tempfile to (re)open so it has a file handle open that can see what ruby-zip wrote
+    tmp_zipfile.open
+
     return tmp_zipfile
   ensure
     (derivative_files || []).each do |tmp_file|

--- a/spec/services/work_pdf_creator_spec.rb
+++ b/spec/services/work_pdf_creator_spec.rb
@@ -11,6 +11,16 @@ describe WorkZipCreator do
     )
   end
 
+  it "returns working File ready for reading" do
+    pdf_file = WorkPdfCreator.new(work).create
+
+    expect(pdf_file).to be_present
+    expect(pdf_file).to be_kind_of(Tempfile)
+    expect(pdf_file.size).not_to eq(0)
+    expect(pdf_file.size).to eq(File.size(pdf_file.path))
+    expect(pdf_file.lineno).to eq(0)
+  end
+
   it "builds zip" do
     pdf_file = WorkPdfCreator.new(work).create
 

--- a/spec/services/work_zip_creator_spec.rb
+++ b/spec/services/work_zip_creator_spec.rb
@@ -12,6 +12,17 @@ describe WorkZipCreator do
     )
   end
 
+  it "returns working File ready for reading" do
+    zip_file = WorkZipCreator.new(work).create
+
+    expect(zip_file).to be_present
+    expect(zip_file).to be_kind_of(Tempfile)
+    expect(zip_file.size).not_to eq(0)
+    expect(zip_file.size).to eq(File.size(zip_file.path))
+
+    expect(zip_file.lineno).to eq(0)
+  end
+
   it "builds zip" do
     zip_file = WorkZipCreator.new(work).create
 


### PR DESCRIPTION
Fails on problem causing #740

Somehow even though the Zip existed at the path the Tempfile was set to, the Tempfile itself returns empty string when `read` for content. 

Somehow that results in the `Aws::S3::Errors::XAmzContentSHA256Mismatch` when asking S3 SDK to upload it. Not sure why. But clear what to fix. 