### PR TITLE
automatically reindex work when attached oral_history_content has changed it's work-indexed content

### DIFF
--- a/app/models/oral_history_content.rb
+++ b/app/models/oral_history_content.rb
@@ -95,10 +95,10 @@ class OralHistoryContent < ApplicationRecord
   private
 
   # Kind of hacky way to trigger reindex of work when transcripts are changed here,
-  # since we now solr index transcripts. Called in after_commit hook.
+  # since we now index transcripts in solr. Called in after_commit hook.
   #
-  # If the last save changed transcript, and we HAVE a work, and kithe configuration
-  # is set up to auto-index that work... autoindex it.
+  # If the last save changed the transcript, and we HAVE a work, and kithe configuration
+  # is currently set up to auto-index that work... autoindex it.
   #
   # Note this means if you are making large scale changes to OralHistoryContent objects,
   # there are no performance concerns, as the naive appraoch might issue an individual

--- a/spec/models/oral_history_content_spec.rb
+++ b/spec/models/oral_history_content_spec.rb
@@ -104,6 +104,33 @@ describe OralHistoryContent do
     end
   end
 
+  describe "auto-index of associated work" do
+    around do |example|
+      oral_history_content # trigger creation, then enable auto indexing callbacks
+      original = Kithe.indexable_settings.disable_callbacks
+      Kithe.indexable_settings.disable_callbacks = false
+
+      example.run
+
+      Kithe.indexable_settings.disable_callbacks = original
+    end
+
+    it "does not update_index if transcript did not change" do
+      expect(oral_history_content.work).not_to receive(:update_index)
+      oral_history_content.update(combined_audio_fingerprint: "fake")
+    end
+
+    it "does update_index if ohms_xml_text changed" do
+      expect(oral_history_content.work).to receive(:update_index)
+      oral_history_content.update(ohms_xml_text: File.open(Rails.root + "spec/test_support/ohms_xml/alyea_OH0010.xml"))
+    end
+
+    it "does update_index if searchable_transcript_source changed" do
+      expect(oral_history_content.work).to receive(:update_index)
+      oral_history_content.update(searchable_transcript_source: "fake")
+    end
+  end
+
   describe "No OHMS Transcript" do
     # ohms does a weird thing wehre it puts "No transcript." in an XML element, let's make sure
     # we're catching it.


### PR DESCRIPTION
transcripts are now indexed with works, so let's try to make auto solr indexing work, respecting all the usual kithe configurations.

This is a bit magic-incantation-y, but the code isn't too bad.

**Note** this means if you are making large scale changes to OralHistoryContent objects,
there are no performance concerns, as the naive appraoch might issue an individual
SQL query for the work associated with each OralHistoryContent... and then issue
a separate non-batched solr update for each. The solution is eager-loading
associated works, and using kithe techniques to control auto-indexing: batch-updating,
or turning off auto-updating.
