### PR TITLE
Allow user to publish all unpublished audio members in an oral history before creating combined audio derivatives.

### DIFF
--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -125,17 +125,36 @@ class Admin::WorksController < AdminController
   # Create_combined_audio_derivatives in the background, if warranted.
   # PATCH/PUT /admin/works/ab2323ac/create_combined_audio_derivatives
   def create_combined_audio_derivatives
-    unless CombinedAudioDerivativeCreator.new(@work).available_members?
-      redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), flash: {
-        error: "Combined audio derivatives cannot be created, because this oral history does not have any published audio segments."
-      }
+    members_just_published = 0
+    if params[:publish_all_audio_members_first] == 'true'
+      # Publish all the audio children of a work, so they can be included
+      # in the combined audio derivatives.
+      # Note: this *does* *not* publish the work itself.
+      @work.class.transaction do
+        @work.all_descendent_members.find_each do |member|
+          next unless member.content_type
+          next unless member.content_type.start_with?('audio')
+          member.update!(published: true)
+          members_just_published += 1
+        end
+      end
+    else
+      unless CombinedAudioDerivativeCreator.new(@work).available_members?
+        redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), flash: {
+          error: "Combined audio derivatives cannot be created, because this oral history does not have any published audio segments."
+        }
       return
+      end
     end
+
     CreateCombinedAudioDerivativesJob.perform_later(@work)
     sidecar = @work.oral_history_content!
     sidecar.combined_audio_derivatives_job_status = 'queued'
     sidecar.save!
     notice = "The combined audio derivative job has been added to the job queue."
+    if members_just_published > 0
+      notice = "#{members_just_published} audio segments have been published, and the combined audio derivative job has been added to the job queue."
+    end
     redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), notice: notice
   end
 

--- a/app/views/admin/works/_combined_audio_derivatives.html.erb
+++ b/app/views/admin/works/_combined_audio_derivatives.html.erb
@@ -3,10 +3,14 @@
   <h2 class="card-header h3">Combined Audio Derivative Files</h2>
   <div class="card-body">
     <% unless view.work_available_members? %>
-      This oral history doesn't have any published audio segments associated with it.
-      <%# (Thus, no point in showing the "Regenerate derivatives" button.) %>
+      <p class="alert-info p-3">This oral history doesn't have any published audio segments associated with it.</p>
+        <%= link_to "Publish all audio segments, then create the combined audio derivatives", create_combined_audio_derivatives_admin_work_path(model, :publish_all_audio_members_first => "true"),
+          method: "put",
+          data: { confirm: "This will publish all audio segments before kicking off the combined audio derivatives job. The work itelf will not be published." },
+          class: "btn btn-primary"#,
+          #[{ publish_all_audio_members_first: :true }]
+          %>
     <% else %>
-
       <% if view.combined_audio_fingerprint.present? %>
         <% if view.derivatives_up_to_date? %>
           <p class="alert-success p-3">

--- a/app/views/admin/works/show.html.erb
+++ b/app/views/admin/works/show.html.erb
@@ -89,7 +89,6 @@
           <ul>
             <li>unpublish the oral history (this will unpublish all the segments as well);</li>
             <li>make any changes you need to the segments of the oral history;</li>
-            <li>republish any and all segments you want to include in the combined audio derivatives;</li>
             <li>regenerate the combined audio derivatives (in the "Oral History" tab);</li>
             <li>republish the oral history.</li>
         </div>


### PR DESCRIPTION
Ref #712 .

This modifies works_controller#create_combined_derivatives by adding a new option, `params['publish_all_audio_members_first']`.

If `publish_all_audio_members_first` is 'true', the controller publishes all unpublished audio members of the item, and then creates the job as it would normally. _It does *not* publish the work; this is meant to be done later, after the user has tested the work along with its combined audio derivatives._

If `publish_all_audio_members_first` is not 'true', the method behaves as before.

On the front end:
We now show a button that triggers the method (with publish_all_audio_members_first = true )  in the (very common) case in which there are no published audio members. (Previously, we didn't show the button, and required the user to publish all the audio items one by one.)