### PR TITLE
specific config for puma in heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,3 @@
+# This specifies what dyno types (worker VMs) are set up for heroku
+
+web: bundle exec puma -C config/heroku_puma.rb

--- a/config/heroku_puma.rb
+++ b/config/heroku_puma.rb
@@ -1,0 +1,21 @@
+# Heroku-recommende configuration from
+# https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#config
+#
+# By default will be creating 2 puma processes, each with 5 thread workers, so 10 workers total.
+# Setting heroku config vars can tune these.
+
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
+threads threads_count, threads_count
+
+preload_app!
+
+rackup      DefaultRackup
+port        ENV['PORT']     || 3000
+environment ENV['RACK_ENV'] || 'development'
+
+on_worker_boot do
+  # Worker specific setup for Rails 4.1+
+  # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
+  ActiveRecord::Base.establish_connection
+end

--- a/config/heroku_puma.rb
+++ b/config/heroku_puma.rb
@@ -1,10 +1,11 @@
 # Heroku-recommende configuration from
 # https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#config
 #
-# By default will be creating 2 puma processes, each with 5 thread workers, so 10 workers total.
+# By default without setting heroku config this will create **1** puma processes, with 5 threads. (1
+# worker is all that fits for our app in a small heroku dyno?)
 # Setting heroku config vars can tune these.
 
-workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+workers Integer(ENV['WEB_CONCURRENCY'] || 1)
 threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
 threads threads_count, threads_count
 


### PR DESCRIPTION
from https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server

These files shouldn't effect existing non-heroku environments, we just have a Procfile telling heroku we want it to start our web dynos with puma, with a specific config file we've also added for this purpose.

Originally we tried telling puma to default to 2 workers with 5 threads each -- that was overwhelming heroku. This one for now says 1 worker with 5 threads. Can be adjusted without code change by heroku config/env change. We are investigating performance/resource characteristics still; things are looking a bit problematic.