### PR TITLE
Tweak solr highlighting parameters

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -129,13 +129,18 @@ class CatalogController < ApplicationController
         "hl.method" => "unified",
         "hl.fl" => "searchable_fulltext",
         "hl.usePhraseHighlighter" => "true",
-        "hl.snippets" => 2,
+        "hl.snippets" => 3,
         "hl.encoder" => "html",
         # Biggest current transcript seems to be OH0624 with 817,139 chars.
         # Set maxAnalyzed Chars to two million? I dunno. Solr suggests if we
         # have things set up right, it ought to be able to handle very big, unclear.
         "hl.maxAnalyzedChars" => "2000000",
         "hl.offsetSource" => "postings",
+
+        "hl.bs.type" => "WORD",
+        "hl.fragsize" => "140",
+        "hl.fragsizeIsMinimum" => "true"
+
       )
     end
 


### PR DESCRIPTION
To control the length of the snippets better, we switch to WORD delimiting instead of default SENTENCE. With SENTENCE, if there was a partiuclarly long "sentence" (or not really a sentence, but a section of, say, the back of the book index with a lot of text with no periods!), then it would return a single "sentence" and be far too long. With WORD, it's less likely there will be a single word that's far too long. (Although still possible, and sort of a lack of feature in Solr that it doesn't let you cap it).

Until Solr 8.5, the "WORD" delimiting in highlighter didn't really work well, it would give you a snippet with the highlighted match always at the beginning! But 8.5 fixes it to put the highlighted match in the middle of the snippet, as you'd want.

We also tweaked highlighting settings to provide *3* highlights if avaialble instead of just two; and tweaked the fragSize to be a bit smaller; both of these get a bit closer to what microsite appears to be doing.

Ref #738