### PR TITLE
move dependency only used by capistrano to development group with capistrano itself

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -142,6 +142,8 @@ group :test do
   gem "database_cleaner", "~> 1.7"
   gem "webmock", "~> 3.5"
   gem "db-query-matchers", "< 2.0"
+  # Used for Cap deployment to auto-lookup hosts from EC2 tags.
+  gem 'aws-sdk-ec2', '>=1.74'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
@@ -149,10 +151,6 @@ end
 # gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 
-# Used for Cap deployment
-gem 'aws-sdk-ec2', '>=1.74'
-#gem 'aws-sdk-core'
-gem 'aws-sdk-core'
 
 
 ##

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -632,7 +632,6 @@ PLATFORMS
 DEPENDENCIES
   access-granted (~> 1.0)
   activerecord-postgres_enum (~> 1.3)
-  aws-sdk-core
   aws-sdk-ec2 (>= 1.74)
   blacklight (~> 7.7.0)
   blacklight_range_limit (~> 7.0)


### PR DESCRIPTION
May save some memory in production, as aws-sdk-ec2 is kind of a memory hog when loaded, and bundler loads automatically if mentioned:x