### PR TITLE
let honeybadger_env be specified in ENV separately

### DIFF
--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -56,6 +56,12 @@ module ScihistDigicoll
     end
 
 
+    # what env for honeybadger to log, if not given we'll use the `service_level` value
+    # (staging/production), or if that's not there either, just Rails.env (development, testing)
+    define_key :honeybadger_env, default: -> {
+      ScihistDigicoll::Env.lookup(:service_level) || Rails.env.to_s
+    }
+
 
     # Rails-style db url, eg postgres://myuser:mypass@localhost/somedatabase
     define_key :rails_database_url

--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -1,6 +1,6 @@
 ---
 api_key: <%= ScihistDigicoll::Env.lookup(:honeybadger_api_key) %>
-env: <%= ScihistDigicoll::Env.lookup(:service_level) || Rails.env.to_s %>
+env: <%= ScihistDigicoll::Env.lookup(:honeybadger_env) %>
 feedback:
   enabled: true
 user_informer:


### PR DESCRIPTION
While still defaulting to previous behavior.

This lets us set HONEYBADGER_ENV to heroku-staging on heroku, to keep it separate from our other staging environment.