### PR TITLE
Redirect corrupted facet params

### DIFF
--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -27,4 +27,23 @@ RSpec.describe CatalogController, solr: true, type: :controller do
       end
     end
   end
+
+  describe "malformed URL params" do
+    describe "facet values as Hash" do
+      render_views
+
+      let(:malformed_facet_param) do
+        { f: { subject_facet: { "0" => "subject1", "1" => "subject2"}, author_facet:  ["author1", "author2"]} }
+      end
+
+      let(:corrected_facet_param) do
+        { f: { subject_facet: ["subject1", "subject2"], author_facet:  ["author1", "author2"]} }
+      end
+
+      it "redirects to be interprted properly" do
+        get :index, params: malformed_facet_param
+        expect(response).to redirect_to(search_catalog_url(corrected_facet_param))
+      end
+    end
+  end
 end


### PR DESCRIPTION
When sharing a search results URL on facebook, facebook will erroneously alter the facet limit params. From eg `?f[facet_name][]=value` to `?f[facet_name][0]=value`

This will result in a Blacklight error. When the facebook crawler crawls it for a preview, as well as when any user clicks on it. We try to catch these, fix them to what Blacklight wants, and REDIRECT to the correct one again with an HTTP 301 Moved Permanently. (Better than two URLs representing the same search, and it looks like Facebook crawler will follow redirect).

Ref #811

Discussion in Blacklight tracker indicates this is a kind of regression, Blacklight already tried to work around facebook mangling of URLs earlier: https://github.com/projectblacklight/blacklight/issues/1784

There's a pending Blacklight PR to fix this "in place", instead of doing a redirect: https://github.com/projectblacklight/blacklight/pull/2313

We'd like to fix this without waiting for a Blacklight release (we are several minor releases behind, and BL upgrades may not be breakage-free), and this approach of a redirect gives us a way to do that without monkey-patching. We also maybe actually like doing the 301 Moved Permanently Redirect to the correct canonical URL for the search?