### PR TITLE
update lodash yarn dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "webpack-dev-server": "^3.9.0"
   },
   "resolutions": {
-    "lodash": ">= 4.17.13",
     "lodash.template": ">= 4.5.0",
     "js-yaml": ">= 3.13.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4225,10 +4225,10 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>= 4.17.13", lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@~4.17.10:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@~4.17.10:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 loglevel@^1.6.4:
   version "1.6.6"


### PR DESCRIPTION
For security warning.

It's a bit tricky to figure out how to update "indirect" dependencies (not specifically mentioned in package.json) with yarn.

Here, we first REMOVED the lodash "resolution" in package.json, which was an earlier attempt to deal with updating indirect dependencies, which wasn't really a good solution.

Then we followed instructions at https://medium.com/@ayushya/upgrading-javascript-packages-deep-dependencies-using-yarn-8b5983d5fb6b

* Hand-edit the yarn.lock to remove the relevant lodash resolution
* re-run `yarn install`

Bingo, now we have lodash 4.17.19 which is what we wanted.