### PR TITLE
First part of flag to store derivatives on restricted access S3

### DIFF
--- a/app/assets/stylesheets/local/admin/attach_files.scss
+++ b/app/assets/stylesheets/local/admin/attach_files.scss
@@ -3,10 +3,18 @@
     width: 100%;
     table-layout: fixed;
     word-wrap: break-word;
+
+    td {
+      vertical-align: middle;
+    }
   }
 
   .attach-files-table-size {
-    width: 6.25rem;
+    width: 6rem;
+  }
+
+  .attach-files-table-storage-type  {
+    width: 8rem;
   }
 
   .attach-files-table-remove {

--- a/app/assets/stylesheets/local/admin/attach_files.scss
+++ b/app/assets/stylesheets/local/admin/attach_files.scss
@@ -5,7 +5,11 @@
     word-wrap: break-word;
   }
 
-  .attach-files-table-size, .attach-files-table-remove {
-    width: 100px;
+  .attach-files-table-size {
+    width: 6.25rem;
+  }
+
+  .attach-files-table-remove {
+    width: 3rem;
   }
 }

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -71,7 +71,12 @@ class Admin::AssetsController < AdminController
       sort_by { |h| h && h.dig("metadata", "filename")}
 
     files_params.each do |file_data|
-      asset = Asset.new
+      asset = Asset.new()
+
+      if derivative_storage_type = params.dig(:storage_type_for, file_data["id"])
+        asset.derivative_storage_type = derivative_storage_type
+      end
+
       asset.position = (current_position += 1)
       asset.parent_id = @parent.id
       asset.file = file_data

--- a/app/javascript/src/js/admin/uppy_dashboard.js
+++ b/app/javascript/src/js/admin/uppy_dashboard.js
@@ -115,10 +115,14 @@ function kithe_createFileUploader(container) {
     }
 
     row.appendChild(document.createElement("td")).innerText = size;
+
     row.appendChild(document.createElement("td")).innerHTML =
-      "<a type='button' data-cached-file-remove='true' href='#' aria-label='Remove' title='Remove'>" +
-        "<i class='fa fa-times-circle' style='font-size: 150%' aria-hidden='true'></i>" +
-      "</a>";
+      "<select class='form-control'><option>public</option><option>restricted</option></select>";
+
+    row.appendChild(document.createElement("td")).innerHTML =
+      "<button type='button' data-cached-file-remove='true' class='btn btn-link' aria-label='Remove' title='Remove'>" +
+        "<i class='fa fa-times-circle' style='font-size: 180%' aria-hidden='true'></i>" +
+      "</button>";
 
     return row;
   }

--- a/app/javascript/src/js/admin/uppy_dashboard.js
+++ b/app/javascript/src/js/admin/uppy_dashboard.js
@@ -118,7 +118,7 @@ function kithe_createFileUploader(container) {
 
     // Storage type control, put in params keyed by file ID
     row.appendChild(document.createElement("td")).innerHTML =
-      "<select name='storage_type_for[" + shrineHash.id + "]' class='form-control'>" +
+      "<select name='storage_type_for[" + shrineHash.id + "]' class='form-control derivative-storage-type'>" +
         "<option>public</option><option>restricted</option>" +
       "</select>";
 

--- a/app/javascript/src/js/admin/uppy_dashboard.js
+++ b/app/javascript/src/js/admin/uppy_dashboard.js
@@ -116,7 +116,9 @@ function kithe_createFileUploader(container) {
 
     row.appendChild(document.createElement("td")).innerText = size;
     row.appendChild(document.createElement("td")).innerHTML =
-      "<button type='button' data-cached-file-remove='true' class='btn btn-outline-primary'>Remove</button>";
+      "<a type='button' data-cached-file-remove='true' href='#' aria-label='Remove' title='Remove'>" +
+        "<i class='fa fa-times-circle' style='font-size: 150%' aria-hidden='true'></i>" +
+      "</a>";
 
     return row;
   }

--- a/app/javascript/src/js/admin/uppy_dashboard.js
+++ b/app/javascript/src/js/admin/uppy_dashboard.js
@@ -116,8 +116,11 @@ function kithe_createFileUploader(container) {
 
     row.appendChild(document.createElement("td")).innerText = size;
 
+    // Storage type control, put in params keyed by file ID
     row.appendChild(document.createElement("td")).innerHTML =
-      "<select class='form-control'><option>public</option><option>restricted</option></select>";
+      "<select name='storage_type_for[" + shrineHash.id + "]' class='form-control'>" +
+        "<option>public</option><option>restricted</option>" +
+      "</select>";
 
     row.appendChild(document.createElement("td")).innerHTML =
       "<button type='button' data-cached-file-remove='true' class='btn btn-link' aria-label='Remove' title='Remove'>" +

--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -198,7 +198,7 @@ module ScihistDigicoll
     #
     #
     def self.appropriate_shrine_storage(bucket_key:, mode: lookup!(:storage_mode), s3_storage_options: {}, prefix: nil)
-      unless %I{s3_bucket_uploads s3_bucket_originals s3_bucket_derivatives
+      unless %I{s3_bucket_uploads s3_bucket_originals s3_bucket_derivatives s3_bucket_restricted_derivatives
                 s3_bucket_on_demand_derivatives s3_bucket_dzi}.include?(bucket_key)
         raise ArgumentError.new("Unrecognized bucket_key: #{bucket_key}")
       end
@@ -262,7 +262,7 @@ module ScihistDigicoll
     # RESTRICTED derivative storage. NOTE we haven't decided for sure yet where to put
     # this in production. It's own bucket? A prefix inside of originals?
     def self.shrine_restricted_derivatives_storage
-      @shrine_derivatives_storage ||=
+      @shrine_restricted_derivatives_storage ||=
         appropriate_shrine_storage( bucket_key: :s3_bucket_restricted_derivatives,
                                     s3_storage_options: {
                                       public: true,

--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -259,6 +259,21 @@ module ScihistDigicoll
                                     })
     end
 
+    # RESTRICTED derivative storage. NOTE we haven't decided for sure yet where to put
+    # this in production. It's own bucket? A prefix inside of originals?
+    def self.shrine_restricted_derivatives_storage
+      @shrine_derivatives_storage ||=
+        appropriate_shrine_storage( bucket_key: :s3_bucket_restricted_derivatives,
+                                    s3_storage_options: {
+                                      public: true,
+                                      upload_options: {
+                                        # derivatives are public and at unique random URLs, so
+                                        # can be cached far-future
+                                        cache_control: "max-age=31536000, public"
+                                      }
+                                    })
+    end
+
     # Note we set shrine S3 storage to public, to upload with public ACLs
     def self.shrine_on_demand_derivatives_storage
       @shrine_on_demand_derivatives_storage ||=

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -12,6 +12,13 @@ class Asset < Kithe::Asset
   # available after request form, with or without medidation by human approval.
   attr_json :oh_available_by_request, :boolean
 
+  # Most of our derivatives are kept in an S3 bucket with public access, even
+  # when the asset is in a non-published state. But actual confidential material
+  # that won't be published may need derivatives kept in a separate restricted access
+  # bucket. Intended for non-published Oral History assets, eg "free access no internet release"
+  attr_json :derivative_storage_type, :string, default: "public"
+  validates :derivative_storage_type, inclusion: { in: ["public", "restricted"] }
+
 
   # Our DziFiles object to manage associated DZI (deep zoom, for OpenSeadragon
   # panning/zooming) file(s).

--- a/app/uploaders/asset_uploader.rb
+++ b/app/uploaders/asset_uploader.rb
@@ -6,6 +6,18 @@ class AssetUploader < Kithe::AssetUploader
   # URL location, to be fetched on promotion.
   plugin :kithe_accept_remote_url
 
+
+  # Re-set shrine derivatives setting, to put DERIVATIVES on restricted storage
+  # if so configured. Only effects initial upload, if setting changes, some code
+  # needs to manually move files.
+  Attacher.derivatives_storage do |derivative_key|
+    if record.derivative_storage_type == "restricted"
+      :restricted_kithe_derivatives
+    else # public store
+      :kithe_derivatives
+    end
+  end
+
   THUMB_WIDTHS = {
     mini: 54,
     large: 525,

--- a/app/views/admin/assets/display_attach_form.html.erb
+++ b/app/views/admin/assets/display_attach_form.html.erb
@@ -41,6 +41,11 @@
                   data: { confirm: "Cancel attach files?" }
             %>
           </div>
+          <p class="text-muted small mt-3">
+            <i class="fa fa-info-circle mr-2" aria-hidden="true"></i>
+            Use the <b>restricted</b> storage type for confidential files such as restricted oral histories.
+            Otherwise, normally use <b>public</b> storage type.
+          </p>
           <table class="table table-sm mt-3 attach-files-table" data-toggle="cached-files-table">
             <tr>
               <th class="attach-files-table-filename">Filename</th>

--- a/app/views/admin/assets/display_attach_form.html.erb
+++ b/app/views/admin/assets/display_attach_form.html.erb
@@ -41,9 +41,13 @@
                   data: { confirm: "Cancel attach files?" }
             %>
           </div>
-
           <table class="table table-sm mt-3 attach-files-table" data-toggle="cached-files-table">
-            <tr><th class="attach-files-table-filename">Filename</th><th class="attach-files-table-size">Size</th><th class="attach-files-table-remove"></th></tr>
+            <tr>
+              <th class="attach-files-table-filename">Filename</th>
+              <th class="attach-files-table-size">Size</th>
+              <th class="attach-files-table-storage-type">Storage Type</th>
+              <th class="attach-files-table-remove"></th>
+            </tr>
           </table>
         </div>
     </div>

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -117,9 +117,21 @@
     </dl>
 
     <h2 class="mt-4">Derivatives</h2>
+
+    <p>
+      Derivative storage type set to: <code><%= @asset.derivative_storage_type %></code>
+    </p>
+
     <ul class="list-unstyled">
       <% @asset.file_derivatives.each_pair do |key, derivative| %>
-        <li><%= link_to key, derivative.url %></li>
+        <li>
+          <%= link_to key, derivative.url %>
+          <% if derivative.storage_key == :restricted_kithe_derivatives %>
+            <span class="badge badge-warning">on restricted storage</span>
+          <% elsif @asset.derivative_storage_type == "restricted" %>
+            <span class="badge badge-danger">unexpectedly on public storage</span>
+          <% end %>
+        </li>
       <% end %>
     </ul>
   </div>

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -12,6 +12,7 @@ Shrine.storages = {
   cache: ScihistDigicoll::Env.shrine_cache_storage,
   store: ScihistDigicoll::Env.shrine_store_storage,
   kithe_derivatives: ScihistDigicoll::Env.shrine_derivatives_storage,
+  restricted_kithe_derivatives: ScihistDigicoll::Env.shrine_restricted_derivatives_storage,
   on_demand_derivatives: ScihistDigicoll::Env.shrine_on_demand_derivatives_storage,
   combined_audio_derivatives: ScihistDigicoll::Env.shrine_combined_audio_derivatives_storage,
   dzi_storage: ScihistDigicoll::Env.shrine_dzi_storage

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -11,4 +11,18 @@ describe Asset do
       expect(Asset.all_derivative_count).to eq(expected)
     end
   end
+
+  describe "restricted derivatives", queue_adapter: :inline do
+    let(:sample_file_location) {  Rails.root + "spec/test_support/images/20x20.png" }
+    let(:asset) { create(:asset, derivative_storage_type: "restricted") }
+    it "are stored in restricted derivatives location" do
+      asset.file = File.open(sample_file_location)
+      asset.save!
+      asset.reload
+
+      derivatives = asset.file_derivatives.values
+
+      expect(derivatives).to all(satisfy { |d| d.storage_key == :restricted_kithe_derivatives })
+    end
+  end
 end

--- a/spec/system/work/file_ingest_spec.rb
+++ b/spec/system/work/file_ingest_spec.rb
@@ -3,11 +3,16 @@ require 'rails_helper'
 RSpec.describe "ingest files to work", :logged_in_user, type: :system, js: true, queue_adapter: :test do
   let(:work) { FactoryBot.create(:work) }
 
+  # the hidden file input used by uppy, we can target directly, hacky, we're not fully testing
+  # what the user actually does, but best way we figured out to test.
+  def add_file_via_uppy_dashboard(file_path)
+    attach_file "files[]", file_path.to_s, make_visible: true
+  end
+
   it "can add files" do
     visit admin_asset_ingest_path(work)
 
-    # the hidden file input used by uppy, we can target directly...
-    attach_file "files[]", (Rails.root + "spec/test_support/images/30x30.png").to_s, make_visible: true
+    add_file_via_uppy_dashboard(Rails.root.join("spec/test_support/images/30x30.png"))
 
     expect(page).to have_css(".attach-files-table td", text: /30x30\.png/)
 
@@ -21,5 +26,23 @@ RSpec.describe "ingest files to work", :logged_in_user, type: :system, js: true,
     asset = work.members.first
     expect(asset).to be_kind_of(Asset)
     expect(asset.title).to eq("30x30.png")
+  end
+
+  it "can add a file with restricted derivative storage", queue_adapter: :inline do
+    visit admin_asset_ingest_path(work)
+
+    add_file_via_uppy_dashboard(Rails.root.join("spec/test_support/images/20x20.png"))
+
+    expect(page).to have_css(".attach-files-table td", text: /20x20\.png/)
+
+    page.find(".derivative-storage-type").find("option", text: "restricted").select_option
+
+    click_on "Attach"
+
+    expect(page).to have_css("h1", text: work.title)
+
+    asset = work.reload.members.first
+
+    expect(asset.file_derivatives.values).to all(satisfy { |d| d.storage_key == :restricted_kithe_derivatives})
   end
 end


### PR DESCRIPTION
Ref #832

This is just the first chunk, to keep the PR from getting too big. No rush on this one though. It includes:

* a flag that can be set on an asset for 'public' vs 'restricted' derivatives storage
* shrine configuration so depending on flag, derivative will be stored in a different place
* UI on file ingest page to set the flag as you ingest
* Some feedback on admin asset show page showing you storage type (restricted vs public) status

The actual storage location in production/staging for restricted derivatives isn't set up yet. And there are some decisions to make about that. This probably won't run on staging yet, but it should work on dev. 

Many more things left to do to be outlined in #832