### PR TITLE
Better Google Analytics reporting for oral histories.

### DIFF
--- a/app/decorators/oh_audio_work_show_decorator.rb
+++ b/app/decorators/oh_audio_work_show_decorator.rb
@@ -72,7 +72,10 @@ class OhAudioWorkShowDecorator < Draper::Decorator
     if member.content_type&.start_with?("image/")
       yield
     else
-      link_to download_path(member.leaf_representative, disposition: :inline) do
+      link_to download_path(member.leaf_representative, disposition: :inline),
+        'data-analytics-category' => 'Work',
+        'data-analytics-action' => "view_oral_history_transcript_pdf",
+        'data-analytics-label' => member.parent.friendlier_id do
         yield
       end
     end

--- a/app/views/works/_show_with_audio_downloads.html.erb
+++ b/app/views/works/_show_with_audio_downloads.html.erb
@@ -90,8 +90,12 @@
             class="play-link"
             title="Listen to '<%= track.title%>'"
             aria-label="Listen to '<%= track.title%>'"
-            href="#" data-role="play-link"
+            href="#"
+            data-role="play-link"
             data-ohms-timestamp-s="<%= decorator.start_time_for(track) %>"
+            data-analytics-category='Work'
+            data-analytics-action="play_oral_history_audio_segment"
+            data-analytics-label="<%= @work.friendlier_id %>"
           >
             <i class="fa fa-play-circle" aria-hidden="true"></i>
           </a>
@@ -108,6 +112,9 @@
             href="#"
             data-role="play-link"
             data-ohms-timestamp-s="<%= decorator.start_time_for(track) %>"
+            data-analytics-category='Work'
+            data-analytics-action="play_oral_history_audio_segment"
+            data-analytics-label="<%= @work.friendlier_id %>"
           >
             <%= track.title %>
             <div class="start-time">

--- a/spec/system/oh_audio_front_end_spec.rb
+++ b/spec/system/oh_audio_front_end_spec.rb
@@ -29,7 +29,7 @@ describe "Audio front end", type: :system, js: true do
     audio_assets.select {|a| a.published }
   }
 
-  let!(:regular_assets) {
+  let!(:image_assets) {
     (5..8).to_a.map do |i|
       create(:asset_with_faked_file,
         title: "Regular file #{i}",
@@ -44,8 +44,16 @@ describe "Audio front end", type: :system, js: true do
     end
   }
 
+  let(:pdf_asset) do
+    create(:asset_with_faked_file, :pdf,
+      faked_derivatives: {},
+      parent: parent_work
+    )
+  end
+
+
   before do
-    parent_work.representative = regular_assets[0]
+    parent_work.representative = pdf_asset
     parent_work.save!
   end
 
@@ -58,6 +66,24 @@ describe "Audio front end", type: :system, js: true do
       expect(page).not_to have_selector('audio')
 
       click_on "Downloads"
+
+
+      # In oh_audio_work_show_decorator.rb we specify that only PDFs should be linked.
+
+      #PDF has a link:
+      linked_pdf_transcripts = find_all('.show-member-list-item a').select { |x| x.text == pdf_asset.title }
+      expect(linked_pdf_transcripts.count).to eq 1
+      #linked_pdf_transcripts[0]
+
+      expect(linked_pdf_transcripts[0]['data-analytics-category']).to eq "Work"
+      expect(linked_pdf_transcripts[0]['data-analytics-action']  ).to eq "view_oral_history_transcript_pdf"
+      expect(linked_pdf_transcripts[0]['data-analytics-label']   ).to eq parent_work.friendlier_id
+      # 3 JPEGS: not linked
+
+
+      expect(find_all('.show-member-list-item a').select { |x| x.text == image_assets[0].title }.count).to eq 0
+      expect(find_all('.show-member-list-item a').select { |x| x.text == image_assets[1].title }.count).to eq 0
+      expect(find_all('.show-member-list-item a').select { |x| x.text == image_assets[2].title }.count).to eq 0
 
       within("*[data-role='audio-playlist-wrapper']") do
         within('.now-playing-container') do
@@ -81,7 +107,9 @@ describe "Audio front end", type: :system, js: true do
       non_audio = page.find_all('.other-files .show-member-list-item')
 
       # Don't show the unpublished non-audio asset (# 6) to the not-logged-in user.
-      expect(non_audio.count). to eq regular_assets.count {|a| a.published }
+      # (The + 1 accounts for the PDF, which is not an image but is also not audio.)
+      expect(non_audio.count). to eq image_assets.count {|a| a.published } + 1
+
 
       # No user is logged in, so there should not be any "Private" badges.
       expect(page).not_to have_css('.badge-warning[title=Private]')
@@ -179,7 +207,7 @@ describe "Audio front end", type: :system, js: true do
       audio_assets.select {|a| a.published }
     }
 
-    let!(:regular_assets) {
+    let!(:image_assets) {
       (5..8).to_a.map do |i|
         create(:asset_with_faked_file,
           title: "Regular file #{i}",
@@ -195,7 +223,7 @@ describe "Audio front end", type: :system, js: true do
     }
 
     before do
-      parent_work.representative = regular_assets[0]
+      parent_work.representative = image_assets[0]
       parent_work.save!
     end
 
@@ -225,12 +253,17 @@ describe "Audio front end", type: :system, js: true do
         # All files are listed, including the unpublished ones:
 
         other_files = page.find_all('.other-files .show-member-list-item')
-        expect(other_files.count).to eq regular_assets.count
+        #  All files = audio files + image files + 1 PDF file.
+        expect(other_files.count).to eq image_assets.count + 1
 
         # Thumbs corresponding to an unpublished asset are labeled:
         other_files.each do |file_listing|
           friendlier_id =  file_listing['data-member-id']
-          asset = regular_assets.select{ |ra| ra.friendlier_id == friendlier_id }.first
+          asset = image_assets.select{ |ra| ra.friendlier_id == friendlier_id }.first
+
+          # If the asset doesn't match any of the images, assume it's the PDF transcript:
+          asset = asset || pdf_asset
+
           expect(asset).not_to eq nil
           if asset.published?
             expect(file_listing).to have_no_css('.badge-warning[title=Private]')

--- a/spec/system/oh_audio_front_end_spec.rb
+++ b/spec/system/oh_audio_front_end_spec.rb
@@ -175,6 +175,13 @@ describe "Audio front end", type: :system, js: true do
       # when you click the links.
       expect(scrubber_times.map {|x| (x*2).round }).to contain_exactly(0,0,1,2)
 
+      # Make sure we're sending a GA action when the user clicks on a track
+      page.find_all('a.play-link').each do |link|
+          expect(link['data-analytics-category']).to eq "Work"
+          expect(link['data-analytics-action']  ).to eq "play_oral_history_audio_segment"
+          expect(link['data-analytics-label']   ).to eq parent_work.friendlier_id
+      end
+
       # You should be able to download the combined audio derivs:
       expect(page).to have_content("Complete Interview Audio File")
       expect(page).to have_content("3 Separate Interview Segments")


### PR DESCRIPTION
Ref #843 
The main task in 843 is done and tested.
Also adding a GA action for in-browser audio player listens as well.