### PR TITLE
Fix WorkZipCreator for new style derivatives

### DIFF
--- a/app/services/work_zip_creator.rb
+++ b/app/services/work_zip_creator.rb
@@ -107,7 +107,7 @@ class WorkZipCreator
                             where(published: true).
                             order(:position).
                             select do |m|
-                              m.leaf_representative.content_type == "image/jpeg" && m.leaf_representative&.file_derivatives(:download_full)
+                              m.leaf_representative.content_type == "image/jpeg" || m.leaf_representative&.file_derivatives(:download_full)
                             end
   end
 

--- a/spec/services/work_zip_creator_spec.rb
+++ b/spec/services/work_zip_creator_spec.rb
@@ -5,9 +5,9 @@ describe WorkZipCreator do
   let(:work) do
     create(:public_work,
       members: [
-        create(:asset_with_faked_file),
-        create(:asset_with_faked_file),
-        create(:public_work, representative: create(:asset_with_faked_file))
+        create(:asset_with_faked_file, faked_content_type: "image/tiff"),
+        create(:asset_with_faked_file, faked_content_type: "image/tiff"),
+        create(:public_work, representative: create(:asset_with_faked_file, faked_content_type: "image/tiff"))
       ]
     )
   end
@@ -66,8 +66,8 @@ describe WorkZipCreator do
     let(:work) do
       create(:work,
         members: [
-          create(:asset_with_faked_file, faked_derivatives: {}),
-          create(:asset_with_faked_file)
+          create(:asset_with_faked_file, faked_content_type: "image/tiff", faked_derivatives: {}),
+          create(:asset_with_faked_file, faked_content_type: "image/tiff")
         ]
       )
     end


### PR DESCRIPTION
In 3f12510b00ec we accidentally changed a `||` to a `&&`, breaking logic. Change it back. 

Tests didn't catch it, because it didn't break jpeg originals, but did break tiff originals. And our tests generally use jpeg originals. Which is kind of a mistake, since it's not realistic, our actual original sare almost never jpg and usually tiff. But fixing the test data will be left for another PR. Not worth trying to fix the tests here IMO. Problem solved, fixing production post derivative migration