### PR TITLE
use our local version instead of Rails number_to_human_size everywhere

### DIFF
--- a/app/decorators/oh_audio_work_show_decorator.rb
+++ b/app/decorators/oh_audio_work_show_decorator.rb
@@ -48,7 +48,7 @@ class OhAudioWorkShowDecorator < Draper::Decorator
       details << ScihistDigicoll::Util.humanized_content_type(asset.content_type)
     end
     if asset.size.present?
-      details << number_to_human_size(asset.size)
+      details << ScihistDigicoll::Util.simple_bytes_to_human_string(asset.size)
     end
 
     details.join(" — ")
@@ -111,7 +111,7 @@ class OhAudioWorkShowDecorator < Draper::Decorator
   end
 
   def combined_mp3_audio_size
-    number_to_human_size(model&.oral_history_content&.combined_audio_mp3&.size)
+    ScihistDigicoll::Util.simple_bytes_to_human_string(model&.oral_history_content&.combined_audio_mp3&.size)
   end
 
   def combined_webm_audio

--- a/app/lib/scihist_digicoll/util.rb
+++ b/app/lib/scihist_digicoll/util.rb
@@ -47,6 +47,8 @@ module ScihistDigicoll
     #
     #   ScihistDigicoll::Util.simple_bytes_to_human_string
     def self.simple_bytes_to_human_string(size)
+      return nil if size.blank?
+
       # Technically since we are using 1024-base instead of 1000,
       # we should use the correctly standardized KiB MiB etc.
       # But to be consistent with Rails, we'll use the technically wrong

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -52,7 +52,7 @@
       <dd class="col-sm-8"><%= @asset.content_type %></dd>
 
       <dt class="col-sm-4">File Size</dt>
-      <dd class="col-sm-8"><%= number_to_human_size(@asset.size) %></dd>
+      <dd class="col-sm-8"><%= ScihistDigicoll::Util.simple_bytes_to_human_string(@asset.size) %></dd>
 
 
       <dt class="col-sm-4">Signatures</dt>

--- a/app/views/admin/works/_member_list_table.html.erb
+++ b/app/views/admin/works/_member_list_table.html.erb
@@ -32,7 +32,7 @@
             <ul class="list-unstyled">
               <% if member.kind_of?(Kithe::Asset) %>
                 <li ><small><%= member.content_type %></small></li>
-                <li><small><%= number_to_human_size(member.size) %></small></li>
+                <li><small><%= ScihistDigicoll::Util.simple_bytes_to_human_string(member.size) %></small></li>
               <% end %>
             </ul>
           </td>

--- a/app/views/admin/works/_oral_history_transcript.html.erb
+++ b/app/views/admin/works/_oral_history_transcript.html.erb
@@ -23,7 +23,7 @@
           <% end %>
         </dd>
         <% if @work.oral_history_content!&.searchable_transcript_source.present? %>
-          <dt class="col-sm-6">size</dt><dd class="col-sm-6"><%= number_to_human_size(@work.oral_history_content!&.searchable_transcript_source.bytesize)%></dd>
+          <dt class="col-sm-6">size</dt><dd class="col-sm-6"><%= ScihistDigicoll::Util.simple_bytes_to_human_string(@work.oral_history_content!&.searchable_transcript_source.bytesize)%></dd>
         <% end %>
     </dl>
 

--- a/spec/system/oh_audio_front_end_spec.rb
+++ b/spec/system/oh_audio_front_end_spec.rb
@@ -150,7 +150,7 @@ describe "Audio front end", type: :system, js: true do
       # You should be able to download the combined audio derivs:
       expect(page).to have_content("Complete Interview Audio File")
       expect(page).to have_content("3 Separate Interview Segments")
-      expect(page).to have_content("25 KB")
+      expect(page).to have_content("2.25 KB")
     end
   end
 

--- a/spec/system/oh_audio_front_end_spec.rb
+++ b/spec/system/oh_audio_front_end_spec.rb
@@ -150,7 +150,7 @@ describe "Audio front end", type: :system, js: true do
       # You should be able to download the combined audio derivs:
       expect(page).to have_content("Complete Interview Audio File")
       expect(page).to have_content("3 Separate Interview Segments")
-      expect(page).to have_content("2.25 KB")
+      expect(page).to have_content("2.2 KB")
     end
   end
 

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -25,5 +25,10 @@ describe ScihistDigicoll::Util do
     it "has no decimal if three whole digits even if there is remainder" do
       expect(ScihistDigicoll::Util.simple_bytes_to_human_string((200 * 1024) + 110)).to eq("200 KB") # not 200.1 KB
     end
+
+    it "returns nil for nil" do
+      # this is rails number_to_human_size behavior
+      expect(ScihistDigicoll::Util.simple_bytes_to_human_string(nil)).to be_nil
+    end
   end
 end


### PR DESCRIPTION
We had written this as an optimization in one particular performance
sensitive spot, but might as well do it everywhere consistently.