### PR TITLE
Facilities to move derivatives between public and restricted storage type

### DIFF
--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -129,7 +129,7 @@ class Admin::AssetsController < AdminController
   private
 
   def asset_params
-    allowed_params = [:title, {admin_note_attributes: []}]
+    allowed_params = [:title, :derivative_storage_type, {admin_note_attributes: []}]
     allowed_params << :published if can?(:publish, @asset)
 
     asset_params = params.require(:asset).permit(*allowed_params)

--- a/app/jobs/ensure_correct_derivatives_storage_job.rb
+++ b/app/jobs/ensure_correct_derivatives_storage_job.rb
@@ -1,10 +1,17 @@
 # Derivatives can be stored in a "restricted" location or a "public" location. If the setting changes
 # or they have become out of sync, this job will fix it, moving/copying/deleting derivatives if required,
 # to now be in the right place.
+#
+# Also makes sure no DZI files for assets set to restricted derivatives
 class EnsureCorrectDerivativesStorageJob < ApplicationJob
 
   def perform(asset)
     ensure_correct_derivative_locations(asset)
+
+    if asset.derivative_storage_type == "restricted"
+      # no dzi files supported for restricted derivatives, as DZI storage is not secure!
+      asset.dzi_file.delete
+    end
   end
 
   private

--- a/app/jobs/ensure_correct_derivatives_storage_job.rb
+++ b/app/jobs/ensure_correct_derivatives_storage_job.rb
@@ -1,0 +1,39 @@
+# Derivatives can be stored in a "restricted" location or a "public" location. If the setting changes
+# or they have become out of sync, this job will fix it, moving/copying/deleting derivatives if required,
+# to now be in the right place.
+class EnsureCorrectDerivativesStorageJob < ApplicationJob
+
+  def perform(asset)
+    ensure_correct_derivative_locations(asset)
+  end
+
+  private
+
+
+  # routine to copy derivatives to current proper storage location modified from:
+  # https://shrinerb.com/docs/changing-location
+  def ensure_correct_derivative_locations(asset)
+    if asset.derivatives_in_correct_storage_location?
+      Rails.logger.debug("#{self.class.name}: All derivatives for #{asset.friendlier_id }already in proper storage type #{asset.derivative_storage_type}, no need to move")
+      return
+    end
+
+    attacher = asset.file_attacher
+    old_attacher = attacher.dup
+
+    # reupload all derivatives, they will wind up in appropriate location
+    # even if they weren't before.
+    attacher.set_derivatives attacher.upload_derivatives(attacher.derivatives)
+
+    begin
+      attacher.atomic_persist           # persist changes if attachment has not changed in the meantime
+      old_attacher.delete_derivatives   # delete old derivatives now re-uploaded
+    rescue Shrine::AttachmentChanged,   # attachment has changed during reuploading
+           ActiveRecord::RecordNotFound # record has been deleted during reuploadin
+
+      # delete the derivatives we re-uploaded, cause they didn't end up
+      # attacched and no longer apply
+      attacher.delete_derivatives
+    end
+  end
+end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -39,6 +39,17 @@ class Asset < Kithe::Asset
   after_promotion DziFiles::ActiveRecordCallbacks, if: ->(asset) { asset.content_type&.start_with?("image/") }
   after_commit DziFiles::ActiveRecordCallbacks, only: [:update, :destroy]
 
+
+  # Ensure that recorded storage locations for all derivatives matches
+  # current #derivative_storage_type setting.  Returns false only if
+  # there are derivatives that exist, in wrong location.
+  def derivatives_in_correct_storage_location?
+    file_derivatives.blank? ||
+      file_derivatives.values.collect(&:storage_key).all?(
+        self.class::DERIVATIVE_STORAGE_TYPE_LOCATIONS.fetch(self.derivative_storage_type)
+      )
+  end
+
   # What is total number of derivatives referenced in our DB?
   #
   # Since they are now referenced as keys inside a JSON hash in Asset, it's a bit

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -18,6 +18,11 @@ class Asset < Kithe::Asset
   # bucket. Intended for non-published Oral History assets, eg "free access no internet release"
   attr_json :derivative_storage_type, :string, default: "public"
   validates :derivative_storage_type, inclusion: { in: ["public", "restricted"] }
+  DERIVATIVE_STORAGE_TYPE_LOCATIONS = {
+    "public" => :kithe_derivatives,
+    "restricted" => :restricted_kithe_derivatives
+  }.freeze
+
 
 
   # Our DziFiles object to manage associated DZI (deep zoom, for OpenSeadragon

--- a/app/uploaders/asset_uploader.rb
+++ b/app/uploaders/asset_uploader.rb
@@ -12,9 +12,9 @@ class AssetUploader < Kithe::AssetUploader
   # needs to manually move files.
   Attacher.derivatives_storage do |derivative_key|
     if record.derivative_storage_type == "restricted"
-      :restricted_kithe_derivatives
+      Asset::DERIVATIVE_STORAGE_TYPE_LOCATIONS.fetch("restricted")
     else # public store
-      :kithe_derivatives
+      Asset::DERIVATIVE_STORAGE_TYPE_LOCATIONS.fetch("public")
     end
   end
 

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -119,7 +119,29 @@
     <h2 class="mt-4">Derivatives</h2>
 
     <p>
-      Derivative storage type set to: <code><%= @asset.derivative_storage_type %></code>
+      <%= simple_form_for(@asset, wrapper: :horizontal_form) do |f| %>
+
+        <p class="text-muted small mt-3">
+            Use the <b>restricted</b> storage type for confidential files such as restricted oral histories.
+            Otherwise, normally use <b>public</b> storage type. After changing Derivative Storage Type
+            it may take a few minutes for derivative locations to be updated.</p>
+        </p>
+
+        <div class="row mb-3">
+          <div class="col-sm-4">
+            <%= f.label :derivative_storage_type %>
+          </div>
+          <div class="col-sm-8">
+            <%= f.input_field :derivative_storage_type,
+              as: :select,
+              collection: Asset::DERIVATIVE_STORAGE_TYPE_LOCATIONS.keys,
+              include_blank: false,
+              class: "custom-select" %>
+          </div>
+        </div>
+
+        <%= f.button :submit, "Update Derivative Storage Type" %>
+      <% end %>
     </p>
 
     <ul class="list-unstyled">

--- a/app/views/admin/works/_member_list_table.html.erb
+++ b/app/views/admin/works/_member_list_table.html.erb
@@ -40,6 +40,9 @@
           </td>
           <td>
             <%= link_to member.title, [:admin, member] %> <%= publication_badge(member) %>
+            <% if member.kind_of?(Asset) && member.derivative_storage_type == "restricted" %>
+              <span class="badge badge-warning">Restricted derivatives storage</span>
+            <% end %>
           </td>
           <td class="datestamp"><%= l member.created_at.to_date, format: :admin  %></td>
           <td class="datestamp"><%= l member.updated_at.to_date, format: :admin %></td>

--- a/spec/jobs/ensure_correct_derivatives_storage_job_spec.rb
+++ b/spec/jobs/ensure_correct_derivatives_storage_job_spec.rb
@@ -34,5 +34,12 @@ describe "EnsureCorrectDerivativesStorageJob" do
         expect(deriv.exists?).to be(true)
       end
     end
+
+    it "Deletes DZI files when ensuring restricted" do
+      expect(Shrine.storages[:dzi_storage]).to receive(:delete_prefixed).with(
+        asset.dzi_file.dzi_uploaded_file.id.sub(/\.dzi$/, "_files/")
+      )
+      job.perform_now
+    end
   end
 end

--- a/spec/jobs/ensure_correct_derivatives_storage_job_spec.rb
+++ b/spec/jobs/ensure_correct_derivatives_storage_job_spec.rb
@@ -24,7 +24,9 @@ describe "EnsureCorrectDerivativesStorageJob" do
       a
     end
 
-    it "copies and sets derivatives to correct location" do
+    it "moves derivatives to correct location" do
+      original_derivatives = asset.file_derivatives.values
+
       job.perform_now
 
       expect(asset.file_derivatives.values).to be_present
@@ -32,6 +34,10 @@ describe "EnsureCorrectDerivativesStorageJob" do
       asset.file_derivatives.values.each do |deriv|
         expect(deriv.storage_key).to eq(:restricted_kithe_derivatives)
         expect(deriv.exists?).to be(true)
+      end
+
+      original_derivatives.each do |deriv|
+        expect(deriv.exists?).to be(false)
       end
     end
 

--- a/spec/jobs/ensure_correct_derivatives_storage_job_spec.rb
+++ b/spec/jobs/ensure_correct_derivatives_storage_job_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe "EnsureCorrectDerivativesStorageJob" do
+  let(:job) { EnsureCorrectDerivativesStorageJob.new(asset) }
+
+  describe "with derivatives in incorrect public location" do
+    let(:sample_file_location) {  Rails.root + "spec/test_support/images/20x20.png" }
+    let(:asset) do
+      # create one with no derivatives
+      a = create(:asset_with_faked_file,
+        derivative_storage_type: "restricted",
+        faked_derivatives: {})
+
+      derivatives_on_public_storage = {
+        "thumb_small" => a.file_attacher.upload_derivative("thumb_small", File.open(sample_file_location), storage: :kithe_derivatives, delete: false),
+        "thumb_large" => a.file_attacher.upload_derivative("thumb_large", File.open(sample_file_location), storage: :kithe_derivatives, delete: false),
+      }
+
+      a.file_attacher.set_derivatives(derivatives_on_public_storage)
+      a.save!
+
+      expect(a.file_derivatives.values.collect(&:storage_key)).to all(eq(:kithe_derivatives))
+
+      a
+    end
+
+    it "copies and sets derivatives to correct location" do
+      job.perform_now
+
+      expect(asset.file_derivatives.values).to be_present
+
+      asset.file_derivatives.values.each do |deriv|
+        expect(deriv.storage_key).to eq(:restricted_kithe_derivatives)
+        expect(deriv.exists?).to be(true)
+      end
+    end
+  end
+end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -23,6 +23,30 @@ describe Asset do
       derivatives = asset.file_derivatives.values
 
       expect(derivatives).to all(satisfy { |d| d.storage_key == :restricted_kithe_derivatives })
+      expect(asset.derivatives_in_correct_storage_location?).to be(true)
+    end
+
+    describe "with derivatives in wrong location" do
+      let(:asset) do
+        # create one with no derivatives
+        a = create(:asset_with_faked_file,
+          derivative_storage_type: "restricted",
+          faked_derivatives: {})
+
+        derivatives_on_public_storage = {
+          "thumb_small" => a.file_attacher.upload_derivative("thumb_small", File.open(sample_file_location), storage: :kithe_derivatives, delete: false),
+          "thumb_large" => a.file_attacher.upload_derivative("thumb_large", File.open(sample_file_location), storage: :kithe_derivatives, delete: false),
+        }
+
+        a.file_attacher.set_derivatives(derivatives_on_public_storage)
+        a.save!
+
+        a
+      end
+
+      it "#derivatives_in_correct_storage_location? is false" do
+        expect(asset.derivatives_in_correct_storage_location?).to be(false)
+      end
     end
   end
 end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -26,6 +26,17 @@ describe Asset do
       expect(asset.derivatives_in_correct_storage_location?).to be(true)
     end
 
+
+    describe "starting out public", queue_adapter: :test do
+      let(:asset) { create(:asset_with_faked_file) } # this creates faked derivatives too
+
+      it "kicks off ensure derivatives storage job when storage type changed" do
+        expect {
+          asset.update!(derivative_storage_type: "restricted")
+        }.to have_enqueued_job(EnsureCorrectDerivativesStorageJob)
+      end
+    end
+
     describe "with derivatives in wrong location" do
       let(:asset) do
         # create one with no derivatives


### PR DESCRIPTION
Ref #832

We catch in ActiveRecord callback if derivative storage type has changed, and execute a background job to move derivatives between storage locations if so. 

* Bg job also makes sure to delete any DZI files for `restricted` storage; we have no way to serve DZI's but from public storage.  It does *not* create DZI files if you move a file from `restricted` to `public`. Images aren't really our use case at all anyway. 

* Not currently handling removing things from derivatives backup bucket, leave that for another ticket. (Is a checkbox in master Issue, to help us not  forget)