### PR TITLE
don't try to copy integer pk of OralHistoryContent when copy_data betweem hosts

### DIFF
--- a/app/models/copy_staging/serialize_work.rb
+++ b/app/models/copy_staging/serialize_work.rb
@@ -61,7 +61,7 @@ module CopyStaging
         model_attributes.delete("representative_id")
         model_attributes.delete("leaf_representative_id")
       elsif model.kind_of?(Work) && model.oral_history_content
-        oral_history_content << { model.oral_history_content.class.name => model.oral_history_content.attributes }
+        oral_history_content << { model.oral_history_content.class.name => model.oral_history_content.attributes.except("id") }
       end
 
       mine = [{ model.class.name => model_attributes }]


### PR DESCRIPTION
Can lead to collisions, there's no need to preserve that pk