### PR TITLE
Remove abstract from WorkShowInfo component

### DIFF
--- a/app/presenters/work_show_info.rb
+++ b/app/presenters/work_show_info.rb
@@ -1,5 +1,11 @@
-# Shows the basic metadata of a work in the public work display.
+# Display the right column of a work show page including, metadata attributes,
+# physical location, 'related items'.
 #
+# In a partial to make it easier to re-use in templates that differ in how
+# they show media, but still need this.
+#
+# For flexibility, does NOT include abstract/description, which usually comes
+# above here, or the "cite as" which usually comes below.
 class WorkShowInfo < ViewModel
   valid_model_type_names "Work"
 

--- a/app/views/works/_show_info.html.erb
+++ b/app/views/works/_show_info.html.erb
@@ -1,13 +1,12 @@
-<%# the right column of a work show page including description, metadata,
-    related items.
+<%# the right column of a work show page including, metadata attributes,
+    physical location, 'related items'.
 
     In a partial to make it easier to re-use in templates that differ in how
     they show media, but still need this.
-%>
 
-<div class="work-description long-text-line-height">
-  <%= DescriptionDisplayFormatter.new(view.description).format  %>
-</div>
+    For flexibility, does NOT include abstract/description, which usually comes
+    above here, or the "cite as" which usually comes below.
+%>
 
 <table class="work chf-attributes">
 

--- a/app/views/works/oh_audio_work_show.html.erb
+++ b/app/views/works/oh_audio_work_show.html.erb
@@ -92,7 +92,12 @@
 
           <%= render "rights_and_social", work: @work %>
 
+          <div class="work-description long-text-line-height">
+            <%= DescriptionDisplayFormatter.new(@work.description).format  %>
+          </div>
+
           <%= WorkShowInfo.new(@work).display %>
+
           <%= render "citation", work: @work  %>
         </div>
 

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -15,7 +15,12 @@
   </div>
 
   <div class="show-metadata">
+    <div class="work-description long-text-line-height">
+      <%= DescriptionDisplayFormatter.new(@work.description).format  %>
+    </div>
+
     <%= WorkShowInfo.new(@work).display %>
+
     <%= render "citation", work: @work  %>
   </div>
 

--- a/spec/system/work_show_spec.rb
+++ b/spec/system/work_show_spec.rb
@@ -51,7 +51,7 @@ describe "Public work show page", type: :system, js: false do
       visit work_path(work)
 
       # Don't show the edit button to users unless they're logged in.
-      expect(page).to have_no_css('a[text()="Edit"]')
+      expect(page).to have_no_css('a', text: "Edit")
 
       # No audio assets, so the playlist should not be present.
       expect(page.find_all(".show-page-audio-playlist-wrapper").count). to eq 0
@@ -81,6 +81,10 @@ describe "Public work show page", type: :system, js: false do
 
       within(".show-date") do
         expect(page).to have_selector("li", count: work.date_of_work.count)
+      end
+
+      within(".work-description") do
+        expect(page).to have_selector("p", text: /#{Regexp.escape(work.description.slice(0, 10))}/)
       end
 
       work.creator.each do |creator|


### PR DESCRIPTION
Because for some uses, in some Oral History layouts (#839), we're going to want to put something between the abstract and the rest of WorkShowInfo.

This does mean that the various places using WorkShowInfo presently now need to copy-paste identical placements of the abstract/description above it, including getting the div classes right etc. We could pull that out into it's own component, but that seems like overkill, this is okay.

Actually, as I try to refactor for hte new OH layout, I'm coming to the theory that divs that mark *layout areas* should always be in the parent template, *not* in the ViewModel component. For maximum flexibility of laying out the same content differently, as I am trying to do. If it's repeated, that's basically "accidental" and okay, it just means two layouts are laying out similarly.  

Added a test to fail on the standard work page if description is entirely missing, which wasn't there before.