### PR TITLE
Reserve space on page for unloaded images using CSS aspect ratio hack

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -22,6 +22,8 @@ $brand-blue: #4bb0c7; // zack instructed us to use this slightly darker shade
 $brand-light-grey: #bcbcbc; // not actually very light
 $brand-dark-grey: #646469;
 
+$brand-image-placeholder-color: #AAA; // not a designated brand color, but oh well
+
 //$brand-blue-text: #338EA2; // brand blue is too light for text on white, here's a darker version 3595AA.
 $brand-blue-text: $brand-blue;
 

--- a/app/assets/stylesheets/local/img_aspectratio_container.scss
+++ b/app/assets/stylesheets/local/img_aspectratio_container.scss
@@ -27,10 +27,3 @@
     object-fit: cover;
   }
 }
-
-
-.test-container {
-  display: inline-block;
-  width: 100%;
-  overflow: hidden;
-}

--- a/app/assets/stylesheets/local/img_aspectratio_container.scss
+++ b/app/assets/stylesheets/local/img_aspectratio_container.scss
@@ -1,0 +1,36 @@
+// Uses a "hack" to have a container around an image to fixes the aspect ratio of the img tag.
+// We use it for lazy-loaded images, so they can take up the correct amount of space on the
+// page even before they are loaded, avoiding page reflow.
+//
+// The .img-aspectratio-container is expected to have an inline style to set `padding-bottom`
+// to proper aspect ratio value, to make this work.
+//
+// For background, see:
+// * http://davidecalignano.it/lazy-loading-with-responsive-images-and-unknown-height/
+// * https://alistapart.com/article/creating-intrinsic-ratios-for-video/
+// * https://www.bram.us/2017/06/16/aspect-ratios-in-css-are-a-hack/
+.img-aspectratio-container {
+  width: 100%;
+  height: 0;
+  //padding-bottom: 100%;
+  position: relative;
+  overflow: hidden;
+
+  img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+
+    //https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit
+    object-fit: cover;
+  }
+}
+
+
+.test-container {
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
+}

--- a/app/assets/stylesheets/local/img_aspectratio_container.scss
+++ b/app/assets/stylesheets/local/img_aspectratio_container.scss
@@ -12,7 +12,6 @@
 .img-aspectratio-container {
   width: 100%;
   height: 0;
-  //padding-bottom: 100%;
   position: relative;
   overflow: hidden;
 

--- a/app/assets/stylesheets/local/scihist_viewer.scss
+++ b/app/assets/stylesheets/local/scihist_viewer.scss
@@ -317,7 +317,7 @@ $scihist_image_viewer_thumb_width: 54px; // Needs to match ImageServiceHelper::T
       }
 
       &.lazyload, &.lazyloading, &.lazyloaded {
-        background: #AAA asset-url('static-progress.svg') no-repeat;
+        background: $brand-image-placeholder-color asset-url('static-progress.svg') no-repeat;
         background-size: 34px 34px;
         background-clip: content-box;
         background-position: center center;

--- a/app/assets/stylesheets/local/work_show.scss
+++ b/app/assets/stylesheets/local/work_show.scss
@@ -112,9 +112,6 @@
       // aspect ratio, cause the dimensions are so responsive. This is just
       // a rough huge limit, if it's not working out just delete this and give up.
       max-height: 300vw;
-
-      // inline-block may be neccesary to get JS aspectratio setting to work
-      display: inline-block;
     }
 
     // A div of btn's

--- a/app/assets/stylesheets/local/work_show.scss
+++ b/app/assets/stylesheets/local/work_show.scss
@@ -93,8 +93,8 @@
   .member-image-presentation {
     position: relative;
 
-    .thumb > a {
-      display: block;
+    .thumb {
+      display: block; // sometimes an 'a', normalize it to block
     }
     .thumb img {
       cursor: zoom-in;

--- a/app/assets/stylesheets/local/work_show.scss
+++ b/app/assets/stylesheets/local/work_show.scss
@@ -100,11 +100,18 @@
       cursor: zoom-in;
       max-width: 100%;
 
+      // Bg will be covered up by actual image src once loaded, but serves
+      // as a placeholder before loaded, whether for lazy loaded or browser loaded
+      background-color: #AAA;
+
+      // If our JS is actually loading, add a stationary "spinner" kind of icon.
+      // Actual animated one used too much CPU when on the page so many times.
       &.lazyload, &.lazyloading {
-        background: #AAA asset-url('static-progress.svg') no-repeat;
-        background-position: center center;
-        background-size: 50%;
+         background: #AAA asset-url('static-progress.svg') no-repeat;
+         background-position: center center;
+         background-size: 50%;
       }
+
       min-height: 50px; // just so it's something big enough to see! Will distort very wide images.
 
       // sanity max-height to keep keep crazy long aspect ratio images from

--- a/app/assets/stylesheets/local/work_show.scss
+++ b/app/assets/stylesheets/local/work_show.scss
@@ -102,12 +102,12 @@
 
       // Bg will be covered up by actual image src once loaded, but serves
       // as a placeholder before loaded, whether for lazy loaded or browser loaded
-      background-color: #AAA;
+      background-color: $brand-image-placeholder-color;
 
       // If our JS is actually loading, add a stationary "spinner" kind of icon.
       // Actual animated one used too much CPU when on the page so many times.
       &.lazyload, &.lazyloading {
-         background: #AAA asset-url('static-progress.svg') no-repeat;
+         background: $brand-image-placeholder-color asset-url('static-progress.svg') no-repeat;
          background-position: center center;
          background-size: 50%;
       }

--- a/app/javascript/packs/lazysizes.js
+++ b/app/javascript/packs/lazysizes.js
@@ -4,6 +4,4 @@
 // https://github.com/aFarkas/lazysizes#include-early
 
 import 'lazysizes';
-import 'lazysizes/plugins/aspectratio/ls.aspectratio.js'
-
 lazySizes.init();

--- a/app/presenters/member_image_presentation.rb
+++ b/app/presenters/member_image_presentation.rb
@@ -49,11 +49,11 @@ class MemberImagePresentation < ViewModel
 
     content_tag("div", class: "member-image-presentation") do
       private_label +
-      content_tag("div", class: "thumb") do
-        content_tag("a", href: view_href, data: view_data_attributes) do
-          ThumbDisplay.new(representative_asset, thumb_size: size, lazy: lazy).display
-        end
+
+      content_tag("a", class: "thumb", href: view_href, data: view_data_attributes) do
+        ThumbDisplay.new(representative_asset, thumb_size: size, lazy: lazy).display
       end +
+
       content_tag("div", class: "action-item-bar") do
         action_buttons_display
       end

--- a/app/presenters/thumb_display.rb
+++ b/app/presenters/thumb_display.rb
@@ -107,7 +107,6 @@ class ThumbDisplay < ViewModel
     img_attributes = {
       alt: "",
       data: {
-        aspectratio: aspect_ratio
       }
     }
 
@@ -115,20 +114,24 @@ class ThumbDisplay < ViewModel
       # tell lazysizes.js to load with class, and put src/srcset only in
       # data- attributes, so the image will not be loaded immediately, but lazily
       # by lazysizes.js.
+
       img_attributes[:class] = "lazyload"
       img_attributes[:data].merge!(src_attributes)
     else
       img_attributes.merge!(src_attributes)
     end
 
-    tag("img", img_attributes)
+    content_tag("div", class: "img-aspectratio-container", style: "padding-bottom: #{aspect_ratio_padding_bottom};") do
+    #content_tag("div", class: "test-container") do
+      tag("img", img_attributes)
+    end
   end
 
-  # used for lazysizes-aspectratio
-  # https://github.com/aFarkas/lazysizes/tree/gh-pages/plugins/aspectratio
-  def aspect_ratio
+  # Used for padding bottom CSS aspect ratio trick
+  def aspect_ratio_padding_bottom
     if asset && asset.width && asset.height
-      "#{asset.width}/#{asset.height}"
+      height_over_width = asset.height.to_f / asset.width.to_f
+      "#{(height_over_width * 100.0).truncate(1)}%"
     else
       nil
     end

--- a/app/presenters/thumb_display.rb
+++ b/app/presenters/thumb_display.rb
@@ -121,8 +121,10 @@ class ThumbDisplay < ViewModel
       img_attributes.merge!(src_attributes)
     end
 
+    # the wrapper div with CSS aspect ratio hack helps reserve space on page before image is loaded.
+    # For lazy-loaded images -- but turns out, helpful even for immediate images, which may load slow
+    # or at any rate not yet be loaded when page is laid out. Minimize page jumping around.
     content_tag("div", class: "img-aspectratio-container", style: "padding-bottom: #{aspect_ratio_padding_bottom};") do
-    #content_tag("div", class: "test-container") do
       tag("img", img_attributes)
     end
   end

--- a/spec/presenters/thumb_display_spec.rb
+++ b/spec/presenters/thumb_display_spec.rb
@@ -63,37 +63,45 @@ describe ThumbDisplay do
     let(:thumb_size) { :mini }
     let(:argument) { build(:asset_with_faked_file)}
     let(:instance) { ThumbDisplay.new(argument, thumb_size: thumb_size) }
+    let(:expected_aspect_ratio) { (argument.height.to_f / argument.width.to_f * 100.0).truncate(1) }
 
     it "renders" do
       deriv    = argument.file_derivatives[:"thumb_#{thumb_size}"]
       deriv_2x = argument.file_derivatives[:"thumb_#{thumb_size}_2X"]
 
-      img_tag = rendered.at_css("img")
+      wrapper = rendered.at_css(".img-aspectratio-container")
+      expect(wrapper).to be_present
+      expect(wrapper["style"]).to eq("padding-bottom: #{expected_aspect_ratio}%;")
+
+      img_tag = wrapper.at_css("img")
 
       expect(img_tag).to be_present
       expect(img_tag["src"]).to eq(deriv.url)
       expect(img_tag["srcset"]).to eq("#{deriv.url} 1x, #{deriv_2x.url} 2x")
-
-      expect(img_tag["data-aspectratio"]).to eq "#{argument.width}/#{argument.height}"
     end
 
     describe "lazy load with lazysizes.js" do
       let(:thumb_size) { :mini }
       let(:argument) { build(:asset_with_faked_file)}
       let(:instance) { ThumbDisplay.new(argument, thumb_size: thumb_size, lazy: true) }
+      let(:expected_aspect_ratio) { (argument.height.to_f / argument.width.to_f * 100.0).truncate(1) }
+
 
       it "renders with lazysizes class and data- attributes" do
         deriv    = argument.file_derivatives[:"thumb_#{thumb_size}"]
         deriv_2x = argument.file_derivatives[:"thumb_#{thumb_size}_2X"]
 
-        img_tag = rendered.at_css("img")
+        wrapper = rendered.at_css(".img-aspectratio-container")
+        expect(wrapper).to be_present
+        expect(wrapper["style"]).to eq("padding-bottom: #{expected_aspect_ratio}%;")
+
+        img_tag = wrapper.at_css("img")
 
         expect(img_tag).to be_present
         expect(img_tag["src"]).not_to be_present
         expect(img_tag["srcset"]).not_to be_present
 
         expect(img_tag["class"]).to eq "lazyload"
-        expect(img_tag["data-aspectratio"]).to eq "#{argument.width}/#{argument.height}"
         expect(img_tag["data-src"]).to eq(deriv.url)
         expect(img_tag["data-srcset"]).to eq("#{deriv.url} 1x, #{deriv_2x.url} 2x")
       end


### PR DESCRIPTION
We "lazy load" many of the images on our work show pages, which can have many thumbnails. So the images only load if the viewer scrolls to have them in view. 

We want to "block out" space on the page for the image even before it's loaded, so we can show an appropriately sized  "placeholder"  on the page where the image will be, and the page won't jump around it's layout as images are loaded. 

Our images are "responsively" sized, so they can be different pixel sizes depending on screen size. Our thumbnails have their *widths* set in CSS (using responsive logic, often %'s), and have their height unspecified, to just be whatever is the proper aspect ratio for the image. So to reserve space on the page, we want to do it in terms of aspect ratio somehow. We know the image aspect ratio, because original height and width are captured for each image as metadata. 

Previously to this PR, we used some Javascript to set the heights of the unloaded images based on their known aspect ratio. It was some JS that came as a plugin with the `lazysizes` JS we are using for lazy loading in the first place. 

This basically worked, but had some problems:
* When we have a lot of thumbs on the page, we're asking the browser to do a LOT of JS, which could effect front-end performance
* It could take a while for the JS to actually execute, so you could still see the images without their properly sized placeholderes for a couple seconds, and then jumping around as their sizes were set. 
* Every time the JS set a size, it caused the browser to do a "layout reflow", re-calculating much of the page, further performance risks. 
* Automated tools for evaluating front-end performance (eg google's "pagespeed insights") really don't like this technique, and reported terrible scores -- I'm not sure it really impacted the user as much as these tools think, but it may have, and it still got in the way of using these tools to find other bottlenecks. 

Alternatives? It turns out that there is a kind of "hacky" way to use *pure CSS* to size a div in terms of a known aspect ratio, such that it will keep that aspect ratio even if it gets resized responsively.  There's no JS involved, so it's more efficient, and is in effect as soon as the browser renders the page, there is no lag while the image is resized. (It may make the initial rendering slower as the browser has to do more work, but it's a net win). 

You do this by adding an additional "wrapper" div around your image, which has it's "padding-bottom" set to a %, which it turns out browsers calculate as a percentage of element width.  Descriptions of this technique at http://davidecalignano.it/lazy-loading-with-responsive-images-and-unknown-height/ and https://alistapart.com/article/creating-intrinsic-ratios-for-video/. 

This PR switches our aspect-ratio-sizing from the JS technique to that CSS technique. 

It turns out this technique is profitable even for non-lazy ordinary load images -- previously, if the network was slow and/or they were especially large, they too could take a noticeable amount of time to come in, and cause some page jumping around when they did. Now even standard loaded images have their proper space on the page reserved before they load, which is an added improvement. 

Downsides? One is that we're adding yet another "wrapper" div to our already unfortunately complex/deep DOM. I am going to look at the DOM around our work show thumbnails, and see if there are any existing divs in the hieararchy that can be easily eliminated to compensate...