### PR TITLE
fail earlier on missing AWS keys when configuring buckets

### DIFF
--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -231,8 +231,8 @@ module ScihistDigicoll
         FasterS3Url::Shrine::Storage.new({
           bucket:            lookup!(bucket_key),
           prefix:            prefix,
-          access_key_id:     lookup(:aws_access_key_id),
-          secret_access_key: lookup(:aws_secret_access_key),
+          access_key_id:     lookup!(:aws_access_key_id),
+          secret_access_key: lookup!(:aws_secret_access_key),
           region:            lookup!(:aws_region)
         }.merge(s3_storage_options))
       else


### PR DESCRIPTION
Debugging puma problems, was a failure here that wasn't as obvious to debug as it could have been. This way it will actually prevent deploy with a raise on deploy