### PR TITLE
update blacklight_range_limit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
       jbuilder (~> 2.7)
       kaminari (>= 0.15)
       rails (>= 5.1, < 7)
-    blacklight_range_limit (7.8.0)
+    blacklight_range_limit (7.8.2)
       blacklight (>= 7.0)
     bootsnap (1.4.6)
       msgpack (~> 1.0)


### PR DESCRIPTION
from 7.8.0 to 7.8.2.

    bundle update blacklight_range_limit --conservative

This does fix a bug we are experiencing where an empty Date constraint shows up in the constraints bar.

![Screenshot 2020-06-26 16 20 36](https://user-images.githubusercontent.com/149304/85897769-fdf11980-b7c8-11ea-824d-baa7f82e7a91.png)

Not sure when that showed up, some past `blacklight` or `blacklight_range_limit` update. This update makes it go away again. 