### PR TITLE
tell travis to cache more stuff including yarn install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ cache:
     - /home/travis/.rvm/
     - ./tmp/solr_dist
     - vendor/bundle
+    - node_modules
 before_install:
   - gem install bundler
   - nvm install node

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ services:
   - postgresql
 cache:
   bundler: true
+  yarn: true
   directories:
     - /home/travis/.rvm/
     - ./tmp/solr_dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ cache:
     - /home/travis/.rvm/
     - ./tmp/solr_dist
     # listing these specifically should not be needed since we have `bundler` and `yarn`
-    # listed above, but possibly is...
+    # listed above, but possibly gets us to caching what we want
     - vendor/bundle
     - node_modules
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ cache:
   directories:
     - /home/travis/.rvm/
     - ./tmp/solr_dist
+    - vendor/bundle
 before_install:
   - gem install bundler
   - nvm install node

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ cache:
   directories:
     - /home/travis/.rvm/
     - ./tmp/solr_dist
+    # listing these specifically should not be needed since we have `bundler` and `yarn`
+    # listed above, but possibly is...
     - vendor/bundle
     - node_modules
 before_install:


### PR DESCRIPTION
yarn install is taking like 120s on travis, telling it to cache yarn might speed up our builds?