### PR TITLE
Use Amazon Simple Email Service for outgoing email

### DIFF
--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -294,8 +294,8 @@ module ScihistDigicoll
     define_key :digital_email_address
 
     # These are the credentials used for accessing Amazon's simple email server:
-    define_key :ses_smtp_username
-    define_key :ses_smtp_password
+    define_key :smtp_username
+    define_key :smtp_password
     define_key :smtp_host
 
     ##

--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -275,11 +275,7 @@ module ScihistDigicoll
 
     define_key :honeybadger_api_key
 
-    # Used as the from (no_reply) and to (digital_tech, digital) email addresses
-    # when sending notices about failed fixity check.
-    define_key :no_reply_email_address
-    define_key :digital_tech_email_address
-    define_key :digital_email_address
+
 
     # Used for sending mail, and if no queue is specified:
     define_key :regular_job_worker_count, default: 0
@@ -288,6 +284,18 @@ module ScihistDigicoll
     # Used (infrequently) by additional job servers whose only purpose is to handle special tasks:
     define_key :special_job_worker_count, default: 0
 
+
+    # OUTGOING EMAIL:
+
+    # From address:
+    define_key :no_reply_email_address
+    # To addresses (these are email lists maintained by IT.)
+    define_key :digital_tech_email_address
+    define_key :digital_email_address
+
+    # These are the credentials used for accessing Amazon's simple email server:
+    define_key :ses_smtp_username
+    define_key :ses_smtp_password
     define_key :smtp_host
 
     ##

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,10 +93,10 @@ Rails.application.configure do
 
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.smtp_settings = {
-      :address => "email-smtp.us-east-1.amazonaws.com",
+      :address => ScihistDigicoll::Env.lookup(:smtp_host),
       :port => 587,
-      :user_name => ScihistDigicoll::Env.lookup(:ses_smtp_username),
-      :password =>  ScihistDigicoll::Env.lookup(:ses_smtp_password),
+      :user_name => ScihistDigicoll::Env.lookup(:smtp_username),
+      :password =>  ScihistDigicoll::Env.lookup(:smtp_password),
       :authentication => :login,
       :enable_starttls_auto => true
     }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,12 +90,15 @@ Rails.application.configure do
     if ScihistDigicoll::Env.lookup(:smtp_host).nil?
       raise RuntimeError, "Please specify smtp_host in local_env.py so we can send emails."
     end
+
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.smtp_settings = {
-      address: ScihistDigicoll::Env.lookup(:smtp_host),
-      domain: 'sciencehistory.org',
-      ssl: false,
-      enable_starttls_auto: false
+      :address => "email-smtp.us-east-1.amazonaws.com",
+      :port => 587,
+      :user_name => ScihistDigicoll::Env.lookup(:ses_smtp_username)
+      :password =>  ScihistDigicoll::Env.lookup(:ses_smtp_password)
+      :authentication => :login,
+      :enable_starttls_auto => true
     }
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,8 +95,8 @@ Rails.application.configure do
     config.action_mailer.smtp_settings = {
       :address => "email-smtp.us-east-1.amazonaws.com",
       :port => 587,
-      :user_name => ScihistDigicoll::Env.lookup(:ses_smtp_username)
-      :password =>  ScihistDigicoll::Env.lookup(:ses_smtp_password)
+      :user_name => ScihistDigicoll::Env.lookup(:ses_smtp_username),
+      :password =>  ScihistDigicoll::Env.lookup(:ses_smtp_password),
       :authentication => :login,
       :enable_starttls_auto => true
     }


### PR DESCRIPTION
Ref #760 

Documentation is at https://chemheritage.atlassian.net/wiki/spaces/HDCSD/pages/1046151169/Amazon+Simple+Email+Server

Do not deploy before merging the Ansible staging branch to production ( the PR is at https://bitbucket.org/ChemicalHeritageFoundation/ansible-inventory/pull-requests/111/ )and ensuring the new variables are available in production. (That said, if you do, nothing bad will happen. But we want to do things in the correct order).