### PR TITLE
WIP Ignore consecutive OHMS timecodes.

### DIFF
--- a/app/models/oral_history_content/ohms_xml.rb
+++ b/app/models/oral_history_content/ohms_xml.rb
@@ -119,24 +119,30 @@ class OralHistoryContent
         return {} unless sync.present?
 
         mbt, stamps = sync.split(":")
-        minutes_between_timecodes = mbt.to_i
 
         result = {}
 
         stamps.split("|").enum_for(:each_with_index).each do |stamp, index|
-          next if stamp.blank?
-          stamp =~ /(\d+)\((\d+)\)/
-          line_num, word_num = $1, $2
-          next unless line_num.present? && word_num.present?
-
-          (result[line_num.to_i] ||= []) << {
-            word_number: word_num.to_i,
-            seconds: index * minutes_between_timecodes * 60,
-          }
+          next unless timecode_hash = process_one_timecode(stamp, index, mbt)
+          line_num = timecode_hash.delete(:line_number)
+          (result[line_num.to_i] ||= []) << timecode_hash
         end
 
         result
       end
+    end
+
+    def process_one_timecode(stamp, index, mbt)
+      minutes_between_timecodes = mbt.to_i
+      return nil if stamp.blank?
+      stamp =~ /(\d+)\((\d+)\)/
+      line_num, word_num = $1, $2
+      return nil unless line_num.present? && word_num.present?
+      {
+        line_number: line_num,
+        word_number: word_num.to_i,
+        seconds: index * minutes_between_timecodes * 60,
+      }
     end
 
     # Iterate over raw_timecodes.

--- a/app/models/oral_history_content/ohms_xml.rb
+++ b/app/models/oral_history_content/ohms_xml.rb
@@ -102,12 +102,13 @@ class OralHistoryContent
     # It looks like: 1:|13(3)|19(14)|27(9)
     #
     # We believe that means:
-    # * `1:` -- 1 minute granularity, so each element is separated by one minute.
-    # * "13(3)" -- 13 line, 3rd word is 1s timecode (as it's first element and 1s granularity)
-    # * "19(14")  -- 19th line 14th word is 2s timecode
+    # * `1:`      -- 1 minute granularity: each timecode is separated by 60 seconds.
+    # * "13(3)"   -- Timecode 1: minute 1 ends at line 13, word 3.
+    # * "19(14)"  -- Timecode 2: minute 2 ends at line 19, word 14.
+    # * "27(9)"   -- Timecode 3: minute 3 ends at line 27, word 9.
     # * Etc.
     #
-    # OHMS seems to actually ignore the word position in placing marker, we may too.
+    # OHMS seems to actually ignore the word position in placing marker; we may too.
     def parse_sync!
       sync = parsed.at_xpath("//ohms:sync", ohms: OHMS_NS).text
       return {} unless sync.present?

--- a/app/models/oral_history_content/ohms_xml.rb
+++ b/app/models/oral_history_content/ohms_xml.rb
@@ -121,7 +121,7 @@ class OralHistoryContent
         result = {}
         stamps.split("|").enum_for(:each_with_index).each do |stamp, index|
           next unless timecode_hash = process_one_timecode(stamp, index, seconds_between_timnecodes)
-          line_num = timecode_hash.delete(:line_number)
+          line_num = timecode_hash[:line_number]
           (result[line_num.to_i] ||= []) << timecode_hash
         end
         result

--- a/app/presenters/ohms_transcript_display.rb
+++ b/app/presenters/ohms_transcript_display.rb
@@ -111,8 +111,16 @@ class OhmsTranscriptDisplay < ViewModel
     if line[:line_num] == 1
       # give a 0 timecode
       sync_html = content_tag("a", format_ohms_timestamp(0), href: "#", class: "ohms-transcript-timestamp", data: { "ohms_timestamp_s" => 0})
-    elsif sync = sync_timecodes[line[:line_num]]
-      sync_html = content_tag("a", format_ohms_timestamp(sync[:seconds]), href: "#", class: "ohms-transcript-timestamp", data: { "ohms_timestamp_s" => sync[:seconds]})
+    elsif timecodes_for_line = sync_timecodes[line[:line_num]]
+      # Although we ignore consecutive timecodes, but
+      # it's possible to imagine a scenario in which
+      # two or more *non-consecutive* timecodes are
+      # associated with the same line.
+      #
+      # For now, the simplest thing that could work is just
+      # to display the first timecode associated with each line.
+      seconds = timecodes_for_line[0][:seconds]
+      sync_html = content_tag("a", format_ohms_timestamp(seconds), href: "#", class: "ohms-transcript-timestamp", data: { "ohms_timestamp_s" => seconds})
     end
 
     # add em together with whitespace on end either way

--- a/app/presenters/ohms_transcript_display.rb
+++ b/app/presenters/ohms_transcript_display.rb
@@ -16,9 +16,7 @@ class OhmsTranscriptDisplay < ViewModel
   # We're also doing things somewhat different than OHMS when we coudn't figure out why it made
   # any sense (like a bare span for an empty line, or using span as a wrapper for p which is
   # probably illegal HTML)
-  #
-  # This is kinda dense code, but it works, not sure it would be cleaner with an view template,
-  # and should be more performant this way.
+
   def display
     paragraphs = []
     current_paragraph = []
@@ -106,9 +104,9 @@ class OhmsTranscriptDisplay < ViewModel
       ohms_line_str = ohms_line_str.sub(match_to_replace, replacement).html_safe()
     end
 
-    # If there are any timestamps associated with#
+    # If there are any timecodes associated with#
     # this line, pick one to show.
-    ts = timestamp_content_tag_for_line(line_number)
+    ts = timecode_content_tag_for_line(line_number)
 
     # add em together with whitespace on end either way
     safe_join([ts, ohms_line_str, " \n"])
@@ -117,7 +115,7 @@ class OhmsTranscriptDisplay < ViewModel
 
   # If there is a timestamp for this line, return its content_tag.
   # Otherwise, just a blank string.
-  def timestamp_content_tag_for_line(line_number)
+  def timecode_content_tag_for_line(line_number)
     tc = timecode_for_line(line_number)
     return '' unless tc
     content_tag(
@@ -145,7 +143,7 @@ class OhmsTranscriptDisplay < ViewModel
     # If this is the first line, try adding a zero timestamp
     # to the first word.
     if line_number == 1
-      timecodes_for_line = add_zero_timestamp(timecodes_for_line)
+      timecodes_for_line = add_zero_timecode(timecodes_for_line)
     end
 
     # Finally, just return the first timecode
@@ -153,20 +151,18 @@ class OhmsTranscriptDisplay < ViewModel
     timecodes_for_line.present? ? timecodes_for_line[0] : nil
   end
 
-
   # The first line is special: we want to add an
   # extra "zero-second" timestamp to it -- as long as
   # the first word doesn't already have
   # a timestamp associated with it.
-  def add_zero_timestamp(timecodes_for_first_line)
-    zero_timestamp = [{:word_number=>1, :seconds=>0}]
-    return zero_timestamp if timecodes_for_first_line.blank?
+  def add_zero_timecode(timecodes_for_first_line)
+    zero_timecode = [{:word_number=>1, :seconds=>0}]
+    return zero_timecode if timecodes_for_first_line.blank?
     first_word_is_free = (timecodes_for_first_line.none? { |k| k[:word_number] == 1 })
     if first_word_is_free
-      return zero_timestamp + timecodes_for_first_line
+      return zero_timecode + timecodes_for_first_line
     end
     # Otherwise just leave it as is.
     timecodes_for_first_line
   end
-
 end

--- a/app/presenters/ohms_transcript_display.rb
+++ b/app/presenters/ohms_transcript_display.rb
@@ -81,6 +81,7 @@ class OhmsTranscriptDisplay < ViewModel
   # * Makes sure there is whitespace at the end. Keep it all appropriately html safe.
   def format_ohms_line(line)
     ohms_line_str = line[:text]
+    line_number = line[:line_num]
 
     # catch speaker prefix
     if ohms_line_str =~ /\A([A-Z]+:) (.*)\Z/
@@ -105,26 +106,67 @@ class OhmsTranscriptDisplay < ViewModel
       ohms_line_str = ohms_line_str.sub(match_to_replace, replacement).html_safe()
     end
 
-    # possibly we need sync anchor html
-    sync_html = ""
-
-    if line[:line_num] == 1
-      # give a 0 timecode
-      sync_html = content_tag("a", format_ohms_timestamp(0), href: "#", class: "ohms-transcript-timestamp", data: { "ohms_timestamp_s" => 0})
-    elsif timecodes_for_line = sync_timecodes[line[:line_num]]
-      # Although we ignore consecutive timecodes, but
-      # it's possible to imagine a scenario in which
-      # two or more *non-consecutive* timecodes are
-      # associated with the same line.
-      #
-      # For now, the simplest thing that could work is just
-      # to display the first timecode associated with each line.
-      seconds = timecodes_for_line[0][:seconds]
-      sync_html = content_tag("a", format_ohms_timestamp(seconds), href: "#", class: "ohms-transcript-timestamp", data: { "ohms_timestamp_s" => seconds})
-    end
+    # If there are any timestamps associated with#
+    # this line, pick one to show.
+    ts = timestamp_content_tag_for_line(line_number)
 
     # add em together with whitespace on end either way
-    safe_join([sync_html, ohms_line_str, " \n"])
+    safe_join([ts, ohms_line_str, " \n"])
+  end
+
+
+  # If there is a timestamp for this line, return its content_tag.
+  # Otherwise, just a blank string.
+  def timestamp_content_tag_for_line(line_number)
+    tc = timecode_for_line(line_number)
+    return '' unless tc
+    content_tag(
+      "a",
+      format_ohms_timestamp(tc[:seconds]),
+      href: "#",
+      class: "ohms-transcript-timestamp",
+      data: { "ohms_timestamp_s" => tc[:seconds]}
+    )
+  end
+
+  # The OHMS editor allows us to associate one timecode per word.
+  # Our display, however, really only accomodates the display of one
+  # of these on the left of each line. This method picks at most one
+  # from the array of timecodes at sync_timecodes[line_number].
+  def timecode_for_line(line_number)
+
+    # Look up the timecodes for this line.
+    # They have already been processed in ohms_xml.rb
+    # to remove consecutive timecodes. In most cases,
+    # there will be either zero or one timecode in
+    # array timecodes_for_line.
+    timecodes_for_line = sync_timecodes[line_number]
+
+    # If this is the first line, try adding a zero timestamp
+    # to the first word.
+    if line_number == 1
+      timecodes_for_line = add_zero_timestamp(timecodes_for_line)
+    end
+
+    # Finally, just return the first timecode
+    # associated with the line.
+    timecodes_for_line.present? ? timecodes_for_line[0] : nil
+  end
+
+
+  # The first line is special: we want to add an
+  # extra "zero-second" timestamp to it -- as long as
+  # the first word doesn't already have
+  # a timestamp associated with it.
+  def add_zero_timestamp(timecodes_for_first_line)
+    zero_timestamp = [{:word_number=>1, :seconds=>0}]
+    return zero_timestamp if timecodes_for_first_line.blank?
+    first_word_is_free = (timecodes_for_first_line.none? { |k| k[:word_number] == 1 })
+    if first_word_is_free
+      return zero_timestamp + timecodes_for_first_line
+    end
+    # Otherwise just leave it as is.
+    timecodes_for_first_line
   end
 
 end

--- a/spec/models/oral_history_content_spec.rb
+++ b/spec/models/oral_history_content_spec.rb
@@ -110,9 +110,9 @@ describe OralHistoryContent do
       it "are as expected" do
         # we'll just check a sampling, we have one-second interval granularity in XML
         expect(ohms_xml.sync_timecodes.count).to eq(28)
-        expect(ohms_xml.sync_timecodes[13]).to  eq([{:word_number=>3, :seconds=>60    }])
-        expect(ohms_xml.sync_timecodes[19]).to  eq([{:word_number=>14, :seconds=>120  }])
-        expect(ohms_xml.sync_timecodes[308]).to eq([{:word_number=>2, :seconds=>1680 }])
+        expect(ohms_xml.sync_timecodes[13]).to  eq([{:line_number=>"13", :seconds=>60,  :word_number=>3}])
+        expect(ohms_xml.sync_timecodes[19]).to  eq([{:line_number=>"19", :seconds=>120, :word_number=>14}])
+        expect(ohms_xml.sync_timecodes[308]).to eq([{:line_number=>"308", :seconds=>1680, :word_number=>2}])
       end
     end
 

--- a/spec/models/oral_history_content_spec.rb
+++ b/spec/models/oral_history_content_spec.rb
@@ -110,10 +110,9 @@ describe OralHistoryContent do
       it "are as expected" do
         # we'll just check a sampling, we have one-second interval granularity in XML
         expect(ohms_xml.sync_timecodes.count).to eq(28)
-        expect(ohms_xml.sync_timecodes[13]).to eq({:word_number=>3, :seconds=>60, line_number: 13})
-        expect(ohms_xml.sync_timecodes[19]).to eq({:word_number=>14, :seconds=>120, :line_number=>19})
-
-        expect(ohms_xml.sync_timecodes[308]).to eq({:word_number=>2, :seconds=>1680, :line_number=>308})
+        expect(ohms_xml.sync_timecodes[13]).to  eq([{:word_number=>3, :seconds=>60    }])
+        expect(ohms_xml.sync_timecodes[19]).to  eq([{:word_number=>14, :seconds=>120  }])
+        expect(ohms_xml.sync_timecodes[308]).to eq([{:word_number=>2, :seconds=>1680 }])
       end
     end
 

--- a/spec/presenters/ohms_transcript_display_spec.rb
+++ b/spec/presenters/ohms_transcript_display_spec.rb
@@ -133,7 +133,7 @@ describe OhmsTranscriptDisplay, type: :presenter do
       it "assigns a zero timestamp" do
         expect(raw_timecodes_for_lines.to_a).to eq ["1(3)", "3(2)", "3(3)"]
         expect(processed_timecodes).to eq({
-            1=>[{:seconds=>60, :word_number=>3}]
+            1=>[{:line_number=>"1", :seconds=>60, :word_number=>3}]
         })
         expect(shown_timecodes).to eq( ["00:00:00", "", ""])
       end
@@ -171,7 +171,7 @@ describe OhmsTranscriptDisplay, type: :presenter do
       let(:end_line)   { 14 }
       it "keeps both, shows the first" do
         expect(raw_timecodes_for_lines.to_a).to eq ["14(1)", "14(3)"]
-        expect(processed_timecodes).to eq({14=>[{:seconds=>600, :word_number=>1}, {:seconds=>660, :word_number=>3}]})
+        expect(processed_timecodes).to eq({14=>[{:line_number=>"14", :seconds=>600, :word_number=>1}, {:line_number=>"14", :seconds=>660, :word_number=>3}]})
         expect(shown_timecodes).to eq(["00:10:00"])
       end
     end
@@ -184,13 +184,12 @@ describe OhmsTranscriptDisplay, type: :presenter do
           (1..25).map { |x| "1719(#{x})"} + # 25 consecutive timestamps in a row.
           ["1721(1)", "1724(7)"]
         )
+        # pp processed_timecodes
         expect(processed_timecodes).to eq({
-          1710=>[{:word_number=>1, :seconds=>15720}],
-          1714=>[{:word_number=>3, :seconds=>15780}],
-          # All the timestamps on 1719 are consecutive.
-          # So they get eliminated from the transcript display.
-          1721=>[{:word_number=>1, :seconds=>17340}],
-          1724=>[{:word_number=>7, :seconds=>17400}]
+          1710=>[{:line_number=>"1710", :word_number=>1, :seconds=>15720}],
+          1714=>[{:line_number=>"1714", :word_number=>3, :seconds=>15780}],
+          1721=>[{:line_number=>"1721", :word_number=>1, :seconds=>17340}],
+          1724=>[{:line_number=>"1724", :word_number=>7, :seconds=>17400}]
         })
         expect(shown_timecodes).to eq([
           "04:22:00", "", "", "",
@@ -205,35 +204,10 @@ describe OhmsTranscriptDisplay, type: :presenter do
       let(:start_line) { 1 }
       let(:end_line)   { 5 }
       it "does not add zero timestamp and eliminates pileup" do
-        #pp raw_timecodes_for_lines.to_a
         expect(raw_timecodes_for_lines.to_a).to eq(["1(1)", "3(2)", "3(3)", "3(4)"])
-
-        #pp processed_timecodes
-        expect(processed_timecodes).to eq({1=>[{:word_number=>1, :seconds=>60}]})
-        #pp shown_timecodes
-
+        expect(processed_timecodes).to eq(1=>[{:line_number=>"1", :seconds=>60, :word_number=>1}])
         expect(shown_timecodes).to eq(["00:01:00", "", "", "", ""])
-
-        # expect(raw_timecodes_for_lines.to_a).to eq(["1710(1)", "1714(3)"] +
-        #   (1..25).map { |x| "1719(#{x})"} + # 25 consecutive timestamps in a row.
-        #   ["1721(1)", "1724(7)"]
-        # )
-        # expect(processed_timecodes).to eq({
-        #   1710=>[{:word_number=>1, :seconds=>15720}],
-        #   1714=>[{:word_number=>3, :seconds=>15780}],
-        #   # All the timestamps on 1719 are consecutive.
-        #   # So they get eliminated from the transcript display.
-        #   1721=>[{:word_number=>1, :seconds=>17340}],
-        #   1724=>[{:word_number=>7, :seconds=>17400}]
-        # })
-        # expect(shown_timecodes).to eq([
-        #   "04:22:00", "", "", "",
-        #   "04:23:00", "", "", "", "", "", "",
-        #   "04:49:00", "", "",
-        #   "04:50:00", ""
-        # ])
       end
-
     end
   end
 end

--- a/spec/presenters/ohms_transcript_display_spec.rb
+++ b/spec/presenters/ohms_transcript_display_spec.rb
@@ -12,114 +12,75 @@ describe OhmsTranscriptDisplay, type: :presenter do
 
   let(:transcript_text) { ohms_xml.parsed.at_xpath("//ohms:transcript", ohms: OralHistoryContent::OhmsXml::OHMS_NS).text }
 
-  # it "produces good html" do
-  #   # we're just gonna spot check, while by the by ensuring that display does not raise.
-  #   parsed = Nokogiri::HTML.fragment(ohms_transcript_display.display)
+  it "produces good html" do
+    # we're just gonna spot check, while by the by ensuring that display does not raise.
+    parsed = Nokogiri::HTML.fragment(ohms_transcript_display.display)
 
-  #   expect(parsed.css("span.ohms-transcript-line").count).to eq(transcript_text.split("\n").count)
-  #   expect(parsed.css("p.ohms-transcript-paragraph").count).to eq(transcript_text.split("\n\n").count)
-  #   # plus one because we have added one for the 0 timestamp
-  #   expect(parsed.css("a.ohms-transcript-timestamp").count).to eq(ohms_xml.sync_timecodes.count + 1)
+    expect(parsed.css("span.ohms-transcript-line").count).to eq(transcript_text.split("\n").count)
+    expect(parsed.css("p.ohms-transcript-paragraph").count).to eq(transcript_text.split("\n\n").count)
+    # plus one because we have added one for the 0 timestamp
+    expect(parsed.css("a.ohms-transcript-timestamp").count).to eq(ohms_xml.sync_timecodes.count + 1)
 
-  #   first_line = parsed.css("div.ohms-transcript-container > p.ohms-transcript-paragraph > span.ohms-transcript-line").first
-  #   expect(first_line.to_html).to eq(
-  #     %Q{<span class="ohms-transcript-line" id="ohms_line_1"><a href="#" class="ohms-transcript-timestamp" data-ohms-timestamp-s="0">00:00:00</a><span class="ohms-speaker">BROCK:</span> This is an oral history interview with Ron Duarte taking place on 13 June \n</span>}
-  #   )
-  # end
+    first_line = parsed.css("div.ohms-transcript-container > p.ohms-transcript-paragraph > span.ohms-transcript-line").first
+    expect(first_line.to_html).to eq(
+      %Q{<span class="ohms-transcript-line" id="ohms_line_1"><a href="#" class="ohms-transcript-timestamp" data-ohms-timestamp-s="0">00:00:00</a><span class="ohms-speaker">BROCK:</span> This is an oral history interview with Ron Duarte taking place on 13 June \n</span>}
+    )
+  end
 
-  # it "properly renders footnotes and references to them" do
-  #   parsed = Nokogiri::HTML.fragment(ohms_transcript_display_with_footnotes.display)
-  #   line_with_first_footnote = parsed.css("#ohms_line_503").to_s
+  it "properly renders footnotes and references to them" do
+    parsed = Nokogiri::HTML.fragment(ohms_transcript_display_with_footnotes.display)
+    line_with_first_footnote = parsed.css("#ohms_line_503").to_s
 
-  #   expect(line_with_first_footnote).to match /Nemours/
-  #   expect(line_with_first_footnote).to include "\"Polyamides,\""
-  #   expect(line_with_first_footnote).to include "[1]"
+    expect(line_with_first_footnote).to match /Nemours/
+    expect(line_with_first_footnote).to include "\"Polyamides,\""
+    expect(line_with_first_footnote).to include "[1]"
 
-  #   expect(parsed.css(".footnote").count).to eq 2
+    expect(parsed.css(".footnote").count).to eq 2
 
-  #   f_array = ohms_xml_with_footnotes.footnote_array
-  #   expect(f_array [0]).to eq "William E. Hanford (to E.I. DuPont de Nemours & Co.), \"Polyamides,\" U.S. Patent 2,281,576, issued 5 May 1942."
-  #   expect(f_array [1]).to eq "Howard N. and Lucille L. Sloane, A Pictorial History of American Mining: The adventure and drama of finding and extracting nature's wealth from the earth, from pre-Columbian times to the present (New York: Crown Publishers, Inc., 1970)."
+    f_array = ohms_xml_with_footnotes.footnote_array
+    expect(f_array [0]).to eq "William E. Hanford (to E.I. DuPont de Nemours & Co.), \"Polyamides,\" U.S. Patent 2,281,576, issued 5 May 1942."
+    expect(f_array [1]).to eq "Howard N. and Lucille L. Sloane, A Pictorial History of American Mining: The adventure and drama of finding and extracting nature's wealth from the earth, from pre-Columbian times to the present (New York: Crown Publishers, Inc., 1970)."
 
-  #   # Footnotes themselves are HTML-escaped
-  #   first_footnote = ohms_transcript_display_with_footnotes.footnote_html(1)
-  #   expect(first_footnote).to match /Nemours/
-  #   expect(first_footnote).to include "&quot;Polyamides,&quot;"
-  #   expect(first_footnote).to include "[1]"
-  # end
+    # Footnotes themselves are HTML-escaped
+    first_footnote = ohms_transcript_display_with_footnotes.footnote_html(1)
+    expect(first_footnote).to match /Nemours/
+    expect(first_footnote).to include "&quot;Polyamides,&quot;"
+    expect(first_footnote).to include "[1]"
+  end
 
-  # # Footnotes and footnote references are expected
-  # # to be well-formed at display time.
-  # # If there are references to empty or missing footnotes,
-  # # there should not be a 500 error.
-  # it "does not raise if footnotes are not available" do
-  #   allow(ohms_xml_with_footnotes).to receive(:footnote_array).and_return([])
-  #   expect(ohms_xml_with_footnotes.footnote_array.count).to eq 0
-  #   expect { ohms_transcript_display_with_footnotes.footnote_html(1) }.not_to raise_error
-  #   expect { ohms_transcript_display_with_footnotes.footnote_html(42) }.not_to raise_error
-  # end
+  # Footnotes and footnote references are expected
+  # to be well-formed at display time.
+  # If there are references to empty or missing footnotes,
+  # there should not be a 500 error.
+  it "does not raise if footnotes are not available" do
+    allow(ohms_xml_with_footnotes).to receive(:footnote_array).and_return([])
+    expect(ohms_xml_with_footnotes.footnote_array.count).to eq 0
+    expect { ohms_transcript_display_with_footnotes.footnote_html(1) }.not_to raise_error
+    expect { ohms_transcript_display_with_footnotes.footnote_html(42) }.not_to raise_error
+  end
 
-  # it "HTML in footnotes is escaped" do
-  #   bad_chars = [ "The mathematician's \"daughter\" proved that x > 4." ]
-  #   allow(ohms_xml_with_footnotes).to receive(:footnote_array).and_return(bad_chars)
-  #   resulting_footnote = ohms_transcript_display_with_footnotes.footnote_html(1)
-  #   expect(resulting_footnote).to include '1. The mathematician&#39;s &quot;daughter&quot; proved that x &gt; 4.'
-  # end
+  it "HTML in footnotes is escaped" do
+    bad_chars = [ "The mathematician's \"daughter\" proved that x > 4." ]
+    allow(ohms_xml_with_footnotes).to receive(:footnote_array).and_return(bad_chars)
+    resulting_footnote = ohms_transcript_display_with_footnotes.footnote_html(1)
+    expect(resulting_footnote).to include '1. The mathematician&#39;s &quot;daughter&quot; proved that x &gt; 4.'
+  end
 
-  # it "Correctly handles several footnotes on one line -- and footnotes with spaces around the integer" do
-  #   allow(ohms_xml_with_footnotes).
-  #     to receive(:footnote_array).
-  #     and_return(["one", "two", "three"])
-  #   line = {
-  #     :text => "DUARTE: My grandfather Duarte [[footnote]] 1[[/footnote]] was Portuguese  [[footnote]]2 [[/footnote]] from the Azores  [[footnote]] 3   [[/footnote]] ",
-  #     :line_num=>10
-  #   }
-  #   formatted_line = ohms_transcript_display_with_footnotes.format_ohms_line(line)
-  #   expect(formatted_line).to include "[1]"
-  #   expect(formatted_line).to include "[2]"
-  #   expect(formatted_line).to include "[3]"
-  # end
+  it "Correctly handles several footnotes on one line -- and footnotes with spaces around the integer" do
+    allow(ohms_xml_with_footnotes).
+      to receive(:footnote_array).
+      and_return(["one", "two", "three"])
+    line = {
+      :text => "DUARTE: My grandfather Duarte [[footnote]] 1[[/footnote]] was Portuguese  [[footnote]]2 [[/footnote]] from the Azores  [[footnote]] 3   [[/footnote]] ",
+      :line_num=>10
+    }
+    formatted_line = ohms_transcript_display_with_footnotes.format_ohms_line(line)
+    expect(formatted_line).to include "[1]"
+    expect(formatted_line).to include "[2]"
+    expect(formatted_line).to include "[3]"
+  end
 
-
-  # context "consecutive times before break" do
-
-  #   let(:ohms_xml_path) { Rails.root + "spec/test_support/ohms_xml/consecutive_timestamps_before_break.xml"}
-  #   let(:parsed) { Nokogiri::HTML.fragment(ohms_transcript_display.display)}
-  #   let(:timecode_values) { ohms_transcript_display.sync_timecodes.values}
-  #   #let(:start_line) { 1710 }
-  #   #let(:end_line) {1725}
-
-  #   it "does not print out excess timecodes" do
-  #     pp ohms_transcript_display.sync_timecodes
-  #     # These lines contain 5 timecodes, with a big gap between the second and third:
-  #     area_around_blank_space = timecode_values.
-  #         select{ |li| li[:line_number] >= start_line && li[:line_number] <= end_line }
-  #     seconds_with_timecodes = area_around_blank_space.
-  #       map { |li| (li[:seconds]) }
-
-  #     # 17280 seconds - 15780 seconds == 25 minutes
-  #     expect(seconds_with_timecodes).to eq [15720, 15780, 17280, 17340, 17400]
-
-  #     # Print out the timecodes in each line.
-  #     # Lines with text, but no timecodes show up as blank strings.
-  #     timecodes_for_each_line = (start_line..end_line).to_a.
-  #       map{ |x| "#ohms_line_#{x} > .ohms-transcript-timestamp" }.
-  #       map{ |selector| parsed.css(selector).text }
-  #     # It only prints out the last timecode before the gap,
-  #     # and the first timecode after it.
-  #     expect(timecodes_for_each_line).to eq [
-  #       "04:22:00", "", "", "",
-  #       "04:23:00", "", "", "", "",
-  #       # .. a 25 minute gap is skipped over ...
-  #       "04:48:00", "",
-  #       "04:49:00", "", "",
-  #       "04:50:00", ""
-  #     ]
-  #   end
-  # end
-
-
-  context "25-minute gap between two consecutive timecodes" do
+  context "real-world example: 25-minute gap between two consecutive timecodes" do
     let(:ohms_ns) { "https://www.weareavp.com/nunncenter/ohms" }
     let(:ohms_xml_path) { Rails.root + "spec/test_support/ohms_xml/smythe_OH0042.xml"}
     let(:parsed) { Nokogiri::HTML.fragment(ohms_transcript_display.display)}
@@ -138,14 +99,14 @@ describe OhmsTranscriptDisplay, type: :presenter do
         line  <= end_line
       end.to_a
     end
-    let(:display_timecodes) do
+    let(:processed_timecodes) do
       ohms_transcript_display.sync_timecodes.select do |line, timecodes|
         line >= start_line &&
         line <= end_line
       end
     end
 
-    it "does not print out excess timecodes" do
+    it "correctly pares down the timecodes" do
       # These 5 lines contain 29 timecodes, with
       # 25 of them on the middle of the 5 lines:
       expect(raw_timestamps_around_gap.to_a).to eq ["1710(1)", "1714(3)"] +
@@ -153,7 +114,7 @@ describe OhmsTranscriptDisplay, type: :presenter do
         ["1721(1)", "1724(7)"]
 
       # Meanwhile, on the front end:
-      expect(display_timecodes).to eq({
+      expect(processed_timecodes).to eq({
         1710=>[{:word_number=>1, :seconds=>15720}],
         1714=>[{:word_number=>3, :seconds=>15780}],
         # All the timestamps on 1719 are consecutive.
@@ -161,22 +122,132 @@ describe OhmsTranscriptDisplay, type: :presenter do
         1721=>[{:word_number=>1, :seconds=>17340}],
         1724=>[{:word_number=>7, :seconds=>17400}]
       })
+    end
 
+    it "correctly assigns the timecodes to each line" do
       # Print out the timecodes in each line.
       # Lines with text, but no timecodes show up as blank strings.
-      timecodes_for_each_line = (start_line..end_line).to_a.
+      shown_timecodes = (start_line..end_line).to_a.
         map{ |x| "#ohms_line_#{x} > .ohms-transcript-timestamp" }.
         map{ |selector| parsed.css(selector).text }
+
       # It only prints out the last timecode before the gap,
       # and the first timecode after it.
-      expect(timecodes_for_each_line).to eq [
+      expect(shown_timecodes).to eq [
         "04:22:00", "", "", "",
         "04:23:00", "", "", "", "", "", "",
         "04:49:00", "", "",
         "04:50:00", ""
       ]
     end
+  end
 
+  context "Various placements of timecodes" do
+    let(:ohms_ns) { "https://www.weareavp.com/nunncenter/ohms" }
+    let(:ohms_xml_path) { Rails.root + "spec/test_support/ohms_xml/various_gaps.xml"}
+    let(:parsed) { Nokogiri::HTML.fragment(ohms_transcript_display.display)}
+
+    let(:raw_timestamps) do
+      sync = Nokogiri::XML(File.open(ohms_xml_path)).
+        at_xpath("//ohms:sync", ohms: ohms_ns).text
+      interval_m, stamps = sync.split(":")
+      stamps.split("|")
+    end
+
+    let(:raw_timestamps_for_lines) do
+      raw_timestamps.select do |ts|
+        line = ts.split("(")[0].to_i
+        line  >= start_line &&
+        line  <= end_line
+      end.to_a
+    end
+
+    let(:processed_timecodes) do
+      ohms_transcript_display.sync_timecodes.select do |line, timecodes|
+        line >= start_line &&
+        line <= end_line
+      end
+    end
+
+    let(:shown_timecodes) do
+      (start_line..end_line).to_a.
+        map{ |x| "#ohms_line_#{x} > .ohms-transcript-timestamp" }.
+        map{ |selector| parsed.css(selector).text }
+    end
+
+    context "line without any timestamps" do
+      let(:start_line) { 8 }
+      let(:end_line)   { 8 }
+      it "doesn't show any." do
+        expect(raw_timestamps_for_lines.to_a).to eq []
+        expect(processed_timecodes).to eq({})
+        expect(shown_timecodes).to eq([""])
+      end
+    end
+
+    context "first line is blank" do
+      let(:start_line) { 1 }
+      let(:end_line)   { 3 }
+      it "assigns a zero timestamp" do
+        allow(ohms_transcript_display).to receive(:sync_timecodes).and_return({})
+        expect(ohms_transcript_display.format_ohms_line({text: "some text", line_num: 1})).
+          to eq("<a href=\"#\" class=\"ohms-transcript-timestamp\" data-ohms-timestamp-s=\"0\">00:00:00</a>some text \n")
+        expect(shown_timecodes).to eq(["00:00:00", "", ""])
+      end
+    end
+
+    context "first word is free, although there are other timestamps on the first line" do
+      let(:start_line) { 1 }
+      let(:end_line)   { 3 }
+      it "assigns a zero timestamp" do
+        expect(raw_timestamps_for_lines.to_a).to eq ["1(3)", "3(2)", "3(3)"]
+        expect(processed_timecodes).to eq({
+            1=>[{:seconds=>60, :word_number=>3}]
+        })
+        expect(shown_timecodes).to eq( ["00:00:00", "", ""])
+      end
+    end
+
+    context "already a timestamp on the first word of the first line." do
+      let(:start_line) { 1 }
+      let(:end_line)   { 3 }
+      it "does not assign a zero timestamp " do
+        allow(ohms_transcript_display).to receive(:sync_timecodes).and_return(
+          { 1=>[{ :seconds=>120, :word_number=>1}] }
+        )
+        expect(ohms_transcript_display.format_ohms_line({text: "some text", line_num: 1})).
+          to eq("<a href=\"#\" class=\"ohms-transcript-timestamp\" data-ohms-timestamp-s=\"120\">00:02:00</a>some text \n")
+      end
+    end
+
+    context "line with two consecutive timestamps" do
+      let(:start_line) { 3 }
+      let(:end_line)   { 3 }
+      it "shows neither" do
+        expect(raw_timestamps_for_lines.to_a).to eq ["3(2)", "3(3)"]
+        expect(processed_timecodes).to eq({})
+        expect(shown_timecodes).to eq( [""])
+      end
+    end
+
+    context "line with two series of consecutive timestamps" do
+    let(:start_line) { 7 }
+    let(:end_line)   { 7 }
+      it "eliminates both series" do
+        expect(raw_timestamps_for_lines.to_a).to eq ["7(2)", "7(3)", "7(8)", "7(9)"]
+        expect(processed_timecodes).to eq({})
+      end
+    end
+
+    context "two nonconsecutive timestamps on the same line" do
+    let(:start_line) { 14 }
+    let(:end_line)   { 14 }
+      it "keeps both, shows the first" do
+        expect(raw_timestamps_for_lines.to_a).to eq ["14(1)", "14(3)"]
+        expect(processed_timecodes).to eq({14=>[{:seconds=>600, :word_number=>1}, {:seconds=>660, :word_number=>3}]})
+        expect(shown_timecodes).to eq(["00:10:00"])
+      end
+    end
 
   end
 end

--- a/spec/presenters/ohms_transcript_display_spec.rb
+++ b/spec/presenters/ohms_transcript_display_spec.rb
@@ -200,5 +200,40 @@ describe OhmsTranscriptDisplay, type: :presenter do
         ])
       end
     end
+    context "real world example w/ minute-1 timecode at word 1 and small pileup at line 3" do
+      let(:ohms_xml_path) { Rails.root + "spec/test_support/ohms_xml/smythe_OH0042.xml"}
+      let(:start_line) { 1 }
+      let(:end_line)   { 5 }
+      it "does not add zero timestamp and eliminates pileup" do
+        #pp raw_timecodes_for_lines.to_a
+        expect(raw_timecodes_for_lines.to_a).to eq(["1(1)", "3(2)", "3(3)", "3(4)"])
+
+        #pp processed_timecodes
+        expect(processed_timecodes).to eq({1=>[{:word_number=>1, :seconds=>60}]})
+        #pp shown_timecodes
+
+        expect(shown_timecodes).to eq(["00:01:00", "", "", "", ""])
+
+        # expect(raw_timecodes_for_lines.to_a).to eq(["1710(1)", "1714(3)"] +
+        #   (1..25).map { |x| "1719(#{x})"} + # 25 consecutive timestamps in a row.
+        #   ["1721(1)", "1724(7)"]
+        # )
+        # expect(processed_timecodes).to eq({
+        #   1710=>[{:word_number=>1, :seconds=>15720}],
+        #   1714=>[{:word_number=>3, :seconds=>15780}],
+        #   # All the timestamps on 1719 are consecutive.
+        #   # So they get eliminated from the transcript display.
+        #   1721=>[{:word_number=>1, :seconds=>17340}],
+        #   1724=>[{:word_number=>7, :seconds=>17400}]
+        # })
+        # expect(shown_timecodes).to eq([
+        #   "04:22:00", "", "", "",
+        #   "04:23:00", "", "", "", "", "", "",
+        #   "04:49:00", "", "",
+        #   "04:50:00", ""
+        # ])
+      end
+
+    end
   end
 end

--- a/spec/presenters/ohms_transcript_display_spec.rb
+++ b/spec/presenters/ohms_transcript_display_spec.rb
@@ -12,91 +12,155 @@ describe OhmsTranscriptDisplay, type: :presenter do
 
   let(:transcript_text) { ohms_xml.parsed.at_xpath("//ohms:transcript", ohms: OralHistoryContent::OhmsXml::OHMS_NS).text }
 
-  it "produces good html" do
-    # we're just gonna spot check, while by the by ensuring that display does not raise.
-    parsed = Nokogiri::HTML.fragment(ohms_transcript_display.display)
+  # it "produces good html" do
+  #   # we're just gonna spot check, while by the by ensuring that display does not raise.
+  #   parsed = Nokogiri::HTML.fragment(ohms_transcript_display.display)
 
-    expect(parsed.css("span.ohms-transcript-line").count).to eq(transcript_text.split("\n").count)
-    expect(parsed.css("p.ohms-transcript-paragraph").count).to eq(transcript_text.split("\n\n").count)
-    # plus one because we have added one for the 0 timestamp
-    expect(parsed.css("a.ohms-transcript-timestamp").count).to eq(ohms_xml.sync_timecodes.count + 1)
+  #   expect(parsed.css("span.ohms-transcript-line").count).to eq(transcript_text.split("\n").count)
+  #   expect(parsed.css("p.ohms-transcript-paragraph").count).to eq(transcript_text.split("\n\n").count)
+  #   # plus one because we have added one for the 0 timestamp
+  #   expect(parsed.css("a.ohms-transcript-timestamp").count).to eq(ohms_xml.sync_timecodes.count + 1)
 
-    first_line = parsed.css("div.ohms-transcript-container > p.ohms-transcript-paragraph > span.ohms-transcript-line").first
-    expect(first_line.to_html).to eq(
-      %Q{<span class="ohms-transcript-line" id="ohms_line_1"><a href="#" class="ohms-transcript-timestamp" data-ohms-timestamp-s="0">00:00:00</a><span class="ohms-speaker">BROCK:</span> This is an oral history interview with Ron Duarte taking place on 13 June \n</span>}
-    )
-  end
+  #   first_line = parsed.css("div.ohms-transcript-container > p.ohms-transcript-paragraph > span.ohms-transcript-line").first
+  #   expect(first_line.to_html).to eq(
+  #     %Q{<span class="ohms-transcript-line" id="ohms_line_1"><a href="#" class="ohms-transcript-timestamp" data-ohms-timestamp-s="0">00:00:00</a><span class="ohms-speaker">BROCK:</span> This is an oral history interview with Ron Duarte taking place on 13 June \n</span>}
+  #   )
+  # end
 
-  it "properly renders footnotes and references to them" do
-    parsed = Nokogiri::HTML.fragment(ohms_transcript_display_with_footnotes.display)
-    line_with_first_footnote = parsed.css("#ohms_line_503").to_s
+  # it "properly renders footnotes and references to them" do
+  #   parsed = Nokogiri::HTML.fragment(ohms_transcript_display_with_footnotes.display)
+  #   line_with_first_footnote = parsed.css("#ohms_line_503").to_s
 
-    expect(line_with_first_footnote).to match /Nemours/
-    expect(line_with_first_footnote).to include "\"Polyamides,\""
-    expect(line_with_first_footnote).to include "[1]"
+  #   expect(line_with_first_footnote).to match /Nemours/
+  #   expect(line_with_first_footnote).to include "\"Polyamides,\""
+  #   expect(line_with_first_footnote).to include "[1]"
 
-    expect(parsed.css(".footnote").count).to eq 2
+  #   expect(parsed.css(".footnote").count).to eq 2
 
-    f_array = ohms_xml_with_footnotes.footnote_array
-    expect(f_array [0]).to eq "William E. Hanford (to E.I. DuPont de Nemours & Co.), \"Polyamides,\" U.S. Patent 2,281,576, issued 5 May 1942."
-    expect(f_array [1]).to eq "Howard N. and Lucille L. Sloane, A Pictorial History of American Mining: The adventure and drama of finding and extracting nature's wealth from the earth, from pre-Columbian times to the present (New York: Crown Publishers, Inc., 1970)."
+  #   f_array = ohms_xml_with_footnotes.footnote_array
+  #   expect(f_array [0]).to eq "William E. Hanford (to E.I. DuPont de Nemours & Co.), \"Polyamides,\" U.S. Patent 2,281,576, issued 5 May 1942."
+  #   expect(f_array [1]).to eq "Howard N. and Lucille L. Sloane, A Pictorial History of American Mining: The adventure and drama of finding and extracting nature's wealth from the earth, from pre-Columbian times to the present (New York: Crown Publishers, Inc., 1970)."
 
-    # Footnotes themselves are HTML-escaped
-    first_footnote = ohms_transcript_display_with_footnotes.footnote_html(1)
-    expect(first_footnote).to match /Nemours/
-    expect(first_footnote).to include "&quot;Polyamides,&quot;"
-    expect(first_footnote).to include "[1]"
-  end
+  #   # Footnotes themselves are HTML-escaped
+  #   first_footnote = ohms_transcript_display_with_footnotes.footnote_html(1)
+  #   expect(first_footnote).to match /Nemours/
+  #   expect(first_footnote).to include "&quot;Polyamides,&quot;"
+  #   expect(first_footnote).to include "[1]"
+  # end
 
-  # Footnotes and footnote references are expected
-  # to be well-formed at display time.
-  # If there are references to empty or missing footnotes,
-  # there should not be a 500 error.
-  it "does not raise if footnotes are not available" do
-    allow(ohms_xml_with_footnotes).to receive(:footnote_array).and_return([])
-    expect(ohms_xml_with_footnotes.footnote_array.count).to eq 0
-    expect { ohms_transcript_display_with_footnotes.footnote_html(1) }.not_to raise_error
-    expect { ohms_transcript_display_with_footnotes.footnote_html(42) }.not_to raise_error
-  end
+  # # Footnotes and footnote references are expected
+  # # to be well-formed at display time.
+  # # If there are references to empty or missing footnotes,
+  # # there should not be a 500 error.
+  # it "does not raise if footnotes are not available" do
+  #   allow(ohms_xml_with_footnotes).to receive(:footnote_array).and_return([])
+  #   expect(ohms_xml_with_footnotes.footnote_array.count).to eq 0
+  #   expect { ohms_transcript_display_with_footnotes.footnote_html(1) }.not_to raise_error
+  #   expect { ohms_transcript_display_with_footnotes.footnote_html(42) }.not_to raise_error
+  # end
 
-  it "HTML in footnotes is escaped" do
-    bad_chars = [ "The mathematician's \"daughter\" proved that x > 4." ]
-    allow(ohms_xml_with_footnotes).to receive(:footnote_array).and_return(bad_chars)
-    resulting_footnote = ohms_transcript_display_with_footnotes.footnote_html(1)
-    expect(resulting_footnote).to include '1. The mathematician&#39;s &quot;daughter&quot; proved that x &gt; 4.'
-  end
+  # it "HTML in footnotes is escaped" do
+  #   bad_chars = [ "The mathematician's \"daughter\" proved that x > 4." ]
+  #   allow(ohms_xml_with_footnotes).to receive(:footnote_array).and_return(bad_chars)
+  #   resulting_footnote = ohms_transcript_display_with_footnotes.footnote_html(1)
+  #   expect(resulting_footnote).to include '1. The mathematician&#39;s &quot;daughter&quot; proved that x &gt; 4.'
+  # end
 
-  it "Correctly handles several footnotes on one line -- and footnotes with spaces around the integer" do
-    allow(ohms_xml_with_footnotes).
-      to receive(:footnote_array).
-      and_return(["one", "two", "three"])
-    line = {
-      :text => "DUARTE: My grandfather Duarte [[footnote]] 1[[/footnote]] was Portuguese  [[footnote]]2 [[/footnote]] from the Azores  [[footnote]] 3   [[/footnote]] ",
-      :line_num=>10
-    }
-    formatted_line = ohms_transcript_display_with_footnotes.format_ohms_line(line)
-    expect(formatted_line).to include "[1]"
-    expect(formatted_line).to include "[2]"
-    expect(formatted_line).to include "[3]"
-  end
+  # it "Correctly handles several footnotes on one line -- and footnotes with spaces around the integer" do
+  #   allow(ohms_xml_with_footnotes).
+  #     to receive(:footnote_array).
+  #     and_return(["one", "two", "three"])
+  #   line = {
+  #     :text => "DUARTE: My grandfather Duarte [[footnote]] 1[[/footnote]] was Portuguese  [[footnote]]2 [[/footnote]] from the Azores  [[footnote]] 3   [[/footnote]] ",
+  #     :line_num=>10
+  #   }
+  #   formatted_line = ohms_transcript_display_with_footnotes.format_ohms_line(line)
+  #   expect(formatted_line).to include "[1]"
+  #   expect(formatted_line).to include "[2]"
+  #   expect(formatted_line).to include "[3]"
+  # end
+
+
+  # context "consecutive times before break" do
+
+  #   let(:ohms_xml_path) { Rails.root + "spec/test_support/ohms_xml/consecutive_timestamps_before_break.xml"}
+  #   let(:parsed) { Nokogiri::HTML.fragment(ohms_transcript_display.display)}
+  #   let(:timecode_values) { ohms_transcript_display.sync_timecodes.values}
+  #   #let(:start_line) { 1710 }
+  #   #let(:end_line) {1725}
+
+  #   it "does not print out excess timecodes" do
+  #     pp ohms_transcript_display.sync_timecodes
+  #     # These lines contain 5 timecodes, with a big gap between the second and third:
+  #     area_around_blank_space = timecode_values.
+  #         select{ |li| li[:line_number] >= start_line && li[:line_number] <= end_line }
+  #     seconds_with_timecodes = area_around_blank_space.
+  #       map { |li| (li[:seconds]) }
+
+  #     # 17280 seconds - 15780 seconds == 25 minutes
+  #     expect(seconds_with_timecodes).to eq [15720, 15780, 17280, 17340, 17400]
+
+  #     # Print out the timecodes in each line.
+  #     # Lines with text, but no timecodes show up as blank strings.
+  #     timecodes_for_each_line = (start_line..end_line).to_a.
+  #       map{ |x| "#ohms_line_#{x} > .ohms-transcript-timestamp" }.
+  #       map{ |selector| parsed.css(selector).text }
+  #     # It only prints out the last timecode before the gap,
+  #     # and the first timecode after it.
+  #     expect(timecodes_for_each_line).to eq [
+  #       "04:22:00", "", "", "",
+  #       "04:23:00", "", "", "", "",
+  #       # .. a 25 minute gap is skipped over ...
+  #       "04:48:00", "",
+  #       "04:49:00", "", "",
+  #       "04:50:00", ""
+  #     ]
+  #   end
+  # end
+
 
   context "25-minute gap between two consecutive timecodes" do
-
+    let(:ohms_ns) { "https://www.weareavp.com/nunncenter/ohms" }
     let(:ohms_xml_path) { Rails.root + "spec/test_support/ohms_xml/smythe_OH0042.xml"}
     let(:parsed) { Nokogiri::HTML.fragment(ohms_transcript_display.display)}
-    let(:timecode_values) { ohms_transcript_display.sync_timecodes.values}
     let(:start_line) { 1710 }
     let(:end_line) {1725}
+    let(:raw_timestamps) do
+      parsed = Nokogiri::XML(File.open(ohms_xml_path))
+      sync = parsed.at_xpath("//ohms:sync", ohms: ohms_ns).text
+      interval_m, stamps = sync.split(":")
+      stamps.split("|")
+    end
+    let(:raw_timestamps_around_gap) do
+      raw_timestamps.select do |ts|
+        line = ts.split("(")[0].to_i
+        line  >= start_line &&
+        line  <= end_line
+      end.to_a
+    end
+    let(:display_timecodes) do
+      ohms_transcript_display.sync_timecodes.select do |line, timecodes|
+        line >= start_line &&
+        line <= end_line
+      end
+    end
 
     it "does not print out excess timecodes" do
-      # These lines contain 5 timecodes, with a big gap between the second and third:
-      area_around_blank_space = timecode_values.
-          select{ |li| li[:line_number] >= start_line && li[:line_number] <= end_line }
-      seconds_with_timecodes = area_around_blank_space.
-        map { |li| (li[:seconds]) }
+      # These 5 lines contain 29 timecodes, with
+      # 25 of them on the middle of the 5 lines:
+      expect(raw_timestamps_around_gap.to_a).to eq ["1710(1)", "1714(3)"] +
+        (1..25).map { |x| "1719(#{x})"} + # 25 consecutive timestamps in a row.
+        ["1721(1)", "1724(7)"]
 
-      # 17280 seconds - 15780 seconds == 25 minutes
-      expect(seconds_with_timecodes).to eq [15720, 15780, 17280, 17340, 17400]
+      # Meanwhile, on the front end:
+      expect(display_timecodes).to eq({
+        1710=>[{:word_number=>1, :seconds=>15720}],
+        1714=>[{:word_number=>3, :seconds=>15780}],
+        # All the timestamps on 1719 are consecutive.
+        # So they get eliminated from the transcript display.
+        1721=>[{:word_number=>1, :seconds=>17340}],
+        1724=>[{:word_number=>7, :seconds=>17400}]
+      })
 
       # Print out the timecodes in each line.
       # Lines with text, but no timecodes show up as blank strings.
@@ -107,12 +171,12 @@ describe OhmsTranscriptDisplay, type: :presenter do
       # and the first timecode after it.
       expect(timecodes_for_each_line).to eq [
         "04:22:00", "", "", "",
-        "04:23:00", "", "", "", "",
-        # .. a 25 minute gap is skipped over ...
-        "04:48:00", "",
+        "04:23:00", "", "", "", "", "", "",
         "04:49:00", "", "",
         "04:50:00", ""
       ]
     end
+
+
   end
 end

--- a/spec/test_support/ohms_xml/smythe_OH0042.xml
+++ b/spec/test_support/ohms_xml/smythe_OH0042.xml
@@ -1,0 +1,2906 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ROOT xmlns="https://www.weareavp.com/nunncenter/ohms" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.weareavp.com/nunncenter/ohms/ohms.xsd"><record id="00089689" dt="2020-04-28"><version>5.4</version><date value="" format="yyyy-mm-dd"/><date_nonpreferred_format>Unknown Date</date_nonpreferred_format><cms_record_id></cms_record_id><title>Oral history interview with Charles P. Smyth</title><accession>OH0042</accession><duration></duration><collection_id>2S</collection_id><collection_name></collection_name><series_id></series_id><series_name></series_name><repository>Science History Institute</repository><funding></funding><repository_url /><file_name></file_name><sync>1:|1(1)|3(2)|3(3)|3(4)|9(6)|15(6)|20(9)|27(11)|33(4)|40(3)|46(5)|59(2)|63(2)|71(17)|80(10)|92(7)|102(2)|112(11)|122(6)|128(4)|137(12)|148(13)|161(5)|171(8)|182(8)|195(2)|206(3)|211(4)|220(6)|229(9)|235(1)|237(2)|245(8)|250(10)|262(6)|273(14)|278(9)|292(2)|296(16)|298(12)|312(4)|316(11)|328(2)|336(9)|346(2)|353(10)|361(6)|373(2)|378(2)|387(9)|394(1)|405(6)|411(7)|424(2)|428(6)|437(12)|444(11)|455(2)|468(2)|475(4)|486(1)|488(2)|491(8)|504(6)|510(1)|517(7)|526(9)|531(12)|538(5)|542(13)|547(9)|555(7)|563(4)|573(2)|582(9)|591(11)|607(12)|616(10)|628(2)|634(12)|641(3)|650(12)|660(10)|666(2)|671(13)|679(6)|684(11)|692(2)|703(15)|718(3)|738(2)|749(2)|755(1)|755(2)|757(2)|760(2)|769(12)|777(8)|783(7)|797(5)|804(1)|813(1)|823(2)|824(15)|829(4)|837(11)|843(12)|852(2)|857(12)|864(2)|872(4)|886(1)|894(13)|905(8)|918(2)|923(7)|930(8)|935(8)|946(2)|952(16)|959(7)|966(2)|972(8)|981(5)|988(2)|990(12)|994(14)|1000(14)|1005(5)|1009(9)|1016(13)|1022(9)|1030(3)|1040(4)|1054(7)|1062(4)|1071(2)|1080(3)|1086(13)|1096(4)|1107(8)|1117(4)|1127(2)|1132(2)|1135(5)|1148(6)|1158(5)|1163(3)|1169(3)|1173(2)|1177(11)|1182(1)|1184(8)|1187(14)|1193(1)|1204(1)|1204(2)|1204(3)|1206(2)|1213(2)|1219(3)|1227(16)|1238(2)|1250(16)|1260(4)|1267(8)|1272(10)|1287(7)|1293(3)|1299(9)|1306(1)|1314(10)|1320(3)|1328(5)|1334(5)|1340(15)|1351(5)|1357(13)|1364(8)|1368(3)|1371(17)|1373(1)|1373(2)|1373(3)|1373(4)|1373(5)|1373(6)|1373(7)|1377(1)|1379(10)|1384(7)|1388(15)|1394(10)|1400(1)|1405(3)|1409(11)|1415(5)|1424(12)|1430(10)|1435(11)|1441(6)|1449(5)|1457(7)|1462(7)|1474(12)|1477(5)|1487(4)|1493(2)|1495(7)|1501(3)|1507(15)|1516(5)|1521(3)|1525(12)|1529(2)|1534(11)|1540(11)|1545(10)|1550(1)|1558(9)|1562(1)|1562(2)|1562(3)|1564(1)|1565(3)|1571(3)|1577(1)|1581(11)|1589(1)|1589(2)|1589(3)|1591(1)|1594(7)|1598(12)|1602(1)|1602(2)|1602(19)|1607(6)|1613(1)|1618(9)|1624(5)|1631(14)|1636(3)|1641(5)|1645(11)|1648(10)|1654(2)|1658(5)|1662(14)|1670(6)|1674(5)|1680(10)|1687(5)|1692(16)|1696(9)|1700(1)|1700(2)|1700(3)|1700(4)|1703(1)|1703(2)|1710(1)|1714(3)|1719(1)|1719(2)|1719(3)|1719(4)|1719(5)|1719(6)|1719(7)|1719(8)|1719(9)|1719(10)|1719(11)|1719(12)|1719(13)|1719(14)|1719(15)|1719(16)|1719(17)|1719(18)|1719(19)|1719(20)|1719(21)|1719(22)|1719(23)|1719(24)|1719(25)|1721(1)|1724(7)|1726(1)|1726(2)|1726(3)|1728(1)|1729(12)|1736(11)|1742(2)|1746(1)|1746(2)|1746(3)|1746(4)|1746(5)|1746(6)|1746(7)|1746(8)|1746(9)|1746(10)|1746(11)|1774(9)|1777(14)|1785(8)|1791(3)|1798(1)|1804(12)|1811(1)|1813(10)|1815(11)|1818(5)|1819(11)|1819(12)|1823(11)|1827(10)|1831(8)|1836(12)|1840(4)|1842(1)|1842(2)|1842(3)|1844(1)|1844(17)|1851(1)|1854(6)|1858(13)|1863(6)|1863(7)|1864(6)|1869(13)|1874(6)|1878(12)|1883(9)|1888(9)|1893(9)|1897(1)|1901(8)|1907(6)|1909(6)|1913(10)|1918(10)|1920(9)|1926(9)|1929(10)|1933(8)|1936(4)|1939(11)|1943(3)|1946(16)|1951(5)|1957(1)|1960(6)|1963(7)|1965(1)|1965(2)|1965(3)|1967(1)|1967(18)|1971(2)|1974(8)|1979(9)|1984(8)|1989(3)|1992(4)|1997(5)|1999(14)|2002(5)|2004(3)|2007(8)|2012(1)|2017(2)|2021(9)|2027(1)|2029(4)|2032(13)|2036(13)|2043(4)|2049(1)|2053(12)|2058(9)|2063(5)|2068(2)|2072(5)|2077(6)|2082(12)|2087(1)|2090(13)|2095(1)|2099(1)|2099(2)|2099(3)|2101(1)|2102(1)|2105(10)|2110(1)|2113(14)|2119(3)|2125(5)|2129(9)|2135(2)|2140(9)|2148(6)|2152(8)|2157(2)|2161(8)|2168(2)|2171(10)|2174(8)|2179(9)|2182(10)|2188(7)|2195(1)|2199(6)|2205(3)|2209(10)|2214(6)|2218(8)|2223(1)|2229(7)|2235(8)|2240(8)|2243(10)|2247(10)|2250(1)|2250(2)|2250(3)|2252(1)|2255(1)|2258(6)|2267(1)|2270(3)|2275(7)|2279(9)|2283(13)|2288(7)|2293(9)|2295(11)|2299(1)|2303(11)|2307(12)|2311(14)|2317(4)|2322(9)|2328(12)|2331(7)|2341(13)|2347(8)|2351(13)|2355(13)|2361(5)|2366(3)|2371(2)|2374(3)|2378(6)|2383(10)|2389(10)|2394(1)|2397(1)|2397(2)|2397(3)|2399(1)|2399(10)|2403(5)|2407(10)|2414(1)|2416(10)|2420(4)|2425(5)|2428(9)|2434(4)|2437(13)|2441(4)|2445(11)|2449(5)|2452(11)|2455(14)|2460(9)|2467(1)|2470(10)|2475(1)|2475(2)|2478(5)|2483(2)|2487(10)|2492(7)|2498(14)|2502(2)|2505(15)|2510(13)|2517(10)|2521(4)|2524(6)|2527(1)|2527(2)|2527(3)|2529(1)|2529(13)|2532(3)|2537(3)|2540(9)|2544(9)|2549(2)|2555(1)|2558(6)|2560(2)|2565(2)|2570(1)|2573(2)|2576(8)|2583(13)|2587(2)|2592(8)|2597(3)|2601(10)|2653(8)|2657(7)|2660(13)|2667(7)|2672(4)|2677(3)|2681(5)|2684(12)|2689(3)|2692(11)|2696(12)|2702(6)|2708(12)|2711(1)|2711(2)|2711(3)|2713(1)|2714(2)|2718(10)|2723(14)|2732(6)|2737(1)|2739(10)|2743(5)|2746(1)|2746(2)|2746(3)|2746(4)|2746(5)|2746(6)|2746(7)|2746(8)|2746(9)|2746(10)|2746(11)|2746(12)|2749(10)|2752(5)|2757(15)|2762(4)|2768(1)|2772(7)|2782(1)|2787(8)|2788(11)|2788(12)|2788(13)|2789(4)|2793(1)|2793(2)|2793(3)|2795(1)|2796(1)|2800(10)|2802(7)|2804(1)|2804(10)|2808(7)|2812(8)|2816(8)|2819(1)</sync><sync_alt></sync_alt><transcript_alt_lang></transcript_alt_lang><translate>0</translate><media_id></media_id><media_url>https://scihist-digicoll-production-derivatives.s3.amazonaws.com/combined_audio_derivatives/88fbb7a9-e693-4c7d-9c01-bcfd05fbdae6/combined_099a56d3aae9f6970a10f589f22d2746.mp3</media_url><mediafile><host>Other</host><avalon_target_domain></avalon_target_domain><host_account_id></host_account_id><host_player_id></host_player_id><host_clip_id></host_clip_id><clip_format>audio</clip_format></mediafile><kembed></kembed><language></language><user_notes></user_notes><index><point><time>0</time><title>Pre-interview Discussion</title><title_alt></title_alt><partial_transcript>untranscribed</partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis></synopsis><synopsis_alt></synopsis_alt><keywords></keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink></hyperlink><hyperlink_text></hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point><point><time>256</time><title>	Family and Early and Undergraduate Education</title><title_alt></title_alt><partial_transcript>STURCHIO: We'd like to start with asking you about your childhood.</partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis>Many family members are scientists. Attends the Lawrenceville school and Princeton University in pursuit of a broad education, and enters the chemistry department. Discusses classmates, professors, curriculum and facilities at Princeton.</synopsis><synopsis_alt></synopsis_alt><keywords>Alyea, Hubert N.;Armstrong, Hamilton F.;Arrhenius, Svante;Benzene ring;Bodenstein, Max;Bureau of Mines (US);Carnegie, Andrew;Chemical Warfare Service;Chemistry curricula;Chemistry Department (Princeton);Clemenceau, Georges;Clinton, New York;Columbia University;Connecticut College;Cousins;Donnan, Frederick George;Early education;Family;Faraday Society;Fathers;Fine Hall (Princeton);First World War (WWI);Foreign Affairs;Frick Chemistry Laboratory (Princeton);Frick, Henry Clay;George V;Hulett, George A.;John C. Green School of Science (Princeton);Lawrenceville school;League of Nations;Leipzig, Germany;Massachusetts Institute of Technology (MIT);McCay, LeRoy W.;Mercury;Military ranks;Mudd, Stuart;National Bureau of Standards (NBS);Nobel Institute for Physical Research;Ordnance Department (US Army);Palmer Laboratory (Princeton);Perrott, George;Philadelphia Orchestra;Physical chemistry;Physics Department (Princeton);Pittsburgh, Pennsylvania;Princeton University;Smyth, Frederic Hastings;Smyth, Henry DeWolf;Specific heats;Taylor, Hugh S.;Undergraduate education;University of Liverpool;University of Pennsylvania;Vassar College;World War I (WWI)</keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink>https://digital.sciencehistory.org/works/cf95jc49c</hyperlink><hyperlink_text>Oral history interview with Hubert N. Alyea</hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point><point><time>1374</time><title>National Bureau of Standards and Chemical Warfare Service</title><title_alt></title_alt><partial_transcript>STURCHIO: Were things very different at the National Bureau of Standards when you went there?</partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis>Works on an electroplating project as part of the war effort. Discusses colleagues at the National Bureau of Standards. Becomes second lieutenant in the Army Ordnance Department and works on poison gas. Discusses safety standards and toxic substances. Names the best physical chemists in that era.</synopsis><synopsis_alt></synopsis_alt><keywords>American University;Baltimore, Maryland;Blum, William;Cambridge, England;Chemical Warfare Service;Columbia University;Compton, Karl T.;Conant, James B.;Cyanide;Electroplating;Fathers;First World War (WWI);Furman, N. Howell;Hulett, George A.;Jones, W. Lauder;Lawrenceville school;Lewis, Gilbert N.;Merck &amp; Company;Mercury;Military ranks;National Bureau of Standards (NBS);Noyes, Arthur A.;Ordnance Department (US Army);Organic chemistry;Pease, Robert N.;Physical chemistry;Princeton University;Richards, Theodore W.;Rutherford, Ernest;Smith, Alexander;Smyth, Henry DeWolf;Standard Oil of Indiana;Tolman, Richard, C.;Undergraduate education;Washburn, Edward W.;Washington, D.C.;Wilson, Robert E.;World War I (WWI);Zinc electroplating</keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink></hyperlink><hyperlink_text></hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point><point><time>2570</time><title>Graduate Education at Harvard University</title><title_alt></title_alt><partial_transcript>STURCHIO: Let's get back to American University and the Chemical Warfare Service. </partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis>Attends Harvard after World War I. Pursues thesis on thallium amalgam project with T. W. Richards. Discusses colleagues and faculty at Harvard.</synopsis><synopsis_alt></synopsis_alt><keywords>Adams, Roger;American University;Armistice;Bryn Mawr College;Cambridge, Massachusetts;Charles River, Cambridge;Chemical Warfare Service;Conant, James B.;Coolidge, Albert Sprague;Craig, William M.;Daniels, Farrington;Forbes, George S.;Graduate school;Harvard University;Instructorships;Journal of the American Chemical Society (JACS);Kohler, Elmer P.;Krepelka, Henry;Lamb, Arthur B.;Lewis, Gilbert N.;Mercury;Nazis;Nobel laureates;Oral examinations (PhD);Organic chemistry;Physical chemistry department (Harvard);Prague, Czechoslovakia;Princeton University;Richards, Theodore W.;Richards, William T.;Thallium amalgams;Thermodynamics;Thesis (PhD);Undergraduate education;University of California, Berkeley;University of Prague;Whitmore, Frank C. &quot;Rocky&quot;;Wolcott Gibbs Laboratory (Harvard)</keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink></hyperlink><hyperlink_text></hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point><point><time>3440</time><title>Early Career at Princeton University</title><title_alt></title_alt><partial_transcript>STURCHIO: It's something how one remembers experiences like that; I remember some of my oral exams also.</partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis>Accepts instructorship at Princeton. Teaches freshman lab while completing thesis. Discusses relationships with Karl Compton and William Foster. Research program options of infrared, atom smashing or dielectrics. Students. Chemical physics versus physical chemistry. Early publications on dipole moment. Research expenses, research support, and consulting. Instrument building.</synopsis><synopsis_alt></synopsis_alt><keywords>American Philosophical Society;Atom smashing;Baker, William O.;Beckman, Arnold O.;Bell Laboratories;Benzene structure;Boyce, Joseph C.;Bureau of Mines (US);California Institute of Technology (Caltech);Chemical physics;Chemistry Department (Princeton);Chicago, Illinois;Compton, Karl T.;Conant, James B.;Cooke, Lester;Cyclohexane ring;Debye, Peter J.W.;Dielectric constants;Dielectrics;Dipole moments;Foster, William C.;General Electric Company (GE);General Radio Company;Groves, Chester;Hannay, N. Bruce;Hulett, George A.;Illinois Institute of Technology;Infrared spectroscopy;Insulation breakdown;Interdepartmental cooperation (Princeton);Jones, W. Lauder;Kekule model;Kekule von Stradonitz, Friedrich August;Kharasch, Morris S.;Magie, William F.;Massachusetts Institute of Technology (MIT);Morgan, Stanley O.;National Academy of Sciences;Office of Naval Research (ONR);Partial vapor pressure;Perrin, Jean B.;Philosophical Magazine;Physical chemistry;Precision condenser;Princeton University;Public Service Corporation of New Jersey;Research funding (Princeton);Russell, Henry Norris;Second World War (WWII);Students;Taylor, Hugh S.;Textbooks;Thermodynamics;Thesis (PhD);Tungsten;Ultracentrifuge;University of Illinois;University of Wisconsin;Williams, John W.;World War II (WWII);Zahn, Charles T.</keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink>https://digital.sciencehistory.org/works/9019s341g</hyperlink><hyperlink_text>Oral history interview with William O. Baker</hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks><hyperlinks><hyperlink>https://digital.sciencehistory.org/works/th83m0405</hyperlink><hyperlink_text>Oral history interview with N. Bruce Hannay</hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point><point><time>5849</time><title>Early Voyages to Europe</title><title_alt></title_alt><partial_transcript>STURCHIO: In one of your autobiographical sketches, you noted you went to Europe first in 1923.</partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis>Travels to Bucharest as the American delegate to the International Union of Pure and Applied Chemistry. Meets Peter Debye and visits his lab in Leipzig. European colleagues Karl Bonhoffer and James Franck.</synopsis><synopsis_alt></synopsis_alt><keywords>Black Sea;Bonhoffer, Karl F.;Bucharest, Romania;Debye, Peter J.W.;Eidgenossische Technische Hochschule (ETH);Franck, James;Gottingen, Germany;Heitler, Walter;International Union of Pure and Applied Chemistry (IUPAC);Istanbul, Turkey;Leipzig, Germany;Nazis;Pauling, Linus;Royal Society of Chemistry;Teller, Edward;Zurich, Switzerland</keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink>https://digital.sciencehistory.org/works/5h73px42w</hyperlink><hyperlink_text>Oral history interview with Linus C. Pauling</hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point><point><time>6609</time><title>Princeton University in the 1920s and 1930s</title><title_alt></title_alt><partial_transcript>STURCHIO: Could we come back to Princeton in the late 1920s and early 1930s and ask [. . .] how life at the chemistry department changed after the new Frick Laboratory was put up and as Hugh Taylor began to expand the department? </partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis>Studies quantum mechanics with Eugene Wigner. Departmental colloquia with Niels Bohr and Niels Bjerrum. Collaboration with Henry Eyring. Princeton attempts to recruit Debye and Enrico Fermi. Publications on resonance shifts in organic molecules. Collaboration with Kodak.</synopsis><synopsis_alt></synopsis_alt><keywords>Benzene structure;Bjerrum, Niels J.;Bohr, Niels H. D.;Bonbright and Company;Bonhoffer, Dietrich;Bonhoffer, Karl F.;Brooker, L. G. S.;Carver, Emmett;Chicago, Illinois;Compton, Karl T.;Crossley, Moses L.;Debye, Peter J.W.;Dipole moments;Eastman Kodak Company;Eidgenossische Technische Hochschule (ETH);Fascism (Italy);Fermi, Enrico;Franck, James;Frick Chemistry Laboratory (Princeton);Fundamentals of Physical Chemistry;Gottingen, Germany;Haber, Fritz;Harvard University;Harz Mountain region, (Germany);Hirschfelder, Joseph O.;Hitler, Adolf;Kekule model;Kharasch, Morris S.;Ladenberg, Rudolf W.;Langmuir, Irving;Latter Day Saints (Mormon);Leipzig, Germany;Lenard, Philipp;Lewis, Gilbert N.;Loomis, Alfred L.;Mees, C.E. Kenneth;Morgan, Stanley O.;Nazis;New Brunswick, Canada;Nobel laureates;Organic chemistry;Ostwald, Wilhelm;Physical chemistry;Princeton University;Quantum theory;Recruitment (Princeton);Resonance charge shifts;Richards, William T.;Sponer, Herta;Stark effect;Stark, Johannes;Taylor, Hugh S.;Teaching;Thallium amalgams;Tuxedo Park, New York;Von Neumann, John;Wigner, Eugene P.</keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink></hyperlink><hyperlink_text></hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point><point><time>8404</time><title>Chemical Physics in the 1920s and 1930s</title><title_alt></title_alt><partial_transcript>STURCHIO: This was quite a place for kinetics in those days. </partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis>Princeton as a center for chemical physics in the interwar years. Edits Journal of Chemical Physics. Section for Chemical Physics is started in the American Chemical Society. Organizes a symposium on dielectrics. Students in the interwar years. Deuterium research and the Manhattan Project.</synopsis><synopsis_alt></synopsis_alt><keywords>ALSOS Mission;Alyea, Hubert N.;American Chemical Society (ACS);American Journal of Science;American Physical Society;Army (US);Azores Islands;Baker, William O.;Bancroft, Wilder D.;Barrier research;Bell Laboratories;Boyce, Joseph C.;California Institute of Technology (Caltech);Chemical physics;Compton, Karl T.;Deuterium;Dielectrics;DuPont (E.I. du Pont de Nemours &amp; Co.);Eyring, Henry;Fundamentals of Physical Chemistry;Gehrig, Lou;Graduate requirements (Princeton);Great Depression;Harvard University;Herring, W. Conyers;Hulett, George A.;Jensen, William B.;Journal of Chemical Physics;Journal of Physical Chemistry;Kirkwood, John G.;Lewis, George L.;Lewis, Gilbert N.;Mack, Edward, Jr.;Manhattan Project;Massachusetts Institute of Technology (MIT);McCay, LeRoy W.;Mont St. Michel;Morgan, Stanley O.;New York Academy of Sciences;New York Yankees;Nobel laureates;Noyes, William A., Jr.;Oesper Professorship;Oesper, Peter F.;Office of Naval Research (ONR);Ohio State University;Onsager, Lars;Paris, France;Physical chemistry;Physical chemistry (Princeton);Princeton University;Radar;Radiation Laboratory (MIT);Ruth, Babe;Second World War (WWII);Seitz, Frederick;Spedding, Frank H.;St. Petersburg, Florida;Stoops, William N.;Strasbourg, Germany;Taylor, Hugh S.;University of California, Berkeley;University of Cincinnati;Urey, Harold C.;Van Vleck, John H.;War Department (US);Washington College;West, Andrew F.;Wiswall, Richard H.;World War II (WWII)</keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink>https://digital.sciencehistory.org/works/cf95jc49c</hyperlink><hyperlink_text>Oral history interview with Hubert N. Alyea</hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks><hyperlinks><hyperlink>https://digital.sciencehistory.org/works/9019s341g</hyperlink><hyperlink_text>Oral history interview with William O. Baker</hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point><point><time>11384</time><title>Appendix: &quot;Scientist in a Jeep:&quot; The ALSOS Mission</title><title_alt></title_alt><partial_transcript>In January 1945, the sweep of the Allied Armies across France seemed to have slowed down.</partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis>Joins the ALSOS Mission and begins work at the Pentagon. Difficulties in leaving for Europe. </synopsis><synopsis_alt></synopsis_alt><keywords>Allied Armies;ALSOS Mission;Battle of the Bulge;C-54 (DC-4);Colleagues (ALSOS Mission);Compton, Karl T.;Department of State (US);Eisenhower, Dwight D.;Goudsmit, Samuel;Manhattan Project;Nazis;Office of Scientific Research and Development (OSRD);Paris, France;Pentagon (US DOD);Princeton University;Radar;Radiation Laboratory (MIT);Recruitment (ALSOS Mission);Saipan;Strasbourg, Germany;Washington, D.C.</keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink></hyperlink><hyperlink_text></hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point><point><time>12175</time><title>Appendix: &quot;Scientist in a Jeep:&quot; Paris</title><title_alt></title_alt><partial_transcript>On the day of my departure, which was a mild spring day in Washington with the sky gray and the mockingbirds singing, I was driven down to the airfield before lunch.</partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis>Flight to Paris. Paris and the Royal Monceau hotel in wartime: accommodations, uniforms, food, transportation. German lessons with E. C. Kemble. Incendiary investigations with Louis Fieser at the Pouderie Nationale.</synopsis><synopsis_alt></synopsis_alt><keywords>Aachen, Germany;Airforce Reserve (US);ALSOS Mission;Arc de Triomphe;Avenue Hoch (Paris);Azores Islands;Baltimore, Maryland;Bauman, Carl A.;C-54 (DC-4);Chemical Warfare Service;Colleagues (ALSOS Mission);Coward, Noel P.;Fieser, Louis F.;First World War (WWI);Fontaine, Lynne;French Revolution;Groves, Leslie R.;Gulf of St. Lawrence;Harvard University;Heidelberg, Germany;Kemble, Edwin C.;Lagos, Portugal;Lavoisier, Antoine-Laurent;Lindbergh, Charles A.;Lloyd's of London;Lunt, Alfred;Manhattan Project;Mont St. Michel;Montgomery, Bernard L.;Nassau Tavern (Princeton);Nazis;New York City, New York;Office of Strategic Services (OSS);Organic chemistry;Paris jail;Paris Metro;Paris operations (ALSOS Mission);Paris, France;Patton, George S.;Pouderie Nationale;Rhine River;Rockwell, Norman;Royal Monceau (Paris);Sevrens-Livry, France;Shaw, George Bernard;Stephenville, Newfoundland;Tomb of the Unknown Soldier (Paris);Washington, D.C.;Wood-burning cars;World War I (WWI)</keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink></hyperlink><hyperlink_text></hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point><point><time>17834</time><title>Appendix: &quot;Scientist in a Jeep:&quot; The Rhineland</title><title_alt></title_alt><partial_transcript>A few days later, word came that I should go down to Aachen, where ALSOS had a few days earlier occupied a house on the outskirts.</partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis>Crosses into Germany. First headquarters and Easter services at Aachen. Investigates the Physical Institute at Cologne. Explores the Rhine district. Explains that ALSOS civilian scientists were unarmed. Crosses the Rhine at Frankfurt on a pontoon bridge. Interrogates Dr. Czerny. Searches for Schumacher. Cinema in Frankfurt, &quot;wine liberation&quot; in Aachen and squab near Cologne. Wetzlar, Giessen, Marburg and Kassel.</synopsis><synopsis_alt></synopsis_alt><keywords>&quot;Little Monceau&quot;  (Aachen);&quot;Superior Charlie&quot;;Aachen headquarters (ALSOS Mission);Aachen, Germany;ALSOS Mission;Arras, France;Bates, Allan A.;Battle of the Bulge;Berlin, Germany;Bonn, Germany;Bradley, Omar N.;Brahms, Johannes;Bunsengesellschaft (German Society of Physical Chemistry);Carolingian chapel (Aaachen);Charlemagne;Chemical Institute (Cologne University);Civilian status (ALSOS Mission);Colleagues (ALSOS Mission);Cologne University;Cologne, Germany;Czerny, Marianus;Duren, Germany;First World War (WWI);Flying fortresses;Frankfurt, Germany;Giessen, Germany;Goudsmit, Samuel;Hayworth, Rita;Heidelberg, Germany;Hitler, Adolf;Holy Roman Empire;International Red Cross;Interrogations (ALSOS Mission);Jurich, Germany;Kassel, Germany;Krefeld, Germany;Leipzig, Germany;Mainz, Germany;Marburg, Germany;Muenchen-Gladbach, Germany;Nazis;Nuclear bomb (German);Oppenheim, Germany;Paris, France;Pash, Boris T.;Patton, George S.;Physical Institute (Cologne University);Pittsburgh, Pennsylvania;Princeton University;Remagen, Germany;Rhine River;Rhine wine;Royal Monceau (Paris);Ruhr River;Schumacher, Hans Joachim;Schutzstaffel (S.S.);Siegfried line;Spectroscopy;Stollwerk, Germany;Strasbourg, Germany;Technische Hochschule (Aachen);Verdun, France;Walter, Bruno;Westinghouse Laboratories;Wetzlar, Germany;World War I (WWI)</keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink></hyperlink><hyperlink_text></hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point><point><time>25372</time><title>Appendix: &quot;Scientist in a Jeep:&quot; Gottingen</title><title_alt></title_alt><partial_transcript>We continued on to Gottingen, where we arrived in the late afternoon.</partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis>Interrogates four prominent professors at the University of Gottingen and offered the rectorship of the university. Discovers headquarters of the German National Research Council at Merseburg. Finds German supply of heavy water at Osterode.</synopsis><synopsis_alt></synopsis_alt><keywords>Aachen, Germany;Alkali metals;Alkaline solution;ALSOS Mission;Belsen concentration camp;Berlin, Germany;Betz, Johann A.;Celle, Germany;Colby, Walter F.;Colleagues (ALSOS Mission);Dayton, Ohio;Discoveries (ALSOS Mission);Elbel, A.;Eucken, Arnold;First World War (WWI);Fundamentals of Physical Chemistry;Gottingen headquarters (ALSOS Mission);Gottingen, Germany;Hanover, Germany;Harz Mountain region, (Germany);Heavy water;Heidelberg headquarters (ALSOS Mission);Heidelberg, Germany;Herold, Paul;Hitler, Adolf;IG Farben;Institute of Physical Chemistry (Univ of Gottingen);Interrogations (ALSOS Mission);Isotope separation;Langley Field, Virginia;Leipzig, Germany;Leuna, Germany;Lindau, Germany;Merseburg, Germany;Multiple warhead;Nazis;Northeim, Germany;Osenberg, Werner;Paris, France;Prandtl, Ludwig;Princeton University;Reichsforschungsrat (German National Research Council);Roosevelt, Franklin D.;Schutzstaffel (S.S.);Spitfires;Standard Oil of Indiana;Stassfurt, Germany;Stolberg, Germany;Taylor, Hugh S.;Telschow, --;Typhus;University of Gottingen;University of Michigan;Wanzleben, Germany;Wasserburg, Germany;World War I (WWI);Wright Field (Dayton, Ohio)</keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink></hyperlink><hyperlink_text></hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point><point><time>28934</time><title>Appendix: &quot;Scientist in a Jeep:&quot; Leipzig</title><title_alt></title_alt><partial_transcript>As Leipzig was nearby, we stopped there and then continued on to Osterode in the Harz, where we had been told that the heavy water was stored in a small factory of Hollemann and Wolff. </partial_transcript><partial_transcript_alt></partial_transcript_alt><synopsis>Visits Debye's former lab in Leipzig. Interviews Hund and Doepple at the University of Leipzig. Recalls earlier visit to Leipzig when Hitler stayed in same hotel. Encounters Nazi tank column and finds supply of uranium yellow cake in Stassfurt. Interrogates Paul Harteck about his work on isotope separation. War ends. Visits Karl Bonhoffer, whose bishop brother was executed by the Nazis. Finds Gestapo scientific papers in buried urns in the Harz region.</synopsis><synopsis_alt></synopsis_alt><keywords>Ammonia synthesis;Berlin, Germany;Blake, Robert W.;Bonhoffer, Dietrich;Bonhoffer, Karl F.;Bothe, Walther;Braunschweig, Germany;Brown Shirts;Celle, Germany;Chemical Institute (Univ of Hamburg);Chemical physics;Clusius, Klaus;Cockcroft, John D.;Colleagues (ALSOS Mission);Cornell University;Cyclotrons;Debye, Peter J.W.;Deuterium oxide;Discoveries (ALSOS Mission);Dollfuss, Engelbert;Estonia;First World War (WWI);Fisher, Russell A.;Friedrichsbrunn, Germany;Gerlach, Walther;Gestapo;Goebbels, Joseph;Gottingen, Germany;Haber, Fritz;Hahn, Otto;Halle, Germany;Hamburg, Germany;Harteck's Institute (Univ of Hamburg);Harteck, Paul;Harz Mountain region, (Germany);Heavy water;Heisenberg, Werner K.;Hitler, Adolf;Hollemann and Wolff Company;Hund, Friedrich;Institute of Physical Chemistry (Leipzig Univ);Institute of Theoretical Physics (Leipzig Univ);Interrogations (ALSOS Mission);Isotope separation;Kaiser Wilhelm Institute;Leipzig, Germany;Lenard, Philipp;Leuna, Germany;London, England;Luneberg, Germany;Navy (US);Nazis;Nobel laureates;Northwestern University;Nuclear bomb (German);Nuclear fission;Office of Naval Research (ONR);Osram Company;Osterode, Germany;Paris, France;Physical chemistry;Physical Institute (Univ of Hamburg);Rensselaer Polytechnic Institute (RPI);Royal Society of Chemistry;Sack, Heinrich;Salzburg, Austria;Schutzpolizei;Schutzstaffel (S.S.);Signal Corps;Speight, Monty;Stark, Johannes;Stassfurt, Germany;Troy, New York;University of Hamburg;University of Leipzig;Uranium;World War I (WWI)</keywords><keywords_alt></keywords_alt><subjects></subjects><subjects_alt></subjects_alt><gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints><hyperlinks><hyperlink></hyperlink><hyperlink_text></hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks></point></index><type></type><description></description><rel /><transcript>[untranscribed pre-interview discussion]
+
+STURCHIO: [interview begins at 4:15] We&#039;d like to start with asking you about your childhood. We know you
+were born in February 1895 in Clinton, New York, and that your father was a
+petrologist. I wonder if you could tell us more about your family?
+
+SMYTH: Yes, my father was a petrologist. He graduated from Columbia in 1888. I
+feel confident that if he had lived a little later, he would have been a
+physical chemist, because his interests lay along those lines of physical
+chemistry. He was not interested in descriptive geology or paleontology but he
+wanted to know how things got there. He was interested in the structure of
+things. My father&#039;s first cousin was a professor of chemistry at Vassar College.
+She was not a research chemist and she left Vassar to become president of
+Connecticut College. That shows a beginning interest in science. My father was a
+great believer in scientific research, so I was brought up to believe that that
+was a great thing to do. It spread through the family. My brother [Henry DeWolf
+Smyth] is a physicist. He was chairman of the physics department here. Frederic
+Hastings Smyth, my first cousin on the Smyth side, took a Ph.D. in physical
+chemistry at MIT, and was in the Chemical Warfare Service during the war. As a
+matter of fact, he devised the crossed alembics over a benzene ring which was
+the symbol of the Chemical Warfare Service that officers wore on their collars.
+He went into industry for a year or two and was with a geophysical lab for a few
+years. He had independent means and quit. After studying philosophy and
+religion, he became an Episcopal clergyman and founded his own small order. That
+was not very scientific.
+
+Getting back to the general tendency to go into science, I also wanted to get a
+broad education. I had time to take a year of chemistry at the Lawrenceville
+school to which I went as a day scholar. I entered Princeton as an A.B., which
+in those days meant taking Latin and Greek, both for entrance credits and during
+my first two years in college. I had to take only one science course in my first
+two years at Princeton. I chose physics because I didn&#039;t know any physics and
+the course was well given, although not stimulating. Then I decided to try and
+get into the chemistry department. I had a very high record on my college
+entrance exam in chemistry, and on the basis of that, the chemistry department
+admitted me in my junior year, although I had no college chemistry. It went very
+well. I graduated with highest special honors in chemistry and had a year of
+graduate work at Princeton in physical chemistry. I just got started on my
+thesis work. I was measuring specific heats, working with a third-year graduate
+student. All we succeeded in doing was to prove that the measurements made in
+this apparatus by a previous worker were incorrect.
+
+Then the war came and I worked for the National Bureau of Standards for six
+months on an electrochemical problem. It seemed to me very remote from the war
+effort, so I managed to get a commission as a second lieutenant in the Ordnance.
+I was transferred to the Chemical Warfare Service and eventually was promoted
+from second lieutenant to first lieutenant, as was nearly everyone else at the time.
+
+STURCHIO: Before we go to the Chemical Warfare Service, could we backtrack to
+Princeton and ask you a few more questions about some of your colleagues there?
+One interesting thing that emerged last week when we interviewed Hubert N. Alyea
+was that he told us one of the reasons he decided to become a chemist was that
+he had met you through his brother, since you and his brother were
+classmates.[[footnote]]1[[/footnote]] He was intrigued to know that one could
+become a chemist, since you were studying chemistry at that time. So we learned
+that Hubert Alyea&#039;s older brother was one of your classmates. Who were some of
+your other classmates at Princeton? Did any of them go on to science as well?
+
+SMYTH: Stuart Mudd went into biology and is now on the faculty of the University
+of Pennsylvania. I think very few of my classmates went on with science. One of
+my classmates, Ham [Hamilton F.] Armstrong, was interested in foreign affairs
+and attended the forming of the League of Nations and became quite close to the
+French prime minister, [Georges] Clemenceau. Ultimately--he had some independent
+means--he founded the magazine Foreign Affairs and was the first
+editor.[[footnote]]2[[/footnote]] He edited that for many years.
+
+STURCHIO: Who were some of the professors you studied with?
+
+SMYTH: George [A.] Hulett was the only man doing substantial research in the
+chemistry department at that time. He was a very able physical chemist, but I
+saw very little of him. I was supposed to be doing a thesis with him, but he was
+working for the Bureau of Mines in Pittsburgh most of the time. He had been a
+consultant for them. He got into war work. I don&#039;t know just what it was. So I
+really saw virtually nothing of him and made no progress on my thesis. It just
+proved the work of another man wrong, and that&#039;s not very satisfactory.
+
+DOEL: Were there any other faculty members also involved in consulting work?
+
+SMYTH: I don&#039;t believe so at that time. The chemistry department was an
+old-fashioned department. There wasn&#039;t a secretary in the department. The
+chairman of the department wrote all of his letters longhand and, not
+surprisingly, used to groan over the amount of his administrative duties. I
+believe at one time he played the violin in the Philadelphia Orchestra, but that
+was not the organization then that it has become in more recent years.
+
+STURCHIO: Who was chairman of the department at the time?
+
+SMYTH: LeRoy W. McCay.
+
+STURCHIO: While we&#039;re talking about some of the faculty and the work they were
+doing then, I wonder if you could tell us about what the chemical curriculum was
+like in those years? Do you recall any of the textbooks that were used and the
+sort of work that was assigned to students?
+
+SMYTH: I don&#039;t remember any textbook in physical chemistry that we used. Hugh
+[S.] Taylor, a young Englishman, had just come here at that time and he was
+starting research. He became a quite eminent physical chemist. He retained his
+British citizenship and as a result of that was knighted by the King. He was
+president of the Faraday Society. If he had become an American citizen, he
+wouldn&#039;t have been knighted.
+
+STURCHIO: He had come fresh from work with [Frederick] Donnan at Liverpool and
+[Max] Bodenstein in Germany. Did you ever have a chance to discuss his work with
+him and the ferment of physical chemistry in Europe at the time?
+
+SMYTH: Very little. [Svante] Arrhenius was another man that he had worked with.
+
+STURCHIO: At the Nobel Institute?
+
+SMYTH: Yes. He probably got started on his kinetics work with Bodenstein. I
+think he was probably just in the initial stages when he was working with
+Donnan. I simply don&#039;t know what Hugh&#039;s thesis work was. He was a very
+hard-driving man. He worked very hard and had a very quick mind. He built up the
+department. He soon became chairman of the department, and he made the
+department into a first-class department. Prior to that, it had been pretty much
+a small college department.
+
+STURCHIO: Wasn&#039;t the department still housed at the old chemistry building at
+Nassau and Washington Roads?
+
+SMYTH: The new building was built in 1929. It moved up a block and has been
+added to very extensively since. They had to wait quite a while until Henry Clay
+Frick, who was an associate of Andrew Carnegie, promised to give money to the
+chemistry lab. Then the First World War came, and the cost of building went up
+excessively. He wanted to wait until the cost of building came down. But that
+never happened, and the building was delayed until 1929. In the meantime Frick
+had died, leaving a considerable sum of money to the university. We spent some
+of that money to build the Frick Chemistry Lab.
+
+STURCHIO: We&#039;d like to come back to that in a little while when we get into the
+1920s. Do you recall what it was like working in the old labs? Your first
+introduction to chemical research was in the old labs.
+
+SMYTH: There was a building known as the John C. Green School of Science, which
+was across the street from the old chemical laboratory. I worked in a room in
+the basement of that building. There were third-year graduate students there,
+and I was a first-year student and completely green in research. That building
+was crude. There were cracks in the floor. Mercury had been spilled and there
+was mercury standing in some of the cracks in the floor. The old building was a
+shambles. When I ultimately came back to Princeton and started research, I
+needed a pretty good lab. The physics department very kindly let me work there
+because they had a fairly new building.
+
+DOEL: Was that in Fine Hall?
+
+SMYTH: It was the Palmer Laboratory.
+
+STURCHIO: What was the name of the third-year graduate student who you worked with?
+
+SMYTH: George Perrott. It&#039;s very nearly the same name as a leading character in
+a very successful and true novel which has just been published as a movie as
+well as a novel. That was Perrott.
+
+STURCHIO: What sort of equipment were you and Perrott working on?
+
+SMYTH: It was adequate equipment but just not good enough to do the job properly.
+
+STURCHIO: Were things very different at the National Bureau of Standards when
+you went there?
+
+SMYTH: There I think I was the first worker in the new chemistry labs. I was
+able to get everything I needed. I didn&#039;t need much for the work I was doing on
+electroplating. Research was totally different in those days. Elaborate
+equipment was not available. There was very little team effort. It wasn&#039;t
+needed. It was a matter of individual effort.
+
+STURCHIO: How is it that you ended up at the National Bureau of Standards? Was
+it a particular contact between someone at Princeton and the National Bureau of
+Standards, or was it just an advertisement that you had responded to?
+
+SMYTH: I can&#039;t tell you. It&#039;s possible that Hulett was in touch with government
+laboratories. He may have told me of the opening.
+
+STURCHIO: [N.] Howell Furman and Robert [N.] Pease were also graduate students
+around that time and went down to Washington about the same time that you did.
+
+SMYTH: Yes, but I saw virtually nothing of them. I don&#039;t remember what they did.
+
+STURCHIO: Who were some of the chemists you did see while you were at the
+National Bureau of Standards?
+
+SMYTH: I was working under Dr. William Blum, a considerably older man. This was
+a problem in improving electroplating, which in those days was supposed to be
+used to put a coat of metal on airplanes. That&#039;s how they made it out to be war
+work. But it didn&#039;t look at all promising to me. I was just trying to improve
+methods for zinc plating with the cyanide bath. I remember getting quite a shot
+of the fumes of the cyanide bath once.
+
+STURCHIO: From mercury on the floor to cyanide fumes.
+
+SMYTH: Life was hazardous in those days.
+
+DOEL: Could you talk about your early research interests with your father?
+
+SMYTH: As a matter of fact I had forgotten about it, but I was reading my
+autobiographical notes the other day [which reminded me that] my father had an
+excellent command of English so that he used to read my first research papers
+before I sent them in for publication.[[footnote]]3[[/footnote]] He used to help
+me shine up the English a little. It always made me perhaps a little over
+particular with my graduate students later on when they used what I considered
+to be bad English.
+
+STURCHIO: Your brother Henry was also going into physics at this time. Did the
+three of you often talk about science at home?
+
+SMYTH: No. Harry was three years younger, and that makes quite a gap at that
+time. Also, I lived at home for one year during my college undergraduate days.
+He went to Lawrenceville just as I did and went into the physics department
+here. He took his Ph.D. here and then went to Cambridge, England and spent two
+years in [Sir Ernst] Rutherford&#039;s laboratory. So we were never close
+scientifically. I was close to Karl [T.] Compton in the physics department. But
+I&#039;m jumping ahead.
+
+STURCHIO: We were at the National Bureau of Standards and you were a little bit
+disappointed about the zinc electroplating, which was not really war-related.
+You were interested in something closer to the war effort.
+
+SMYTH: I managed to get a second lieutenancy in the Ordnance Department, and the
+Chemical Warfare Service was just being organized at American University on the
+outskirts of Washington. I started working there with twenty-three other men,
+all in the same room. We were working on poison gas. They really had ventilation
+there. It was so powerful that you could feel it in your ears when someone
+opened the door to come into the room.
+
+STURCHIO: That&#039;s a good thing, isn&#039;t it?
+
+SMYTH: Oh, yes. The rule was that if the gas alarm sounded, you didn&#039;t draw a
+breath. You put on your gas mask and then headed for the door. I did that for a
+time. Then I was assigned to a division which was trying to develop toxic smoke
+because smoke would penetrate carbon filter gas masks. The carbon would absorb
+the gas, but the smoke particles would go right on through. The idea was to get
+something that would nullify enemy gas masks. They tested all kinds of
+substances for possible use for the production of toxic smoke.
+
+[END OF AUDIO FILE 1.1]
+
+STURCHIO: You went to the Army Ordnance and then later the Chemical Warfare
+Service. There has been some historical work recently on the work of the
+Chemical Warfare Service in World War I, and people have remarked that it was
+quite a collection of chemists. Everybody who was anybody in American chemistry
+was working on the project. Could you talk about some of the people you met?
+
+SMYTH: My first boss there was Robert E. Wilson, who was about two or three
+years older than me. He had tremendous drive, was very bright, and ultimately
+became president of Standard Oil of Indiana. I have very high regard for him. He
+was a very busy, very hard-driving man. Another man was James B. Conant, whom I
+got to know although I saw very little of him. He was an organic chemist, and we
+didn&#039;t overlap. Very soon I became an architect of my own doing. In other words,
+they built a shack for my work down in a little gully. It was a two-room shack,
+and there we tested our various substances on white mice and often on the
+experimenters themselves. I think I breathed more toxic substances than any
+chemist in my acquaintance.
+
+I remember G. [Gilbert] N. Lewis came to visit the laboratory. He had just
+returned from France on some mission where he had gone into the front line. He
+came down to visit me in my little shack, which was in a slight valley. He
+couldn&#039;t stand the atmosphere. He was a very nice fellow, only he got out of
+there as soon as he could.
+
+STURCHIO: Of course, if all of the vapors were heavier than air.
+
+SMYTH: At that time my ultimate boss was R. [Richard] C. Tolman, who was number
+three in the organization of the Second World War effort in science.
+
+STURCHIO: Did you have much chance to talk to Tolman?
+
+SMYTH: I saw him quite a bit. He was a very brilliant but odd man.
+
+STURCHIO: His interests in theoretical physical chemistry were much closer to
+the kinds of interests that you were developing at the time. Did you find that
+you had more to talk to him about than some of the others?
+
+SMYTH: I don&#039;t think we talked general science very much. Tolman was a bachelor
+at the time. He drank pretty heavily at times. I remember he was a civilian when
+I first started in with him. Then he was made a major. The week before he became
+a major he took a boat from Baltimore to Washington. It took all night, so he
+could have one big last binge. I guess he drank himself into oblivion on the
+boat and reported for work Monday morning ready for progress. He was a
+tremendously able man. He was probably one of the four best physical chemists in
+the country.
+
+STURCHIO: Who would you say the others were?
+
+SMYTH: G. N. Lewis was number one without question. E. [Edward] W. Washburn was another.
+
+STURCHIO: Would you put T. [Theodore] W. Richards in there?
+
+SMYTH: Well, Richards was somewhat older. These were four quite young men.
+Richards was perhaps at a higher level working on atomic weights, although
+Richards was basically a physical chemist.
+
+STURCHIO: What about Arthur [A.] Noyes?
+
+SMYTH: I think quite possibly at that time and a little before, Arthur Noyes
+might have been the number one physical chemist. He became an administrator. He
+didn&#039;t come to Washington as far as I know. I had no contact with him. [brief untranscribed material] Another
+well-known man in physical who was called to Princeton in the 1920s was
+Alexander Smith from Columbia. He had agreed to come to Princeton and then
+changed his mind. That was a very good thing for Princeton because Smith did no
+more work after that. He would have been just a used-up salary at Princeton.
+
+STURCHIO: I&#039;ve heard from other people that Smith had been capable of being
+somewhat irascible as an administrator.
+
+SMYTH: I don&#039;t know. I never met Smith.
+
+STURCHIO: While we&#039;re talking about people in the Chemical Warfare Service, I
+noticed that Lauder [W.] Jones had also been at American University at that
+time. Did you run into him there?
+
+SMYTH: I had met him but I hardly knew him. He was a very nice man and a very
+good organic chemist. When they called him here, he made a very good start and
+was turning out good organic chemists. Merck profited very highly from him. I
+think two of Lauder Jones&#039; men ultimately became top men at Merck. Then he had
+this tragic accident. His wife had developed mental trouble so he was alone with
+his one daughter, who was a very charming young girl. They were out in
+Yellowstone Park. She was taking pictures. They went to Yellowstone Canyon,
+which has a steep incline and then goes down precipitously. She was taking
+pictures of the falls and got too far down on that slope. He grabbed her but she
+couldn&#039;t hold on. He was never the same after that.
+
+STURCHIO: That&#039;s understandable.
+
+SMYTH: That was a great tragedy.
+
+STURCHIO: Let&#039;s get back to American University and the Chemical Warfare
+Service. After the Armistice, I gather you were still at American University and
+it was time to make a choice as to what to do next. Could you tell us a little
+bit about what happened?
+
+SMYTH: I had some contact with Arthur B. Lamb who was the editor of the Journal
+of the American Chemical Society. We didn&#039;t work together, but in some way Lamb
+was a tremendously agreeable chap. He said to me, &quot;Why don&#039;t you come to
+Harvard?&quot; He didn&#039;t try to get me to work with him, but he suggested trying T.
+W. Richards. So I went up to Cambridge and talked to Richards. I was completely
+charmed by him. He was a delightful person. So I went to Harvard. My original
+plan had been to get a quick Ph.D. at Princeton, because you always lose at
+least a year when you transfer from one place to another. I figured I could
+probably have done a Ph.D. in two years at Princeton and then gone on somewhere
+else. I probably would have gone to Berkeley as a postdoc.
+
+STURCHIO: To work with Lewis?
+
+SMYTH: It probably would have been Lewis. But I was charmed by Richards. He
+offered to dig up some funds to make me a research assistant. After that I got a
+fellowship, and I actually did the work for my Harvard Ph.D. in fifteen months
+in Cambridge. I wrote up my thesis in my first year as instructor here.
+
+STURCHIO: Did you go to Cambridge in 1918?
+
+SMYTH: It was February of 1919. I was in uniform when I started work. I kept on
+my uniform for three or four days because it felt more natural than civilian
+clothes. There was still a big naval training unit in Cambridge, housed in
+dormitories by the Charles River. I got a room in one of the dormitories. I was
+going back to my room one day after lunch, and these boys were coming back from
+lunch, too. I met them not as marching units but as groups of individuals on a
+narrow street. I was a first lieutenant and they were mere midshipmen, I guess.
+So every one of them had to salute me as I went down the street. [laughter] And
+after a while more of them went down the street and I saw what was happening.
+When they got to me, every one of them would salute me and I had to return it. I
+went back to my room and changed into civilian clothes immediately. [laughter]
+
+STURCHIO: Was it the Wolcott Gibbs Laboratory that you were working in?
+
+SMYTH: Yes. I had very nice quarters at the laboratory. It looked absolutely
+palatial after the rather dingy Princeton quarters.
+
+STURCHIO: Who were some of the other people working with Richards then? There
+must have been quite a lively community in the physical chemistry department.
+
+SMYTH: I took up a problem that Farrington Daniels had been working on. Richards
+thought that Daniels had gotten some results on the electromotive forces of
+thallium amalgams which seemed contrary to the accepted laws of thermodynamics.
+So Richards felt we ought to explore that. I started that and discovered that
+mercury was soluble in thallium. That had been neglected in the previous work.
+Lewis had neglected it, too. I measured the electromotive force of the thallium
+electrode dipped in mercury, and Daniels had neglected the fact that what he was
+measuring was an amalgam with fifteen percent of mercury dissolved in the
+thallium. It was a very small matter and quite unimportant, but it rounded out a
+reasonable thesis.[[footnote]]4[[/footnote]] I worked from January to June, when
+the lab closed for the summer. Then I came back and worked for the entire second
+year. That was all the time I spent in Cambridge.
+
+STURCHIO: How did Richards direct a problem like that, or did he leave you to yourself?
+
+SMYTH: He came around practically every day. It was very different from the days
+many years later when there was a well-deserved Nobel laureate at Harvard and
+his graduate students were lucky if they saw him once in two weeks. Richards
+would come into my lab. He always had this charming manner. He was a very nice
+looking little man with white hair and mustache and a delightful voice. He was
+very cultivated. His father had been the leading American marine painter.
+Richards had inherited his abilities so that Richards had to decide whether to
+be a painter or a chemist. The odd thing was that the same abilities were
+transferred down to his son, William T. Richards. Bill Richards was a very good
+friend of mine. He was an undergraduate when I was a graduate student there. We
+used to play tennis together.
+
+STURCHIO: Then you became colleagues somewhat after that.
+
+SMYTH: Yes.
+
+DOEL: Who did you associate with in particular when you were at Harvard?
+
+SMYTH: [Albert] Sprague Coolidge was in the laboratory. He was a quite able man
+but perhaps a little eccentric. I didn&#039;t see very much of him. The man in the
+next laboratory was a Texan named [William M.] Craig. Then there was a
+Czechoslovakian named Henry Krepelka. The building was small. There was just
+Krepelka, Craig, Coolidge and myself. Coolidge used to fill his thermostat with
+a hose. One time he forgot it, but he didn&#039;t mind because he wore boots. The
+weather was bad outside. He came in and waded in an inch or two of water, but
+Richards didn&#039;t like it too well. Craig used to borrow Krepelka&#039;s tools, and I
+remember Krepelka lamenting in loud broken English, &quot;Craig is swiping all of my tools.&quot;
+
+STURCHIO: It sounds like a typical lab.
+
+SMYTH: Krepelka went on to be dean of the faculty of sciences at the University
+of Prague. He was a strong anti-Nazi, and I was afraid that the Nazis would
+eliminate him when they invaded Prague. I heard he had survived, but I lost all
+touch with him.
+
+STURCHIO: Do you have much contact with the other faculty, for instance [Elmer
+P.] Kohler and [George S.] Forbes?
+
+SMYTH: Not very much. I think I took a lecture course with Forbes. I didn&#039;t sign
+up for any lecture courses, but I sat in on Forbes&#039; lectures, and Kohler&#039;s, who
+was perhaps the father of the whole school of organic chemists--Roger Adams,
+[James B.] Conant, Rocky [Frank C.] Whitmore, amongst others. In those days
+Harvard had a regular system of training a very good Ph.D. He&#039;d go to Bryn Mawr
+as an assistant professor of chemistry there. Then if he continued to be good,
+they&#039;d call him back to Harvard. Bryn Mawr people would seem to resent this, but
+at the time their chemistry department was a small-scale training school for Harvard.
+
+STURCHIO: What were lectures by Forbes and Kohler like? Do you recall being
+impressed by either one of them?
+
+SMYTH: Kohler was a very clear lecturer and thinker. He had a very dry way of
+speaking. He was one of my examiners on my final oral exam. In those days at
+Harvard, the final oral was sort of a farce. They had a written preliminary that
+you had to pass. When it came to the final oral, they fit in all the oral
+candidates in the morning and spent probably fifteen or twenty minutes on a
+candidate. I remember coming in, and Richards saw I was a little nervous. He
+said, &quot;Charlie, just tell us a little bit about your work.&quot; I stumbled along for
+a few sentences, and he said, &quot;All right, that will do.&quot; Then Kohler asked me a
+question that could be answered by yes or no. I didn&#039;t have the slightest idea
+of the correct answer so I said, &quot;Yes.&quot; Kohler said, &quot;You guessed wrong.&quot;
+[laughter] &quot;That will do.&quot; That was my entire exam.
+
+STURCHIO: It&#039;s something how one remembers experiences like that; I remember
+some of my oral exams also. After you finished your work at Harvard, did you
+ever consider going abroad or doing something other than coming back to
+Princeton? Could you tell us what the circumstances were of your ending up back
+at Princeton?
+
+SMYTH: I had really expected to take another year at Harvard, but I had
+completed the minimum requirements. Princeton offered me an instructorship. They
+were going to add a man in general chemistry, and they said I could come without
+my degree and write my thesis here in Princeton, which I did. That seemed too
+good an opportunity to miss. That&#039;s why I came to Princeton when I did.
+
+STURCHIO: Did you plan to stay at Princeton? What was your thinking then about
+where you would end up eventually?
+
+SMYTH: I don&#039;t really know. I think I had an open mind.
+
+STURCHIO: How did you find things when you came back? You had been away from the
+chemistry department for a while. Had it changed?
+
+SMYTH: Hugh Taylor gave me my undergraduate physical chemistry. I think that was
+his first year at Princeton. I think the department was moving up then. I just
+had charge of freshmen lab. They used to have weekly quizzes. That was one hour
+a week with a big freshmen course of one hundred or two hundred men split into
+groups of twenty. I had two or three groups of twenty. The rest was just lab.
+
+STURCHIO: Do you recall the text that you and your colleagues were using and
+what the experience was like for the undergraduates then? What kind of work did
+they get?
+
+SMYTH: I think they were fairly good courses. They may have used Alexander
+Smith&#039;s textbook, but I&#039;m not certain.[[footnote]]5[[/footnote]] They used to
+get two lectures a week and then one of these quizzes. Then they had a
+three-hour session of lab. That was counted as four hours of coursework. After
+two or three years, I was given a lecture division and went on from there. I
+carried on the freshmen lecturing for twenty-five years until I said that I
+thought I had done it long enough.
+
+[END OF AUDIO FILE 1.2] 
+
+STURCHIO: [interview resumes at 1:02:34] You were writing your thesis your first year and teaching these labs.
+
+SMYTH: Yes. My thesis was typed by a secretary in the department of geology
+because the chemistry department had no secretary at that time. Everything was
+done longhand or this way. There was a very nice elderly woman named Rice who
+worked in her spare time. She was paid privately by one of the professors of
+geology. The university didn&#039;t hire any secretaries then except, I suppose, for
+the administration.
+
+STURCHIO: Things have changed in some ways.
+
+SMYTH: Yes.
+
+STURCHIO: Did you meet Karl Compton around this time?
+
+SMYTH: I don&#039;t know when I first met Karl Compton. I had taken courses in
+physics as an undergraduate, but not with Compton. I had one with Dean W.
+[William] F. Magie, who was dean of the faculty and was a physicist of the old
+school. He was a very polished gentlemen, and I think it was Magie that taught
+me thermodynamics. It seemed to be fairly easy. There was plenty of space in the
+physics lab so they gave me a place to work. First it was in the basement, and
+then I was promoted to the ground floor. Most of my early research was done
+there. I did have one piece of research on partial vapor pressures which I did
+in the top floor of the old chemistry lab. The windows didn&#039;t fit. When the
+north winds blew the windows would rattle and the drafts would sweep across the
+room. That was the laboratory of Professor [William] Foster, the lecturer in
+general chemistry. I persuaded him to write his own textbook instead of using
+the Alexander Smith book. He had his lectures all written out, so he wrote his
+own textbook.[[footnote]]6[[/footnote]] He very kindly invited me to be a
+partner, but I was a person of limited physical capacity. I couldn&#039;t do my share
+of writing for a textbook and keep my research going the way I wanted it to go,
+so I declined. He had this big drafty laboratory adjacent to his office. I had a
+desk in his office because that was adjacent to the freshmen chemistry labs in
+those days. So here was this big empty room where I worked on partial vapor pressures.
+
+STURCHIO: I imagine you were thinking about the direction to go in for a
+research program.
+
+SMYTH: I used to talk to Karl Compton about choices of a research program. I
+thought of three possibilities. One was a very vague one. Chemistry was
+primitive in those days. Jean [B.] Perrin, who was the leading French physical
+chemist, had proposed new ideas about infrared. Infrared was supposed to have
+mysterious effects on chemical reactions. I thought that sounded like an
+interesting thing to try. Then people talked about atom smashing in those days.
+
+Lester Cooke, who was a professor in the physics department, had an idea for
+developing high voltage by having two brass disks quite close together and
+charging them up and having the space between the two disks break in a circuit
+which included the set-up for discharge through a tungsten wire. The idea was to
+put in a tremendous voltage. They didn&#039;t know how to get high voltages in the
+fashion which is normal nowadays. Cooke was going to have a revolver mounted and
+point it at these two disks. He was going to close the circuit by shooting a
+bullet passing between the two thin disks to penetrate and close the circuit
+which would put a very high voltage on this tungsten wire which was in the
+circuit. That appealed to me quite strongly. I was very seriously attracted. 
+
+[untranscribed audio to 1:10:34] But
+I found that a fellow at General Electric had essentially the same idea. He was
+at least a year ahead of me and also had the resources of General Electric at
+his disposal. So it looked to me like a hopeless competition if I undertook
+that. Later he was never able to try it because he said they needed to have a
+high voltage that he had prepared to test insulation breakdown. That&#039;s an
+example of the General Electric lab at that time. It was probably the best
+industrial research lab in the country and yet they had to change, deny a man
+the chance of smashing the atom in order to test some insulation. It very soon
+developed away from a situation like that.
+
+I discussed these things with Compton. He told me about some new developments in
+the ideas of dielectrics that he thought were worth investigating. That appealed
+to me. As a matter of fact, he had already started a young assistant professor
+of the physics department, Charles [T.] Zahn, on measuring the dielectric
+constants of gases. I started measuring the dielectric constants of
+liquids.[[footnote]]7[[/footnote]] I knew absolutely nothing about the
+background or techniques. Compton was unfamiliar with it, too. We didn&#039;t work
+together. He just tossed that out as an idea. He was a terribly nice, outgoing
+man with a tremendous ability to handle people as well as ideas.
+
+My first graduate student was a first year physics graduate student who had been
+a Princeton undergraduate. There were Princeton undergraduates whose ideas about
+the weekend were different [from mine]. For them the weekend started on Thursday
+and continued through Monday. That was Joe&#039;s idea, so we didn&#039;t progress very
+well. We became very good friends but there wasn&#039;t much progress.
+
+STURCHIO: What was his name?
+
+SMYTH: Joe [Joseph C.] Boyce. When Compton went to MIT he took Joe along with
+him as an instructor or assistant professor in the physics department there. Joe
+later left and became dean of the graduate school at Illinois Tech in Chicago.
+He was a very nice fellow with a great deal of energy, but he was not a devoted
+research man.
+
+STURCHIO: The topic that you started working on was at once notably theoretical
+and also something that bridged physics and chemistry. It&#039;s clear that Compton&#039;s
+influence was important. How did your colleagues in chemistry feel about your
+taking up a topic that was more chemical physics than physical chemistry?
+
+SMYTH: They didn&#039;t mind at all.
+
+STURCHIO: Were there many other people working in that area at that time? Not
+just at Princeton, but elsewhere?
+
+SMYTH: There was a man named J. [John] W. Williams at Wisconsin. This ultimately
+developed into the determination of molecular dipole moments. Williams had a
+little head start on me and was doing very well. Then he gave it up and switched
+into biochemistry. He made the National Academy fairly early by his work in
+biochemistry. If he had stayed on in dielectrics, he might never have made the
+National Academy. He was a very bright fellow.
+
+STURCHIO: Didn&#039;t he do a lot of work with the ultracentrifuge?
+
+SMYTH: Did he?
+
+STURCHIO: He made quite a name for himself in that area.
+
+SMYTH: He was a very good chap and an extremely nice fellow.
+
+STURCHIO: Had Compton told you about [Peter] Debye&#039;s work? Was that one of the
+things that you were discussing, or did you discover that on your own?
+
+SMYTH: I don&#039;t know. I knew about Debye&#039;s work very early. I think my first
+serious graduate student came to me from the Bell Telephone Laboratories. S.
+[Stanley] O. Morgan really worked on the thing and we got
+results.[[footnote]]8[[/footnote]] Ultimately, he went back to Bell Labs after
+he got his degree here and became head of the chemistry division.
+
+STURCHIO: You had several other students who were at Bell Labs, notably Bill
+[William O.] Baker and [N.] Bruce Hannay.
+
+SMYTH: They were my star students, particularly Bill Baker. Bruce Hannay was
+almost as good, but Bill had greater breadth, I guess.
+
+STURCHIO: We&#039;d like to come back to them, but we&#039;re getting a little bit ahead
+of ourselves. Morgan and you managed to get some interesting results, but
+already you had published a couple of pieces in the Philosophical Magazine that
+laid out some very interesting early ideas on how to relate the study of dipole
+moments to the new developments in the electronic theory of
+valence.[[footnote]]9[[/footnote]] What sort of reaction did you get to your
+first few papers in this area? What did people have to say about the work?
+
+SMYTH: They were favorable because dipole moment was a fairly easy concept to
+understand. I remember using dipole moment measurements to attack one of the
+organic theories that involves structure.[[footnote]]10[[/footnote]] Jim Conant
+wrote me a brief note saying he hoped I would send a reprint of that paper bound
+in black to Morris [S.] Kharasch in Chicago. [laughter] Actually it made quite
+good sense, although I didn&#039;t send it in black binding.
+
+STURCHIO: It sounds like Conant had quite a sense of humor. One of the first
+things you published with Morgan was to show some of the current ideas about
+benzene structure were not quite accurate.[[footnote]]8[[/footnote]]
+
+SMYTH: Yes. That was probably the most important thing that I ever did because
+just at that time, x-ray analysis hadn&#039;t gotten very far. The physical chemists
+were unwilling to accept this planar benzene ring. The structure of carbon and
+its compounds didn&#039;t lend itself to planar ranges. It&#039;s much easier for a
+physical chemist to picture the cyclohexane ring than the benzene ring. The
+dipole moment gave a very simple proof that the old [Friedrich August] Kekulé
+model was right.
+
+STURCHIO: That&#039;s the kind of result that everybody hopes for. Something that
+most chemists in a number of areas can see as significant. That must have been
+very gratifying to see those kinds of results that soon.
+
+SMYTH: Yes. It was hard getting research done in those days because there were
+fifteen graduate students allowed in the entire department. The graduate school
+was so small and Hugh Taylor was going ahead fast. Lauder Jones took some so
+there were not many left. If I had one graduate student, I was pleased. If I had
+two, I was happy.
+
+STURCHIO: In addition to finding capable students to help in the work, I suppose
+one thing that appealed to you about the dipole moment work was that it didn&#039;t
+cost much to do, as opposed to the high voltage work that you had considered doing.
+
+SMYTH: In those days we had no conception of research expenses such as soon
+became the routine. I don&#039;t have the exact figures in mind, but somewhere along
+that time, the Public Service Corporation of New Jersey gave the chemistry
+department, I think, $30,000 to be spent in three years, or it may have been
+$50,000 to be spent in five years. Hugh Taylor was wondering how we were going
+to spend all of that money. He talked to me about it and asked me if I could use
+some. I never dreamed of these vast modern sums for research. We got on very
+well without money. You were able to get a postdoc for $1500 a year in those
+days. Somewhere along in there I got a postdoc.
+
+STURCHIO: What set-up did you have when you began this work on dielectrics and
+dipole moments? You were saying you did it in the physics department. Did you
+need much equipment and where did you get it from?
+
+SMYTH: I needed a precision condenser to make capacitance measurements. You
+couldn&#039;t buy one in those days. So I designed one. The chemistry lab did not
+have a mechanic nor did the physics department. A little elderly man named Mr.
+Fisher, who was the mechanic for the entire university, built it. It took him
+about a year to make this precision condenser. It wasn&#039;t too bad a job, but it
+was hardly good enough. Then the General Radio Company started work at just
+about that time and made a very good precision condenser. But that cost two or
+three hundred dollars. I didn&#039;t have that much. My personal salary when I
+started was $1800. I was getting more by that time, but not much. So I applied
+to the American Philosophical Society, of which I became a member rather early.
+They turned me down. But I guess by that time the money came from Public
+Service. So I got started with that and the shop could make measuring cells. You
+could get it done for small sums, but everything moved slowly, of course.
+
+STURCHIO: What other sources of support did you and your colleagues go to at
+that time in the mid-1920s? Things quickly changed in a few years, but you
+mentioned the American Philosophical Society and money from Public Service.
+
+SMYTH: [untranscribed audio to 1:28:25] I don&#039;t know [where I got money. I think the first real money I ever got
+for research was from the Office of Naval Research after World War II.
+
+STURCHIO: That was in about 1945 or 1946?
+
+SMYTH: Yes.
+
+DOEL: The 1920s was also the time that the General Education Board was getting
+ready to give money to Princeton to endow scientific research. Do you remember
+discussions in the department about that?
+
+SMYTH: The only thing that comes back to me is that there was money. Probably I
+got some money from them, but certainly not much. It didn&#039;t take very much to do
+research in those days.
+
+DOEL: Do you feel that the money that was coming in from Public Service and
+other sources helped to set up any new type of research programs in the
+chemistry department?
+
+SMYTH: It must have to some extent.
+
+DOEL: Do you recall any specific programs which grew as a result of having
+access to these new funds?
+
+SMYTH: No. I think it was a matter of having a program and scrounging around to
+see that you got the necessary dollars to buy what equipment was needed. Then
+sometimes the department would get a few dollars.
+
+STURCHIO: Were your colleagues doing any industrial consulting in the 1920s or
+did that come later on?
+
+SMYTH: Hulett consulted regularly for the Bureau of Mines, but I don&#039;t think he
+did much industrial work. I think Taylor may have done some.
+
+STURCHIO: Hadn&#039;t Morgan come from Bell Labs and then gone back after studying
+with you?
+
+SMYTH: Yes.
+
+STURCHIO: Did Bell Labs ever offer to help you with your research, or did you
+have any formal arrangements with them eventually?
+
+SMYTH: No.
+
+STURCHIO: The kind of work you were doing fitted in very nicely with their program.
+
+SMYTH: Yes.
+
+DOEL: In the 1920s there was also an attempt to establish cooperative research
+among a number of departments--astronomy, where Henry [N.] Russell was involved,
+and to a certain degree chemistry. Do you recall the discussions or actual work
+that was done?
+
+SMYTH: I don&#039;t remember anything about the formal arrangements for that. I was
+never involved. In a way, it was complete cooperation in my case with the
+physics department because I was effectively being given my space and janitor
+service and glass blowing. (Ultimately, the chemistry department got a glass
+blower.) Physics had a man named Chester Groves who had been a janitor and they
+pulled him in to set up physics lecture experiments. He had a remarkable sense
+for apparatus, so that when I designed a new piece of apparatus, I used to
+sketch it and then show it to Chester to see what suggestion he could make to
+make it more compact or simpler to build. That was entirely in the physics department.
+
+[END OF AUDIO FILE 1.3]
+
+STURCHIO: [interview resumes at 1:35:37] The role of instrument builders in science departments in that period
+is not much appreciated these days. Things have changed so much. Now one goes to
+a catalog and buys a piece of equipment. We had an interview with Arnold [O.]
+Beckman last year.[[footnote]]11[[/footnote]] He told us about his days at the
+University of Illinois where he used to give a course on glass blowing. This is
+just at about the same time that you&#039;re talking about Chester Groves and
+designing your own apparatus. Beckman was also doing the same sort of thing at
+Illinois and Caltech. It seems that kind of relationship between scientists
+trying to create apparatus and training mechanics in the department is something
+that historians and practicing scientists don&#039;t appreciate.
+
+SMYTH: I remember the chemistry department sent a man to one of the industrial
+glass blowing companies for training. Then he came back as glass blower in the
+chemistry department. In all of my early work, the physics department did it.
+
+STURCHIO: In one of your autobiographical sketches, you noted you went to Europe
+first in 1923.[[footnote]]3[[/footnote]] Was that just a vacation or were you
+there on research business?
+
+SMYTH: It was primarily a vacation. I went to Europe again two years later as an
+American delegate to the International Union of Pure and Applied Chemistry. They
+met in Bucharest. That was really something of a joy ride, because we took a
+tour down the Black Sea to Istanbul and back. I had planned to go from there
+through Greece purely for touring purposes. I had a visa for Greece but Debye
+then invited me to come to Zurich, and I gave a lecture just at that time. So I
+by-passed Greece in order to give the lecture. I had a very good time at Zurich.
+It was the Technische Hochschule [ETH] where Debye was. I was there just at the
+end of the academic year. We went on a big picnic by the lakeshore with Debye
+and his students.
+
+STURCHIO: Was that the first time you had met Debye and had a chance to discuss
+science with him?
+
+SMYTH: I think I had probably met Debye at some meeting. The invitation may have
+been the outgrowth of that, but I&#039;m not sure.
+
+STURCHIO: You must have had a lot to discuss with him since you were working in
+such a close area.
+
+SMYTH: Oh, yes. It was great to be there. Debye had such a clear, scientific
+vision. Linus [C.] Pauling had an almost equally clear vision, but Debye was
+normally right and Pauling wasn&#039;t always right. I always believed Pauling at the
+time; it was when I got away and started thinking things over that I could see flaws.
+
+Debye used to give the elementary physics lectures. This was later at Leipzig. I
+spent several months in Leipzig working in Debye&#039;s lab. Debye himself didn&#039;t
+have a lab. I worked on x-ray scattering there. But they had some system at
+Leipzig such that the big physics course was given and so many lectures were
+given. Then it was possible to add some lectures if everyone wanted it. Debye
+asked the students if they wanted more lectures. And they enthusiastically
+replied that they did. I just happened to see him as he came from that lecture,
+grinning from ear to ear. He was so pleased that the boys wanted him to give the
+initial lectures. They must have been wonderful lectures because he had an
+extraordinary clarity of mind.
+
+STURCHIO: Can you talk a little bit more about your sojourn in Leipzig in 1933?
+Did you go mainly to work with Debye? Were there other people in Leipzig at the time?
+
+SMYTH: I went to work with Debye. [Werner K.] Heisenberg was head of the
+theoretical institute. It was a physical institute. There were practically no
+close relationships between the theoretical physicists and Debye&#039;s people, who
+were also theoretical physicists but pretty closely tied to reality.
+
+STURCHIO: Did you have a chance on your earlier visit to Zurich or this trip to
+Leipzig, to have much contact with other European chemists?
+
+SMYTH: Yes. [Karl F.] Bonhoffer came to Leipzig after I was there. This was in
+1933, just after the Nazis had come into power. When I arrived in Leipzig, Debye
+was in England receiving a medal from the Royal Society. He had left his
+institute in charge of a young non-Aryan whom I knew quite well. He had received
+word that the Nazis were going to pick him up, so he hid with his fiancée&#039;s
+family. He was in hiding when I was there, so I was on my own. It was pretty
+much a one-man institute. Debye had a lot of people working there, but I don&#039;t
+think there was a group such as I found on another occasion at [James] Franck&#039;s
+Institute. In fact, it was the same year.
+
+STURCHIO: Did you go to Franck&#039;s Institute afterwards?
+
+SMYTH: I went to Gottingen to visit Franck&#039;s Institute and the laboratories. I
+had met Franck before, and he invited me to supper one night. He was Jewish, but
+he had been seriously wounded in the World War I. Because of that the Nazis let
+him keep his professorship at Gottingen. Franck was a wonderful fellow. Out of
+respect for his Jewish colleagues, he refused to come to the laboratory,
+although he was still a professor. But his group which he had built up used to
+come and have supper with him at his apartment. There were about seven or eight
+of us. That included [Edward] Teller. Another, [Walter] Heitler, was less well
+known but quite well known for his molecular structure work. He left Germany and
+went to one of the Irish universities, where he was a professor of theoretical
+physics. Fraulein Herta Sponer, the only woman in the group, was a very good
+person. There were two or three others. That evening made a very strong
+impression on me. It was a lovely late spring evening with the setting sun. You
+could look out over the green hills that surround Gottingen. There was this
+group who were obviously very fond of each other. It was a very closely-knit
+group. I just saw them that one time.
+
+Later I saw Franck and Fraulein Sponer and one or two others in this country. We
+had a symposium here at Princeton which they attended. Everyone had on a tuxedo.
+Alfred [L.] Loomis used to bring people together for research. He was a New York
+stock broker who was a partner in Bonbright and Company. He had his estate in
+Tuxedo Park and he bought the estate next to his and converted that house into a
+research lab where people used to go as guests. Bill Richards went there and
+spent some weeks as a guest. I was there just for a symposium. They were then
+talking about Franck&#039;s departure for the United States. All of his students had
+gone to the railroad station in Gottingen to see him off. They quoted his
+speech. They said that the head professor had delivered his well-known speech of
+departure which apparently he read anytime he went anywhere. [laughter]
+
+STURCHIO: Franck ended up in Chicago when he did come to the United States.
+
+Could we come back to Princeton in the late 1920s and early 1930s and ask how
+life at the chemistry department changed after the new Frick Laboratory was put
+up and as Hugh Taylor began to expand the department? Can you talk about your
+students and colleagues of those years?
+
+SMYTH: We had more graduate students then. I was still giving the large freshmen
+elementary chemistry course, which took a great deal out of me physically. I
+always had at least one bad headache a week after I had given these two days of
+freshmen lecturing. There was just something about my nervous system.
+
+STURCHIO: Was that in the main lecture hall in Frick with a couple of hundred students?
+
+SMYTH: Yes. Sometimes there were more than one hundred. It went from
+seventy-five up to a couple of hundred. I had two divisions. I also gave one
+small course in atomic structure and radioactivity of a very primitive sort, but
+it was fun.
+
+STURCHIO: Was that an undergraduate course?
+
+SMYTH: It was a one-term undergraduate course. Later I gave a graduate course in
+molecular structure.
+
+STURCHIO: Those were exciting years for the development of quantum theory and
+new applications in chemistry, courses that you found useful to teach.
+
+SMYTH: I was never mathematically minded. [John] Von Neuman and [Eugene P.]
+Wigner came to Princeton somewhere about that time. Wigner gave a course on the
+new quantum mechanics, and I and two or three other chemists took the course. I
+ended by not making any use of it. It just gave me some sense of what they were
+talking about. I was primarily an experimentalist. I wasn&#039;t only interested in
+experimental data, but they had to prove something. I was interested in testing
+theory by experiment as when I did the partial vapor pressures of
+liquids.[[footnote]]12[[/footnote]] That I undertook to test the theory that
+[Irving] Langmuir had advanced. Langmuir said to me, &quot;I&#039;ll guess I&#039;ll have to
+abandon that theory.&quot;
+
+STURCHIO: You were making a habit of that. You had shown G. N. Lewis was wrong
+with thallium amalgams.
+
+SMYTH: Well, that&#039;s not a good habit. It was just accidental in the case of
+Lewis. If you see a way of testing an appealing theory--I examined the Kekulé
+model and proved that right. So I wasn&#039;t always proving something wrong.
+
+STURCHIO: Do you recall who else went to Wigner&#039;s lectures with you?
+
+SMYTH: Hugh Taylor may have gone to some. I&#039;m not sure whether [Henry] Eyring
+was here at the time. I think he may have gone. Of course, he was a good
+theoretical man, one of the very best.
+
+DOEL: Were there any regular meetings among the department faculty or colloquia
+where you had a chance to discuss research?
+
+SMYTH: We had regular colloquia. We had some very good people. I remember at one
+point Niels [H. D.] Bohr was here, either at the Institute or at the physics
+department. I went to his lectures in physics. They were two or three very
+elementary public lectures. Bohr spoke as though he had a hot potato in his
+mouth. He spoke excellent English but he was quite hard to understand. So he
+spoke very slowly. They put a microphone on him. He would go to the blackboard
+and write something on it and then turn to the audience. Then he would turn
+around and go to the blackboard again. Ultimately, he got himself wound up in
+the cord. So he was trying to reach the blackboard and someone had to get up and
+rotate him in the reverse direction. [laughter] I&#039;m afraid that&#039;s all I remember
+about the lecture--his practical example in rotation.
+
+Later we had a Danish physical chemist giving a colloquium in the chemistry lab.
+I think it was [Niels] Bjerrum. He gave this lecture and Bohr came over. He was
+a friend of Bjerrum&#039;s. I happened to be sitting in the front row and Bohr was
+sitting next to me. Bjerrum would go to the blackboard and write something down.
+Bohr was very much interested. He would jump up and give his views on the
+subject. Frequently he would disagree with Bjerrum. At one point Bjerrum had the
+only piece of chalk, and the two were grabbing at each other to get the piece of
+chalk. The ideas were coming so fast. That was great fun. It was very stimulating.
+
+STURCHIO: Princeton must have been quite a place for science in those days. It
+still is. But it must have been very exciting to have people like Bohr around.
+Could you talk a little more about some of your colleagues in chemistry at the
+time? You mentioned Henry Eyring. What was he like?
+
+SMYTH: Henry was fine. I had some long talks with him. In his early days, before
+he became famous, he was very helpful to me. We did one piece of work together,
+and we considered making a joint paper but then decided that it would be better
+if each one of us published separately, which we did.[[footnote]]13[[/footnote]]
+The same idea came out in those two papers. Eyring by that time was very well
+known as the theoretician, so he got the credit for the theory. He deserved it,
+too. It&#039;s all down to the best of theories. Eyring was an awfully nice fellow
+and extremely useful to me. Later, when he had a lot of graduate students and
+was away lecturing quite often out of town, I just didn&#039;t feel that I could come
+between him and his graduate students to talk about my ideas.
+
+Eyring was a tremendous worker. He worked twelve months a year, sixteen hours a
+day. On Sundays, he went to New Brunswick and functioned as a Mormon bishop. I
+came back from one of my vacations and ran into Henry in the hall. Henry said,
+&quot;You&#039;ll be glad to know that I am now a general.&quot; I said, &quot;How come?&quot; It seemed
+that he had gotten an idea about the theory of a certain organic reaction. So he
+collaborated with an organic chemist to carry out the reaction. [Moses L.]
+Crossley was in natural organic synthesis. They went in the opposite direction
+of Eyring&#039;s theory but that didn&#039;t matter. Eyring had worked on it and said, &quot;Of
+course, I was only second-in-command. The organic chemist was in charge. But for
+a Mexican to be second-in-command (he was a Mexican citizen) was being a
+general. So I was a general.&quot; He had such a nice way of saying it all. We
+maintained that relationship. The last time I saw him I didn&#039;t know that he had
+cancer. It was at some symposium that we had here celebrating the fiftieth
+anniversary of the Frick laboratory. Eyring made a point of coming to me and
+telling me how much his association with me had meant to him. Of course, my
+association with him had meant a great deal to me also. He died of cancer about
+a year later. I didn&#039;t happen to see him in the intervening year. I respected
+him tremendously, scientifically, and was very fond of him personally.
+
+STURCHIO: Which other colleagues were you close to in those years in chemistry?
+
+SMYTH: I guess Eyring was the only one that I was very close to. Very early on I
+used to talk to Karl Compton. Karl knew an awful lot more than I did.
+
+DOEL: There was an attempt to call Debye to Princeton in the 1930s?
+
+SMYTH: I remember that. I went to Leipzig and visited Debye&#039;s laboratory in the
+summer of 1928. Then I went there again for some months in 1933. When I was
+about to make one of those trips, Karl Compton asked me to approach Debye about
+the possibility of coming to Princeton.
+
+[END OF AUDIO FILE 1.4]
+
+SMYTH: [interview resumes at 2:05:35] They had very bad luck in that, and they also tried to get [Enrico] Fermi
+at one time. Either Debye or Fermi almost certainly would have accepted to go to
+Princeton if the call had come at just the right time. Fermi ran up against the
+Italian fascists, who copied Hitler in their anti-semitism which pushed Fermi
+out of Italy. If Princeton had had the resources to make that call at just that
+time, I think he probably would have come to Princeton. When I first knew Debye,
+he was with the Technische Hochschule in Zurich. Then he went to Leipzig, and I
+also went there. By the end of 1933, I think we had already called [Rudolf W.]
+Ladenberg to Princeton. He was a good man, a German physicist, but of a much
+smaller stature then Fermi or Debye. Ladenberg continued his work, but it was
+not of great moment when those two other men were still roaring ahead.
+
+This is a digression, but during my years when I was in Leipzig in 1933, Debye
+told me when they tried to call Bonhoffer to Leipzig. [Wilhelm] Ostwald had
+started physical chemistry at Leipzig. Ostwald&#039;s son had lived on an estate
+outside of Leipzig which had an arch over the gateway saying, &quot;Enter Ye.&quot; There
+was a great physical chemistry tradition at Leipzig which had not been
+maintained as the younger Ostwald grew in age. So they called Bonhoffer, who was
+the best physical chemist in Germany probably at that time. This was just after
+the Nazis had come into power and two German Nobel laureates in
+physics--[Johannes] Stark, famous for the Stark effect, and [Philipp]
+Lenard--were consulted as to the suitability of Bonhoffer. Whether it was Lenard
+or Stark, I&#039;m not quite sure, but one said, &quot;I do not know that Bonhoffer is
+Jewish or has Jewish blood in him.&quot; He didn&#039;t, as far as I know. &quot;But I do know
+that he was a pupil of [Fritz] Haber&#039;s,&quot; who was a Jew, &quot;and his methods must
+therefore be impure.&quot;
+
+Anyway, the university elected to cut Bonhoffer from there. That was just about
+the time that I was there, but he actually came to Leipzig after that. I saw him
+at the end of the war, when he had left Leipzig and was staying at his summer
+place in the Harz Mountains. I went up to see if I could learn something from
+him and was able to actually do something for him. At that time his brother,
+Bishop [Dietrich] Bonhoffer, had been executed by the Nazis. Bishop Bonhoffer
+was supposed to have had some connection with the July revolution against
+Hitler. When he was imprisoned, his brother was afraid that he was going to be
+beheaded because the Nazis regarded beheading as a worse fate than shooting.
+Actually, the German baron who was leader of the plot against Hitler was hung by
+a loose noose so that he was a long time in dying. That was the worst thing that
+they could do.
+
+Karl Bonhoffer&#039;s camera had been confiscated by the American troops who had
+arrived just a few days before. It was routine to confiscate all cameras and
+field glasses. Bonhoffer said that he had a very beautiful new camera that had
+been confiscated. It just would have been thrown on a pile and the Americans
+would run a tank over it. So I went to the local commanding officer and told him
+Bonhoffer&#039;s story and later I heard that Bonhoffer&#039;s camera had been returned to him.
+
+STURCHIO: If we can come back to your research at Princeton in the 1920s and
+1930s, you had mentioned that you were always interested in trying to test
+theoretical results with experiments. I was intrigued by a number of your papers
+in this period. We talked about the ones with Morgan on the benzene
+structure.[[footnote]]8[[/footnote]] You had also done a couple of papers a few
+years later on testing new ideas about resonance using new methods.[[footnote]]14[[/footnote]]
+
+SMYTH: Yes. That was shown by the dipole moments.
+
+STURCHIO: That was an issue of some currency at the time in organic theory. What
+kind of reaction did those papers get from people?
+
+SMYTH: They got a good reaction. As a matter of fact, it was after that that I
+had pleasant contact with Kharasch in Chicago.
+
+STURCHIO: Also related to that work on charge shifts in organic molecules, you
+had published at least one paper with [L. G. S.] Brooker at
+Kodak.[[footnote]]15[[/footnote]] How did that collaboration come about?
+
+SMYTH: I don&#039;t remember. I think we published three papers all together. Brooker
+had worked on these dyes where there had been apparently large resonance charge
+shifts, so that they were obvious candidates for dipole moment study. There the
+charge distribution showed in the large dipole moments.
+
+STURCHIO: Did you maintain any kind of relationship with Kodak after that?
+
+SMYTH: No I didn&#039;t, to my regret. I knew C. E. K. Mees quite well. I used to see
+him at meetings. He spoke here in Princeton, and I saw him even after he
+retired. Otherwise, I think my best friend at Kodak was a fellow graduate
+student at Harvard. We had been tennis partners and played together at the
+Harvard University tennis championships. That was Emmett Carver. I think he was
+the general fix-it man at Eastman Kodak. I was told that when something went
+wrong, Carver would be called in.
+
+DOEL: During the 1920s and 1930s, do you recall any discussions among your
+colleagues about whether it was a good idea to establish any kind of national
+institute for chemistry? Was there any push or drive or interest in this?
+
+SMYTH: I suppose we had discussions, but I just don&#039;t remember them. Taylor was
+very active in it. I think at one time Taylor perhaps tended to run a one-man
+department. He had a very quick mind and very good judgment and was very
+aggressive and energetic. That was perfectly natural for him to go ahead on his own.
+
+STURCHIO: Certainly more and more resources were coming in during that period.
+
+SMYTH: Yes. Taylor brought Eyring here, and after he had been here a while, the
+question of continuing Eyring came up. I said, &quot;By all means keep Eyring,
+whatever happens.&quot; They practically offered the whole university to Eyring to
+stay here when he was called to go to Utah. Eyring&#039;s wife was a sister of one of
+the twelve apostles of the Mormon church, so they were tops socially there.
+Eyring didn&#039;t care a hoot about the social side of things, but his wife may
+have. He didn&#039;t care at all for social life here in Princeton. I think she
+hardly went out at all after the first few years at Princeton. She was a very
+nice woman, but I hardly knew her. I think we had them to the house once for
+dinner. We would have been very glad to have had them often, but I don&#039;t think
+she would have welcomed it. So she put very heavy pressure on him to go.
+Otherwise, I think he would have stayed here.
+
+Joe [Joseph O.] Hirschfelder, who was one of Eyring&#039;s good pupils, told me that
+he did his best work here at Princeton. That isn&#039;t necessarily a tribute to
+Princeton, because a theoretical man is apt to do his best work when he&#039;s at
+just about the age that Eyring was then.
+
+STURCHIO: This was quite a place for kinetics in those days. Eyring, Taylor,
+Alyea&#039;s early work on inhibition--there were many others doing that kind of work
+as well. Also, with the work that you and your students were doing in another
+area of chemical physics, it occurs to me that there couldn&#039;t have been any
+place in the country--with the possible exception of Berkeley or Caltech--that
+was as good a place for physical chemistry in the interwar years as Princeton
+was. Does that seem like a reasonable characterization?
+
+SMYTH: I think so. I may be over-optimistic. We were tops in analytical
+chemistry too, but that was a relatively unimportant subject by that time as
+compared to physical chemistry. In the early days, most of chemistry was
+analytical. McCay was a very good analytical chemist. He was not a great
+research man, but I spent eighteen hours a week in a quantitative analysis
+course. It was supposed to be nine hours, but it just took so long to do these
+laborious old-fashioned precipitations and filtrations, washings and dryings and
+weighings. That was what chemistry consisted of to McCay.
+
+STURCHIO: By World War II chemistry was very different at Princeton.
+
+SMYTH: Yes. By 1930 it was very different. I started in 1920.
+
+STURCHIO: Can we talk about some of your other students and could you talk about
+the rise of chemical physics in the 1930s? You were an editor of the Journal of
+Chemical Physics, and there were a number of different schools of thought about
+the relations between physical chemistry and chemical physics. There was
+
+[Wilder D.] Bancroft, who was from the much older school, and there were people
+like you and Eyring who had a very different view of the relationship.
+
+SMYTH: Bancroft was a brilliant man, but very much original. His grandfather was
+an eminent historian and also an ambassador to England. Bancroft was a great
+fellow, personally. He was a great big man and loved to wear a diamond and gold
+tie pin. He could be found in the baseball park when an ACS meeting was in
+progress. Occasionally he was found in my company at the ballpark.
+ [untranscribed discussion about lunch]
+
+In the
+winters and early spring the ACS met in St. Petersburg, and the New York Yankees
+with Babe Ruth and Lou Gehrig were training there. There were more chemists at
+the ballpark than there were at the section meetings. [laughter]
+
+STURCHIO: That&#039;s understandable. That must have been one of the better ACS
+meetings of the year.
+
+SMYTH: Oh, it was the best that I ever attended. [laughter]
+
+STURCHIO: This was a period when the ACS took over Bancroft&#039;s Journal of
+Physical Chemistry and when people like Harold [C.] Urey and you were involved
+in setting up the Journal of Chemical Physics.
+
+SMYTH: Harold Urey was editor-in-chief. The Journal of Physical Chemistry
+continued under Bancroft but it was an entirely new thing.
+
+STURCHIO: Did the group of you really have a sense of it being a new field? Was
+there a sense of group identity among the people working in chemical physics?
+
+SMYTH: It was not very long after that that they started a section of chemical
+physics at the ACS. The American Physical Society also did something, though
+I&#039;ve forgotten how they did it. I think I belonged to a chemical physics section
+of the American Physical Society. I probably don&#039;t anymore, because I haven&#039;t
+paid any dues recently. The ACS would have symposia and every once in a while
+one of those would tend to be chemical physics. I remember organizing a
+symposium on dielectrics for the New York Academy of Science. I got Lars Onsager
+and Jack [John G.] Kirkwood to speak. I knew [John H.] Van Vleck very well. He
+was a pure theoretical physicist at Harvard. He ultimately got the Nobel Prize
+for his work on magnetism [1977]. He wrote a book which had a lot of the theory
+of dielectrics in it.[[footnote]]16[[/footnote]] He and I were quite close. I
+remember his entertaining me in Cambridge. He took me over to the faculty club
+there. It was just after the war, and the faculty club had patriotically served
+horse meat instead of beef during the war and they carried it on as a custom.
+They tried to push me into eating horse meat. I declined. I had eaten it often
+in Paris, but not willingly.
+
+STURCHIO: Who were some of your other students during the 1930s and 1940s?
+
+SMYTH: It&#039;s very hard for me to place them exactly. Stan Morgan was my first.
+They usually didn&#039;t go on with dielectrics when they left me. Stan did to some
+extent. [Smyth indicates publication list.] This starts with something on the
+moisture content of typical coal which was my first published paper with Hulett
+and Ed Mack [Edward Mack, Jr.]. This was published in the American Journal of
+Science in 1918.[[footnote]]17[[/footnote]] Ed Mack was a pupil of Hulett&#039;s so
+we collaborated. Ed Mack later was chairman of the department at Ohio State. He
+was a very able man, though not one of my pupils. I rather was his.
+
+I lost track of W. [William] N. Stoops. He followed Morgan. Here&#039;s a joint paper
+with Morgan and J. [Joseph] C. Boyce.[[footnote]]8[[/footnote]] Boyce was the
+physicist who had the short working week. [looking through publication list; untranscribed to 2:33:38]
+
+George L. Lewis was named George
+Leoutsacos. He was a Greek boy from New England. He had a great problem with
+changing his name because he wanted to become G. N. Lewis. [laughter] But he
+took the name George Leoutsacos Lewis. He used to sleep in an uncomfortable
+chair in my office occasionally, and then not show up in the lab for a couple of
+days. He&#039;s now with Du Pont.
+
+P. [Peter] F. Oesper&#039;s father was a professor of chemistry at the University of
+Cincinnati. Oesper was a very bright fellow and very nice, but he didn&#039;t have
+the drive. He didn&#039;t amount to anything after he left here.
+
+STURCHIO: His father endowed a chair in the history of chemistry at Cincinnati.
+In fact, they just hired a colleague of ours, William [B.] Jensen, to teach
+history of chemistry as the Oesper professor.
+
+SMYTH: I&#039;m very glad to hear that. Oesper was a very nice looking boy. He
+couldn&#039;t have been nicer and was very bright.
+
+[END OF AUDIO FILE 1.5]
+
+SMYTH: R. [Richard] H. Wiswall was a good man. This is in 1941.
+
+STURCHIO: Why not tell us more about Bill Baker?
+
+SMYTH: When Bill Baker applied here he was a student at Washington College in
+Maryland. When he graduated from Washington College he was really at the
+educational level of the average man completing the junior year at Princeton or
+MIT. He lacked some of the requirements the dean of the graduate school, Dean
+[Andrew F.] West, had set up. He required that everyone admitted must be able to
+read Latin prose. We had to talk a lot of men around that. I don&#039;t remember
+whether Bill Baker had Latin. He was a very cultivated chap and absolutely
+outclassed the other members of his class at Washington College. When Bill came
+up to talk things over as a candidate, we had to take a fellow like that, no
+matter what deficiencies there were in his training. So we took him and he was
+absolutely tops right from the beginning, and an extremely nice fellow to have
+around. He had original ideas. He was one of the few graduate students who
+didn&#039;t just work on one of my ideas. He worked to some extent on his own, but it
+was a very pleasant and happy collaboration. He had always been interested in
+birds. We used to go walking together to look at birds because I&#039;ve always been
+interested in them, although Bill knew a lot more about them.
+
+He went on from there. By the time he left I knew he was the brightest graduate
+student that I had had. I had another probably equally bright man years later
+who was thrown into academic work. Although he was bright, he didn&#039;t know how to
+concentrate. We did a piece of work in dielectrics. Then he apparently got
+interested in astronomy and didn&#039;t do much of anything. But it was a very happy
+collaboration for me with Bill Baker.
+
+STURCHIO: He worked on molecular rotation in the solid state?[[footnote]]18[[/footnote]]
+
+SMYTH: Yes. Then he went on to make use of that at Bell Labs.
+
+STURCHIO: I did an interview with Bill Baker last year and was intrigued when he
+talked about his work with you and his years at
+Princeton.[[footnote]]19[[/footnote]] He mentioned that he was a graduate
+student at the same time as Frederick Seitz and [W.] Conyers Herring and that he
+was very interested in the solid state physics work that was going on at that
+time. Were you following those conversations?
+
+SMYTH: No. I don&#039;t think I was. Bill must have been doing that on his own. I
+never knew Conyers Herring. I knew Fred Seitz, but after he left Princeton.
+
+STURCHIO: Did Baker stay in touch with you after he went to Bell Labs?
+
+SMYTH: Yes. He used to come to see me every once in a while. We more or less
+stayed in touch.
+
+STURCHIO: As you said, he had a very interesting and productive career at Bell
+Labs over the years. This might be a good time to move on to World War II. Could
+you tell us about your experiences then?
+
+SMYTH: Yes. One more thing about Bill Baker. After I had retired from Princeton,
+I worked for the Office of Naval Research for about fifteen years. They had some
+special anniversary and had a banquet. They wanted to get an outstanding
+scientist to address them, and Bill Baker was the person who did it.
+
+DOEL: What major changes or problems do you recall during the Great Depression?
+Did it affect the department? What research was being done there to a great extent?
+
+SMYTH: It affected departments in that there were virtually no promotions, and
+there was inevitably some bitterness because of that. This was all perfectly
+natural, but no one was fired here. During that general era, I can remember W.
+[William] A. Noyes, Jr. came here looking for a job, and Frank [H.] Spedding did
+too. We would have had to go to associate professorship to get Noyes--probably
+Spedding might have come as an assistant professor.
+
+DOEL: Were you also involved in the deuterium research being done at Princeton?
+
+SMYTH: No. I was not.
+
+DOEL: Were you aware of the work that was going on? Did you have contact with
+the people?
+
+SMYTH: Yes. I think I was, but I was not involved in it in any way. I was
+practically a one man show, a very limited show.
+
+STURCHIO: That&#039;s a useful transition--the deuterium research into World War II.
+We know that you did some work on the Manhattan Project during the war and also
+some consulting work for the War Department. Then of course there was the ALSOS
+mission. Perhaps you could talk about each of those in turn.
+
+SMYTH: I worked on the Manhattan Project for eighteen months. I was slow in
+finding anything good. I was invited to come up to work in the Radiation
+Laboratory at MIT. I didn&#039;t know a thing about radar, but radar was distantly
+related to dielectrics. Both of them involved research on electric waves. I was
+all set to go. I spent a day there. The Radiation Laboratory there was terribly
+crowded. They were using the halls for offices. There were desks in the halls of
+the building. I knew quite a few people there. All kinds of people were working
+on radar who didn&#039;t know much about it. That seemed like a pretty good thing to do.
+
+Then Hugh Taylor signed on a project just starting for the Manhattan Project. He
+said, &quot;Why not stay on at Princeton? There would be no dislocation, and you
+could be useful that way.&quot; So I did because that was really straight physical
+chemistry that was going on. We were doing barrier research. I stayed with that
+for twenty months. Then the barrier problem seemed to be pretty well solved. It
+was just going to be a little tidying up. I thought I wouldn&#039;t be doing much if
+I stayed longer. So I approached the radar people at MIT again and they said,
+&quot;Sure, come on up.&quot; But they asked if I would like to go out to Saipan to set up
+a radar station for the Army there.
+
+Well, I knew absolutely nothing about radar, which I pointed out. They said,
+&quot;Oh, that doesn&#039;t make any difference.&quot; I could spend two or three weeks there,
+and they would indoctrinate me. All I would have to do would be to prevent some
+high military officer from locating the radar station in a place that was more
+or less inaccessible to radar waves. I didn&#039;t know how good I would be at
+controlling a high commanding officer--keeping him in line.
+
+Just at that time, my brother happened to remark to me that he had seen Sam
+Goudsmit, whom I did not know at the time. I happened to run into him in
+Washington. Sam had asked if I would like to join them on the scientific
+intelligence mission in Europe, going into Germany as the Army advanced into
+Germany. I was very well-equipped for that because I knew something about
+physics and a little about chemistry (you&#039;d cover both), and spoke a little
+German, pretty bad German. So when Sam didn&#039;t approach me directly, I called up
+Karl Compton who was high up in the military science organization in Washington
+then, and asked him. He said he thought that was a good thing to do and it would
+be useful. Then I called up Sam Goudsmit. He explained to me--I don&#039;t remember
+whether he brought it up over the phone--that there was a difficult problem
+because in Paris, there wasn&#039;t any heat in the hotel and I would have to use up
+all of my food allowance on buying brandy to keep warm in a Paris hotel.
+[laughter] &quot;But come on down to Washington anyway and look things over.&quot; So I did.
+
+I went to the Pentagon and sort of went through the mill. It looked like a fine
+thing to me, so I accepted and went right down in February. I used to spend a
+few days in the Pentagon. Just about the time that I learned to find my way to
+the one-room office that the mission had (you had to go through hallway after
+hallway of the Pentagon), they got ready to send me across. I was due to fly on
+a certain day, but this was a civilian mission combined with the Army. The
+civilians had to have passports. The State Department had been duly notified
+that I needed a passport, but they got me two days before departure time. No
+passport had come. That&#039;s the way the State Department used to function. Their
+passport division was a national disgrace. It was run by a woman and all the
+papers were just lying there somewhere, so my outfit called up the State
+Department and said that I was going the day after tomorrow. &quot;Please produce the
+passport.&quot; And they did. I had been looking over in the ALSOS office in the
+Pentagon which was commanded by a young major. They had a lot of papers that
+ALSOS had collected in occupied France. They hadn&#039;t gotten into Germany yet. Or,
+they had just gotten into Strassburg, which was Germany at that time.
+
+I flew across. I was naturally excited as it was my first long flight. I don&#039;t
+know how much detail is interesting to you or not.
+
+STURCHIO: Please tell us about anything you find interesting.
+
+SMYTH: I can talk indefinitely. I was going to write a book about it; I have
+sixty pages written, but then I bogged down. [See Appendix, 3:09:40]
+
+We flew out of Washington after an extensive briefing on what to do in case of
+an accident. There were sixteen passengers on an old DC-4, known as a C-54 to
+the Army. They had a stewardess who was a 250-pound young man, a corporal. We
+flew to Newfoundland. We left Washington in the spring with the mockingbirds
+singing, and put down in deep snow in Newfoundland to take on gas and have
+dinner in Newfoundland. That was my first experience in an Army mess. Then, we
+flew on to the Azores for breakfast. We arrived in the Azores in lovely spring
+weather. Then we flew from there to Paris, where you could just see the smashed
+bridges from the plane. We could see Mont Saint Michel, which I knew rather
+well, on the horizon. We got into Paris at dusk. There were very dim yellow
+lights on the Paris streets, which were not supposed to be bombed. I think it
+was declared an open city. I reported at a luxury hotel, where I was given a
+room. The Army quartermaster had taken over the kitchen in the hotel
+unfortunately, and we had regular Army food, which wasn&#039;t at all improved by the
+fact that French waiters were bringing it to us. I went down to breakfast in the
+morning and I reported to the office, which was only a ten-minute walk away. It
+was in an apartment house; the Army had taken over the sixth floor. They had a
+lot of fresh material brought in by ALSOS expeditions to the front. I worked on
+those papers for a couple of weeks. I was slated to go into the Ruhr region. [untranscribed discussion about lunch arrangements]
+
+[END OF AUDIO FILE 1.6]
+
+APPENDIX: SCIENTIST IN A JEEP
+
+[audio begins at 3:09:40] In January 1945, the sweep of the Allied Armies across France seemed to have
+slowed down. The Battle of the Bulge, although ultimately disastrous to the
+Nazis, had shaken us out of any unwarranted complacency. The small part of the
+Manhattan Project on which I had been working for a year and a half, had
+progressed to a point where there seemed little more to do on the problem with
+which I had been primarily concerned. The laboratory seemed far from the great
+action that was occurring all over the world, and I was eager to get nearer to
+what seemed to be activity more closely related to the immediate progress of the
+war. I therefore communicated with the Radiation Laboratory at M.I.T., where I
+had been offered a job to work on radar nearly two years previously. After
+talking with them, and making clear how I felt about the war, I received an
+opportunity to go to Saipan as an advisor on the use of radar equipment. I knew
+nothing about radar, but I was told that I could very quickly learn all that was
+necessary, so that I could leave for the Far East in a short time.
+
+At this time my brother remarked one day that he had been talking to a
+distinguished physicist, Samuel Goudsmit, in Washington, and Sam had asked
+whether I would be interested in the possibility of going to Europe on an
+intelligence mission with the Army. I was very much interested, as I was far
+better qualified to go into Germany with the Army than I was to learn the
+elements of radar and go out to Saipan. In either case I would be very close to
+the war that was going on. It seemed that K. T. Compton, the president of M.I.T.
+and a former colleague and friend in Princeton, was high up in the organization
+which was involved in this scientific intelligence mission. I immediately called
+Karl in Washington and asked him about it. He showed me its importance and
+indicated my probable usefulness. I therefore got word to Goudsmit that I was
+very much interested in any opportunity which might develop, and almost
+immediately was asked to come to Washington to talk the matter over. I signed on
+and shortly withdrew from my work on the Manhattan Project.
+
+Let me interpolate at this point that, as this is a personal narrative, the
+first person singular will appear very frequently in what follows. My job
+initially consisted of commuting from Princeton to Washington, where I lived in
+a luxury hotel from which I commuted to the Pentagon at an early hour every
+morning. When I reached the Pentagon, if I had a suitcase or documents with me I
+had to show them to the guard, opening the suitcase to assure him that I had no
+bomb with which to blow up the building, a routine precaution. After passing the
+guard, I started the long exploratory trip to reach the inner depths of the
+great building, in which the ALSOS Mission was housed in a single room. Here I
+spent the day delving into documents, some of which had possible intelligence
+interests. They had a lot of papers that ALSOS had collected in occupied France.
+They hadn&#039;t gotten far into Germany yet; they had just gotten into Strasbourg,
+which was Germany at that time.
+
+At the end of the day all documents were locked away, and the major responsible
+for the office looked the room over very carefully to make sure that no paper
+was exposed to view. If security guards had subsequently found any paper left
+overnight on anyone&#039;s desk, the major would have been subject to disciplinary
+action. This work at the Pentagon continued for a matter of two or three weeks.
+In the meantime, the necessary papers were filled in and the nature of my
+mission was explained to me very briefly, because in intelligence work of this
+character the left hand was not supposed to know what the right hand was doing.
+
+The Office of Scientific Research and Development, my nominal employer, applied
+for a passport which was necessary because I was a civilian. Although I was to
+be attached to the army and wear a uniform with no insignia of rank, it might be
+necessary for me to go to some neutral country, notably Switzerland. Since if I
+went into Switzerland in a military uniform I was liable to arrest, a civilian
+suit, as well as a passport, was essential. The usual application for passport
+was made to the State Department, and arrangements were made for my departure by
+plane. Of course, it was necessary to take a physical examination, which was
+given to me in the Pentagon. Having just had my fiftieth birthday, I was
+delighted and rather proud to be told by the medical authorities that I was fit
+for arduous duty. When I mentioned this with some satisfaction to my colleagues,
+they congratulated me and expressed gratification that they could now count on
+me to carry their bedding rolls when we got on the other side. In my
+satisfaction this did not dampen my ardor.
+
+The next hurdle was obtaining my passport. In the days before the war, it took
+months to obtain a passport. There were very few applications for passports to
+process in those days, but my passport didn&#039;t come and didn&#039;t come. The Office
+of Scientific Research and Development, hereinafter referred to as O.S.R.D.,
+telephoned the State Department, explaining the vital character of my work and
+the absolute necessity of a passport, but nothing happened. Finally, about three
+days before my scheduled departure, O.S.R.D. called up the State Department and
+informed them that I was flying to Paris on March 12th and please have the
+passport ready. Accordingly, I went down the next day and collected the passport
+from the musty office where the papers had been lying since the filing of my
+application. 
+
+On the day of my departure, which was a mild spring day in Washington with the
+sky gray and the mockingbirds singing, I was driven down to the airfield before
+lunch. The small number of men, passengers considered to be a full load for the
+flight, consisted of fourteen army officers and two civilian ALSOS scientists in
+officer&#039;s uniforms, who were briefed for the flight. Prior to this, I had never
+realized what a wide, cold, dangerous place the North Atlantic was, and
+consequently felt more philosophical over the high premium that I had had to pay
+for the one-year insurance policy which O.S.R.D. had required me to get before
+departure. Apparently, no American insurance company would take the risk of
+insuring the ALSOS civilians, but Lloyd&#039;s of London was willing to take us on. I
+always wondered whether they would have rung their ship&#039;s bell if I had been
+lost, as they did when one of their insured ships sank.
+
+We were shown how to use a life preserver, in the form of an inflatable vest,
+and how to use flares and smoke signals in case we should &quot;ditch&quot; and be
+floating around in the North Atlantic. Then we were given a steak dinner,
+somewhat reminiscent of the last meal given a convict before he is sent to the
+electric chair. I was very much excited by all this and felt a sense of
+exhilaration in spite of certain grim aspects of the occasion. We went aboard
+the C-54 (in civilian terminology, the DC-4) about two o&#039;clock. The
+&quot;stewardess,&quot; a huge corporal, weighed nearly as much as two passengers. We were
+fortunate in that the plane was one of the first to have upholstered chairs for
+the passengers instead of hard, backless bucket seats let down from its outer
+metal shell.
+
+We took off in hazy weather, with low ceiling, and flew up the coast near
+Baltimore, which we did not see, and New York, which was shrouded in haze.
+Finally we saw the Maine coast thousands of feet below us, and intermittently
+glimpsed forest, mountains and sea, until, as sunset approached, we came out of
+the murk and saw, far below, the Gulf of St. Lawrence appearing lavender through
+the haze, dotted with white ice cakes and flows. We continued through the
+twilight, and, when the earth had darkened completely, came down through the
+murk to the airfield at Stephenville, Newfoundland. Great piles of snow greeted
+us on the ground and the temperature was close to zero degrees, in sharp
+contrast to the spring which we had left behind in Washington.
+
+Dinner that night was my first experience in an army mess, and it was quite
+satisfactory. When we took off, in absolute darkness, we soon ran into rough
+weather, and at one point, the airplane hit a pocket and seemed to drop suddenly
+out from underneath the passengers. I seemed to be suspended in air above my
+seat, although actually it must have been only for a fraction of a second. I was
+sitting next to the aisle, but my ALSOS colleague, Carl [A.] Bauman, was next to
+the window. As the ceiling was much lower near the window, it came down on his
+head when the plane dropped, and several stitches had to be taken at the point
+of contact. The only damage regarded as serious occurred when an officer&#039;s pack
+fell into the aisle and smashed a bottle of whisky.
+
+At sunrise, we had gotten out of the cold, dark weather and were making our way
+through great white, fluffy clouds hanging in a deep blue sky with a blue sea
+far below. The pilot sent back word to ask if I would like to come up forward
+and see what was going on. Of course it was great fun for me to have a pilot&#039;s
+view of the vast expanse of sea and sky and cloud. I was even allowed to play
+with the altimeter, a radar device that sent down a beam to be reflected from
+the surface of the water back to the plane and so measure the altitude of the
+plane with considerable accuracy.
+
+We came down at Lagos in the Azores at breakfast time to delightful warm, spring
+weather. Here we had breakfast, Carl Bauman had his head stitched up, and we had
+time to look around for a few minutes before reboarding the plane. It seemed
+almost grotesque to see a native cart with huge wood discs as wheels and oxen as
+the motive power, creaking past a modern bomber or great transport plane. We
+flew throughout the day in bright sunny weather and hit the coast of France in
+the late afternoon. Far below, one would see an occasional smashed bridge as
+evidence of war. Far off to the north one glimpsed a mass of buildings on a rock
+which was recognizable as Mont St. Michel.
+
+We reached Paris at dusk and, after a not long delay, got a taxi which bore us
+through dimly lit streets to a luxury hotel, the Royal Monceau, on the Avenue
+Hoch, one of the avenues radiating from the Arc de Triomphe. The flight had
+required about twenty-three hours in the air, as contrasted with our present-day
+seven hours or so on a modern jet plane. (Another thing that had been necessary before I could fly had been a
+request from General [Dwight D.] Eisenhower for my presence in the European
+Theater. This request did not arrive immediately, but came in ample time, and, I
+fear, did not evidence great concern over the matter on the part of the general,
+as the cable requesting my presence was signed for General Eisenhower by a lieutenant.)
+
+Paris on the evening of our arrival
+seemed strangely dark and quiet, and the nearly empty streets were lit by dim
+yellow lamps. Paris had been declared an open city, and was not supposed to be bombed.
+
+We arrived at the Hotel after dinner and regrettably found no food available.
+This was not very serious under the circumstances, as the flight on a C-54 is
+not a stimulant to the appetite. Carl Bauman and I were assigned to a
+comfortable room with two beds and bedding. Our bedding rolls were not needed as
+I recall it. The bedding roll, which was a very significant part of life in
+those days, consisted of three very heavy blankets folded together and rolled to
+form a cylinder, and wrapped in a heavy canvas sheet, which had pockets to hold
+a few clothes and papers. A canvas valise, usually left in storage in Paris,
+held spare clothes and a second pair of shoes. A small musette bag slung over
+the shoulder could be used to carry toilet articles and pajamas, if they were
+going to be worn.
+
+Before leaving Washington, I had been fitted with an officer&#039;s uniform. The only
+problem was to get the tailor to allow sufficient room for me inside the
+uniform. In addition, one had a couple of suits of army-issue heavy underwear.
+It was said that they were so stiff that you didn&#039;t have to hang them up, you
+just stood them up on the floor beside your cot. Before leaving Washington I was
+told that I would use up my $6.00 a day living allowance on brandy to keep warm
+while I was in Paris. I don&#039;t like brandy very well and found this stiff G.I.
+underwear a more than adequate substitute for brandy. The flannel shirts and
+extra khaki trousers, both light and heavy pairs, also served a very useful
+purpose. We were also provided with a knitted khaki sweater and a knitted cap,
+which could be worn under the plastic helmet liner, upon which, in turn, a steel
+helmet was superimposed [when in or near a combat area]. [3:40:29]
+
+[END OF AUDIO FILE SMYTH PERSONAL RECOLLECTIONS 1.1]
+
+[audio resumes at 3:44:46] All in all, it made a very useful outfit, especially when covered by the
+officer&#039;s trench coat with a warm removable wool liner, which could even
+pinch-hit as a bathrobe.
+
+Now back to the hotel, the Royal Monceau. On my first morning in Paris, we all
+started at an early hour after breakfast in the big dining room, which was for
+the most part a navy mess with some army officers using it. We walked up to the
+headquarters of the mission, which was known as the Alsos Mission, usually
+spelled in capitals ALSOS. At the time I did not know it, but I learned many
+months later that the name ALSOS was a pun concocted by someone who remembered
+more of his Greek than I did, a pun on the name of General [Leslie R.] Groves,
+the commanding officer of the Manhattan Project. The Greek word for &quot;groves&quot; is &quot;alsos.&quot;
+
+The office, which was on a street just the other side of the Arc de Triomphe,
+was five flights up marble-treaded stairs in an apartment house which had been
+converted on our floor to a series of offices. Here we worked on the papers that
+had been gathered by ALSOS expeditions to the front. This was a matter of
+sorting through a vast number of documents of all kinds, correspondence,
+business papers and occasional scientific papers which had been picked up, but
+particularly correspondence and travel requisitions and the like, which had been
+found here and there. Much was to be learned, however laboriously, by the
+careful scanning of these many papers [and putting two and two together. We
+worked seven days a week from very early morning until late afternoon, but on
+Sundays knocked off around four o&#039;clock]. [3:48:50]
+
+[untranscribed material, 3:48:50-3:49:52, outline dictated by a woman; untranscribed material, 3:49:52-3:52:00, substance appears elsewhere in transcript ]
+
+[3:52:14] My first breakfast at the Royal Monceau was in the agreeable company of a Marine
+Lt. Colonel who had arrived by parachute several months before on a mission for
+the OSS [Office of Strategic Services]. In general, there were assorted army and
+navy officers with an occasional civilian. Later, I recognized Charles [A.]
+Lindbergh, who I believe was colonel in the Air Force Reserve at that time. Noel
+[P.] Coward showed up in civilian clothes, as I recall it. I learned much later
+that he had performed important intelligence work during the war. Theatrical
+people might well have been there, as Paris was then a place for officers and
+enlisted men to spend their leave, and a good deal of theatrical entertainment
+was provided. [. . .] [3:54:40]
+
+[audio resumes at 3:56:47] The spacious dining room of the hotel was that of a great Paris luxury hotel.
+The waiters were, for the most part, boys in their teens, mostly low teens,
+wearing old, black waiter&#039;s clothes, probably inherited or borrowed from former
+waiters. The food was served in metal dishes with lids and looked very imposing
+until the lids were taken off. It sustained life and was not at all bad, but the
+cooks, whether Army, Navy or luxury hotel chefs, had done little to improve the
+adequate, but undistinguished materials furnished by the quartermaster. Very few
+restaurants were open in Paris, and we were not supposed to frequent them in any
+case. Later, when we were in the field, it was possible to get much better food
+cooked by local women of the country.
+
+We walked past the tomb of the Unknown Soldier at the Arc de Triomphe, en route
+to our office. Everyone in uniform was expected to salute when passing this
+tomb, and the performance of the ALSOS scientists in this regard was not viewed
+favorably by the military men who often accompanied them. I usually got by,
+because I had been a lieutenant in the Chemical Warfare Service in the First
+World War, but I was a bit rusty. When we got to the office, if the elevator was
+working we went up to the fifth floor in luxury. If it was not working, a
+characteristic condition of French elevators, we climbed five flights of marble
+stairs, which usually had at least one woman on her knees cleaning the marble
+treads with a mop or dirty rag.
+
+On the streets one encountered many men in uniform, for the most part American
+with occasional British. The traffic was light, [most of it consisted of American
+vehicles, jeeps, and trucks, some British, and a few cars belonging to the Free
+French]. Many of the [French] cars were wood-burners; that is, [they had large
+cylinders on the back into which fuel was placed in the form of two-inch wooden
+cubes. When the car was started, some sort of heating process was applied to
+vaporize material to distill the wood destructively so that the gasses could be
+fed into the cylinders of the engine and take the place of gasoline vapor. I was
+told that] the wood-burning equipment added [50%] to the weight of the car and
+[about the same to the cost. It was not a device to be recommended under ordinary
+conditions]. There were a few cars driving at high speed, with young Frenchmen in
+them [who were obviously exhilarated by the thought of nearby victory]. These
+young men were, in their bearing, somewhat reminiscent of the young
+brown-shirted Nazis that I had seen in [Germany] in 1933, when the Nazis had just
+taken over.
+
+Transportation by the Paris subway, the Metro, was excellent; also, it was free
+to Americans in uniform. A few Americans claimed that the atmosphere on the
+trains suffered from the general lack of soap in the country, but I did not
+notice anything wrong. The attitude of the French, those one encountered on the
+street, seemed more friendly than in past years when I had visited as a tourist.
+This might well be, as the French of those days tolerated tourists largely as a
+source of income, otherwise deploring them. There were frequent patriotic
+displays in the form of processions of men to the tomb of the Unknown Soldier.
+The numbers involved were often small, but sometimes numbered a hundred or more
+and included a brass band.
+
+One of my ALSOS colleagues, Professor E. [Edwin] C. Kemble, chairman of the
+physics department at Harvard, wanted to improve his German. In some way he
+located a chemical engineer [of] German origin, [who had lived] in various parts of
+Europe, and at the moment was [a prisoner] in the Paris jail. Kemble had arranged
+[to have] him brought by an ALSOS jeep to our office to give German lessons [and
+invited me to share in] the lessons. I was glad to do this, except for the fact
+that I expected to be sent forward at any minute. I told Kemble this, but he
+said, &quot;Come along anyway,&quot; and I had one joint lesson with Kemble. Oddly enough,
+it was the best-taught lesson that [I can recall in my study of five foreign
+languages]. An hour with this chap out of the Paris jail did a great deal to
+brush up my slightly rusty German. However, as I had expected, my orders to go
+to the front [at Aachen] came before I could have [any more lessons. Kemble
+continued, but I did not see him again to hear how he had progressed].
+
+[the following section of the transcript has been heavily edited; time codes  are approximate]
+
+Another colleague was Louis Fieser, professor of organic chemistry at Harvard,
+one of the leading organic chemists of the United States, [and the inventor of
+what was said to be our most effective incendiary. He had been] sent over to
+investigate German work on incendiaries. His investigations started at the
+Pouderie Nationale [at Sevrens-Livry in the outskirts of] Paris. Fieser asked me
+to join him in the investigation, and we went out early in the morning to start
+the job. The Pouderie Nationale was in a group of buildings, one of which had
+been the residence of the famous [18th-century] French chemist, [Antoine-Laurent]
+Lavoisier, who had been one of the pioneers in the development of chemical
+science. He had the misfortune to live at the time of the French Revolution,
+when those in authority concluded that the Revolution had no need of chemists
+[and sent him to the guillotine].
+
+The buildings had been occupied by the German army, who had [made it a center for
+work on incendiaries, flares, smokes and signals, among other things. The
+building had also served as a barracks]. Fieser and I, with some assistance, [went
+over a variety of incendiaries, flares, signals, etc., that the Germans had
+developed, or at any rate used, during the war. An experimental bomb pit proved
+extremely useful as we never knew when one of the experimental bombs or
+incendiaries was going to explode. We had arrangements for igniting it in this
+pit, while we observed well-protected], through a very narrow slit [in the thick
+wall of a small room built for observers. Actually, a mirror on the wall
+opposite the slit made it possible, in case something seemed particularly
+dangerous, to simply view in the mirror the reflection of what could be seen
+directly through the slit. This would eliminate all danger of] flying fragments.
+I am afraid that [we were more] like two boys celebrating the 4th of July [than we
+were serious investigating scientists or military representatives. We had a
+great many varieties of different colors and noises].
+
+[One interesting aspect of the visit was the unusual memento left by the Germans
+who had occupied the place. A highly talented artist had painted] murals on the
+whitewashed walls. [4:15:20]
+
+[END OF AUDIO FILE SMYTH PERSONAL RECOLLECTIONS 1.2]
+
+[audio resumes at 4:19:44; transcript heavily edited]
+[They were splendid caricatures of the German Army. They were highly
+reminiscent of a caricature by Norman Rockwell painted life-size on the barroom
+wall in the Nassau Tavern in Princeton. Regrettably, I had no camera to
+photograph them. Probably they will have been destroyed, but they were really
+superb life-size cartoons.]
+
+Louis Fieser had come over with a special objective and did not stay very long,
+but he was more heavily equipped than most of us and, in particular, carried a
+swagger stick with a dagger concealed in it. One night in a house in central
+Germany, a house with no electricity, half a dozen of us were sitting on the
+floor of a second story room with one candle as the only light. Someone had come
+on a monocle in the course of his search for papers. Louis acquired this
+monocle, screwed it into his eye, and gave an exhibition of what all of us
+enthusiastically regarded as the action and speech of a Prussian officer. Louis
+was a good companion as well as a fine organic chemist [and a highly successful teacher.]
+
+[untranscribed audio, 4:23:40-4:49:18; repeats substance related elsewhere in the transcript]
+
+We were able to go occasionally in the evening to entertainment provided for the
+troops. In one case this consisted of [G.] Bernard Shaw&#039;s &quot;Arms and the Man,&quot;
+played by the Lunts. Once I was able to satisfy my craving for opera by going to
+the Opéra Comique on a Sunday evening. [4:50:12]
+
+[END OF AUDIO FILE SMYTH PERSONAL RECOLLECTIONS 1.3]
+
+[audio resumes at 4:54:46] I got off sufficiently early to have a bite to eat and get to the opera. This
+proved to have been a mistake. The opera house was unheated and although
+everyone kept on his winter overcoat it was still cold. All the singers had sore
+throats, and most of the audience coughed vigorously. Although I am a great
+opera buff, the opera was unknown to me, as the composer. I hope they continue
+to be unknown as it was a very dreary evening, and I caught the universal cold.
+
+This was more serious than it sounds because word came that [George S.] Patton
+was to cross the Rhine in the vicinity of Heidelberg. A day or two later word
+reached us, as ALSOS was sending an expedition. It was not my job to go along,
+as I was scheduled to go to the Ruhr when the time came, but they said I could
+come if I wanted to. But the cold got worse, and it seemed foolish for me to
+risk serious illness by going along. When I learned later that the first night
+was spent sleeping on the floor of a schoolhouse, the windows of which had been
+shattered by the sound waves of Patton&#039;s artillery, I was glad that I had not
+risked it. A few days later, word came that I should go down to Aachen, where
+ALSOS had a few days earlier occupied a house on the outskirts.
+
+[untranscribed audio, 4:57:50-5:09:10; repeats substance related elsewhere in transcript]
+
+[material below to 5:09:10 is not in this portion of the audio]
+
+[The ALSOS mission had not come to Paris merely to interpret information; it had
+come to obtain it. But we now knew that the information we most needed was in
+Germany. We had obtained material when Strasbourg fell, and recently had been
+able to get into Cologne. But our main interest was in getting farther into
+Germany. The first allied troops across the Rhine had gotten there six days
+before my arrival in Paris, and were holding on with some difficulty. I had been
+told that I should go into the Ruhr region, where a vast amount of information
+might be expected to lie. However, I could not go there until General [Bernard
+L.] Montgomery, who was in command of the northern part of our army near or
+along the Rhine, had decided that he had sufficient supplies and troops to make
+a sure thing of it. I therefore waited in Paris for something to happen.]
+
+[This first crossing in force occurred on the night of March 22nd, nine days
+after my arrival in Paris. The city of Cologne, on the west bank of the Rhine,
+had been entered by American troops on March 7th, two weeks earlier, and Bonn
+had been taken very shortly thereafter. Much of my work in Paris had consisted
+of studying papers brought by ALSOS from laboratories in Cologne and Bonn. As it
+was thought that more could be learned by repeating the visit to Cologne, it was
+decided that I should go down to Aachen, where ALSOS had set up a forward base
+in a house on the outskirts of the city. From there it would be possible to move
+quickly into the Ruhr if it should be accessible.]
+
+[On the morning of March 27th, a dark, chill, rainy morning, I took off for
+Aachen. I believe that my jeep was accompanied by another, but I am a little
+rusty in the matter. When we had loaded the jeep with our bedding rolls], Col.
+[Boris T.] Pash and Dr. Goudsmit came out to see us off. This was the real start
+of what I had come over to do. Goudsmit even went so far as to offer me the loan
+of a pair of sheets which he said had been used only once. My heart was warmed
+by the offer, but I felt that I would be more comfortable swathed in my own
+blankets and saw no reason, in any case, why I should use his sheets. So we took
+off, drove through the outskirts of Paris, and headed to the northeast.
+
+We soon entered territory which had been the major battlefield of World War I.
+As we went along we saw German prisoners working on the road under the watchful
+eye of black American G.I.&#039;s, who were very spruce and military in their
+appearance. They were obviously relishing their work. I refer to the guards and
+not the prisoners. In the vicinity of Arras, a familiar name from the First
+World War, we lost our way. There were no normal road signs, as they had been
+removed to make the going rough for the Germans if they should get back. In a
+few places there were signs pointing to American bases; I recall my amusement on
+seeing one sign labeled &quot;Superior Charlie.&quot; Presently we found the road suddenly
+much better, but what we had taken for the road proved to be an airstrip. As we
+progressed farther, we found bombers and transport planes parked near the strip.
+It was obvious that it was not the place for us, and we turned tail and got off
+the airfield as soon as possible.
+
+We continued through fog and drizzle until mid-afternoon, when the weather
+cleared and we approached Aachen. On the way we had encountered bombed cities.
+Indeed, I seem to recall going past Verdun, famous as the bloodiest battlefield
+of the First World War, where 1,000,000 men had become casualties. We reached
+Aachen in the late afternoon and made our way carefully through the streets,
+which were littered with the rubble of buildings destroyed by bombing and
+artillery fire. In the midst of this desolation, we came upon a pair of G.I.&#039;s
+throwing a baseball back and forth like any pair of boys on a college campus at
+home. We ultimately found the ALSOS house on the eastern outskirts, in rather
+pleasant surroundings with grass and fields around it. ALSOS had established
+itself here and they were regularly keeping house. I was assigned to a
+mattressless bed in a double room. The other bed, similarly without mattress,
+but like mine still having a spring, was occupied by Dr. Allan [A.] Bates of the
+Westinghouse Laboratories in Pittsburgh.
+
+Aachen, which was just west of the Siegfried line, practically touching the
+Germans&#039; massive defensive line, had fallen to the Americans in mid-October of
+1944, but progress had been very slow after that. Real advances to the east had
+not occurred until February, when very heavy fighting brought the allied lines
+gradually forward to the Rhine. Patton&#039;s crossing of the Rhine occurred on the
+night of March 22nd at the little town of Oppenheim, twenty miles south of
+Mainz, and the British crossing had occurred north of the Ruhr on the following
+night. I had arrived in Aachen four days later, in late afternoon of March 27th.
+Over 300,000 German troops still remained in the Ruhr area. Aachen made a good
+base from which to operate in Cologne and along the western bank of the Rhine.
+
+The house in which we were quartered was good-sized and reasonably comfortable
+and probably was not very warm. Some three or four captains and lieutenants, and
+several enlisted men had charge of the quarters and looked after the three or
+four scientists who were intermittently present. This house and a similar house
+later established in Heidelberg on the Philosophenweg became a forward
+headquarters for ALSOS, so much so, in fact, that the Aachen house had a small
+sign &quot;Little Monceau&quot; attached to it to show that it was a small version of the
+Royal Monceau in Paris. Here, as in other advanced headquarters, one or two
+German women were brought in to help out with the work, notably the cooking, and
+the result was that the food was an improvement over that produced by the chefs
+at the Royal Monceau.
+
+One young woman, a rather pathetic creature, had been a camp follower and was
+seriously attached to a German soldier named Willi. Willi had ultimately been
+killed in the fighting, leaving his girl unattached. She was brought to the
+house every day, from some house which had survived in the area.
+
+One night shortly after we had gone to bed, all hell seemed to have broken loose
+on the eastern horizon. [5:25:12]
+
+[END OF AUDIO FILE SMYTH PERSONAL RECOLLECTIONS 1.4]
+
+[audio resumes at 5:29:46] Bright white light appeared, intensified by frequent great flashes. At first we
+thought that it might be another German attempt at a breakthrough like that
+which had occurred at the Battle of the Bulge in December, but we concluded that
+an ammunition dump had probably been hit and was going off, one part after
+another. It was like so many other episodes that we encountered, of which we saw
+neither the beginning nor the end, and we never knew what really had happened.
+
+Easter Sunday occurred while I was still at Aachen, and a couple of us went to
+church. The service was a Catholic Mass held in the ancient chapel supposed to
+be the greatest surviving monument of Carolingian art, having been built around
+800 A.D. The G.I.&#039;s came in by ones and twos, holding their steel helmets and
+their carbines. The helmets were put on the floor and the carbines leaned
+against the backs of the chairs. The service, conducted in Latin, went on and on
+but was very impressive in that extraordinary atmosphere. In this chapel,
+Charlemagne and later emperors of the Holy Roman Empire had been crowned. Today
+it was filled with soldiers from a foreign land, some of whom might die in
+battle in the coming weeks. Because of the reverence of the congregation and the
+tradition and beauty of the chapel, it was a service of extraordinary solemnity.
+
+At the end, as we filed slowly out, a Red Cross man in G.I. uniform stopped me
+and held out a knitted cap, saying that he had seem me drop it and thought that
+I could probably use it. I certainly could. It had been in the helmet I was
+carrying in one hand, and as soon as I was out of the church I put the knitted
+cap back on, and the helmet on top of that. That knitted cap had stopped many an
+icy wind and would continue to do so in the weeks to come. This was the first,
+and the most important aid that I received from the Red Cross. The two
+subsequent occasions involved doughnuts when I was in a very hungry state and no
+other source of food was at hand. I deeply appreciated the assistance and always
+contribute to the Red Cross.
+
+As soon as possible we drove from Aachen over to Cologne, which was a pretty
+badly damaged city. The magnificent cathedral stood almost untouched, fronting
+its great square. As we drove near there we stopped to have a brief look, but
+were not welcome as sightseers. Previous sightseers had exposed themselves
+unduly to the view of the German troops across the river, and the latter had
+opened up with mortar fire which wounded one or two of the sentries on guard in
+the square, although the sightseers themselves had gotten out of there in time.
+
+We proceeded rapidly on our way to the Physical Institute of the university,
+which was nearby. ALSOS had already visited this place but had left a great many
+papers, which we removed. The Chemical Institute seemed to have very little to
+offer; indeed, it left little impression on me. Near the Physical Institute was
+an art museum belonging to the university. It had been damaged to such an extent
+that the smashed upper part of the structure had fallen down into the lower
+part. Facing what had been the main entrance was a grand staircase, at the top
+of which was an Egyptian Mummy in its case. It had survived bombardment as well
+as many centuries.
+
+Getting to the museum and the Physical Institute from the point where we had
+parked our car involved going down a street which ran down to the river Rhine,
+on the far side of which were German troops. As the street offered a clear view
+to the troops across the river, we were rather nervous but hugged the walls of
+the houses and nothing happened. This was not the idle sightseeing excursion
+that it may sound to have been. One of the professors at the university had been
+engaged in nuclear research, and some of the papers that had been previously
+gathered suggested him as a worthwhile target, but we did not find him, and I do
+not know whether the papers that we gathered in our expedition proved
+worthwhile. This was one of many such trips which occasionally turned up
+extremely valuable material.
+
+In the course of one of these trips close to the Rhine bank, I saw a puff of
+yellow-brown smoke suddenly blossom in the sky above the far bank. This was the
+only German anti-aircraft fire that I ever saw; indeed, the only anti-aircraft
+fire that I saw in my entire mission. Our walk down the street en route to the
+university&#039;s Physical Institute was the only occasion on which I was aware of
+being exposed to enemy fire. [untranscribed audio to 5:46:28]
+
+From time to time, it was necessary to visit some headquarters to find out how
+the war was progressing; in other words, to find out where we could go with
+reasonable safety and what route we could follow to dig up the information that
+we were seeking. I believe it was at the corps headquarters at Krefeld, a large
+industrial city in the Rhine area, where I particularly remember seeing a big
+map on the wall covered with a thin sheet of plastic on which the lines were
+marked in colored crayon which could be changed from day to day as the military
+situation changed or left indefinitely until change was necessary. We always
+received cooperation and help whenever possible. In addition to Krefeld, we
+visited, among other cities, Muenchen-Gladbach, which was southwest of Krefeld,
+Krefeld itself being about thirty-five miles northeast of Aachen. We also
+visited Bonn, up the Rhine from Cologne. I do not remember any great
+accomplishment in any of these places, which, in the case of Krefeld and
+Muenchen-Gladbach, were heavily industrialized.
+
+Allan Bates, my roommate at Aachen, was a metallurgist, and interested in the
+steel plants in the Rhine district. I accompanied him to one great steel mill
+very close to the Rhine bank. It was completely shut down and totally deserted.
+We wandered about this vast iron shed looking at what had been left, which was a
+good deal. Indeed, a seemingly prime target for bombing was intact. Firing was
+going on at the time and the continuous pounding of a nearby heavy machine gun
+reverberated and echoed back and forth in the huge shell of the steel mill.
+Heavier artillery was firing from behind us, throwing shells over our heads at
+the German troops just across the Rhine.
+
+The territory between Aachen and Cologne had seen very heavy fighting a few
+weeks previously and two cities, Duren and Julich, were virtually leveled by
+artillery fire and bombing. We drove past one or the other of these cities on
+many of our trips to the Rhine. One of them still had part of its ancient walls
+standing, and a small tower still stood at one of the gates. On the wall were
+inscribed the words, &quot;You are entering this city courtesy of the 301st artillery
+regiment&quot; (I am not sure that this was the right regiment, but it was some
+similar name). Nearby was an earlier inscription, &quot;Die Juden sind unerwunscht&quot;
+(Jews are unwelcome). In the awful desolation of one of these cities, a very
+small park dividing a street showed not only fresh green, but also a few roses
+in bloom. This was hard to believe, as it was late March or early April, and had
+been pretty cold weather. Flames were flickering in some of the ruins nearby,
+and one wonders if heat from the burning city had brought out the green and the blossoms.
+
+It was not unusual, when entering a city that had been bombed severely, to find
+an inscription on an inconspicuous wall welcoming the visitor in the name of the
+military unit which had passed that way. The most frequent inscription found on
+walls, however, was the information that &quot;Kilroy was here.&quot; From the location of
+these inscriptions one was tempted to conclude that Kilroy suffered severely
+from dysentery.
+
+The jeep in which we traveled was normally equipped with a machine gun mount but
+no machine gun. The military personnel were all equipped with carbines or
+pistols or both, but the civilian scientists carried no weapons, because, if
+captured, they could have been legally shot if caught with weapons, instead of
+being shot illegally by Nazi S.S. men. However, no ALSOS personnel were captured
+or even wounded, although a few had close calls. The ALSOS scientists carried
+identity cards showing a so-called assimilated rank, entitling them to treatment [6:00:20]
+
+[END OF AUDIO FILE SMYTH PERSONAL RECOLLECTIONS 1.5]
+
+[audio resumes at 6:04:46] as military officers, if captured, and more importantly, as it turned out, to
+the provision of quarters commensurate with the rank indicated. My assimilated
+rank was that of colonel, and I always got pretty fair quarters. As weapons were
+confiscated from German civilians wherever found, it was possible for the ALSOS
+military to visit some central cache of captured weapons, and pick up anything
+that they wanted in addition to the weapons officially issued to them. After the
+armistice was signed, one of my military friends got me a small Browning .25,
+which felt very reassuring on my belt occasionally.
+
+At our Aachen base these scrounged weapons were sometimes tried out by shooting
+at a target set up against an abandoned railroad embankment 100 yards behind the
+house where we lived. As the top of the embankment carried a path which was used
+as a shortcut by the citizens of Aachen, there was some protest over our choice
+of a target site, but nothing serious ever happened. One early spring morning,
+when I came out into the garden of the house, a blackbird, very different from
+the American blackbird, and a member of the thrush family, was pouring out his
+magnificent song while perched in a small blooming fruit tree. Under the tree
+was a Florida G.I. recently attached to ALSOS, preparing to test out a Colt .45
+on the blackbird. I persuaded him that the target already provided against the
+embankment was a much better one and feel that my saving this lovely song was a
+major accomplishment. Fortunately, this particular G.I. was transferred shortly thereafter.
+
+The Technishe Hochschule at Aachen had been an important center for aeronautical
+research, but no material of importance remained there when I arrived. Indeed, I
+visited the institute largely as a matter of form, and was accompanied by some
+G.I.&#039;s who had been assigned the task of collecting--&quot;liberating,&quot; to use the
+technical term--some of the institute&#039;s office furniture, to be transported back
+to Paris for the ALSOS office there. This did not seem a very glorious
+undertaking, but was probably useful.
+
+Word reached us in Aachen that American troops had just occupied the city of
+Frankfurt, much farther to the southeast. Allan Bates and I set out together for
+Frankfurt. As I recall it, we traveled separately in two jeeps accompanied by an
+officer and an enlisted man in each jeep. We aimed to cross the Rhine at
+Remagen, scene of the first Rhine crossing, two or three weeks earlier. It was a
+beautiful early spring day. As we approached Remagen, the road became crowded
+with advancing American troops and tanks. As we rolled down the hill approaching
+the Rhine we traveled through orchards of fruit trees in bloom, on which clouds
+of dust were settling from the tanks. High above us could be heard the song of a
+lark, which ascended high and then plummeted to the ground, as larks have a way
+of doing. It seemed strangely incongruous among the clanking armor and clouds of dust.
+
+The bridge on which the initial crossing had been made by a handful of American
+troops had collapsed under bombardment. It may be recalled that the Germans had
+previously equipped the bridge with explosives to be blown if they had to
+retreat. The last German troops crossed ahead of the small advancing American
+unit, and the Major commanding the German unit had neglected to set off the
+explosives. This had infuriated Hitler to such an extent that he had the major
+shot immediately.
+
+The collapsed bridge had been replaced by a pontoon bridge built downstream by
+American engineers, to permit the bulk of the American forces to cross. The
+crossing was underway when we arrived, and we found our place among the tanks
+and trucks to cross the bridge, which was just a foot or two out of the swirling
+green waters of the Rhine. The water was a pale silty green, the silt coming
+from the melting snows of the Alps way up stream. As we moved, we observed one
+truck which appeared to be filled with bottles of champagne being carried
+forward for high officers&#039; consumption, and replacing in the truck what might
+well have been gasoline, much needed for army jeeps and tanks.
+
+As the reader doubtless knows, the pontoon bridge consisted of a long row of
+boats side to side with two tracks laid across them. Each of the two tracks was
+a comfortable width to accommodate a wheel or the track of a tank. When one
+drove across, one was very close to the water, so much so as to seem almost
+afloat. The far bank of the river, that is the eastern shore, rose steeply into
+the forest. We found a road that turned south through the forest and headed up
+the Rhine. This road had very little traffic on it, and seemed almost like a
+forest road, but we were soon astonished to meet a &quot;duck,&quot; that strange
+invention, like an amphibious tank in general appearance, but capable of
+carrying a number of troops or weapons. We passed in opposite directions, and
+continued our way toward Frankfurt, where we arrived late in the day.
+
+Although the city had been rather heavily bombed, the railroad station had been
+left intact at the front. One could approach it from the front and almost think
+that it was intact, but actually it was a mere shell, the tracks and the roof
+having been destroyed. The station faced a large square lined with hotels, some
+of which extended into side streets. Our arrival was four days after the city&#039;s
+evacuation by German troops. In spite of this, the hotel where we managed to
+locate rooms seemed like any other big city hotel, with certain exceptions. The
+exceptions were that the desk clerk was a noncom, there was no running water in
+the large building, and there probably was no heat.
+
+I cannot remember whether there was electricity or not, as we always carried
+flashlights just in case. Our bedding rolls supplied the bedding and the army
+supplied the water in the form of large canvas tanks set up in the square in
+front of the hotel. If we wanted to wash we filled a helmet with water and
+carried it upstairs to our bedroom. If we wanted to drink, we filled our
+canteen, put a pill or two in it, stoppered the canteen, shook thoroughly, and
+after half an hour or so, removed the stopper and drank, or if it was at
+bedtime, removed the stopper and let it stand overnight. If one drank it within
+half an hour after chlorination, it was pretty bad, but the chlorine evaporated
+out overnight very nicely so that the water was reasonably potable by morning.
+
+Prior to Frankfurt, our intelligence investigations had been largely the
+collection of papers, but here I had my first opportunity to interrogate a
+German scientist and more or less flubbed it. I was driven out to the
+university, which was not badly battered, where we found Dr. [Marianus] Czerny,
+whose name was familiar to me because of his spectroscopic investigations. He
+also seemed to be familiar with my work. After we talked quietly, like two
+scientists getting together for the first time, he expressed his distaste for
+the war and its interference with his research, and shook his head sadly over
+the bad state of affairs in Germany. I sympathized with him and deplored the
+interference in his research caused by the war, but failed to discover, as I did
+later, that he had done some work in connection with a possible German atom bomb.
+
+It was a pleasant interview, as were most of my interrogations of German
+scientists, probably because this came naturally to me and because it was more
+often than not the best means of approach. On one or two occasions, I heard an
+interrogation by an officer who thundered at the victim of his inquiry and
+learned nothing. I do not remember in what language the interrogation was
+conducted, but probably I spoke English slowly and Czerny spoke German slowly.
+In case of need, I could make myself understood in German and could usually
+understand German quite well.
+
+I learned that a man named [Hans Joachim] Schumacher, who had done postdoctoral
+research at Princeton a good many years earlier, had been working at Frankfurt.
+He was not to be found at the University, but I found his home address, which
+was a small apartment not very far away. I learned that Schumacher had been very
+successful scientifically and that he got along very well with the Nazis and had
+prospered politically to such an extent that he had become President of the
+Bunsengesellschaft or the German society of Physical Chemistry. At his apartment
+I found his wife and small child, but no Schumacher. It seemed he had gotten
+along so well with the Nazis that he had found it desirable to leave, as some of
+the prominent Nazis had done; that is, to leave for South America, address
+totally unknown. His wife was a rather attractive and, under the circumstances,
+a pathetic young woman who seemed to be getting along as best she could. There
+was nothing that one could do for her, whatever one&#039;s sympathy.
+
+I was a little surprised at Schumacher&#039;s success with the Nazis because his
+appearance was somewhat non-Aryan, but I should not have been surprised as there
+were many other similar cases. [6:35:47]
+
+[END OF AUDIO FILE SMYTH PERSONAL RECOLLECTIONS 1.6]
+
+[audio resumes at 6:39:46] In particular, I remember attending a concert in Leipzig twelve years earlier,
+some two or three months after the Nazis had taken over. The concert was by the
+famous Gewandhaus Orchestra in their home concert hall in Leipzig. The great
+Bruno Walter had been scheduled to lead the orchestra that night but, because of
+his non-Aryan blood, he was replaced by a prominent conductor who was strongly
+in favor with the Nazis, in spite of a non-Aryan appearance. I remember the
+gas-lit hall full of good German burghers paying tribute to Brahms, but rejecting
+a non-Aryan conductor.
+
+It may have been in Frankfurt that two young officers and I decided one evening
+to go to the movies. This seemed a strange thing to do, but one of the first
+things that the Army did was to set up a movie theater for the entertainment of
+the troops. We started out before dark and walked a few blocks to a small movie
+house where power was supplied by an American generator on a truck which had
+been wheeled to the door of the theater. The movie was a good one with Rita
+Hayworth in it. When we came out the blackout was in full swing, and it was a
+real blackout. You could not see a thing; no sky, no sign of anything, just
+complete blackness. We had to hold on to each other and grope our way through
+the streets, where, of course, there was no traffic. It was an interesting
+experience, which we never repeated. We returned from Frankfurt to Aachen
+uneventfully on April 6th, encountering relatively few American troops on the way.
+
+When we first arrived at the Little Monceau in Aachen we found that they had a
+small supply of wine on hand, acquired recently in a raid on a deserted wine
+shop in Cologne. Someone discovered that the shop had a cellar containing
+several barrels of wine. The word spread, and a number of G.I.&#039;s came to the
+cellar to fill their canteens and any other vessels they could find with wine.
+As the numbers of &quot;wine liberators&quot; increased, there were not enough spigots on
+the barrels the satisfy them, so those who couldn&#039;t get at the spigots used
+their pistols to open up more holes in the barrels. The result was a flow of
+wine which caused a small lake on the cellar floor, according to the reports
+reaching me. One might have hoped for a little good Rhine wine, but the stuff
+that our boys had acquired had been vermouth of a dubious quality. It was not a
+wholly creditable performance, but at least the little bit that was left was
+consumed gradually, and at no time did I see any drunkenness in the ALSOS unit,
+as near the front as we were.
+
+Another incident developed when we went to a company headquarters established in
+a Stollwerk candy factory somewhere in the Cologne area. We went there in the
+hope of being able to cadge some lunch, which was often possible if one arrived
+at a company mess at the right time. We were a little bit late, but we were
+hospitably received. There were three or four of us who preferred a company mess
+to a K-ration eaten off the hood of the jeep. The cook apologized that he had
+only a little bit of chicken left, but we made out all right, as the little bit
+of chicken was far beyond our dreams. The reason for the chicken is the reason
+that I am recounting this.
+
+When this unit at whose headquarters we were had first reached the city, they
+established a headquarters in a house and were billeted here and there. Some
+citizen of the city sent word to the German troops across the river of where the
+headquarters were located, the result being a bombardment of mortar fire in
+which the commanding officer was seriously wounded. Search for the source of
+information ensued, and it developed that the spy--or loyal German subject,
+depending on one&#039;s view--had sent the message by carrier pigeon to the German
+troops on the far side. The carrier pigeons were located and brought to the
+company mess, where they provided a gourmet meal of squab to the G.I.&#039;s. Word of
+this incident reached the press, and reporters appearing at the company
+headquarters demanded to see the company eating squab. No pigeons had survived
+the gourmet meal, but some chickens were found, and the press photographers took
+photographs of the G.I.&#039;s gnawing on chicken bones, which, for press purposes,
+served as an adequate substitute for squab. Indeed, they doubtless showed up
+better in the pictures and did not influence the press reporting of the fine
+meal depicted in the picture as squab. Here we have another example of press
+enterprise, if not accuracy.
+
+On the day following our return from Frankfurt, we drove over to Cologne and
+visited the Chemical Institute once more to collect a number of additional
+documents. Normally, documents brought back to Aachen were studied at our house,
+the Little Monceau, for as much time as we had free, and were sent back to Paris
+whenever transportation was available. In the course of our driving in the
+general area of Aachen, we sometimes encountered strategic bridges which were
+protected from divebombing by sausage balloons attached to the ground or the
+bridge by long steel cables, which extended from 100 to 300 or 400 feet in the
+air. These cables could have entangled hostile divebombers.
+
+During these activities of the ALSOS mission, the great drive of the American
+armies toward the east had been progressing with surprising rapidity. Word came
+that we could proceed some distance into central Germany now. Consequently, we
+crossed the Rhine again on April 10th and drove east and north to Marburg. On
+the way, we passed through Wetzlar, familiar as a source of fine optical
+equipment, and Giessen, a small university town which had been heavily damaged
+by the bombing. One building of the university had been bombed to such an extent
+that one corner of it formed a pinnacle, at the third floor level of which one
+could make out a board with pegs sticking out of it designed for the drying of
+chemical flasks and beakers. This was the only evidence that this had once been
+a university chemical laboratory.
+
+We continued from Giessen to Marburg where we found a house on the outskirts of
+the city to spend the night. The house had been largely emptied of furniture and
+small things by its normal occupants, but beds with springs on them remained.
+The house had a lovely view over a small valley to a sloping green hill where we
+could make out the monuments of a cemetery. The town, which had not been much
+damaged, presented an interesting tangle of old streets.
+
+On the following morning, which was brilliantly clear, we sensed something far
+overhead in the sky and, looking up, saw a great fleet of flying fortresses
+heading to the northeast toward Berlin. These fortresses were clearly visible,
+gleaming in the brilliant sunlight, but tiny specks darting in and out among
+them were fighters accompanying them as protection. There was something
+strangely uplifting to the spirit of an American in this sight of the tremendous
+power of the United States coming into play. For years, until relatively
+recently, we had heard reports and read them in the papers of the demolition of
+Britain by German bombing and the destruction of our warships in the Pacific by
+Japanese bombers. Now it was thrilling in the extreme to see these great
+American weapons on their way to destroy our enemies.
+
+We left Marburg shortly and drove through Kassel. In his memoirs of the war,
+General Omar [N.] Bradley tells of an offer by the airborne chief of staff to
+organize a large scale air drop on Kassel for April 20th. Bradley declined the
+offer, saying he expected to be in Kassel by April 10th. Actually, the American
+forces captured Kassel on April 2nd, nine days before our passage through the
+city on the 11th, and eighteen days before the date proposed for an air drop.
+
+We continued on to Gottingen, where we arrived in the late afternoon. Gottingen
+was an ancient but small city, the seat of one of the great universities;
+indeed, second only to Berlin in science. Many old streets and houses remained
+in the city, and a large part of the ancient city wall was intact. We made our
+way through the city toward a house where we expected to set up quarters. The
+city itself was in turmoil, having been evacuated by the German troops only a
+few days previously. As we drove through one of the major streets, we saw a
+single American tank clanking up the street with a German dog pursuing hotly,
+barking and snarling--undoubtedly a good Nazi, possibly an S.S. dog. An American
+G.I. was sitting on the rear end of the tank with his legs spread out to hold
+himself in position, while the dog was snarling almost at his feet. The G.I.
+pulled a large pistol which he held in both hands while he took two or three
+shots at the dog, missing completely. Like most incidents which we encountered
+along the way, that&#039;s all there was to it, but it seems to stick in my mind.
+
+When we arrived at the house, which one or two advance members of ALSOS had
+reserved for us, we found it near the outskirts of the city, surrounded by a
+small garden. The house itself, which a German inhabitant later told me was
+called the &quot;Strawberry House&quot; because of the color of its stucco walls, had
+belonged to a successful German industrialist who had done himself quite well.
+There was elaborate plumbing, not functioning at the time, and a considerable
+amount of bedroom space where we could set up sleeping bags. Also, much of the
+furniture remained. This was to be established as the northeastern ALSOS
+Headquarters, to be used for some months to come. Aachen was soon abandoned, and
+Heidelberg became central ALSOS Headquarters.
+
+My operations list shows almost immediate interviews with four prominent
+professors at the University of Gottingen, [Ludwig] Prandtl, [Johann A.] Betz,
+[Arnold] Eucken, and Telschow. Prandtl&#039;s name was familiar as that of the number
+one aerodynamicist in the world. His institute was ranked first as a great
+center of aerodynamics research. It was now being used, in part, as an officers&#039;
+mess. Prandtl himself had retired, to be succeeded by Betz. I remember Prandtl
+as a quiet, elderly German of poise and distinction. Betz appeared to be about
+the same age as Prandtl, whom he had succeeded as director. I had no competence
+in aerodynamics, but could at least get an idea of the status of their research [7:10:30]
+
+[END OF AUDIO FILE SMYTH PERSONAL RECOLLECTIONS 1.7]
+
+[audio resumes at 7:14: 45] and to what extent it was being continued. It had presumably been slowed down
+but not wholly stopped.
+
+Later arrivals at ALSOS included men from Wright Field in Dayton, Ohio and
+Langley Field in Virginia, and finally a former pupil of Prandtl, now in
+America, and probably Prandtl&#039;s successor as the number one man in the world.
+Eucken was an old acquaintance. He was one of the leading physical chemists of
+Germany, and I spent a day going over the work of his Institute of Physical
+Chemistry, which was not very actively engaged in military research. We talked
+on a friendly basis, and Eucken presented me with two volumes of his
+Fundamentals of Physical Chemistry.[[footnote]]20[[/footnote]] The edition which he
+gave me had been published in Leipzig in 1944, the fifth year of the war. It was
+interesting as a well-produced and bound book, far superior in appearance to the
+books that Germany produced immediately after the First World War.
+
+[audio resumes at 7:18:15] On April 13th, when I entered the great room at the Aerodynamics Institute which
+was used as an officers&#039; mess, I became conscious of a hushed atmosphere, and
+then I learned that word had just come of the death of President [Franklin D.]
+Roosevelt. Although he had seemed far away, he had been a great leader of the
+war effort, and though his appearance in pictures had given every indication of
+bad health, his sudden death came as a shock to everyone.
+
+Professor Walter [F.] Colby of the University of Michigan, whom I have mentioned
+before, was secretary of the civilian division of ALSOS. He also was with us in
+Gottingen. He was a man of wisdom, who had done much to build up the physics
+department at Michigan, and a man of culture and quiet charm, who made a very
+effective intelligence operator and a very pleasant companion. Word came to us
+that a committee from the faculty of the University of Gottingen would like to
+wait upon us. Presently, three prominent professors, one of them Eucken, one, I
+believe, a professor of English, and another I can&#039;t recall--came to see Colby
+and me. After telling of the chaotic state of things at the university, they
+asked us if we would take over the supervision of the university. What it
+amounted to was the temporary acceptance of the presidency or rectorship of one
+of the greatest German universities. The idea seemed rather preposterous and, of
+course, was out of the question. I suspect that when we eyed each other we had
+to force a certain solemnity because the whole idea struck us as being so
+ridiculous as to be almost amusing. We discussed some of the difficulties, but
+said regretfully that prior important commitments would prevent our acceptance
+of any academic authority.
+
+From letters and documents previously found by ALSOS, it had become evident that
+something important was going on in the vicinity of Northeim, about twenty-one
+kilometers north of Gottingen. This had been a prime objective in coming to
+Gottingen. On April 12th, Colby and I, with two jeeps and a military escort of
+perhaps four men including our drivers, drove to the vicinity of Northeim and
+discovered our objective in the nearby country in a place called Lindau.
+Actually, in a small medieval fortress built of red stone, surrounded by a moat,
+and called the Wasserburg, we found the director and the files of the
+Reichsforschungsrat, the German National Research Council.
+
+The director, Dr. Werner Osenberg, was there with a middle-aged woman secretary
+and great quantities of files covering a vast amount of German research. A small
+model of a multiple warhead for an airplane bomb was among the files and
+reports. All that was of such importance that we requested that a small military
+unit be stationed at the Wasserburg to guard it from possible attack by hostile
+Germans. The myth of werewolves still persisted. It was thought that stray bands
+of S.S. men or other hostile Germans might be hiding in the countryside, ready
+to attack small allied units or do whatever damage they could. A small military
+unit of perhaps fifteen men commanded by a captain arrived soon to guard the
+files and Dr. Osenberg until they could be removed to a safer place. During the
+next few days I alternated between Gottingen and Lindau.
+
+On April 17th we left Gottingen for the town of Celle, about 150 kilometers to
+the north. This was an ancient city of 25,000 inhabitants with many old
+stucco-covered houses and a castle standing in a park. It was in
+British-occupied territory, which meant a considerable change to us. On arrival
+we looked for a place to stay and were received hospitably by some British
+officers quartered in a large building. They showed us a large room with quite a
+bit of empty space in one corner and said that we were more than welcome to lay
+our sleeping bags on that part of the floor. As the floor looked rather hard, we
+hoped other arrangements might be possible, which proved to be the case. We
+found other quarters in a large house occupied only by an elderly lady. Here the
+four of us, of whom I was the only civilian and consequently unarmed, set up our
+sleeping bags in the dining room. This seemed the safest thing to do since we
+did not want to get separated in what was potentially hostile territory.
+
+One item was the principal feature of the room. It was apparently a large
+portrait of Adolph Hitler, a very common sight in many, if not most, German
+houses. I did not examine the portrait, which was on the whole very imposing and
+no worse than most of the Hitler portraits, until the lady of the house
+complained to us that the previous occupants of the room, presumably British
+tommies, had profaned the portrait of her grandfather by putting a Hitler
+mustache on it. Regrettably, there was nothing we could do to remove the
+mustache, which I am afraid we regarded as rather funny.
+
+On the opposite side of the street a few doors from our house, a yellow flag
+hanging from a house indicated that it was being used as a typhus hospital. This
+made us feel a little cautious.
+
+We succeeded in getting ourselves invited to eat at a British mess, which proved
+interesting. The British officers told us that the evening before, while it was
+still daylight, German bombers had come overhead, but British Spitfires had
+taken off after them and apparently succeeded in catching up with them because
+they returned shortly afterward, dipping their wings as a sign of triumph.
+
+The notorious Nazi prison camp of Belsen was near Celle. One of the British
+officers told me that a Scottish regiment had been the first to enter Belsen and
+had found conditions so horrible that they did not bother to arrest the camp
+guards for future trial, but they themselves meted out immediate justice. Some
+of the British officers I talked to had been to the camp themselves and said
+that conditions were unbelievable. One inmate, a middle-aged woman, had gone
+completely out of her mind and was going about costumed only in a large hat.
+This was in pretty chilly weather in Northern Germany. I thought of making a
+visit to the camp as part of my investigative job, but decided against it on
+learning that some young British medics had been sent over hastily after the
+opening of the camp. Although they had been inoculated for typhus before leaving
+Britain, some caught typhus and died, the time elapsed between the inoculation
+and the attainment of immunity having been insufficient.
+
+The main ALSOS objective in the Celle area was a factory engaged in the
+manufacture of parachute silk. A physicist named Groth had established a
+laboratory in this factory where he had built a centrifuge for isotope
+separation. Although it was a small-scale laboratory apparatus, it was of
+considerable importance, and was further inspected by ALSOS. The military
+members of the ALSOS mission who visited the factory liberated considerable
+quantities of parachute silk, enough to make scarves for almost the whole ALSOS
+mission both in Germany and in Paris. I still have a scarf made of camouflage
+parachute silk.
+
+From Celle we drove to Hanover to visit a big chemical factory in the vicinity.
+Hanover had been severely bombed. As we drove through the streets we saw where a
+bomb had landed near a street-car track and had blown the track so that it
+pointed vertically, rising thirty feet from street level. In another place, a
+large bomb had missed a railroad bridge and had made a large crater in the
+street which passed under the bridge. As it rained a good deal of the time, the
+crater was full of water. My driver, practicing the ALSOS principle of driving
+fast in a straight line, continued into the small lake filling the crater. It
+was all right until we got to about the middle of the lake when our engine was
+flooded and we came to an ignominious halt in two or three feet of water. We
+were not happy at the idea of having to wade through the lake, and we needed
+help in extracting the car. My driver merely ordered some passing citizens to
+push the car out of the lake, which they did with complete obedience and good
+humor. It was a striking example of the German attitude of subservience to
+authority. Our uniforms represented authority, though at the moment not much
+wisdom. When the car had been pulled out of the lake, the motor soon dried out
+and we proceeded on our way.
+
+The chemical factory proved to be a large one, where we found little of
+immediate interest. However, we were heartily welcomed by two managers or
+directors, who stood at the entrance bowing low like orientals. As we entered
+the building, a man appeared suddenly at the end of a long hall, and disappeared
+even more suddenly. Apparently he was one of many slave laborers who had been
+liberated when our army arrived. They presented a serious problem, not only here
+but all over liberated Germany. [7:45:20]
+
+[END OF AUDIO FILE SMYTH PERSONAL RECOLLECTIONS 1.8]
+
+[audio resumes at 7:49:45]  [. . .] They had been kept at this factory in a barbed wire enclosure, where
+they spent the night; the days, of course, being spent working in the factory.
+When discipline was removed, they raided the factory and drank some of the
+chemicals. One man had died from drinking ethyl acetate in excess. It was
+necessary for military guards to be placed around the barbed wire enclosure at
+night, and to some extent during the day, to keep the partially liberated slaves
+from raiding the countryside. I was told, in fact, that the guards had to carry
+their rifles, but loaded them with sand instead of bullets. The sand seemed to
+be sufficient. The attitude of the factory directors was one of complete
+civility, even servility. However, there was nothing we could do for them that
+had not already been done, and, in view of their use of slave labor, we were not
+particularly anxious to help out.
+
+The next day we visited Wanzleben at Stassfurt, where more chemical
+manufacturing was to be seen. The name of Stassfurt should be familiar to anyone
+who has studied elementary chemistry as the original source of the alkali
+metals. After returning to Gottingen for a day, we drove to Leuna and Merseburg
+to visit the huge plant of I. G. Farben. This enormous plant was approximately
+five miles long in an irregular chain of buildings. In width, the plant varied
+from a quarter to three quarters of a mile. It had been heavily bombed, and one
+could see where great external pipes had been almost tied into knots by the
+violence of the explosions. Tremendous damage had been done, but the Germans had
+shown an extraordinary resilience in their ability to rebuild these plants. Much
+of the structure was in ruins, but some was under reconstruction and some was
+working full steam ahead.
+
+A green pasture near the plant was heavily pocked with craters. Apparently, one
+of our squadrons of planes had dumped the bomb load on the pasture instead of on
+the factory. Here we collected documents and reports of possible but not
+compelling interest. This may well have been the most important manufacturing
+center in Germany because here gasoline was synthesized and explosives and
+fertilizers were manufactured, not to mention a vast assortment of other
+chemical materials.
+
+From here we went to Stolberg, where, in the castle, we secured more records of
+the Reichsforschungsrat. Then back to Leuna for two days. Here we now
+encountered a small group of intelligence men from the U.S. Navy. One of them
+was an acquaintance of mine, Monty Speight, who years later became president of
+Standard Oil in Indiana. These men told us that they had interrogated two
+high-up research directors, who had intimated that they knew the whereabouts of
+the German supply of heavy water. We consequently interviewed Dr. Paul Herold
+and Dr. E. [Eberhardt] Elbel. Herold&#039;s name was familiar as an industrial
+chemist of prominence. Many prominent chemists from other countries had visited
+these laboratories and factories, and the register showed familiar names
+including that of my Princeton colleague, Sir Hugh Taylor, to whose chair at
+Princeton I ultimately succeeded. These visits from other countries had, of
+course, been made before the war. The Navy men had apparently been pretty tough
+in their interrogation, threatening serious consequences if those interrogated
+didn&#039;t come clean. Consequently, we did not have serious difficulty in
+extracting the location of the heavy water, which had been transported from
+Norway to a small factory near the Harz region.
+
+As Leipzig was nearby, we stopped there and then continued on to Osterode in the
+Harz, where we had been told that the heavy water was stored in a small factory
+of Hollemann and Wolff. When we located the factory supposed to contain the
+heavy water, we could not find the water at first. The factory consisted of a
+large number of small buildings, some quite small and some of medium size, and
+an initial search did not reveal the water. We encountered an Estonian in the
+otherwise deserted plant who somehow appeared and wanted to tell us something.
+He told us of a very checkered career during the war. He had been brought to
+Osterode from Estonia. I seem to recall that at one point he had been shot or
+knifed and left for dead. But he recovered, and was happy to lead us to the
+heavy water.
+
+It was somewhat out of the way, and not particularly obvious in spite of there
+being twenty-one big cylinders or drums. It was not pure heavy water, that is,
+deuterium oxide, but was a concentrated alkaline solution. I am not certain of
+its history, but believe it was the material that the Germans had moved from
+Norway. The ship on which it was being transported was wrecked or sunk by
+bombing. The cylinders containing the water had not been quite full and thus
+floated and were rescued from the sea and brought to this little factory. We had
+no facilities for transporting it, but went back to Gottingen immediately and
+sent word of our discovery from there. Some time later trucks appeared at
+Gottingen where they were directed to the heavy water at Osterode. From there I
+believe it was transported to British territory and shipped to England.
+
+While investigating the great sprawling I.G. plant at Leuna, we had stayed in
+the nearby city of Halle. From Halle to Leipzig was not a long drive.
+Consequently, when we first left Halle we drove over to Leipzig, in spite of the
+fact that we did not expect any great intelligence yield. We arrived in Leipzig
+rather early in the morning and, as we drove through the outskirts, noticed a
+crowd standing around a man lying on the ground. On stopping to investigate, we
+found that an old German had been hit by a passing car and apparently was
+seriously hurt. He was unconscious, his head and face showing a great deal of
+blood. The car that hit him had passed on, leaving him in the street. As there
+was no way of getting the man to the hospital unless we took him, we found a
+litter somewhere, put the unconscious man on it, laid the litter across the jeep
+(it was too long to fit in it), and headed for a hospital. It was necessary to
+stop and inquire as to the exact whereabouts of the hospital, and when we
+stopped a small crowd immediately gathered to see two Americans in uniform
+carrying a bloody-headed German. From familiarity with Gestapo behavior, they
+probably thought we had done this to the German, and did not seem very friendly,
+but directed us to a hospital. On arrival there, one of us went in and got
+people to come out and carry the unconscious man inside the hospital. Like most
+episodes, this was the end of it as far as we were concerned. I trust that the
+man recovered.
+
+We continued on into the city, passing what remained of the hotel where I had
+lived for 4-1/2 months, beginning about two months after the Nazis had taken
+over the German government in 1933. It was thought that my familiarity with the
+city and the laboratories might help gain some information of possible value.
+The Chemical Institute yielded nothing of value except the whereabouts of
+Professor Bonhoffer, perhaps the leading German physical chemist, who had taken
+refuge in a summer cottage in the Harz region. Peter Debye, the director of the
+Physical Institute--or rather the former director--with whom I had worked for
+4-1/2 months in 1933, had long since left to be director of the Kaiser Wilhelm
+Institute for Physics in Berlin. From there he had gone to the United States to
+become head of the Chemistry department at Cornell University.
+
+This may sound odd, but actually Debye was probably the world&#039;s leading physical
+chemist or chemical physicist. When I had arrived in Leipzig in 1933, Debye was
+absent, receiving a medal from the Royal Society in London. Heinrich Sack, a
+private docent, whom Debye had left in charge of his institute in his absence,
+was a non-Aryan. Sack had just received word from friends that Nazi bully-boys
+would probably arrive shortly to arrest him and beat him up or send him to a
+concentration camp. Sack, therefore, absented himself to hide with the family of
+his fiancée.
+
+There was, therefore, no one in charge when I arrived in 1933. Debye, on his
+return, from time to time gave me interesting information about Nazi methods. It
+seemed that German science now had two Nazi dictators, Lenard and Stark, both of
+them old physicists who had received Nobel Prizes, and deservedly, but were
+extremely reactionary and apparently honestly believed in Nazi doctrine and
+methods. When any important action was to be taken in the German scientific
+world, these two old men were consulted. Accordingly, when the University of
+Leipzig proposed to bring Bonhoffer to direct the Institute of Physical
+Chemistry at the University, [8:20:18]
+
+[END OF AUDIO FILE SMYTH PERSONAL RECOLLECTIONS 1.9]
+
+[audio resumes at 8:24:46] they had to consult Lenard and Stark as to his suitability. One of these elderly
+czars said, &quot;I do not know Bonhoffer, but I do know that he studied with Haber,
+who is a non-Aryan, and that his methods must, therefore, be impure.&quot; Haber, at
+the time, was a world-leading physical chemist, whose discovery of ammonia
+synthesis, before the First World War, had made it possible for the Germans to
+prolong the war two years longer than would have been possible in the absence of
+this method, which was an initial step in the manufacture of explosives.
+
+In spite of the opposition of Stark and Lenard, the university had ultimately
+succeeded in bringing Bonhoffer to Leipzig. Debye had been born in Holland and,
+having retained his Dutch citizenship, was not wholly dependent on the Nazis. He
+told me that Heisenberg, the eminent German theoretical physicist who was
+director of the Institute of Theoretical Physics at Leipzig, had indicated no
+enthusiasm for Nazism, but had felt that it might be his duty to join up with
+the Nazis in order to help to rescue German science from the hands of Lenard and
+Stark. Something of the sort evidently occurred because, many years later,
+Heisenberg was the principal physicist in the nuclear bomb work. He was not in
+Leipzig when I visited there on April 26, 1945.
+
+I talked with Professor Friedrich Hund, a theoretical physicist of some
+eminence, whom I had known slightly in the past. Hund was a small,
+pleasant-looking middle-aged man who was very friendly, but conveyed no useful
+information. I was given the impression that another physicist, whose name I
+believe was Doepple, was available, but probably would not be friendly. When I
+talked to him I found him disagreeable-looking and definitely hostile in attitude.
+
+I had no recollection of his being there during my visit twelve years earlier,
+but he seemed to know about it. He said, &quot;Once you came here as a guest of the
+Institute and now you come with a hostile army.&quot; This was quite true, but the
+snarling manner in which he said it angered me, and I indicated that I was here
+because the Germans had made the war. The discussion was futile, and in my
+anger, my German vocabulary largely evaporated. Hund, who was standing not far
+away, sensed that things were not well, and when I terminated the discussion
+with Doepple, who was the last man I was to talk to, Hund shook his head sadly
+and escorted me in friendly fashion to the door of the Institute. He was the
+last man of the Institute staff whom I saw, a pathetic little figure clad in
+mountain-climbing costume, probably all that was left of his wardrobe after many
+years of war.
+
+Leipzig had been badly damaged by bombing. As we drove through the main square
+of the city, the Hotel Hauffe, where I had stayed for several months in 1933,
+loomed up in fragments which extended up just about to the floor where I had
+lived. Joseph Goebels had dined at the next table to me and later Hitler and
+most of his gang had stayed during a meeting of the Saxon division of the Nazi
+party. This had involved a meeting in the Leipzig fair hall and a great parade
+of 100,000 &quot;brown shirts&quot; through the square. During this four-hour march I
+stood wedged in a crowd close to the reviewing stand, a low platform which
+raised Hitler alone slightly above the long column of marchers. He stood there
+hour after hour returning the salute of the marchers. I was told a day or two
+later by one of the marchers that Hitler had seemed to look into the eye of
+every man and had appeared to return the salute given by every man. He had a
+strange magnetism for the Nazi rabble.
+
+I and an American family, who were the only guests remaining in the hotel, were
+standing in the small lobby of the hotel as he came through one day. Everyone
+leapt to attention, and everyone, with one exception, gave the Nazi salute,
+which Hitler returned in a casual fashion. He looked hard at the one man who had
+not given the salute, and I felt rather uncomfortable, but nothing happened to
+me. At another time during the day, I came out of my room on an upper floor and
+started to walk down the stairs. On the flight of stairs just below my flight I
+could hear two men in conversation. One was speaking in a very rich voice,
+wholly dominating the conversation. I believe that this was Hitler. I listened
+but could not catch any words, only the dominance of one man over the other.
+This rich, full voice was very different from the angry snarl of Hitler&#039;s voice
+on the radio.
+
+Throughout Hitler&#039;s stay in the Hotel, the building was surrounded by a guard of
+500 rifle-bearing Schutzpolizei. This was very different from the guard of the
+Austrian chancellor when he stayed in my hotel in Salzburg later in the summer.
+Chancellor [Engelbert] Dollfuss wandered alone through the lobby of the hotel.
+One rifle-bearing sentry walked up and down in front of the entrance. Hitler
+lived to bring on a world war. Dolfuss, an unassuming and harmless little man,
+was assassinated a few months after I saw him. After leaving Leipzig, we found
+the heavy water at Osterode and returned to Gottingen.
+
+[the following material, to the next time code, has been moved to this part of the transcript; audio can be found from 9:08:00-9:18:20]
+
+[Captain, later Major, Robert [W.] Blake wanted me to go with him to Stassfurt,
+so with Blake acting as driver we set out one cold rainy morning to Braunschweig
+to check in with the military headquarters for the immediate area. We found the
+headquarters in the city post office, which was serving as a barracks for our
+troops. We learned that there was rumor of a small Nazi tank column which had
+broken or slipped through our lines, and its whereabouts were not precisely
+known. While information was being sought as to the whereabouts of this column,
+we waited in the large post office room which was full of cots.]
+
+[There were several G.I.&#039;s sitting on these cots, and I found a vacant one to sit
+on, and Blake did likewise on a cot across the room from me. One quite youthful
+G.I. not far from me seemed to be very drunk. He was muttering to himself and
+began to make it evident that his brother had been killed by the Nazis and that
+he was going to kill Nazis in revenge. This muttering continued while he shined
+up a large Nazi ceremonial dagger which he soon began brandishing while saying
+that he was going to start out and kill Nazis. He got up from his cot and
+started down an aisle in my direction. Everyone watched his progress with
+interest but no one did anything to halt it. I watched his progress with
+particular interest, as he was heading toward me. I tried to look as small and
+un-Nazi-like as possible but got rather scared as he approached me continuing to
+mutter about killing Nazis. Finally he came right by me without regarding me as
+a Nazi and the crisis passed, but I have to admit to being somewhat scared. The
+boy soon quieted down of his own volition, and before long the message that we
+had been waiting for arrived.]
+
+[Apparently, a certain road was almost sure to be free of the German column, so
+we started out in the rain with a very gloomy sky. After we had gone a short
+distance, we encountered two or three big 155 guns heading to the front, a very
+impressive sight with their great barrels pointing toward the sky. We continued
+on our way, and after some miles noticed a deer perhaps fifty yards off the road
+in an open field. The deer was acting very strangely and seemed very distraught.
+We continued on our way and very soon to the right of the road a few hundred
+yards from where the deer had been we saw an American tank drawn up and beyond
+it several Nazi soldiers walking toward the tank with their hands clasped over
+their heads in indication of surrender. We watched for a moment and concluded
+that this was a fragment, if not the last fragment, of the manpower of the Nazi
+tank column. We continued on our way and neither saw nor heard anything more of
+the Nazi tanks.]
+
+[Finally we reached Stassfurt. Here there was a considerable chemical plant where
+Blake wanted to look at the supply of uranium. We found plenty of it in the form
+of yellowcake, a uranium salt. It was contained largely in large sacks, which
+had leaked yellowcake onto the ground. We actually walked in damp yellowcake, a
+very large supply of which indicated that the Nazis were not poor in uranium
+supplies. We duly reported this and after looking around a little further,
+returned to our base.]
+
+Now my big objective was [Paul] Harteck&#039;s Institute at the University of
+Hamburg, but Hamburg was still in the hands of the German Army. Therefore I
+remained at Gottingen, occupying myself with visiting institutes and talking
+with various scientists while waiting for the imminent fall of Hamburg. On May
+3rd, word came over the radio that Hamburg was to surrender to British troops on
+the following morning. Unfortunately, on that day I seemed to be coming down
+with the flu, and the weather was unpromising in the extreme. However, I went to
+an Army medical clinic in Gottingen to see what could be done. The ranking
+medical man present was a corporal who was well provided with large antibiotic
+pills. He administered two of these to me and provided me with a few more, and
+presently I began to feel better.
+
+The following morning, May 4th, was cold and drizzly, and I started for Hamburg
+with jeep and driver. As we approached the city after a long drive, we began to
+pass truckloads of German prisoners being transported out of the city to prison
+camps where they could be cared for. It was interesting to see these trucks
+crowded with German troops, so crowded that in many trucks they could not sit
+down. The trucks were open and exposed to the drizzle, and the prisoners did not
+look happy. We continued on to the outskirts, where in the early evening we
+located sleeping quarters in a house occupied by British officers.
+
+The following morning I was duly awakened at seven o&#039;clock by a British enlisted
+man who offered me tea in British fashion. I declined it with thanks, got some
+breakfast, and my driver and I started out to find the university. The city was
+seemingly quiet, and we had no serious difficulty in finding the university,
+where the institute that I was seeking was guarded by British troops. In
+particular, a young second lieutenant was commanding the small detachment
+guarding Harteck&#039;s institute. We had no problem in finding Professor Harteck,
+who not only was a well-known physical chemist, but later was discovered to have
+been possibly the most effective scientist in the German nuclear bomb effort.
+Harteck was pleasant, but not out-going. He was concerned, as we knew, with
+isotope separation by means of the centrifuge which we had found previously in
+the silk factory at Celle. After he had outlined the work of his institute, we
+visited the Physical Institute as well as the Chemical Institute.
+
+We learned that something was to be seen in a village not far from Hamburg, and
+went out there to locate a small dairy where a Norwegian, strangely enough, had
+built a so-called betatron. This instrument was like a large glass doughnut,
+perhaps two-and-a-half to three feet in diameter, containing electrodes which
+circulated a beam of electrons round and round, building up energy until it had
+sufficient energy to bombard a target. This was not a new principle, being
+somewhat analogous to the cyclotron, but the particular type of instrument was
+unfamiliar to me. The Norwegian inventor-designer and constructor was not
+present. I heard later that he had subsequently returned to Norway, where after
+the war he was dealt with as a traitor.
+
+When we returned to Hamburg, we had a chance to observe the destruction wrought
+by repeated bombing. The allied newspapers had announced many weeks before,
+after one particularly severe bombing, that the city of Hamburg had ceased to
+exist. In our observations this was true for some three or four blocks near the
+outskirts. Here several factories had been completely destroyed, but the major
+buildings in the heart of the city were virtually intact. A good many houses had
+their roofs stove in, but the total damage seemed much less than in some other
+cities that we had seen.
+
+After three nights in the Hamburg area, we returned to Gottingen to report what
+we had found. ALSOS immediately sent a second expedition, [8:55:28]
+
+[END OF AUDIO FILE SMYTH PERSONAL RECOLLECTIONS 1.10]
+
+[audio resumes at 8:59:46] with the necessary number of military men, commanded by Major Russell [A.]
+Fisher, who had been professor of physics at Northwestern University. Fisher
+found Harteck still under British guard (in actual fact, the second lieutenant--
+pronounced &quot;leftenant&quot;--was a Canadian). The British released Harteck to our
+military, who brought him back to Gottingen, where he was placed in the best
+corner bedroom in our house, under guard. He was served meals in his room and
+kept in his room, where at night a young officer laid his own bedding roll
+across the door and slept the night. Harteck was a distinguished-looking man of
+young middle age.
+
+After a brief stay in Gottingen, he was transported back to a castle where
+prominent and potentially useful Nazi prisoners were brought and kept for
+questioning. A number of the high-up Nazis reached this castle, commonly
+referred to as a &quot;dustbin.&quot; Apparently there was a failure in communication as
+[Sir John D.] Cockcroft, a leading British nuclear scientist, came to Hamburg to
+interview Harteck, only to find that he had been removed by the Americans. A
+slight international ruckus occurred over this, but it never reached me, and I
+hope that it did not reach the young Canadian lieutenant. Such a failure of
+communications is not improbable under the conditions of extreme secrecy
+required in our intelligence operations. Eventually, Harteck came to Rennselaer
+Polytechnic Institute in Troy, New York, as Distinguished Professor of Physical
+Chemistry. Many years after this, I visited a research project which he was
+carrying out with the support of the Office of Naval Research of the U.S. Navy.
+
+On the way back from Hamburg to Gottingen, we went to the old Hanseatic city of
+Luneburg, where I went to Army headquarters to send a telegram back to Paris. It
+took some searching to find the Signal Corps office, which was closed by a
+locked door with a sign on it reading, &quot;The war is over, so what the hell&#039;s the
+hurry.&quot; Eventually, I was able to find someone to send the message. According to
+my records, this was on the morning of May 7th, and the war officially ended at
+midnight on the 8th. According to history, headquarters were a little ahead of
+the game.
+
+[untranscribed audio, 9:06:20-9:18:30; repeats substance related elsewhere in the transcript]
+
+As I had learned in Leipzig that the distinguished physical chemist, Professor
+Bonhoffer, had left Leipzig for his summer home at Friedrichsbrunn in the Harz,
+I drove up there accompanied by a single driver. We checked in at a company
+command post at Friedrichsbrunn to discover the military situation as well as
+the location of Bonhoffer&#039;s summer cottage. The commander of the American unit
+was a captain, who told me about the recent fighting in the area. We had already
+seen many houses flying white flags, which in many cases were just sheets or
+pillowcases hung out of a window, so we knew that there had been recent action.
+
+The captain told us that the area had been occupied by die-hard S.S. men. The
+villagers had wanted to surrender in order to save their village from possible
+destruction, but the S.S. men had refused at first and had then given the mayor
+of the town permission to go over to the American lines to negotiate a
+surrender. As the mayor advanced from the German lines toward the American
+lines, the S.S. men had shot him in the back with their machine guns and had
+continued the battle. It had been typical S.S. technique to hang out white flags
+on a house, and, when American approached the house, to open up on them with
+machine guns. There was no kindly feeling on the part of the Americans toward
+these savages, and the fighting had been severe and rough.
+
+We learned from the American captain where to find Bonhoffer and proceeded to
+his cottage. We found him very worn, looking older than his years. He had
+learned several weeks earlier that two of his brothers, one of them the
+distinguished Liberal Bishop Bonhoffer, had been condemned to death, probably by
+beheading, for alleged participation in the July 20, 1944 revolution and
+attempted assassination of Hitler. Although he had learned of their arrest some
+weeks before, he did not know whether the sentence had been carried out. Many
+years later, I read that the condemned Bonhoffer had been removed from prison in
+Berlin as the Russians approached, to be transported by truck with other
+prisoners to some other place of confinement, and had been shot by his guards
+when the going got difficult. No mention was made of the other brother.
+
+Not surprisingly, Karl Bonhoffer was strongly anti-Nazi. Although he had been
+working on war projects, he said that they were of no real military importance,
+a line taken by a number of other German scientists in saying that the war had
+been made to serve science rather than science the war. He played down the
+importance of heavy water and expressed the view that it would be ten years
+before any practical use could be made of it in the atomic energy problem. We
+knew better than this, but I did not say anything. He claimed further to be very
+much on the outside on this problem and said that Harteck and Clusius were in
+the inner circle with Heisenberg, [Walther] Gerlach and [Walther] Bothe. He said
+further that Harteck, Hund, Jost and [Otto] Hahn, the discoverer of nuclear
+fission, were among the good scientists who were definitely not Nazis. He
+himself had been considering a full-time position [9:30:35]
+
+[END OF AUDIO FILE SMYTH PERSONAL RECOLLECTIONS 1.11]
+
+[audio resumes at 9:34:46] with the Osram Company but had not yet decided to accept it. In further
+conversation he told me that a new camera, which he had just acquired, had been
+confiscated by the Americans and asked if I would use my good offices to recover
+it for him. It was common practice of our army on entering a town to confiscate
+all weapons and cameras, and, after selecting any that they wanted for
+themselves, to run a tank over the unwanted material. I agreed to intercede and
+to ask the commanding captain to return the camera to Bonhoffer. The captain
+agreed, and I went my way, hearing later that the camera had been returned.
+
+When we learned that Gestapo papers of importance had been concealed in burial
+urns and buried at a certain spot in the forest in the Harz, three of us
+followed excellent directions to this spot, dug at the point which had been
+indicated, and found the urns. There were only a few of them, but they contained
+interesting Gestapo estimates of prominent government research men. Many of
+these men had been on our list to investigate and some of them had already been
+found and interrogated. To my surprise, the Gestapo estimates were very accurate
+evaluations of the ability of each man. Good scientists were labeled good
+scientists, whatever their feelings toward the Nazis may have been, and poor
+scientists, some of them high up in Nazi research circles, were labeled as
+deficient in scientific ability, though loyal Nazis. Along with the burial urns,
+which we took away with us, was a small rocket or aerial bomb about two feet
+long. It was obviously ready for use, but we did not know how it should be used,
+and handled it with care and took it away with the burial urns.
+
+[END OF AUDIO FILE SMYTH PERSONAL RECOLLECTIONS 1.12]
+
+[END OF INTERVIEW]
+
+[9:42-20-10:09:38 portion of news broadcast, incidentally recorded]
+
+ [[footnotes]]
+
+[[note]]Hubert N. Alyea, interview by Jeffrey L. Sturchio and Ron Doel in
+Princeton, New Jersey, 22 and 30 May 1986; Beckman Center for the History of
+Chemistry, Transcript #0010. [[/note]]
+
+[[note]]Foreign Affairs. Volume 1 published in 1922; H. F. Armstrong editor from
+1928. [[/note]]
+
+[[note]]See Beckman Center for the History of Chemistry oral history research
+file #0042 for a copy of undated typewritten autobiographical notes (pp.13).[[/note]]
+
+[[note]]T. W. Richards and C. P. Smyth, &quot;Solid Thallium Amalgams and the
+Electrode Potential of Pure Thallium,&quot; Journal of the American Chemical Society,
+44 (1922): 524-545; Richards and Smyth, &quot;The Heat of Solution of Thallium in
+Dilute Thallium Amalgams,&quot; ibid., 45 (1923): 1455-1460.[[/note]]
+
+[[note]]A. Smith, Textbook of Elementary Chemistry (New York: Century Company, 1914).[[/note]]
+
+[[note]]W. Foster, Introduction to General Chemistry (Princeton, New Jersey:
+Princeton University Press, 1924).[[/note]]
+
+[[note]]C. P. Smyth, &quot;The Electric Moments of Typical Organic Molecules,&quot;
+Journal of the American Chemical Society, 46 (1924): 2151-2166; Smyth and C. T.
+Zahn, &quot;The Dielectric Constants of Ethane, Ethylene, Acetylene and Butylene, and
+the Symmetry of Unsaturated Bonds,&quot; ibid., 47 (1925): 2501-2506.[[/note]]
+
+[[note]]C. P. Smyth and S. O. Morgan, &quot;The Electric Moments of Substituted
+Benzene Molecules and the Structure of the Benzene Ring,&quot; Journal of the
+American Chemical Society, 49 (1927):1030-1038; Smyth, Morgan and J. C. Boyce,
+&quot;The Dielectric Polarization of Liquids. I. The Dielectric Constants and
+Densities of Solutions of the Chlorobenzenes in Benzene and in Hexane,&quot; ibid.,
+50 (1928): 1536-1560.[[/note]]
+
+[[note]]C. P. Smyth, &quot;The Calculation of the Electric Moment of the Molecule of
+a Substance,&quot; Philosophical Magazine, [6] 45 (1923): 849-863; Smyth, &quot;Electric
+Moment and Molecular Structure,&quot; ibid., 47 (1924): 530-544.[[/note]]
+
+[[note]]C. P. Smyth, &quot;Some Applications of Electric Moments to Electronic
+Theories of Valence,&quot; Journal of the American Chemical Society, 51 (1929): 2380-2388.[[/note]]
+
+[[note]]Arnold O. Beckman, interview by Arnold Thackray and Jeffrey L. Sturchio
+in Philadelphia PA, 23 April and 23 July 1985; Beckman Center for the History of
+Chemistry, Transcript #0014. [[/note]]
+
+[[note]]C. P. Smyth and E. W. Engel, &quot;Molecular Orientation and the Partial
+Vapor Pressures of Binary Mixtures. I. Systems Composed of Normal Liquids,&quot;
+Journal of the American Chemical Society, 51 (1929): 2646-2660; Smyth and Engel,
+&quot;II. Systems Containing an Alcohol,&quot; ibid., 2660-2670.[[/note]]
+
+[[note]]H. Eyring, &quot;Steric Hindrance and Collision Diameters,&quot; Journal of the
+American Chemical Society, 54 (1932): 3191-3203; C. P. Smyth, &quot;The Polarities of
+Covalent Bonds,&quot; Journal of the American Chemical Society, 60 (1938): 183-189;
+Smyth, &quot;Induction, Resonance and Dipole Moment,&quot; ibid., 63 (1941): 57-66.[[/note]]
+
+[[note]]C. P. Smyth and W. S. Walls, &quot;The Dipole Moments and Structures of
+Certain Long-Chain Molecules,&quot; Journal of Chemical Physics, 1 (1933): 200-204.[[/note]]
+
+[[note]]L. G. S. Brooker, R. H. Spague, C. P. Smyth and G. L. Lewis, &quot;Color and
+Constitution. I. Halochromism of Anhydronium Bases Related to the Cyanine Dyes,&quot;
+Journal of the American Chemical Society, 62 (1940): 1116-1125.[[/note]]
+
+[[note]]J. H. Van Vleck, The Theory of Electric and Magnetic Susceptibilities
+(New York: Oxford University Press, 1932).[[/note]]
+
+[[note]]G. A. Hulett, E. Mack and C. P. Smyth, &quot;The Moisture Content of Some
+Typical Coals,&quot; American Journal of Science, series 4, 45 (1918): 174-184.[[/note]]
+
+[[note]]C. P. Smyth and W. O. Baker, &quot;The Rotation of Some Long Molecules in the
+Solid State,&quot; Journal of Chemical Physics, 5 (1937): 666.[[/note]]
+
+[[note]]William O. Baker, interview by Jeffrey L. Sturchio and March Goldstein
+at AT&amp;T Bell Laboratories, 23 May and 18 June 1985; Beckman Center for the
+History of Chemistry, Transcript #0013.[[/note]]
+
+[[note]]Eucken, Arnold, Fundamentals of Physical Chemistry (New York: McGraw
+Hill, 1925).[[/note]]
+
+ [[/footnotes]]
+
+</transcript><transcript_alt></transcript_alt><rights></rights><fmt>audio</fmt><usage></usage><userestrict>0</userestrict><xmllocation></xmllocation><xmlfilename></xmlfilename><collection_link></collection_link><series_link></series_link></record></ROOT>

--- a/spec/test_support/ohms_xml/various_gaps.xml
+++ b/spec/test_support/ohms_xml/various_gaps.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ROOT xmlns="https://www.weareavp.com/nunncenter/ohms" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.weareavp.com/nunncenter/ohms/ohms.xsd"><record id="00089981" dt="2020-05-18"><version>5.4</version><date value="" format="yyyy-mm-dd"/><date_nonpreferred_format>Unknown Date</date_nonpreferred_format><cms_record_id></cms_record_id><title>Fifty-line interview</title><accession>SILENCEISGOLDEN</accession><duration></duration><collection_id></collection_id><collection_name></collection_name><series_id></series_id><series_name></series_name><repository>Science History Institute</repository><funding></funding><repository_url /><interviewee>Miss Piggy</interviewee><interviewer>Kermit the Frog</interviewer><file_name></file_name><sync>1:|1(3)|3(2)|3(3)|7(2)|7(3)|7(8)|7(9)|12(2)|12(3)|14(1)|14(3)|16(1)|16(2)|16(4)|16(5)|20(1)|20(8)|20(9)|21(3)|22(5)|22(6)|22(7)</sync><sync_alt></sync_alt><transcript_alt_lang></transcript_alt_lang><translate>0</translate><media_id></media_id><media_url>https://scihist-digicoll-staging-derivatives.s3.amazonaws.com/combined_audio_derivatives/88fbb7a9-e693-4c7d-9c01-bcfd05fbdae6/combined_099a56d3aae9f6970a10f589f22d2746.mp3</media_url><mediafile><host>Other</host><avalon_target_domain></avalon_target_domain><host_account_id></host_account_id><host_player_id></host_player_id><host_clip_id></host_clip_id><clip_format>audio</clip_format></mediafile><kembed></kembed><language></language><user_notes></user_notes><index></index><type></type><description></description><rel /><transcript>Yes, my father was a petrologist. He graduated from Columbia in 1888.
+I feel confident that if he had lived a little later, 
+he would have been a physical chemist, because his interests
+lay along those lines of physical chemistry. He was not interested
+in descriptive geology or paleontology but he wanted to know how
+things got there. He was interested in the structure of things.
+My father&#039;s first cousin was a professor of chemistry at Vassar College.
+She was not a research chemist and she left Vassar to become
+president of Connecticut College. That shows a beginning interest
+in science.
+
+My father
+was a
+great believer
+in
+scientific research,
+
+so I was brought up to believe that that was a great thing to do.
+It spread through the family. My brother [Henry DeWolf Smyth]
+is a physicist. He was chairman of the physics department here.
+Frederic Hastings Smyth, my first cousin on the Smyth side,
+took a Ph.D. in physical chemistry at MIT, and was in the
+Chemical Warfare Service during the war. As a matter of fact,
+he devised the crossed alembics over a benzene ring which
+was the symbol of the Chemical Warfare Service that officers
+wore on their collars. He went into industry for a year or two
+and was with a geophysical lab for a few years. He had independent
+means and quit. After studying philosophy and religion, he became
+an Episcopal clergyman and founded his own small order.
+That was not very scientific.</transcript><transcript_alt></transcript_alt><rights></rights><fmt>audio</fmt><usage></usage><userestrict>0</userestrict><xmllocation></xmllocation><xmlfilename></xmlfilename><collection_link></collection_link><series_link></series_link></record></ROOT>


### PR DESCRIPTION
Ref. #750 .
Related to #729 .
Changes the code to ignore all *consecutive* timecodes, per our discussion on Slack.

We could get rid of a bunch of this new code if we changed the rule slightly so that any line with more than one timecode will have *all* its timecodes ignored. This is actually almost the same thing from the point of view of whoever is syncing the interview. But for now I'm following the instructions to the letter.