### PR TITLE
More robust validation for ohms XML

### DIFF
--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -103,7 +103,7 @@ class Admin::WorksController < AdminController
     else
       Rails.logger.debug("Could not accept invalid OHMS XML for work #{@work.friendlier_id}:\n  #{xml.slice(0, 60).gsub(/[\n\r]/, '')}...\n\n  #{validator.errors.join("\n  ")}")
       redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), flash: {
-        error: "OHMS XML file was invalid and could not be accepted: #{validator.errors.join(';<br/>')}"
+        error: "OHMS XML file was invalid and could not be accepted: #{validator.errors.join('; ')}"
       }
     end
   end

--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -102,7 +102,9 @@ class Admin::WorksController < AdminController
       redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), notice: "OHMS XML file updated"
     else
       Rails.logger.debug("Could not accept invalid OHMS XML for work #{@work.friendlier_id}:\n  #{xml.slice(0, 60).gsub(/[\n\r]/, '')}...\n\n  #{validator.errors.join("\n  ")}")
-      redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), flash: { error: "OHMS XML file was invalid and could not be accepted!" }
+      redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), flash: {
+        error: "OHMS XML file was invalid and could not be accepted: #{validator.errors.join(';<br/>')}"
+      }
     end
   end
 

--- a/app/models/oral_history_content/ohms_xml_validator.rb
+++ b/app/models/oral_history_content/ohms_xml_validator.rb
@@ -54,42 +54,16 @@ class OralHistoryContent
         end
       end
 
-      # Make sure each [[footnote]] and [[note]] tag
-      # can be matched up with its corresponding closing tag.
-      #
-      # Recipe:
-      #
-      # Split the string by opening tags,
-      # then make sure each chunk
-      # contains exactly one closing tag,
-      # except for the first chunk
-      # (before the first opening tag),
-      # which should have zero closing tags.
-      #
-      # This falls short of a full parser, of course,
-      # but that's likely overkill.
-      text.split(FOOTNOTE_REF_OPENING_RE).each_with_index do |x, i|
-        number_of_closing_tags = x.scan(FOOTNOTE_REF_CLOSING_RE).length
-        stray_closing_tag_before_first_opening_tag =
-          (i == 0 && number_of_closing_tags != 0)
-        stray_or_missing_closing_tag_after_opening_tag =
-          (i >  0 && number_of_closing_tags != 1)
-        if stray_closing_tag_before_first_opening_tag || stray_or_missing_closing_tag_after_opening_tag
-          return ["Mismatched [[footnote]] tag(s) around footnote reference #{i + 1}."]
-        end
-      end
+      tag_pairs = {}
+      tag_pairs[:references] = [FOOTNOTE_REF_OPENING_RE, FOOTNOTE_REF_CLOSING_RE]
+      tag_pairs[:notes] = [FOOTNOTE_OPENING_RE, FOOTNOTE_CLOSING_RE]
 
-      text.split(FOOTNOTE_OPENING_RE).each_with_index do |x, i|
-        number_of_closing_tags = x.scan(FOOTNOTE_CLOSING_RE).length
-        stray_closing_tag_before_first_opening_tag =
-          (i == 0 && number_of_closing_tags > 0)
-        stray_or_missing_closing_tag_after_opening_tag =
-          (i > 0 && number_of_closing_tags != 1)
-        if stray_closing_tag_before_first_opening_tag || stray_or_missing_closing_tag_after_opening_tag
-          return ["Mismatched [[note]] tag(s) around [[note]] #{i + 1}."]
-        end
+      if (err = error_in_matching_tags(:references))
+        return ["Mismatched [[footnote]] tag(s) around footnote reference #{err + 1}."]
       end
-
+      if (err = error_in_matching_tags(:notes))
+        return ["Mismatched [[note]] tag(s) around [[note]] #{err + 1}."]
+      end
       result = []
       referenced_footnotes = Set.new
 
@@ -130,6 +104,47 @@ class OralHistoryContent
         notes[0].scan(ONE_FOOTNOTE_RE).
           map{ |x| x[0].gsub(/\s+/, ' ').strip }
       end
+    end
+
+    # Make sure each [[footnote]] and [[note]] tag
+    # can be matched up with its corresponding closing tag.
+    # This falls short of a full parser, of course,
+    # but that's likely overkill.
+    def error_in_matching_tags(tag_type)
+      tag_pairs = {
+        references: [
+          FOOTNOTE_REF_OPENING_RE,
+          FOOTNOTE_REF_CLOSING_RE
+        ],
+        notes: [
+          FOOTNOTE_OPENING_RE,
+          FOOTNOTE_CLOSING_RE
+        ]
+      }
+
+      opening_tag, closing_tag =  tag_pairs[tag_type]
+
+      text.split(opening_tag).each_with_index do |x, i|
+        # Split the string by opening tags
+        number_of_closing_tags = x.scan(closing_tag).length
+
+        # The first chunk, before the first opening tag, should have
+        # zero closing tags.
+        stray_closing_tag_before_first_opening_tag =
+          (i == 0 && number_of_closing_tags != 0)
+        # All other chunks should contain exactly one closing tag.
+        stray_or_missing_closing_tag_after_opening_tag =
+          (i >  0 && number_of_closing_tags != 1)
+
+        # Return the index of the chunk that failed the test:
+        if stray_closing_tag_before_first_opening_tag ||
+          stray_or_missing_closing_tag_after_opening_tag
+          return i
+        end
+      end
+
+      # Great, no errors:
+      return nil
     end
 
   end

--- a/app/models/oral_history_content/ohms_xml_validator.rb
+++ b/app/models/oral_history_content/ohms_xml_validator.rb
@@ -12,6 +12,8 @@ class OralHistoryContent
   #   # if not then
   #   validator.errors # => array of strings
   class OhmsXmlValidator
+    OHMS_NS = "https://www.weareavp.com/nunncenter/ohms"
+
     attr_reader :errors
 
     def initialize(xml_str)
@@ -21,21 +23,58 @@ class OralHistoryContent
     def valid?
       @errors = []
 
-      doc = Nokogiri::XML(@xml_str) { |config| config.strict }
+      @doc = Nokogiri::XML(@xml_str) { |config| config.strict }
 
-      self.class.xsd.validate(doc).each do |error|
+      self.class.xsd.validate(@doc).each do |error|
         @errors << "XSD validation error: #{error.message}"
       end
 
+      @errors = @errors + footnote_errors
+
       return @errors.empty?
+
     rescue Nokogiri::XML::SyntaxError => e
       @errors << "#{e.class}: #{e.message}"
       return false
+    end
+
+    def footnote_errors
+      errors = []
+      text_lines = text.split("\n")
+      text_lines_with_footnotes =  text_lines.select{ |l| l.include?('[[footnote]]') }
+      text_lines_with_footnotes.each do |line|
+        footnote_re = %r{\[\[footnote\]\] *(\d+?) *\[\[\/footnote\]\]}
+        line.scan(footnote_re).each do |f_match|
+          footnote_reference_number = f_match[0].to_i
+          if footnote_array[footnote_reference_number - 1] == nil
+            errors << "Reference to missing footnote #{footnote_reference_number}"
+          end
+        end
+      end
+      errors
     end
 
     # lazy load/parse
     def self.xsd
       @xsd ||= Nokogiri::XML::Schema(File.read(Rails.root + "lib/ohms/ohms.xsd"))
     end
+
+    def text
+      @text ||= begin
+        transcript = @doc.at_xpath("//ohms:transcript", ohms: OHMS_NS)
+        transcript ? transcript.text : ''
+      end
+    end
+
+    def footnote_array
+      @footnote_array ||= begin
+        footnotes_re = /\[\[footnotes\]\](.*)\[\[\/footnotes\]\]/m
+        return [] unless notes = text.scan(footnotes_re)[0]
+        one_footnote_re = /\[\[note\]\](.*?)\[\[\/note\]\]/m
+          notes[0].scan(one_footnote_re).
+          map{ |x| x[0].gsub(/\s+/, ' ').strip }
+      end
+    end
+
   end
 end

--- a/spec/models/oral_history_content/ohms_xml_validator_spec.rb
+++ b/spec/models/oral_history_content/ohms_xml_validator_spec.rb
@@ -24,11 +24,57 @@ describe OralHistoryContent::OhmsXmlValidator do
   end
 
   describe "valid OHMS xml" do
-    let(:xml_str) { File.read(Rails.root + "spec/test_support/ohms_xml/duarte_OH0344.xml")}
-
+    let(:xml_str) { File.read(Rails.root + "spec/test_support/ohms_xml/hanford_OH0139.xml")}
     it "is valid" do
+      foonote_re = /\[\[note\]\].*?\[\[\/note\]\]/m
+      xml_str_minus_first_footnote = xml_str.sub(foonote_re, '')
+      expect(xml_str.scan(foonote_re).count).to eq 2
+      expect(xml_str_minus_first_footnote.scan(foonote_re).count).to eq 1
+
       expect(validator.valid?).to be(true)
       expect(validator.errors).to be_empty
     end
   end
+
+  describe "reference to a missing footnote" do
+    let(:xml_str) { File.read(Rails.root + "spec/test_support/ohms_xml/hanford_OH0139.xml")}
+    it "is not valid" do
+      foonote_re = /\[\[note\]\].*?\[\[\/note\]\]/m
+      xml_str_minus_first_footnote = xml_str.sub(foonote_re, '')
+      expect(xml_str.scan(foonote_re).count).to eq 2
+      expect(xml_str_minus_first_footnote.scan(foonote_re).count).to eq 1
+      val = OralHistoryContent::OhmsXmlValidator
+        .new(xml_str_minus_first_footnote)
+      expect(val.valid?).to be(false)
+      expect(val.errors).to eq ["Reference to missing footnote 2"]
+    end
+  end
+
+  describe "no footnote section at all, but references present" do
+    let(:xml_str) { File.read(Rails.root + "spec/test_support/ohms_xml/hanford_OH0139.xml")}
+    it "is not valid" do
+      foonotes_re = /\[\[footnotes\]\].*?\[\[\/footnotes\]\]/m
+      xml_str_minus_all_footnotes = xml_str.sub(foonotes_re, '')
+      expect(xml_str.scan(foonotes_re).count).to eq 1
+      expect(xml_str_minus_all_footnotes.scan(foonotes_re).count).to eq 0
+      val = OralHistoryContent::OhmsXmlValidator
+        .new(xml_str_minus_all_footnotes)
+      expect(val.valid?).to be(false)
+      expect(val.errors).to eq ["Reference to missing footnote 1", "Reference to missing footnote 2"]
+    end
+  end
+
+  describe "space next to the number in a footnote reference" do
+    let(:xml_str) { File.read(Rails.root + "spec/test_support/ohms_xml/hanford_OH0139.xml")}
+    it "is tolerated" do
+      foonote_ref_re = %r{\[\[footnote\]\] *(\d+?) *\[\[\/footnote\]\]}
+      xml_str_with_spaces_in_footnote = xml_str.sub(foonote_ref_re, '[[footnote]]   2   [[/footnote]]')
+      expect(xml_str.scan(foonote_ref_re).count).to eq 2
+      expect(xml_str_with_spaces_in_footnote.scan(foonote_ref_re).count).to eq 2
+      val = OralHistoryContent::OhmsXmlValidator
+        .new(xml_str_with_spaces_in_footnote)
+      expect(val.valid?).to be(true)
+    end
+  end
+
 end

--- a/spec/models/oral_history_content/ohms_xml_validator_spec.rb
+++ b/spec/models/oral_history_content/ohms_xml_validator_spec.rb
@@ -108,7 +108,7 @@ describe OralHistoryContent::OhmsXmlValidator do
     end
   end
 
-  describe "unclosed footnote reference" do
+  describe "two consecutive opening footnote reference tags" do
     let(:bad_footnote_ref) { "[[footnote]]note 1[[footnote]]" }
     let(:xml_str) { hanford_xml.sub(footnote_ref_re, bad_footnote_ref) }
     it "is not valid" do


### PR DESCRIPTION
Ref #743  .
The current validation for OHMS XML checks for malformed XML.
This PR adds checks preventing the upload of:
- Footnotes with no references to them;
- References to nonexistent footnotes.
It also lists the problems to the user on the front end at upload time rather than just noting "Could not accept invalid OHMS XML", as there are more things that can go wrong.