### PR TITLE
temporarily set default ENV value to disable staff logins

### DIFF
--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -105,7 +105,10 @@ module ScihistDigicoll
     # set in ENV LOGINS_DISABLED or local_env.yml, to globally
     # prevent access to pages requiring authentication. May be useful
     # for maintenance tasks.
-    define_key :logins_disabled, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM
+    define_key :logins_disabled, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM, default: -> {
+      # temporarily disable in production
+      Rails.env.production?
+    }
 
     # For ActiveJob queue, among maybe other things.
     define_key :persistent_redis_host, default: "localhost:6379"


### PR DESCRIPTION
Only on production to avoid breaking CI. For now we find it easier to change this default in code than to try to change local_env.yml on deployed servers