### PR TITLE
use faster_s3_url gem for faster generation of S3 urls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,8 @@ gem "shrine", "~> 3.0" #, path: "../shrine"
 gem "uppy-s3_multipart"
 gem "content_disposition", "~> 1.0"
 
+gem 'faster_s3_url', "< 2" # for generating s3 urls faster!
+
 # slack notifications on capistrano deploys
 gem 'slackistrano', "~> 4.0"
 gem "whenever" # automatic crontob maintenance, on capistrano deploys

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,6 +234,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.14.0)
       faraday (>= 0.7.4, < 1.0)
+    faster_s3_url (0.1.0)
     fastimage (2.1.7)
     ffi (1.13.1)
     ffi-compiler (1.0.1)
@@ -655,6 +656,7 @@ DEPENDENCIES
   devise (~> 4.5)
   draper (~> 4.0, >= 4.0.1)
   factory_bot_rails
+  faster_s3_url (< 2)
   font-awesome-rails (~> 4.7)
   honeybadger (~> 4.0)
   html_aware_truncation (~> 1.0)

--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -1,6 +1,7 @@
 require 'socket'
 require "shrine/storage/file_system"
 require "shrine/storage/s3"
+require 'faster_s3_url/shrine/storage'
 
 
 module ScihistDigicoll
@@ -210,7 +211,7 @@ module ScihistDigicoll
       if mode == "dev_file"
         Shrine::Storage::FileSystem.new("public", prefix: "shrine_storage_#{Rails.env}/#{shared_bucket_path_prefix}")
       elsif mode == "dev_s3"
-        Shrine::Storage::S3.new({
+        FasterS3Url::Shrine::Storage.new({
           bucket:            lookup(:s3_dev_bucket),
           prefix:            "#{lookup(:s3_dev_prefix)}/#{shared_bucket_path_prefix}",
           access_key_id:     lookup(:aws_access_key_id),
@@ -218,7 +219,7 @@ module ScihistDigicoll
           region:            lookup(:aws_region)
         }.merge(s3_storage_options))
       elsif mode == "production"
-        Shrine::Storage::S3.new({
+        FasterS3Url::Shrine::Storage.new({
           bucket:            lookup(bucket_key),
           prefix:            prefix,
           access_key_id:     lookup(:aws_access_key_id),


### PR DESCRIPTION
https://github.com/jrochkind/faster_s3_url

This results in only modest perf improvement for our typical S3 public URLs (although saving a couple tens of ms off ramelli doesn't hurt), but would really matter if we ever try generating a page full of presigned URLs, as our architecture is now techically capable of with 'restricted' derivatives, although we don't intend to do so, doesn't hurt to be prepared. Plus 'dogfood' the gem I made as a result of my S3 url generation performance investigation.