### PR TITLE
Remove the .show-title layout div from TitleAndDates ViewModel component

### DIFF
--- a/app/views/works/_title_and_dates.html.erb
+++ b/app/views/works/_title_and_dates.html.erb
@@ -1,4 +1,4 @@
-<header class="show-title">
+<header>
   <% if view.genre.present? %>
     <div class="show-genre">
       <%= view.display_genres %>

--- a/app/views/works/oh_audio_work_show.html.erb
+++ b/app/views/works/oh_audio_work_show.html.erb
@@ -88,7 +88,9 @@
   <div class="bottom" id="ohmsScrollable">
       <div class="tab-content">
         <div class="tab-pane active" id="ohDescription" role="tabpanel" aria-labelledby="ohDescriptionTab">
-          <%= WorkTitleAndDates.new(@work).display %>
+          <div class="show-title">
+            <%= WorkTitleAndDates.new(@work).display %>
+          </div>
 
           <%= render "rights_and_social", work: @work %>
 

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -7,7 +7,9 @@
 
 <div class="show-page-layout work-show" itemscope itemtype="http://schema.org/CreativeWork" class="row">
 
-  <%= WorkTitleAndDates.new(@work).display %>
+  <div class="show-title">
+    <%= WorkTitleAndDates.new(@work).display %>
+  </div>
 
   <div class="show-hero">
     <%= MemberImagePresentation.new(decorator.representative_member, size: :large).display %>


### PR DESCRIPTION
Each use of TitleAndDates should wrap it in it's own .show-title. The .show-title selector is used for page layout. This lets us be more flexible on an upcoming Oral History layout (#839) where we want to put some additional content in the .show-title section of the screen, that isn't from TitleAndDates.

This actually seems to make it consistent with how these elements were factored on collection show pages! Kind of accidental that htey didn't match, until now.

I am coming to the general principle that selectors targetted for layout should never be in viewcomponent, they should always be in the parent. Then it's more flexible to make different decisons about what content goes in what layout slot.

I am also realizing that our CSS around show page layouts is kind of a spagetti mess! But so it goes, not gonna fix that now.