### PR TITLE
extract Work#is_oral_history?

### DIFF
--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -468,9 +468,4 @@ class Admin::WorksController < AdminController
       admin_works_path
     end
     helper_method :cancel_url
-
-    def work_is_oral_history?
-      @work.genre && @work.genre.include?('Oral histories')
-    end
-    helper_method :work_is_oral_history?
 end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -171,4 +171,9 @@ class Work < Kithe::Work
     @member_count ||= members.size
   end
 
+  # We have enough checks for special treatment of oral history, it makes
+  # sense to make a method to encapsulate it.
+  def is_oral_history?
+    genre && genre.include?("Oral histories")
+  end
 end

--- a/app/presenters/citable_attributes.rb
+++ b/app/presenters/citable_attributes.rb
@@ -45,7 +45,7 @@ class CitableAttributes
 
   # Oral histories
   def treat_as_oral_history?
-    work.genre != nil && work.genre.include?('Oral histories')
+    work.is_oral_history?
   end
 
 

--- a/app/presenters/work_combined_audio_derivatives.rb
+++ b/app/presenters/work_combined_audio_derivatives.rb
@@ -20,24 +20,21 @@ class WorkCombinedAudioDerivatives < ViewModel
   end
 
   def combined_mp3_audio
-    return nil unless model.genre.present?
-    return nil unless model.genre.include?('Oral histories')
+    return nil unless model.is_oral_history?
     return nil unless work_available_members?
     oh_content = model.oral_history_content!
     oh_content.combined_audio_mp3&.url(public:true)
   end
 
   def combined_webm_audio
-    return nil unless model.genre.present?
-    return nil unless model.genre.include?('Oral histories')
+    return nil unless model.is_oral_history?
     return nil unless work_available_members?
     oh_content = model.oral_history_content!
     oh_content.combined_audio_webm&.url(public:true)
   end
 
   def combined_audio_fingerprint
-    return nil unless model.genre.present?
-    return nil unless model.genre.include?('Oral histories')
+    return nil unless model.is_oral_history?
     model.oral_history_content!.combined_audio_fingerprint
   end
 

--- a/app/views/admin/works/show.html.erb
+++ b/app/views/admin/works/show.html.erb
@@ -55,7 +55,7 @@
     <a class="nav-item nav-link active" id="nav-metadata-tab" data-toggle="tab" href="#nav-metadata" role="tab" aria-controls="nav-home" aria-selected="true">Metadata</a>
     <a class="nav-item nav-link" id="nav-members-tab" data-toggle="tab" href="#nav-members" role="tab" aria-controls="nav-profile" aria-selected="false">Members</a>
 
-    <% if work_is_oral_history? %>
+    <% if @work.is_oral_history? %>
       <a class="nav-item nav-link" id="nav-oral-histories-tab" data-toggle="tab" href="#nav-oral-histories" role="tab" aria-controls="nav-profile" aria-selected="false">Oral History</a>
     <% end %>
 
@@ -80,7 +80,7 @@
 
   </div>
   <div class="tab-pane" id="nav-members" role="tabpanel" aria-labelledby="nav-members-tab">
-    <% if work_is_oral_history? && @work.published? %>
+    <% if @work.is_oral_history? && @work.published? %>
       <div class="admin-work-toolbar d-flex flex-wrap">
         <div class="alert alert-warning mb-3 mt-2 mx-1">
           <i class="fa fa-warning"></i>
@@ -109,7 +109,7 @@
     <%= render "member_list_table", work: @work %>
   </div>
 
-  <% if work_is_oral_history? %>
+  <% if @work.is_oral_history? %>
 
     <div class="tab-pane" id="nav-oral-histories" role="tabpanel" aria-labelledby="nav-oral-histories-tab">
       <%= WorkCombinedAudioDerivatives.new(@work).display %>


### PR DESCRIPTION
We have several places that need to check for this special case, just make a method for it instead of doing it in multiple places treating 'Oral histories' as a duplicated 'magic string' and not necessarily always doing it exactly the same way.