### PR TITLE
Freeze blacklight in Gemfile to 7.7.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,12 @@ gem 'lockbox'
 gem 'rails', '~> 6.0.0'
 gem 'webpacker', '~> 5.0'
 
-
-gem "blacklight", "~> 7.0", ">= 7.1.0.alpha"
+# lock blacklight to current MINOR version. While BL minor version releases
+# are theoretically backwards compat, experience shows they often cause problems.
+# So you need to manually change this spec to allow updates when you want
+# to spend the time to update Blacklight to latest -- you will usually want to update
+# blacklight_range_limit to latest at same time.
+gem "blacklight", "~> 7.7.0"
 gem "blacklight_range_limit", "~> 7.0" # version sync'd with blacklight
 
 gem "draper", "~> 4.0", ">= 4.0.1" # "decorators", which we use as view models

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -631,7 +631,7 @@ DEPENDENCIES
   access-granted (~> 1.0)
   aws-sdk-core
   aws-sdk-ec2 (>= 1.74)
-  blacklight (~> 7.0, >= 7.1.0.alpha)
+  blacklight (~> 7.7.0)
   blacklight_range_limit (~> 7.0)
   bootsnap (>= 1.4.4)
   bootstrap (~> 4.3)


### PR DESCRIPTION
While BL minor version releases are theoretically intended to be backwards compatible,
our experience is that upgrading blacklight even to a minor version frequently causes
problems.

By locking to 7.7.x, we can run `bundle update` or `bundle update some_arg` to update other dependencies, and bundler will never update blacklight beyond 7.7.x, becuase we've told it not to here. This will let us use bundler for dependency management in a more convenient way, to keep other dependecies up to date, without worrying it'll update blacklight.

The downside is that blacklight really will be fixed to 7.7.x unless we take manual action to change the Gemfile to try a new version. So new 7.x's will be out with bugfixes or improvements, but we'll just be stuck on the old one.  We will need to periodically remember to try new ones and see if they work, to avoid getting stuck on an old version. Or eventually something will force our hand, we'll need to update to a new version of Blacklight becuase 7.7.x is incompatible with something else we need to update, etc.

But for now, we think this is more manageable, we want to be able to periodically run `bundle update` to update ALL our dependencies to latest non-breaking versions, and can't afford to deal with the individual attention that Blacklight minor versions often require to avoid problems or copious deprecation warnings. 

(Right now the reaosn we are sticking to 7.7.x instead of 7.8.0 or 7.9.0 is to avoid some copious deprecation warnings that would fill up our logs, which are non-trivial to deal with, in 7.8.0).