### PR TITLE
Avoid n+1 query in home page recent items

### DIFF
--- a/app/presenters/recent_items.rb
+++ b/app/presenters/recent_items.rb
@@ -39,6 +39,7 @@ class RecentItems
 
   def fetch_bag
     @@bag ||= Work.where('published = true').
+      includes(:leaf_representative).
       order('updated_at desc').
       limit(@how_many_works_in_bag)
   end


### PR DESCRIPTION
I noticed an "n+1 query" problem in my logs in dev when loading home page. Each of the recent items needs it's `representative_asset` to display a thumb. They were being fetched in a separate SQL query for each, since they weren't being pre-loaded. Easily fixed at the point of DB fetching by adding the ActiveRecord 'includes'.