### PR TITLE
Tell s3 to use far-future HTTP cache headeres in public derivatives responses

### DIFF
--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -184,6 +184,19 @@ module ScihistDigicoll
     # In production, different bucket keys are actual keys to look up actual bucket names in the Env
     # system (local_env.yml or ENV), usually a different bucket per key.
     #
+    # If you want to configure to have shrine treat the bucket as public (set public ACLs on upload
+    # and generate public URLs by default), and you might also want to set far-future cache
+    # headers, pass:
+    #
+    #      s3_storage_options: {
+    #        public: true,
+    #        upload_options: {
+    #          # since shrine urls should be at random unique keys, we can cache forever
+    #          cache_control: "max-age=31536000, public"
+    #        }
+    #      })
+    #
+    #
     def self.appropriate_shrine_storage(bucket_key:, mode: lookup!(:storage_mode), s3_storage_options: {}, prefix: nil)
       unless %I{s3_bucket_uploads s3_bucket_originals s3_bucket_derivatives
                 s3_bucket_on_demand_derivatives s3_bucket_dzi}.include?(bucket_key)
@@ -237,7 +250,12 @@ module ScihistDigicoll
       @shrine_derivatives_storage ||=
         appropriate_shrine_storage( bucket_key: :s3_bucket_derivatives,
                                     s3_storage_options: {
-                                      public: true
+                                      public: true,
+                                      upload_options: {
+                                        # derivatives are public and at unique random URLs, so
+                                        # can be cached far-future
+                                        cache_control: "max-age=31536000, public"
+                                      }
                                     })
     end
 
@@ -268,7 +286,7 @@ module ScihistDigicoll
                                       upload_options: {
                                         # our DZI's are all public right now, and at unique-to-content
                                         # URLs, cache forever.
-                                        cache_control: "max-age=31536000,public"
+                                        cache_control: "max-age=31536000, public"
                                       }
                                     })
     end


### PR DESCRIPTION
Our derivatives are in a public bucket, and we use public S3 URLs with them. Eg:

`https://scihist-digicoll-production-derivatives.s3.amazonaws.com/8c180322-f939-4ed1-8c70-bd6763260936/thumb_standard/701668916a578f43019f50a5149fe8bb.jpeg`

The last component of that URL is a long random string, supplied by shrine. Especially when "namespaced" by the asset PK and derivative type, it is virtually impossible for the same URL to ever refer to a different image. If the image were re-generated, it gets a new URL with a new long random string.

This means a derivative URL is basically permanent, and can be cached indefinitely. By responding with far-future cache headers (as long a cache value as HTTP spec allows), browsers can cache these images and not re-load them, or some intermediate caches could too. If we ever use a CDN, it also tells most CDNs that these are cache-foreverable.

We can set some options when uploading the derivative files to S3, to tell S3 when it delivers them, it should use these cache headers.

**Note** This will only apply to NEWLY uploaded derivatives, existing derivatives won't have this metadata set. We could possibly go back and set it for all existing derivatives; or it might be good enough to implement this optimization going forward. 

We were already setting this for DZI tiles (thankfully, there are so many!), but now do it for derivative files too.

Whether the comma is followed by a space or not in `max-age=31536000, public` doesn't matter, both are legal, but we'll use spaces since that seems to be in more common usage and is perhaps easier to read.