### PR TITLE
custom capistrano remote invoke rake, instead of using capistrano-rake gem

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -33,8 +33,6 @@ install_plugin Capistrano::SCM::Git
 
 require 'capistrano/honeybadger'
 
-require 'capistrano/rake' # let us run rake tasks on remote hosts
-
 # our custom EC2 autodiscover server definition module
 require_relative "config/deploy/lib/cap_server_autodiscover"
 

--- a/Gemfile
+++ b/Gemfile
@@ -124,8 +124,6 @@ group :development do
   gem 'capistrano-passenger', '~> 0.2'
   gem 'capistrano-rails', '~> 1.2'
   gem 'capistrano-maintenance', '~> 1.0', require: false
-  gem 'capistrano-rake', require: false
-
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,8 +159,6 @@ GEM
     capistrano-rails (1.5.0)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
-    capistrano-rake (0.2.0)
-      capistrano (>= 3.0)
     capybara (3.33.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -642,7 +640,6 @@ DEPENDENCIES
   capistrano-maintenance (~> 1.0)
   capistrano-passenger (~> 0.2)
   capistrano-rails (~> 1.2)
-  capistrano-rake
   capybara (>= 2.15)
   capybara-screenshot
   citeproc-ruby (~> 1.0)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -77,8 +77,12 @@ set :whenever_roles, [:cron]
 # When running rake tasks with `cap staging invoke:rake rake:task:name`, via
 # the capistrano-rake gem, run them on the jobs host, that's a good one for
 # putting extra work on.
+#
+# And if we have multiple jobs servers, we still only
+# want to execute on ONE of them, the one marked primary, or else just
+# first one listed. (can be overridden with env PRIMARY_ONLY=false)
 set :rake_roles, [:jobs]
-
+set :rake_primary_only, ENV["PRIMARY_ONLY"] || true
 
 # This is a no-op task, but our server definition script currently
 # outputs to console the server definitions, so a no-op task will do it.

--- a/lib/capistrano/tasks/remote_rake.rake
+++ b/lib/capistrano/tasks/remote_rake.rake
@@ -5,6 +5,9 @@
 # Will execute on server identified by cap role(s) `rake_roles` -- locally fixed
 # to include the un-merged https://github.com/sheharyarn/capistrano-rake/pull/7
 #
+# Also added a feature to respect `rake_primary_only` setting to run on only primary server
+# with role, that is only ONE server if we have multiple jobs servers, which is pretty much
+# what we want for what we use this for.
 namespace :invoke do
   desc "Execute a rake task on a remote server (cap invoke:rake TASK=db:migrate)"
   task :rake do
@@ -13,7 +16,13 @@ namespace :invoke do
       # Default to :app roles
       rake_roles = fetch(:rake_roles, :app)
 
-      on roles(rake_roles) do
+      rake_servers = if fetch(:rake_primary_only, false).to_s == "true"
+        primary(rake_roles)
+      else
+        roles(rake_roles)
+      end
+
+      on rake_servers do
         within current_path do
           with rails_env: fetch(:rails_env) do
             execute :rake, ENV['TASK']

--- a/lib/capistrano/tasks/remote_rake.rake
+++ b/lib/capistrano/tasks/remote_rake.rake
@@ -1,0 +1,30 @@
+# Invoke a rake task on remote capistrano server.
+#
+# Copied and customized from https://github.com/sheharyarn/capistrano-rake
+#
+# Will execute on server identified by cap role(s) `rake_roles` -- locally fixed
+# to include the un-merged https://github.com/sheharyarn/capistrano-rake/pull/7
+#
+namespace :invoke do
+  desc "Execute a rake task on a remote server (cap invoke:rake TASK=db:migrate)"
+  task :rake do
+    if ENV['TASK']
+
+      # Default to :app roles
+      rake_roles = fetch(:rake_roles, :app)
+
+      on roles(rake_roles) do
+        within current_path do
+          with rails_env: fetch(:rails_env) do
+            execute :rake, ENV['TASK']
+          end
+        end
+      end
+
+    else
+      puts "\n\nFailed! You need to specify the 'TASK' parameter!",
+           "Usage: cap <stage> invoke:rake TASK=your:task"
+    end
+  end
+
+end


### PR DESCRIPTION
Gem was really simple code. Contained a bug/problem, that we submitted a PR
for but it did not get a response.
https://github.com/sheharyarn/capistrano-rake/pull/7 So we can just copy
locally and modify, it's fine

Also, while we're customizing, added rake_primary_only feature to only run cap remote rake task on a single server even if there are multiple eg jobs role

Ref #792