### PR TITLE
update solr_wrapper solr version from 8.0.0 to 8.5.2

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -22,4 +22,4 @@ collection:
   persist: <%= Rails.env.test? ? "false" : "true" %>
   dir: solr/config
   name: scihist_digicoll_<%= Rails.env %>
-version: 8.0.0
+version: 8.5.2


### PR DESCRIPTION
Ref #786

This does not effect production machines, but should effect solr in dev and test, including on travis. 

On your dev machine, you may have to manually force solr upgrade, after merging this, this OUGHT to work, I think:

    $ ./bin/rake solr:stop solr:clean solr:start
    $ RAILS_ENV=test ./bin/rake solr:stop solr:clean