### PR TITLE
DB and model for an OH available_by_request_mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,6 +108,8 @@ gem 'sitemap_generator', '~> 6.0' # google sitemap generation
 
 gem 'sane_patch', '< 2.0' # time-limited monkey patches
 
+gem 'activerecord-postgres_enum', '~> 1.3' # can record postgres enums in schema.rb dump
+
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,9 @@ GEM
       activesupport (= 6.0.3.2)
     activerecord-import (1.0.5)
       activerecord (>= 3.2)
+    activerecord-postgres_enum (1.3.0)
+      activerecord (>= 5, < 6.1)
+      pg
     activestorage (6.0.3.2)
       actionpack (= 6.0.3.2)
       activejob (= 6.0.3.2)
@@ -627,6 +630,7 @@ PLATFORMS
 
 DEPENDENCIES
   access-granted (~> 1.0)
+  activerecord-postgres_enum (~> 1.3)
   aws-sdk-core
   aws-sdk-ec2 (>= 1.74)
   blacklight (~> 7.7.0)

--- a/app/models/oral_history_content.rb
+++ b/app/models/oral_history_content.rb
@@ -51,7 +51,17 @@ class OralHistoryContent < ApplicationRecord
     succeeded: 'succeeded'
   }
 
-  # backed by a pg enum even. methods such as `available_by_request_off?` are available,
+  # Some assets marked non-published in this work are still available by request. That feature needs to be turned
+  # on here at the work level, in one of two modes:
+  #
+  #   * automatic: after filling out request form, user gets access without human intervention
+  #   * manual_review: after filling out request form, request needs to be approved by human
+  #   * off: by request form feature not enabled
+  #
+  # Once enabled at the work level, individual assets also need their oh_available_by_request flag
+  # set, for extra sure this non-published asset is meant to be available by request.
+  #
+  # backed by a pg enum. methods such as `available_by_request_off?` are available,
   # along with scopes like `OralHistoryContent.available_by_request_automatic`
   enum available_by_request_mode: {off: 'off', automatic: 'automatic', manual_review: 'manual_review'}, _prefix: :available_by_request
 

--- a/app/models/oral_history_content.rb
+++ b/app/models/oral_history_content.rb
@@ -51,6 +51,10 @@ class OralHistoryContent < ApplicationRecord
     succeeded: 'succeeded'
   }
 
+  # backed by a pg enum even. methods such as `available_by_request_off?` are available,
+  # along with scopes like `OralHistoryContent.available_by_request_automatic`
+  enum available_by_request_mode: {off: 'off', automatic: 'automatic', manual_review: 'manual_review'}, _prefix: :available_by_request
+
   after_commit :after_commit_update_work_index_if_needed
 
   # Sets IO to be combined_audio_mp3, writing directly to "store" storage,

--- a/db/migrate/20200810180533_add_available_by_request_mode_to_oral_history_content.rb
+++ b/db/migrate/20200810180533_add_available_by_request_mode_to_oral_history_content.rb
@@ -1,0 +1,7 @@
+class AddAvailableByRequestModeToOralHistoryContent < ActiveRecord::Migration[6.0]
+  def change
+    create_enum :available_by_request_mode_type, %w[off automatic manual_review]
+
+    add_column :oral_history_content, :available_by_request_mode, :available_by_request_mode_type, null: false, default: "off"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_02_144008) do
+ActiveRecord::Schema.define(version: 2020_08_10_180533) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_enum :available_by_request_mode_type, [
+    "off",
+    "automatic",
+    "manual_review",
+  ]
 
 
   create_function :kithe_models_friendlier_id_gen, sql_definition: <<-SQL
@@ -156,6 +162,7 @@ ActiveRecord::Schema.define(version: 2020_06_02_144008) do
     t.string "combined_audio_derivatives_job_status"
     t.datetime "combined_audio_derivatives_job_status_changed_at"
     t.text "searchable_transcript_source"
+    t.enum "available_by_request_mode", default: "off", null: false, enum_name: "available_by_request_mode_type"
     t.index ["work_id"], name: "index_oral_history_content_on_work_id", unique: true
   end
 


### PR DESCRIPTION
Separate PR for easier review, but to be used in #840

off, automatic, or manual_review

We use an actual postgres 'enum' type. So it can be more human readable than integer, while still efficiently stored in the database. https://www.postgresql.org/docs/9.1/datatype-enum.html

Column is marked no-nil-allowed, and default value `off`

For postgres enum type to be represented in rails schema.rb (so we don't need to use structure.sql), we add a gem https://github.com/bibendi/activerecord-postgres_enum . That also gives us methods to use in migrations instead of writing out the raw SQL.