### PR TITLE
remove empty representative_attributes so we don't create an empty Asset on that association

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -84,6 +84,11 @@ class Admin::CollectionsController < AdminController
           if hash[:description].present?
             hash[:description] = DescriptionSanitizer.new.sanitize(hash[:description])
           end
+
+          # remove empty representative_attributes so we don't create an empty Asset on that association
+          if hash[:representative_attributes] && hash[:representative_attributes].values.all?(&:blank?)
+            hash.delete(:representative_attributes)
+          end
         end
     end
 end


### PR DESCRIPTION
Ref #806

After merging this, we should go delete the empty 'placeholder' asset in #806, so it'll stop showing up on fixity reports.