### PR TITLE
Add searchable_plain_text_transcript column to oral_history_content t…

### DIFF
--- a/db/migrate/20200601154653_add_oh_searchable_full_text.rb
+++ b/db/migrate/20200601154653_add_oh_searchable_full_text.rb
@@ -1,0 +1,5 @@
+class AddOhSearchableFullText < ActiveRecord::Migration[6.0]
+  def change
+    add_column :oral_history_content, :searchable_plain_text_transcript, :text
+  end
+end

--- a/db/migrate/20200602144008_rename_searchable_transcript_source.rb
+++ b/db/migrate/20200602144008_rename_searchable_transcript_source.rb
@@ -1,0 +1,5 @@
+class RenameSearchableTranscriptSource < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :oral_history_content, :searchable_plain_text_transcript, :searchable_transcript_source
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_01_154653) do
+ActiveRecord::Schema.define(version: 2020_06_02_144008) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -153,7 +153,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_154653) do
     t.text "ohms_xml_text"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "searchable_plain_text_transcript"
+    t.text "searchable_transcript_source"
     t.index ["work_id"], name: "index_oral_history_content_on_work_id", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_27_142734) do
+ActiveRecord::Schema.define(version: 2020_06_01_154653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -153,6 +153,7 @@ ActiveRecord::Schema.define(version: 2020_05_27_142734) do
     t.text "ohms_xml_text"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "searchable_plain_text_transcript"
     t.index ["work_id"], name: "index_oral_history_content_on_work_id", unique: true
   end
 


### PR DESCRIPTION
…able

This will be used for a plain text transcript that can be indexed in solr to support serach over it. It will be indexed in solr only for works that do NOT have an OHMS xml transcript, this will only be used when that's not present (and staff UI prompt should probably say that).

We are commiting it now first, before writing features on top of it, to get it in there so various features can be written on top without waiting for each other.

Having this in the table does mean that every time Rails fetches a row from this table (say to display an oral history), it will fetch back this columnw ith a lot of content, which isn't actually needed except at indexing time. I dn't think that will cause a problem, for now that's just what we're doing.