### PR TITLE
Handle mis-ordered date range limit params

### DIFF
--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -45,5 +45,26 @@ RSpec.describe CatalogController, solr: true, type: :controller do
         expect(response).to redirect_to(search_catalog_url(corrected_facet_param))
       end
     end
+
+    describe "range value out of order" do
+      render_views
+
+      let(:out_of_order_range_params) do
+        {
+          range: {
+            year_facet_isim: {
+              begin: "2010",
+              end: "2000"
+            }
+          }
+        }
+      end
+
+      it "treats as if ordered properly" do
+        get :index, params: out_of_order_range_params
+        expect(response.status).to eq(200)
+        expect(response.body).to include("2000 to 2010")
+      end
+    end
   end
 end


### PR DESCRIPTION
If you have a query with a date range limit, where the "start" is AFTER the "end", blacklight_range_limit will raise a `BlacklightRangeLimit::InvalidRange`. This results in an HTTP 406 "Not Acceptable" being delivered to the browser. This could be considered acceptable behavior. But it also results in an uncaught exception  being reported by Honeybadger.

This happens from time to time in our logs. It looks like it probably is real users, just entering dates out of order. While a 406 response might be okay... why not just treat it as if they were entered in the "correct" order instead, probably giving the user what they wanted, and avoiding the honeybadger uncaught error report?

That is what this commit does. Code adapted from something similar we were doing in earlier chf_sufia app.