### PR TITLE
Rake tasks to check derivatives -- do they all exist in storage?

### DIFF
--- a/lib/tasks/scihist.rake
+++ b/lib/tasks/scihist.rake
@@ -176,7 +176,7 @@ namespace :scihist do
           uploaded_file = derivative.file
           s3_path = [uploaded_file.storage.prefix, uploaded_file.id].compact.join("/")
 
-          unless store[s3_path]
+          unless store.has_key?(s3_path)
             missing_count += 1
             progress_bar.log("Missing file: #{derivative.asset_id}:#{derivative.key}, #{derivative.file.url(public: true)}")
           end

--- a/lib/tasks/scihist.rake
+++ b/lib/tasks/scihist.rake
@@ -126,12 +126,12 @@ namespace :scihist do
   end
 
   namespace :derivatives do
-    require 'sdbm'
+    require 'pstore'
 
-    desc "Dump all paths from storage (s3) to a SDBM file for analysis"
+    desc "Dump all paths from storage (s3) to a PSTORE file for analysis"
 
     task :dump => :environment do
-      ENV["DESTINATION"] ||= "./tmp/derivative_paths.sdbm"
+      ENV["DESTINATION"] ||= "./tmp/derivative_paths.pstore"
 
 
       s3_iterator = S3PathIterator.new(
@@ -140,10 +140,13 @@ namespace :scihist do
         progress_bar_total: Kithe::Derivative.count
       )
 
-      SDBM.open ENV["DESTINATION"] do |store|
-        # clear out all existing data
-        store.clear
+      if File.exist?(ENV['DESTINATION'])
+        FileUtils.rm(ENV['DESTINATION'])
+      end
 
+      store = PStore.new(ENV['DESTINATION'])
+
+      store.transaction do
         # for bookkeeping save storage please
         store["SHRINE_STORAGE_RECORDED"] = ScihistDigicoll::Env.shrine_derivatives_storage.inspect
 
@@ -156,16 +159,18 @@ namespace :scihist do
 
     desc "check all derivative references exist as files on storage from SDBM produced by :dump"
     task :check => :environment do
-      ENV["SOURCE"] ||= "./tmp/derivative_paths.sdbm"
+      ENV["SOURCE"] ||= "./tmp/derivative_paths.pstore"
 
       missing_count = 0
       checked_count = 0
 
-      SDBM.open(ENV["SOURCE"]) do |store|
-        if store.empty?
-          raise ArgumentError.new("No data found in DB at #{ENV["SOURCE"]}, create it with scihist:derivatives:dump or set path in ENV SOURCE")
-        end
+      unless File.exist?(ENV['SOURCE'])
+        raise ArgumentError.new("No pstore DB found at #{ENV["SOURCE"]}, create it with scihist:derivatives:dump or set path in ENV SOURCE")
+      end
 
+      store = PStore.new(ENV['SOURCE'])
+
+      store.transaction(true) do
         # kind of lame non-user-friendly, but it's what we got for now...
         puts "Checking for storage: #{ScihistDigicoll::Env.shrine_derivatives_storage.inspect}\n\n"
         puts "DB was created for storage: #{store["SHRINE_STORAGE_RECORDED"]}"
@@ -176,7 +181,7 @@ namespace :scihist do
           uploaded_file = derivative.file
           s3_path = [uploaded_file.storage.prefix, uploaded_file.id].compact.join("/")
 
-          unless store.has_key?(s3_path)
+          unless store.root?(s3_path)
             missing_count += 1
             progress_bar.log("Missing file: #{derivative.asset_id}:#{derivative.key}, #{derivative.file.url(public: true)}")
           end
@@ -185,7 +190,6 @@ namespace :scihist do
           progress_bar.increment
         end
       end
-
 
       puts "\n\nMissing derivative files: #{missing_count} out of #{checked_count} (#{(missing_count.to_f / checked_count * 100).round(2)}%)"
     end

--- a/lib/tasks/scihist.rake
+++ b/lib/tasks/scihist.rake
@@ -131,7 +131,7 @@ namespace :scihist do
     desc "Dump all paths from storage (s3) to a SDBM file for analysis"
 
     task :dump => :environment do
-      ENV["DESTINATION"] ||= "./derivative_paths.sdbm"
+      ENV["DESTINATION"] ||= "./tmp/derivative_paths.sdbm"
 
 
       s3_iterator = S3PathIterator.new(
@@ -156,7 +156,7 @@ namespace :scihist do
 
     desc "check all derivative references exist as files on storage from SDBM produced by :dump"
     task :check => :environment do
-      ENV["SOURCE"] ||= "./derivative_paths.sdbm"
+      ENV["SOURCE"] ||= "./tmp/derivative_paths.sdbm"
 
       missing_count = 0
       checked_count = 0

--- a/lib/tasks/scihist.rake
+++ b/lib/tasks/scihist.rake
@@ -145,7 +145,7 @@ namespace :scihist do
         store.clear
 
         # for bookkeeping save storage please
-        store["_shrine_storage"] = ScihistDigicoll::Env.shrine_derivatives_storage.inspect
+        store["SHRINE_STORAGE_RECORDED"] = ScihistDigicoll::Env.shrine_derivatives_storage.inspect
 
         s3_iterator.each_s3_path do |s3_path|
           store[s3_path] = "true"
@@ -168,7 +168,7 @@ namespace :scihist do
 
         # kind of lame non-user-friendly, but it's what we got for now...
         puts "Checking for storage: #{ScihistDigicoll::Env.shrine_derivatives_storage.inspect}\n\n"
-        puts "DB was created for storage: #{store["_shrine_storage"]}"
+        puts "DB was created for storage: #{store["SHRINE_STORAGE_RECORDED"]}"
 
         progress_bar = ProgressBar.create(total: Kithe::Derivative.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
 

--- a/lib/tasks/scihist.rake
+++ b/lib/tasks/scihist.rake
@@ -158,7 +158,6 @@ namespace :scihist do
     task :check => :environment do
       ENV["SOURCE"] ||= "./derivative_paths.sdbm"
 
-      progress_bar = ProgressBar.create(total: Kithe::Derivative.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
       missing_count = 0
       checked_count = 0
 
@@ -166,6 +165,12 @@ namespace :scihist do
         if store.empty?
           raise ArgumentError.new("No data found in DB at #{ENV["SOURCE"]}, create it with scihist:derivatives:dump or set path in ENV SOURCE")
         end
+
+        # kind of lame non-user-friendly, but it's what we got for now...
+        puts "Checking for storage: #{ScihistDigicoll::Env.shrine_derivatives_storage.inspect}\n\n"
+        puts "DB was created for storage: #{store["_shrine_storage"]}"
+
+        progress_bar = ProgressBar.create(total: Kithe::Derivative.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
 
         Kithe::Derivative.find_each do |derivative|
           uploaded_file = derivative.file

--- a/lib/tasks/scihist.rake
+++ b/lib/tasks/scihist.rake
@@ -169,7 +169,7 @@ namespace :scihist do
 
         Kithe::Derivative.find_each do |derivative|
           uploaded_file = derivative.file
-          s3_path = [uploaded_file.storage.prefix, uploaded_file.id].join("/")
+          s3_path = [uploaded_file.storage.prefix, uploaded_file.id].compact.join("/")
 
           unless store[s3_path]
             missing_count += 1

--- a/lib/tasks/scihist.rake
+++ b/lib/tasks/scihist.rake
@@ -130,7 +130,7 @@ namespace :scihist do
 
     desc "Dump all paths from storage (s3) to a PSTORE file for analysis"
 
-    task :dump => :environment do
+    task :dump_paths => :environment do
       ENV["DESTINATION"] ||= "./tmp/derivative_paths.pstore"
 
 
@@ -157,15 +157,15 @@ namespace :scihist do
     end
 
 
-    desc "check all derivative references exist as files on storage from SDBM produced by :dump"
-    task :check => :environment do
+    desc "check all derivative references exist as files on storage from DB produced by :dump"
+    task :check_paths => :environment do
       ENV["SOURCE"] ||= "./tmp/derivative_paths.pstore"
 
       missing_count = 0
       checked_count = 0
 
       unless File.exist?(ENV['SOURCE'])
-        raise ArgumentError.new("No pstore DB found at #{ENV["SOURCE"]}, create it with scihist:derivatives:dump or set path in ENV SOURCE")
+        raise ArgumentError.new("No pstore DB found at #{ENV["SOURCE"]}, create it with scihist:derivatives:dump_paths or set path in ENV SOURCE")
       end
 
       store = PStore.new(ENV['SOURCE'])


### PR DESCRIPTION
The "opposite" of derivative orphan checker. Orphan checker goes through all files on S3, and makes sure they are all referenced in DB.

This one goes through all derivatives referenced in DB, and makes sure they exist on S3.

Turns out it's a LOT faster to download the complete list of paths on S3, and then check that locally for each derivative in DB. Rather than try to check each derivative in DB with a seperate request to S3 to see if it exists. Like orders of magnitude faster, this way can complete in seconds.

So we have two tasks, `scihist:derivatives:dump_paths` dumps to a local SDBM db. (file-based key-value store built into ruby stdlib). The `scihist:derivatives:check_paths` checks against it. This does mean if derivatives are being modified concurrently, it could be wrong if the dumped DB file of S3 paths is not up to date. It only takes seconds to dump though, so that's good.

We first tried ruby stdlib [sdbm](https://ruby-doc.org/stdlib-2.6.3/libdoc/sdbm/rdoc/SDBM.html) to store the dumped paths, but it appeared to be buggy, switched to [pstore](https://ruby-doc.org/stdlib-2.5.3/libdoc/pstore/rdoc/PStore.html)