### PR TITLE
WIP Adjustments to the UI around the combined audio derivs admin interface

### DIFF
--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -126,6 +126,13 @@ class Admin::WorksController < AdminController
   # PATCH/PUT /admin/works/ab2323ac/create_combined_audio_derivatives
   # Unfortunately, if the job fails for any reason, the user will not be notified.
   def create_combined_audio_derivatives
+    if CombinedAudioDerivativeCreator.new(@work).audio_members.empty?
+      redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), flash: {
+        error: "Combined audio derivatives cannot be created, because this oral history does not have any published audio segments."
+      }
+      return
+    end
+
     CreateCombinedAudioDerivativesJob.perform_later(@work)
     notice = "The combined audio derivative job has been launched."
     redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), notice: notice

--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -126,7 +126,7 @@ class Admin::WorksController < AdminController
   # PATCH/PUT /admin/works/ab2323ac/create_combined_audio_derivatives
   # Unfortunately, if the job fails for any reason, the user will not be notified.
   def create_combined_audio_derivatives
-    if CombinedAudioDerivativeCreator.new(@work).audio_members.empty?
+    unless CombinedAudioDerivativeCreator.new(@work).available_members?
       redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), flash: {
         error: "Combined audio derivatives cannot be created, because this oral history does not have any published audio segments."
       }

--- a/app/jobs/create_combined_audio_derivatives_job.rb
+++ b/app/jobs/create_combined_audio_derivatives_job.rb
@@ -1,7 +1,7 @@
 class CreateCombinedAudioDerivativesJob < ApplicationJob
   def perform(work)
     deriv_creator = CombinedAudioDerivativeCreator.new(work)
-    return unless deriv_creator.audio_members.count > 0
+    return unless deriv_creator.available_members?
     # Generate the derivatives:
     deriv_info = deriv_creator.generate
     if deriv_info.errors

--- a/app/presenters/work_combined_audio_derivatives.rb
+++ b/app/presenters/work_combined_audio_derivatives.rb
@@ -11,17 +11,18 @@ class WorkCombinedAudioDerivatives < ViewModel
     render 'admin/works/combined_audio_derivatives', model: model, view: self
   end
 
+  def work_published_audio_members_available?
+    @work_published_audio_members_count ||= CombinedAudioDerivativeCreator.new(model).available_members?
+  end
 
-  def work_audio_members
-    model.members.to_a.select do |m|
-      (m.is_a? Asset) && m.content_type && m.content_type.start_with?("audio/")
-    end
+  def work_available_members_count
+    @work_available_members_count ||= CombinedAudioDerivativeCreator.new(model).available_members_count
   end
 
   def combined_mp3_audio
     return nil unless model.genre.present?
     return nil unless model.genre.include?('Oral histories')
-    return nil unless work_audio_members.count > 0
+    return nil unless work_published_audio_members_available?
     oh_content = model.oral_history_content!
     oh_content.combined_audio_mp3&.url(public:true)
   end
@@ -29,7 +30,7 @@ class WorkCombinedAudioDerivatives < ViewModel
   def combined_webm_audio
     return nil unless model.genre.present?
     return nil unless model.genre.include?('Oral histories')
-    return nil unless work_audio_members.count > 0
+    return nil unless work_published_audio_members_available?
     oh_content = model.oral_history_content!
     oh_content.combined_audio_webm&.url(public:true)
   end

--- a/app/presenters/work_combined_audio_derivatives.rb
+++ b/app/presenters/work_combined_audio_derivatives.rb
@@ -11,7 +11,7 @@ class WorkCombinedAudioDerivatives < ViewModel
     render 'admin/works/combined_audio_derivatives', model: model, view: self
   end
 
-  def work_published_audio_members_available?
+  def work_available_members?
     @work_published_audio_members_count ||= CombinedAudioDerivativeCreator.new(model).available_members?
   end
 
@@ -22,7 +22,7 @@ class WorkCombinedAudioDerivatives < ViewModel
   def combined_mp3_audio
     return nil unless model.genre.present?
     return nil unless model.genre.include?('Oral histories')
-    return nil unless work_published_audio_members_available?
+    return nil unless work_available_members?
     oh_content = model.oral_history_content!
     oh_content.combined_audio_mp3&.url(public:true)
   end
@@ -30,7 +30,7 @@ class WorkCombinedAudioDerivatives < ViewModel
   def combined_webm_audio
     return nil unless model.genre.present?
     return nil unless model.genre.include?('Oral histories')
-    return nil unless work_published_audio_members_available?
+    return nil unless work_available_members?
     oh_content = model.oral_history_content!
     oh_content.combined_audio_webm&.url(public:true)
   end

--- a/app/views/admin/works/_combined_audio_derivatives.html.erb
+++ b/app/views/admin/works/_combined_audio_derivatives.html.erb
@@ -1,14 +1,14 @@
 <div class="card bg-light mb-3">
   <h2 class="card-header h3">Combined Audio Derivative Files</h2>
   <div class="card-body">
-    <% if view.work_audio_members.count == 0 %>
-      This oral history doesn't have any audio files associated with it.
+    <% if view.work_published_audio_members.count == 0 %>
+      This oral history doesn't have any published audio segments associated with it.
     <% else %>
       <% if view.combined_audio_fingerprint.present? %>
         <% if view.derivatives_up_to_date? %>
           <p class="alert-success p-3">
             <i class="fa fa fa-thumbs-up pr-1" aria-hidden="true"></i>
-            The combined audio derivatives for this oral history are up to date. Their fingerprint is <code class="border"><%= view.combined_audio_fingerprint%></code>.</p>
+            The combined audio derivatives, created from <%= view.work_published_audio_members.count %> published audio segments, are up to date. Their fingerprint is <code class="border"><%= view.combined_audio_fingerprint%></code>.</p>
           </p>
           <ul>
             <% if view.combined_mp3_audio.present? %>
@@ -28,6 +28,9 @@
               </li>
             <% end %>
           </ul>
+          <p>
+            <%= link_to "Regenerate combined audio derivatives", create_combined_audio_derivatives_admin_work_path(model), method: "put", class: "btn btn-primary" %>
+          </p>
         <% else %>
           <p class="alert-danger p-3">
             <i class="fa fa fa-thumbs-down pr-1" aria-hidden="true"></i>
@@ -39,7 +42,7 @@
         <% end %>
       <% else %>
         <p>
-            This oral history has <%= view.work_audio_members.count %>  audio segment(s).
+            This oral history has <%= view.work_published_audio_members.count %> published audio segment(s).
         </p>
         <p>
           There are no combined audio derivatives for this oral history yet.

--- a/app/views/admin/works/_combined_audio_derivatives.html.erb
+++ b/app/views/admin/works/_combined_audio_derivatives.html.erb
@@ -2,7 +2,7 @@
 <div class="card bg-light mb-3">
   <h2 class="card-header h3">Combined Audio Derivative Files</h2>
   <div class="card-body">
-    <% unless view.work_published_audio_members_available? %>
+    <% unless view.work_available_members? %>
       This oral history doesn't have any published audio segments associated with it.
       <%# (Thus, no point in showing the "Regenerate derivatives" button.) %>
     <% else %>

--- a/app/views/admin/works/_combined_audio_derivatives.html.erb
+++ b/app/views/admin/works/_combined_audio_derivatives.html.erb
@@ -1,8 +1,9 @@
 <div class="card bg-light mb-3">
   <h2 class="card-header h3">Combined Audio Derivative Files</h2>
   <div class="card-body">
-    <% if view.work_published_audio_members.count == 0 %>
+    <% if view.work_published_audio_members.empty? %>
       This oral history doesn't have any published audio segments associated with it.
+      <%# (Thus, no point in showing the "Regenerate derivatives" button.) %>
     <% else %>
       <% if view.combined_audio_fingerprint.present? %>
         <% if view.derivatives_up_to_date? %>

--- a/app/views/admin/works/_combined_audio_derivatives.html.erb
+++ b/app/views/admin/works/_combined_audio_derivatives.html.erb
@@ -1,7 +1,8 @@
+<%# view is WorkCombinedAudioDerivatives #%>
 <div class="card bg-light mb-3">
   <h2 class="card-header h3">Combined Audio Derivative Files</h2>
   <div class="card-body">
-    <% if view.work_published_audio_members.empty? %>
+    <% unless view.work_published_audio_members_available? %>
       This oral history doesn't have any published audio segments associated with it.
       <%# (Thus, no point in showing the "Regenerate derivatives" button.) %>
     <% else %>
@@ -9,7 +10,7 @@
         <% if view.derivatives_up_to_date? %>
           <p class="alert-success p-3">
             <i class="fa fa fa-thumbs-up pr-1" aria-hidden="true"></i>
-            The combined audio derivatives, created from <%= view.work_published_audio_members.count %> published audio segments, are up to date. Their fingerprint is <code class="border"><%= view.combined_audio_fingerprint%></code>.</p>
+            The combined audio derivatives, created from <%= view.work_available_members_count %> published audio segments, are up to date. Their fingerprint is <code class="border"><%= view.combined_audio_fingerprint%></code>.</p>
           </p>
           <ul>
             <% if view.combined_mp3_audio.present? %>
@@ -43,7 +44,7 @@
         <% end %>
       <% else %>
         <p>
-            This oral history has <%= view.work_published_audio_members.count %> published audio segment(s).
+            This oral history has <%= view.work_available_members_count %> published audio segment(s).
         </p>
         <p>
           There are no combined audio derivatives for this oral history yet.


### PR DESCRIPTION
Ref #734 
Ref #704 
Ref #711 

- Use `work_published_audio_members.count` rather than `work_audio_members_count` in figuring out whether to display the "redo combined audio derivs button".
- Offer the user a chance to recreate them even if they are considered "up to date".
- Also, list the number of segments incorporated into the already-created combined audio derivs.

TODO
- [x] Actually hide the button if there are no published segments (per @jrochkind 's comment on 704.)
- [x] Tests will need to be adjusted.