### PR TITLE
Assorted fixes to CSS-based aspectratio placeholder for thumbs

### DIFF
--- a/app/assets/stylesheets/local/img_aspectratio_container.scss
+++ b/app/assets/stylesheets/local/img_aspectratio_container.scss
@@ -21,8 +21,5 @@
     left: 0;
     width: 100%;
     height: 100%;
-
-    //https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit
-    object-fit: cover;
   }
 }

--- a/app/assets/stylesheets/local/oh_audio.scss
+++ b/app/assets/stylesheets/local/oh_audio.scss
@@ -283,6 +283,7 @@
       }
 
       .image {
+        width: 54px; // thumb_mini width
         padding-left: 0;
       }
 

--- a/app/presenters/thumb_display.rb
+++ b/app/presenters/thumb_display.rb
@@ -83,6 +83,7 @@ class ThumbDisplay < ViewModel
     tag "img", alt: "", src: placeholder_img_url, width: "100%";
   end
 
+
   # A thumb 'img' tag that provides srcset wtih double-res image for better
   # display on high-res screens.
   #
@@ -129,14 +130,15 @@ class ThumbDisplay < ViewModel
     end
   end
 
-  # Used for padding bottom CSS aspect ratio trick
+  # Used for padding bottom CSS aspect ratio trick. Get height and width from requested thumb.
   def aspect_ratio_padding_bottom
-    if asset && asset.width && asset.height
-      height_over_width = asset.height.to_f / asset.width.to_f
-      "#{(height_over_width * 100.0).truncate(1)}%"
-    else
-      nil
-    end
+    thumb = asset&.file("thumb_#{thumb_size}")
+
+    return nil unless thumb && thumb.width && thumb.height
+
+    height_over_width = thumb.height.to_f / thumb.width.to_f
+
+    "#{(height_over_width * 100.0).truncate(1)}%"
   end
 
   def res_1x_url

--- a/app/presenters/thumb_display.rb
+++ b/app/presenters/thumb_display.rb
@@ -122,10 +122,15 @@ class ThumbDisplay < ViewModel
       img_attributes.merge!(src_attributes)
     end
 
-    # the wrapper div with CSS aspect ratio hack helps reserve space on page before image is loaded.
-    # For lazy-loaded images -- but turns out, helpful even for immediate images, which may load slow
-    # or at any rate not yet be loaded when page is laid out. Minimize page jumping around.
-    content_tag("div", class: "img-aspectratio-container", style: "padding-bottom: #{aspect_ratio_padding_bottom};") do
+    if aspect_ratio_padding_bottom
+      # the wrapper div with CSS aspect ratio hack helps reserve space on page before image is loaded.
+      # For lazy-loaded images -- but turns out, helpful even for immediate images, which may load slow
+      # or at any rate not yet be loaded when page is laid out. Minimize page jumping around.
+      content_tag("div", class: "img-aspectratio-container", style: "padding-bottom: #{aspect_ratio_padding_bottom};") do
+        tag("img", img_attributes)
+      end
+    else
+      # don't have aspect ratio to reserve space pre-load, just image tag
       tag("img", img_attributes)
     end
   end

--- a/spec/presenters/thumb_display_spec.rb
+++ b/spec/presenters/thumb_display_spec.rb
@@ -80,6 +80,25 @@ describe ThumbDisplay do
       expect(img_tag["srcset"]).to eq("#{deriv.url} 1x, #{deriv_2x.url} 2x")
     end
 
+    describe "with no aspect ratio available" do
+      let(:argument) do
+        build(:asset_with_faked_file).tap do |asset|
+          thumb = asset.file("thumb_#{thumb_size}")
+          thumb.metadata.delete("height")
+          thumb.metadata.delete("width")
+          asset.save!
+        end
+      end
+
+      it "renders without aspectratio-container" do
+        wrapper = rendered.at_css(".img-aspectratio-container")
+        expect(wrapper).not_to be_present
+
+        img_tag = rendered.at_css("img")
+        expect(img_tag["src"]).to be_present
+      end
+    end
+
     describe "lazy load with lazysizes.js" do
       let(:thumb_size) { :mini }
       let(:argument) { build(:asset_with_faked_file)}


### PR DESCRIPTION
1221fb65 (Jonathan Rochkind, 72 minutes ago)
   calculate aspect ratio from thumb, not original

   PDFs don't have an original height/width, but the selected thumb still
   does. This is better anyway, we're reserving space on the page for the
   thumb after all, use the actual thumb we'll be displaying. With shrine 3,
   we know have height and width recorded for it

4009464f (Jonathan Rochkind, 50 minutes ago)
   Don't display with wrapper div for CSS aspect ratio unless aspect ratio
   info available

3dfcab74 (Jonathan Rochkind, 13 minutes ago)
   on OH download list, reserve space for thumbnail

   New CSS-based aspectratio we need to actually reserve width on the page, or
   else the aspectratio code will result in 0x0 image

d514d04e (Jonathan Rochkind, 12 minutes ago)
   using object-fit seemed clever, but resulted in weird image dispay where
   sometimes a pixel or two line was cut off, which at small sizes can make
   image display odd. This didn't really seem to be helping.

