### PR TITLE
index OHMS fulltext into solr

### DIFF
--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -95,5 +95,18 @@ class WorkIndexer < Kithe::Indexer
     # for now we index 'published', not sure if we'll move to ONLY indexing
     # things that are published.
     to_field "published_bsi", obj_extract("published?")
+
+
+    # Transcript text, use OHMS transcript if we got it, otherwise plaintext if
+    # we got it.
+    to_field "searchable_fulltext" do |rec, acc|
+      if rec.oral_history_content
+        if rec.oral_history_content.ohms_xml&.transcript_text.present?
+          acc << rec.oral_history_content.ohms_xml.transcript_text
+        elsif rec.oral_history_content.searchable_transcript_source
+          acc << searchable_transcript_source
+        end
+      end
+    end
   end
 end

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -101,10 +101,10 @@ class WorkIndexer < Kithe::Indexer
     # we got it.
     to_field "searchable_fulltext" do |rec, acc|
       if rec.oral_history_content
-        if rec.oral_history_content.ohms_xml&.transcript_text.present?
+        if rec.oral_history_content.has_ohms_transcript?
           acc << rec.oral_history_content.ohms_xml.transcript_text
-        elsif rec.oral_history_content.searchable_transcript_source
-          acc << searchable_transcript_source
+        elsif rec.oral_history_content.searchable_transcript_source.present?
+          acc << rec.oral_history_content.searchable_transcript_source
         end
       end
     end

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -226,8 +226,8 @@
     <field name="latest_year" type="int_sortmissinglast" stored="true" indexed="true" multiValued="false"/>
     <field name="earliest_year" type="int_sortmissinglast" stored="true" indexed="true" multiValued="false"/>
 
-    <!-- create a field for fulltext (eg oral history transcripts), let's try with omitNorms false,
-         and stored=false too to save space since it can be so big. Dont' expect to need multi-valued,
+    <!-- create a field for fulltext (eg oral history transcripts), let's try with omitNorms false.
+         stored=true is necessary for highlighting. Dont' expect to need multi-valued,
          but I don't think it hurts in any way to allow it.
 
 
@@ -236,7 +236,7 @@
 
          https://lucene.apache.org/solr/guide/8_0/highlighting.html#Highlighting-SchemaOptionsandPerformanceConsiderations
        -->
-    <field name="searchable_fulltext" type="text_en" stored="false" indexed="true" multiValued="true" omitNorms="true" storeOffsetsWithPositions="true"/>
+    <field name="searchable_fulltext" type="text_en" stored="true" indexed="true" multiValued="true" omitNorms="true" storeOffsetsWithPositions="true"/>
 
     <!-- added by Science History Institute, a dynamic field that's good for string facets, using docValues fields -->
     <dynamicField name="*_facet" type="string_dv" multiValued="true"/>

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -226,6 +226,11 @@
     <field name="latest_year" type="int_sortmissinglast" stored="true" indexed="true" multiValued="false"/>
     <field name="earliest_year" type="int_sortmissinglast" stored="true" indexed="true" multiValued="false"/>
 
+    <!-- create a field for fulltext (eg oral history transcripts), let's try with omitNorms false,
+         and stored=false too to save space since it can be so big. Dont' expect to need multi-valued,
+         but I don't think it hurts in any way to allow it.  -->
+    <field name="searchable_fulltext" type="text_en" stored="false" indexed="true" multiValued="true" omitNorms="true"/>
+
     <!-- added by Science History Institute, a dynamic field that's good for string facets, using docValues fields -->
     <dynamicField name="*_facet" type="string_dv" multiValued="true"/>
 

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -228,8 +228,15 @@
 
     <!-- create a field for fulltext (eg oral history transcripts), let's try with omitNorms false,
          and stored=false too to save space since it can be so big. Dont' expect to need multi-valued,
-         but I don't think it hurts in any way to allow it.  -->
-    <field name="searchable_fulltext" type="text_en" stored="false" indexed="true" multiValued="true" omitNorms="true"/>
+         but I don't think it hurts in any way to allow it.
+
+
+         storeOffsetsWithPositions gets us faster highlighting for very large fields, in return for
+         somewhat larger index size.
+
+         https://lucene.apache.org/solr/guide/8_0/highlighting.html#Highlighting-SchemaOptionsandPerformanceConsiderations
+       -->
+    <field name="searchable_fulltext" type="text_en" stored="false" indexed="true" multiValued="true" omitNorms="true" storeOffsetsWithPositions="true"/>
 
     <!-- added by Science History Institute, a dynamic field that's good for string facets, using docValues fields -->
     <dynamicField name="*_facet" type="string_dv" multiValued="true"/>


### PR DESCRIPTION
Into a new field we define in solr schema, 'searchable_fulltext'. We're trying with omitNorms -- hits on smaller values will NOT be ranked higher than hits on larger values. 

In dev, after making a solr/schema.xml change, I discovered you need to:

        ./bin/rake solr:stop solr:clean solr:start scihist:solr:reindex

In staging/prod, capistrano should take care of all but the reindex.

We can merge this and fulltext will start being INDEXED into solr, but it's not being used by anything yet, it's not being included in searches. Boosts of existing fields may have to be changed to make room for this one, that's for later work.