### PR TITLE
remove all versions and backups when moving derivatives to restricted

### DIFF
--- a/app/jobs/ensure_correct_derivatives_storage_job.rb
+++ b/app/jobs/ensure_correct_derivatives_storage_job.rb
@@ -53,9 +53,13 @@ class EnsureCorrectDerivativesStorageJob < ApplicationJob
   # are stored, couldn't figure out a good implementation without that.  There is
   # a risk this code will silently fail to delete derivatives on backup
   # if they aren't stored where it thinks!
+  #
+  # Also assumes buckets ARE versioned, and uses appropriate command to delete all
+  # versions.
   def remove_from_backup_bucket(asset)
     if backup_bucket = ScihistDigicoll::Env.derivatives_backup_bucket
-      bucket.objects(prefix: "#{asset.id}/").batch_delete!
+      prefix = "#{asset.id}/"
+      bucket.object_versions(prefix: prefix).batch_delete!
     end
   end
 end

--- a/app/jobs/ensure_correct_derivatives_storage_job.rb
+++ b/app/jobs/ensure_correct_derivatives_storage_job.rb
@@ -88,14 +88,14 @@ class EnsureCorrectDerivativesStorageJob < ApplicationJob
     # remove all versions from derivatives backup bucket if we have one
     if backup_bucket = ScihistDigicoll::Env.derivatives_backup_bucket
       backup_bucket.object_versions(prefix: derivative_prefix).batch_delete!
-    elsif production?
+    elsif ScihistDigicoll::Env.production?
       raise RuntimeError.new("In production tier, but missing derivatives backup bucket settings presumed to exist")
     end
 
     # remove all versions from dzi backup bucket if we have one
     if dzi_backup_bucket = ScihistDigicoll::Env.dzi_backup_bucket
       dzi_backup_bucket.object_versions(prefix: dzi_prefix).batch_delete!
-    elsif production?
+    elsif ScihistDigicoll::Env.production?
       raise RuntimeError.new("In production tier, but missing derivatives backup bucket settings presumed to exist")
     end
   end

--- a/app/jobs/ensure_correct_derivatives_storage_job.rb
+++ b/app/jobs/ensure_correct_derivatives_storage_job.rb
@@ -6,7 +6,6 @@
 class EnsureCorrectDerivativesStorageJob < ApplicationJob
 
   def perform(asset)
-    byebug
     ensure_correct_derivative_locations(asset)
   end
 

--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -322,7 +322,7 @@ module ScihistDigicoll
           secret_access_key: lookup(:aws_secret_access_key),
           region: region)
 
-        Aws::S3::Bucket.new(name: bucket_name, client: @client)
+        Aws::S3::Bucket.new(name: bucket_name, client: client)
       elsif production?
         raise RuntimeError.new("In production tier, but missing derivatives backup bucket settings presumed to exist")
       end
@@ -344,7 +344,7 @@ module ScihistDigicoll
           secret_access_key: lookup(:aws_secret_access_key),
           region: region)
 
-        Aws::S3::Bucket.new(name: bucket_name, client: @client)
+        Aws::S3::Bucket.new(name: bucket_name, client: client)
       elsif production?
         raise RuntimeError.new("In production tier, but missing derivatives backup bucket settings presumed to exist")
       end

--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -309,9 +309,7 @@ module ScihistDigicoll
     # Returns an S3::Bucket for the derivatives backup, used by our derivative storage
     # type mover to make sure non-public derivatives don't exist in backups either.
     #
-    # Can return nil, except in production will raise instead of nil, to make sure
-    # we don't accidentally avoid deleting from backup bucket in production where
-    # we assume it must exist.
+    # Can return nil if not defined!
     def self.derivatives_backup_bucket
       bucket_name = lookup(:s3_bucket_derivatives_backup)
       region      = lookup(:s3_backup_bucket_region)
@@ -331,9 +329,7 @@ module ScihistDigicoll
     # Returns an S3::Bucket for the DZI backup, used by our derivative storage
     # type mover to make sure non-public derivatives don't exist in backups either.
     #
-    # Can return nil, except in production will raise instead of nil, to make sure
-    # we don't accidentally avoid deleting from backup bucket in production where
-    # we assume it must exist.
+    # Can return nil if no defined!
     def self.dzi_backup_bucket
       bucket_name = lookup(:s3_bucket_dzi_backup)
       region      = lookup(:s3_backup_bucket_region)
@@ -345,8 +341,6 @@ module ScihistDigicoll
           region: region)
 
         Aws::S3::Bucket.new(name: bucket_name, client: client)
-      elsif production?
-        raise RuntimeError.new("In production tier, but missing derivatives backup bucket settings presumed to exist")
       end
     end
 

--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -302,8 +302,8 @@ module ScihistDigicoll
 
 
     # Location of some backup buckets we sometimes need to purge files from
-    define_key :s3_derivatives_backup_bucket
-    define_key :s3_dzi_backup_bucket
+    define_key :s3_bucket_derivatives_backup
+    define_key :s3_bucket_dzi_backup
     define_key :s3_backup_bucket_region
 
     # Returns an S3::Bucket for the derivatives backup, used by our derivative storage

--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -311,19 +311,25 @@ module ScihistDigicoll
     #
     # Can return nil if not defined!
     def self.derivatives_backup_bucket
-      bucket_name = lookup(:s3_bucket_derivatives_backup)
-      region      = lookup(:s3_backup_bucket_region)
+      unless defined?(@derivatives_backup_bucket)
+        @derivatives_backup_bucket = begin
+          bucket_name = lookup(:s3_bucket_derivatives_backup)
+          region      = lookup(:s3_backup_bucket_region)
 
-      if bucket_name.present? && region.present?
-        client = Aws::S3::Client.new(
-          access_key_id:     lookup(:aws_access_key_id),
-          secret_access_key: lookup(:aws_secret_access_key),
-          region: region)
+          if bucket_name.present? && region.present?
+            client = Aws::S3::Client.new(
+              access_key_id:     lookup(:aws_access_key_id),
+              secret_access_key: lookup(:aws_secret_access_key),
+              region: region)
 
-        Aws::S3::Bucket.new(name: bucket_name, client: client)
-      elsif production?
-        raise RuntimeError.new("In production tier, but missing derivatives backup bucket settings presumed to exist")
+            Aws::S3::Bucket.new(name: bucket_name, client: client)
+          elsif production?
+            raise RuntimeError.new("In production tier, but missing derivatives backup bucket settings presumed to exist")
+          end
+        end
       end
+
+      @derivatives_backup_bucket
     end
 
     # Returns an S3::Bucket for the DZI backup, used by our derivative storage
@@ -331,17 +337,23 @@ module ScihistDigicoll
     #
     # Can return nil if no defined!
     def self.dzi_backup_bucket
-      bucket_name = lookup(:s3_bucket_dzi_backup)
-      region      = lookup(:s3_backup_bucket_region)
+      unless defined?(@dzi_backup_bucket)
+        @dzi_backup_bucket = begin
+          bucket_name = lookup(:s3_bucket_dzi_backup)
+          region      = lookup(:s3_backup_bucket_region)
 
-      if bucket_name.present? && region.present?
-        client = Aws::S3::Client.new(
-          access_key_id:     lookup(:aws_access_key_id),
-          secret_access_key: lookup(:aws_secret_access_key),
-          region: region)
+          if bucket_name.present? && region.present?
+            client = Aws::S3::Client.new(
+              access_key_id:     lookup(:aws_access_key_id),
+              secret_access_key: lookup(:aws_secret_access_key),
+              region: region)
 
-        Aws::S3::Bucket.new(name: bucket_name, client: client)
+            Aws::S3::Bucket.new(name: bucket_name, client: client)
+          end
+        end
       end
+
+      @dzi_backup_bucket
     end
 
 

--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -313,7 +313,7 @@ module ScihistDigicoll
     # we don't accidentally avoid deleting from backup bucket in production where
     # we assume it must exist.
     def self.derivatives_backup_bucket
-      bucket_name = lookup(:s3_derivatives_backup_bucket)
+      bucket_name = lookup(:s3_bucket_derivatives_backup)
       region      = lookup(:s3_backup_bucket_region)
 
       if bucket_name.present? && region.present?
@@ -335,7 +335,7 @@ module ScihistDigicoll
     # we don't accidentally avoid deleting from backup bucket in production where
     # we assume it must exist.
     def self.dzi_backup_bucket
-      bucket_name = lookup(:s3_dzi_backup_bucket)
+      bucket_name = lookup(:s3_bucket_dzi_backup)
       region      = lookup(:s3_backup_bucket_region)
 
       if bucket_name.present? && region.present?


### PR DESCRIPTION
Ref #832 and #866 

Needs ansible PR with new local_env.yml keys just in production, s3_derivatives_backup_bucket; s3_dzi_backup_bucket; s3_backup_bucket_region

Needs to be manually tested in
- [x] staging (everything works when moving derivative storage type; derivatives, dzis, and versions of both are gone in buckets)
- [x] production (above plus all versions are gone in _backup_ buckets too)

This doesn't have a lot of tests, I just can't see a good way to make a worthwhile test that doesn't assume too much.