### PR TITLE
Staff UI for marking Oral history assets as "available by request" even when private

### DIFF
--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -116,10 +116,15 @@ class Admin::AssetsController < AdminController
     redirect_to edit_admin_work_path(new_child), notice: "Asset promoted to child work #{new_child.title}"
   end
 
+  def work_is_oral_history?
+    @asset.parent.genre && @asset.parent.genre.include?('Oral histories')
+  end
+  helper_method :work_is_oral_history?
+
   private
 
   def asset_params
-    allowed_params = [:title, {admin_note_attributes: []}]
+    allowed_params = [:title, :oh_available_by_request, {admin_note_attributes: []}]
     allowed_params << :published if can?(:publish, @asset)
 
     asset_params = params.require(:asset).permit(*allowed_params)

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -124,7 +124,7 @@ class Admin::AssetsController < AdminController
   private
 
   def asset_params
-    allowed_params = [:title, :oh_available_by_request, {admin_note_attributes: []}]
+    allowed_params = [:title, {admin_note_attributes: []}]
     allowed_params << :published if can?(:publish, @asset)
 
     asset_params = params.require(:asset).permit(*allowed_params)

--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -187,7 +187,7 @@ class Admin::WorksController < AdminController
   def update_oh_available_by_request
     @work.transaction do
       params[:available_by_request]&.each_pair do |asset_pk, value|
-        @work.members.find{ |m| m.id == asset_pk}.update(oh_available_by_request: value)
+        @work.members.find{ |m| m.id == asset_pk}&.update(oh_available_by_request: value)
       end
     end
     redirect_to admin_work_path(@work, anchor: "nav-oral-histories")

--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -9,7 +9,7 @@ class Admin::WorksController < AdminController
            :reorder_members_form, :demote_to_asset, :publish, :unpublish,
            :submit_ohms_xml, :download_ohms_xml,
            :remove_ohms_xml, :submit_searchable_transcript_source, :download_searchable_transcript_source,
-           :remove_searchable_transcript_source, :create_combined_audio_derivatives]
+           :remove_searchable_transcript_source, :create_combined_audio_derivatives, :update_oh_available_by_request]
 
   # GET /admin/works
   # GET /admin/works.json
@@ -181,6 +181,16 @@ class Admin::WorksController < AdminController
 
     notice = "The combined audio derivative job has been added to the job queue."
     redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), notice: notice
+  end
+
+  # PUT /admin/works/ab2323ac/update_oh_available_by_request
+  def update_oh_available_by_request
+    @work.transaction do
+      params[:available_by_request]&.each_pair do |asset_pk, value|
+        @work.members.find{ |m| m.id == asset_pk}.update(oh_available_by_request: value)
+      end
+    end
+    redirect_to admin_work_path(@work, anchor: "nav-oral-histories")
   end
 
 

--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -186,6 +186,8 @@ class Admin::WorksController < AdminController
   # PUT /admin/works/ab2323ac/update_oh_available_by_request
   def update_oh_available_by_request
     @work.transaction do
+      @work.oral_history_content!.update( params.require(:oral_history_content).permit(:available_by_request_mode))
+
       params[:available_by_request]&.each_pair do |asset_pk, value|
         @work.members.find{ |m| m.id == asset_pk}&.update(oh_available_by_request: value)
       end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -8,6 +8,10 @@ class Asset < Kithe::Asset
 
   attr_json :admin_note, :text, array: true, default: -> { [] }
 
+  # only used for oral histories, some assets marked non-published are still
+  # available after request form, with or without medidation by human approval.
+  attr_json :oh_available_by_request, :boolean
+
 
   # Our DziFiles object to manage associated DZI (deep zoom, for OpenSeadragon
   # panning/zooming) file(s).

--- a/app/models/oral_history_content.rb
+++ b/app/models/oral_history_content.rb
@@ -64,6 +64,11 @@ class OralHistoryContent < ApplicationRecord
   # backed by a pg enum. methods such as `available_by_request_off?` are available,
   # along with scopes like `OralHistoryContent.available_by_request_automatic`
   enum available_by_request_mode: {off: 'off', automatic: 'automatic', manual_review: 'manual_review'}, _prefix: :available_by_request
+  AVAILABLE_BY_REQUEST_INPUT_PROMPT = {
+    "Off — Disabled" => "off",
+    "Automatic — Yes, after filling out a form — Used with 'Free access, without internet release'" => "automatic",
+    "Manual Review — Yes, after filling out a form and an administrator approves — Used with 'restricted', 'semi-restricted', and others." => "manual_review"
+  }.freeze
 
   after_commit :after_commit_update_work_index_if_needed
 

--- a/app/models/oral_history_content.rb
+++ b/app/models/oral_history_content.rb
@@ -64,11 +64,6 @@ class OralHistoryContent < ApplicationRecord
   # backed by a pg enum. methods such as `available_by_request_off?` are available,
   # along with scopes like `OralHistoryContent.available_by_request_automatic`
   enum available_by_request_mode: {off: 'off', automatic: 'automatic', manual_review: 'manual_review'}, _prefix: :available_by_request
-  AVAILABLE_BY_REQUEST_INPUT_PROMPT = {
-    "Off — Disabled" => "off",
-    "Automatic — Yes, after filling out a form — Used with 'Free access, without internet release'" => "automatic",
-    "Manual Review — Yes, after filling out a form and an administrator approves — Used with 'restricted', 'semi-restricted', and others." => "manual_review"
-  }.freeze
 
   after_commit :after_commit_update_work_index_if_needed
 

--- a/app/presenters/work_manage_oral_history_available_by_request.rb
+++ b/app/presenters/work_manage_oral_history_available_by_request.rb
@@ -9,6 +9,6 @@ class WorkManageOralHistoryAvailableByRequest < ViewModel
 
 
   def private_asset_members
-    work.members.find_all { |m| m.kind_of?(Asset) && !m.published? }
+    @private_asset_members ||= work.members.find_all { |m| m.kind_of?(Asset) && !m.published? }
   end
 end

--- a/app/presenters/work_manage_oral_history_available_by_request.rb
+++ b/app/presenters/work_manage_oral_history_available_by_request.rb
@@ -1,0 +1,14 @@
+class WorkManageOralHistoryAvailableByRequest < ViewModel
+  valid_model_type_names "Work"
+
+  alias_method :work, :model
+
+  def display
+    render 'admin/works/oral_history_available_by_request', model: model, view: self
+  end
+
+
+  def private_asset_members
+    work.members.find_all { |m| m.kind_of?(Asset) && !m.published? }
+  end
+end

--- a/app/views/admin/assets/edit.html.erb
+++ b/app/views/admin/assets/edit.html.erb
@@ -38,6 +38,12 @@
     <% if can? :publish, @asset %>
       <%= f.input :published %>
     <% end %>
+
+    <% if work_is_oral_history? %>
+      <%= f.input :oh_available_by_request, as: :boolean, label: "(Oral history) available by request" %>
+    <% end %>
+
+
   </div>
 <% end %>
 

--- a/app/views/admin/assets/edit.html.erb
+++ b/app/views/admin/assets/edit.html.erb
@@ -39,11 +39,6 @@
       <%= f.input :published %>
     <% end %>
 
-    <% if work_is_oral_history? %>
-      <%= f.input :oh_available_by_request, as: :boolean, label: "(Oral history) available by request" %>
-    <% end %>
-
-
   </div>
 <% end %>
 

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -30,7 +30,17 @@
   </div>
 
   <div class="col-sm-6">
+
+      <% if !@asset.published? && work_is_oral_history? && @asset.oh_available_by_request %>
+        <div class="row">
+          <div class="col-sm-12 h3">
+            <span class="badge badge-warning">Un-published, but marked available by request</span>
+          </div>
+        </div>
+      <% end %>
+
     <dl class="row">
+
       <dt class="col-sm-4">Created</dt>
       <dd class="col-sm-8"><%= l @asset.created_at, format: :admin %></dd>
 

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -33,8 +33,13 @@
 
       <% if !@asset.published? && work_is_oral_history? && @asset.oh_available_by_request %>
         <div class="row">
-          <div class="col-sm-12 h3">
-            <span class="badge badge-warning">Un-published, but marked available by request</span>
+          <div class="col-sm-12">
+            <span class="h3">
+              <span class="badge badge-warning">Un-published, but marked available by request</span>
+            </span>
+              <% if @asset.parent %>
+                More info at <%= link_to "Work Oral History Management", admin_work_path(@asset.parent, anchor: "nav-oral-histories") %>
+              <% end %>
           </div>
         </div>
       <% end %>

--- a/app/views/admin/works/_oral_history_available_by_request.html.erb
+++ b/app/views/admin/works/_oral_history_available_by_request.html.erb
@@ -6,24 +6,54 @@
     </div>
 
     <div class="text-muted text-small mb-2">
-      <p>Should <b>marked non-published</b> assets be available anyway by request, after the patron fills out a form?</p>
+      <p>Make <b>marked non-published</b> assets be available anyway by request, after the patron fills out a form?</p>
     </div>
 
     <% if view.private_asset_members.present? %>
       <%= form_with(model: view.work.oral_history_content!, url: update_oh_available_by_request_admin_work_path(view.work), method: :put, local: true) do |f|  %>
 
-        <div class="form-group mb-2">
-          <label for="oral_history_content_available_by_request_mode" class="col-form-label">Marked un-published assets available by request</label>
-            <%= f.select :available_by_request_mode,
+        <table class="table table-sm">
+          <tr>
+            <td style="width: 2rem">
+              <%= f.radio_button :available_by_request_mode, "off" %>
+            </td>
+            <td>
+              <label for="oral_history_content_available_by_request_mode_off">No</label>
+              <div class="text-muted">Disabled / Off</div>
+              <div class="text-muted">NOT using 'Available by Request' feature</div>
+
+            </td>
+          </tr>
+          <tr>
+            <td><%= f.radio_button :available_by_request_mode, "automatic" %></td>
+            <td>
+              <label for="oral_history_content_available_by_request_mode_automatic">Automatic</label>
+              <div class="text-muted">Yes, after filling out a form</div>
+              <div class="text-muted">Used with <code>free access, without internet release</code></div>
+            </td>
+          </tr>
+          <tr>
+            <td><%= f.radio_button :available_by_request_mode, "manual_review" %></td>
+            <td>
+              <label for="oral_history_content_available_by_request_mode_manual_review">Manual Review</label>
+              <div class="text-muted">Yes, after filling out a form and an administrator approves</div>
+              <div class="text-muted">Used with <code>restricted</code>, <code>permissions required</code>, and others</div>
+            </td>
+          </tr>
+        </table>
+
+            <%# f.select :available_by_request_mode,
                     OralHistoryContent::AVAILABLE_BY_REQUEST_INPUT_PROMPT,
                     {},
                     class: "custom-select" %>
-        </div>
 
-        <table class="table">
+        <%= submit_tag "Save Changes", class: "btn btn-primary mb-3" %>
+
+
+        <table class="table table-sm">
           <% view.private_asset_members.each do |asset| %>
             <tr>
-              <td>
+              <td style="width: 2rem">
                 <%= hidden_field_tag "available_by_request[#{asset.id}]", false %>
                 <%= check_box_tag "available_by_request[#{asset.id}]", true, asset.oh_available_by_request,
                   id: "available_by_request_#{asset.friendlier_id}",
@@ -39,8 +69,6 @@
             </tr>
           <% end %>
         </table>
-
-        <%= submit_tag "Update", class: "btn btn-primary" %>
       <% end %>
     <% else %>
       <hr>

--- a/app/views/admin/works/_oral_history_available_by_request.html.erb
+++ b/app/views/admin/works/_oral_history_available_by_request.html.erb
@@ -9,29 +9,34 @@
       Oral history assets that are not <code>published</code> but are available by request, after the potential patron fills out a form. At the moment, only <code>Free access, without internet release</code> level of access is supported, with assets delivered automatically without human intervention after the form is filled out.
     </div>
 
-    <%= form_with(url: update_oh_available_by_request_admin_work_path(view.work), method: :put, local: true) do %>
+    <% if view.private_asset_members.present? %>
+      <%= form_with(url: update_oh_available_by_request_admin_work_path(view.work), method: :put, local: true) do %>
 
-      <table class="table">
-        <% view.private_asset_members.each do |asset| %>
-          <tr>
-            <td>
-              <%= hidden_field_tag "available_by_request[#{asset.id}]", false %>
-              <%= check_box_tag "available_by_request[#{asset.id}]", true, asset.oh_available_by_request,
-                id: "available_by_request_#{asset.friendlier_id}",
-                title: "#{asset.title} is available by request" %>
-            </td>
-            <td>
-              <label for="<%= "available_by_request_#{asset.friendlier_id}" %>" class="w-100">
-                <%= asset.title %>
-              </label>
-            </td>
-            <td><%= asset.friendlier_id %></td>
-            <td><%= ScihistDigicoll::Util.humanized_content_type(asset.content_type) %></td>
-          </tr>
-        <% end %>
-      </table>
+        <table class="table">
+          <% view.private_asset_members.each do |asset| %>
+            <tr>
+              <td>
+                <%= hidden_field_tag "available_by_request[#{asset.id}]", false %>
+                <%= check_box_tag "available_by_request[#{asset.id}]", true, asset.oh_available_by_request,
+                  id: "available_by_request_#{asset.friendlier_id}",
+                  title: "#{asset.title} is available by request" %>
+              </td>
+              <td>
+                <label for="<%= "available_by_request_#{asset.friendlier_id}" %>" class="w-100">
+                  <%= asset.title %>
+                </label>
+              </td>
+              <td><%= asset.friendlier_id %></td>
+              <td><%= ScihistDigicoll::Util.humanized_content_type(asset.content_type) %></td>
+            </tr>
+          <% end %>
+        </table>
 
-      <%= submit_tag "Update", class: "btn btn-primary" %>
+        <%= submit_tag "Update", class: "btn btn-primary" %>
+      <% end %>
+    <% else %>
+      <hr>
+      <p>There are no unpublished assets.</p>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/works/_oral_history_available_by_request.html.erb
+++ b/app/views/admin/works/_oral_history_available_by_request.html.erb
@@ -10,7 +10,17 @@
     </div>
 
     <% if view.private_asset_members.present? %>
-      <%= form_with(url: update_oh_available_by_request_admin_work_path(view.work), method: :put, local: true) do %>
+      <%= form_with(model: view.work.oral_history_content!, url: update_oh_available_by_request_admin_work_path(view.work), method: :put, local: true) do |f|  %>
+
+        <div class="form-group row mb-2">
+          <label for="oral_history_content_available_by_request_mode" class="col-sm-2 col-form-label">Available by request</label>
+          <div class="col-sm-10">
+            <%= f.select :available_by_request_mode,
+                    OralHistoryContent.available_by_request_modes.except(:manual_review).collect {|k, v| [k.humanize, v]},
+                    {},
+                    class: "custom-select" %>
+          </div>
+        </div>
 
         <table class="table">
           <% view.private_asset_members.each do |asset| %>

--- a/app/views/admin/works/_oral_history_available_by_request.html.erb
+++ b/app/views/admin/works/_oral_history_available_by_request.html.erb
@@ -6,7 +6,7 @@
     </div>
 
     <div class="text-muted text-small mb-2">
-      <p>Should <b>marked</b> non-<code>published</code> assets be available anyway by request, after the patron fills out a form?</p>
+      <p>Should <b>marked non-published</b> assets be available anyway by request, after the patron fills out a form?</p>
     </div>
 
     <% if view.private_asset_members.present? %>

--- a/app/views/admin/works/_oral_history_available_by_request.html.erb
+++ b/app/views/admin/works/_oral_history_available_by_request.html.erb
@@ -1,0 +1,37 @@
+<div class="card bg-light mb-3">
+  <h2 class="card-header h3">Assets Available By Request</h2>
+  <div class="card-body">
+    <div class="alert alert-warning mb-2">
+      <i class="fa fa-warning"></i> This feature is under construction and not yet functional.
+    </div>
+
+    <div class="text-muted text-small mb-2">
+      Oral history assets that are not <code>published</code> but are available by request, after the potential patron fills out a form. At the moment, only <code>Free access, without internet release</code> level of access is supported, with assets delivered automatically without human intervention after the form is filled out.
+    </div>
+
+    <%= form_with(url: update_oh_available_by_request_admin_work_path(view.work), method: :put, local: true) do %>
+
+      <table class="table">
+        <% view.private_asset_members.each do |asset| %>
+          <tr>
+            <td>
+              <%= hidden_field_tag "available_by_request[#{asset.id}]", false %>
+              <%= check_box_tag "available_by_request[#{asset.id}]", true, asset.oh_available_by_request,
+                id: "available_by_request_#{asset.friendlier_id}",
+                title: "#{asset.title} is available by request" %>
+            </td>
+            <td>
+              <label for="<%= "available_by_request_#{asset.friendlier_id}" %>" class="w-100">
+                <%= asset.title %>
+              </label>
+            </td>
+            <td><%= asset.friendlier_id %></td>
+            <td><%= ScihistDigicoll::Util.humanized_content_type(asset.content_type) %></td>
+          </tr>
+        <% end %>
+      </table>
+
+      <%= submit_tag "Update", class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/works/_oral_history_available_by_request.html.erb
+++ b/app/views/admin/works/_oral_history_available_by_request.html.erb
@@ -1,25 +1,23 @@
 <div class="card bg-light mb-3">
-  <h2 class="card-header h3">Assets Available By Request</h2>
+  <h2 class="card-header h3">Un-Published Assets Available By Request</h2>
   <div class="card-body">
     <div class="alert alert-warning mb-2">
       <i class="fa fa-warning"></i> This feature is under construction and not yet functional.
     </div>
 
     <div class="text-muted text-small mb-2">
-      Oral history assets that are not <code>published</code> but are available by request, after the potential patron fills out a form. At the moment, only <code>Free access, without internet release</code> level of access is supported, with assets delivered automatically without human intervention after the form is filled out.
+      <p>Should <b>marked</b> non-<code>published</code> assets be available anyway by request, after the patron fills out a form?</p>
     </div>
 
     <% if view.private_asset_members.present? %>
       <%= form_with(model: view.work.oral_history_content!, url: update_oh_available_by_request_admin_work_path(view.work), method: :put, local: true) do |f|  %>
 
-        <div class="form-group row mb-2">
-          <label for="oral_history_content_available_by_request_mode" class="col-sm-2 col-form-label">Available by request</label>
-          <div class="col-sm-10">
+        <div class="form-group mb-2">
+          <label for="oral_history_content_available_by_request_mode" class="col-form-label">Marked un-published assets available by request</label>
             <%= f.select :available_by_request_mode,
-                    OralHistoryContent.available_by_request_modes.except(:manual_review).collect {|k, v| [k.humanize, v]},
+                    OralHistoryContent::AVAILABLE_BY_REQUEST_INPUT_PROMPT,
                     {},
                     class: "custom-select" %>
-          </div>
         </div>
 
         <table class="table">

--- a/app/views/admin/works/show.html.erb
+++ b/app/views/admin/works/show.html.erb
@@ -115,6 +115,7 @@
       <%= WorkCombinedAudioDerivatives.new(@work).display %>
       <%= render "ohms_xml",  work: @work %>
       <%= render "oral_history_transcript", work: @work %>
+      <%= WorkManageOralHistoryAvailableByRequest.new(@work).display %>
     </div>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,6 +139,7 @@ Rails.application.routes.draw do
         get "download_searchable_transcript_source"
         put "remove_searchable_transcript_source"
         put "create_combined_audio_derivatives"
+        put "update_oh_available_by_request"
       end
       collection do
         get 'batch_update', to: "works#batch_update_form"

--- a/spec/controllers/admin/works_controller_spec.rb
+++ b/spec/controllers/admin/works_controller_spec.rb
@@ -135,6 +135,26 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
     end
   end
 
+  context "change oh available by request" do
+    let(:was_true_asset) { create(:asset_with_faked_file, :mp3, oh_available_by_request: true) }
+    let(:was_false_asset) { create(:asset_with_faked_file, :mp3, oh_available_by_request: false) }
+    let(:work) { create(:oral_history_work, members: [was_true_asset, was_false_asset])}
+
+    it "changes" do
+      put :update_oh_available_by_request, params: {
+        id: work.friendlier_id,
+        available_by_request: {
+          was_true_asset.id => "false",
+          was_false_asset.id => "true",
+          "no_such_id" => "true"
+        }
+      }
+      expect(response).to redirect_to(admin_work_path(work, anchor: "nav-oral-histories"))
+      expect(was_false_asset.reload.oh_available_by_request).to be true
+      expect(was_true_asset.reload.oh_available_by_request).to be false
+    end
+  end
+
   context "protected to logged in users" do
     context "without a logged-in user", logged_in_user: false do
       it "redirects to login" do

--- a/spec/controllers/admin/works_controller_spec.rb
+++ b/spec/controllers/admin/works_controller_spec.rb
@@ -143,6 +143,9 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
     it "changes" do
       put :update_oh_available_by_request, params: {
         id: work.friendlier_id,
+        oral_history_content: {
+          available_by_request_mode: "automatic"
+        },
         available_by_request: {
           was_true_asset.id => "false",
           was_false_asset.id => "true",
@@ -150,6 +153,8 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
         }
       }
       expect(response).to redirect_to(admin_work_path(work, anchor: "nav-oral-histories"))
+
+      expect(work.reload.oral_history_content.available_by_request_mode).to eq("automatic")
       expect(was_false_asset.reload.oh_available_by_request).to be true
       expect(was_true_asset.reload.oh_available_by_request).to be false
     end


### PR DESCRIPTION
Ref #830

Assets have an `oh_available_by_request` flag individually (using attr_json). 

But the main UI to set it is a list of assets on the work edit page. This is also where the switch for "with" and "without" approval/human intervention will go, once we support with-human-intervention. Or should we plan for this now, to get the metadata flag in there?

Limited controller test. No test of the front-end checkboxes right now. I feel like calling it a day, but let me know if you think a presenter test of the staff front-end checkboxes is needed.