### PR TITLE
DownloadOptions use our homegrown bytes_to_human_string

### DIFF
--- a/app/models/download_option.rb
+++ b/app/models/download_option.rb
@@ -24,9 +24,8 @@ class DownloadOption
     parts << ScihistDigicoll::Util.humanized_content_type(content_type) if content_type.present?
     parts << "#{width.to_s} x #{height.to_s}px" if width.present? && height.present?
 
-    # Rails 'number_to_human_size' is actually specifically for computer storage unit size,
-    # translates to KB or MB or GB etc.
-    parts << ActiveSupport::NumberHelper.number_to_human_size(size) if size.present?
+    # translate bytes to KB or MB or GB etc.
+    parts << ScihistDigicoll::Util.simple_bytes_to_human_string(size) if size.present?
 
     subhead = parts.join(" — ") # em-dash
 

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -11,4 +11,19 @@ describe ScihistDigicoll::Util do
     end
   end
 
+  describe "#simple_bytes_to_human_string" do
+    it "has correct units with no zero after decimal" do
+      expect(ScihistDigicoll::Util.simple_bytes_to_human_string(1024)).to eq("1 KB")
+    end
+
+    it "has correct units with decimals" do
+      expect(ScihistDigicoll::Util.simple_bytes_to_human_string(1124)).to eq("1.1 KB")
+      expect(ScihistDigicoll::Util.simple_bytes_to_human_string(98343434)).to eq("93.8 MB")
+      expect(ScihistDigicoll::Util.simple_bytes_to_human_string(2.48 * 1024 * 1024 * 1024)).to eq("2.5 GB")
+    end
+
+    it "has no decimal if three whole digits even if there is remainder" do
+      expect(ScihistDigicoll::Util.simple_bytes_to_human_string((200 * 1024) + 110)).to eq("200 KB") # not 200.1 KB
+    end
+  end
 end


### PR DESCRIPTION
We put the size of derivatives next to a link to download in the download menu, and we format it human-readably like "104 MB" instead of just a raw number of bytes like `104567233`

We were using ActiveSupport::NumericHelper.number_to_human_size, but that turned out to be a real performance problem,  in a way that really really matters when we might do it 6 derivatives * 600 children == 3600 times on a page. (Whether we should re-architect the app to NOT do that is another story). 

The Rails built-in method is super slow perhaps because it does so many checks for i18n localization (to get the right units? How do you say GB in Chinese? I don't think we are concerned), perhaps because it has even fancier handling of edge cases that we don't really need. 

Turns out a very short DIY implementation (cribbed from StackOverflow, modified a bit) is orders of magnitude faster. This can speed up delivery of Ramelli by like 40%!

It was kind of a hacky nightmare figuring this out, it's hard to explain how I figured it out, at least right now in text. 

There is definitely more optimization still to be done, but this is a big jump! 