### PR TITLE
bump jquery-rails from 4.3.5 to 4.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,7 +291,7 @@ GEM
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     jmespath (1.4.0)
-    jquery-rails (4.3.5)
+    jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)


### PR DESCRIPTION
Ref #745
This updates the underlying jquery to [3.5.1](https://blog.jquery.com/2020/05/04/jquery-3-5-1-released-fixing-a-regression/), which addresses security vulnerabilities:
- https://github.com/advisories/GHSA-gxr4-xjj5-5px2
- https://github.com/advisories/GHSA-jpcq-cgw6-v4j6

as reported in https://github.com/sciencehistory/scihist_digicoll/network/alert/yarn.lock/jquery/open
Procedure: `bundle update jquery-rails`.