### PR TITLE
More careful abolute path to load .ruby-version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Include just the major/minor version of whatever we find in .ruby-version,
 # ie `~> 2.5` or `~> 2.6`, not including additional that may be in 2.3
-ruby "~> #{File.read('.ruby-version').chomp.split('.').slice(0,3).join('.')}"
+ruby "~> #{File.read(File.join(__dir__ , '.ruby-version')).chomp.split('.').slice(0,3).join('.')}"
+
 
 gem 'lockbox'
 


### PR DESCRIPTION
Our Gemfile is dynamically loading the local .ruby-version file and doing a bit of trivial parsing of it's contents to supply a `ruby` decleration in Gemfile.

To load .ruby-version, it was supplying a relative path assuming that the current working directory was app root. This seems a safe assumption, but for some reason it was failing in a weird edge case involving passenger on heroku. Without debugging exactly what was going on -- it doesn't hurt to be more specific, using the ruby special variable `__dir__` (directory of current source file) to construct an absolute path to `.ruby-version` in the same directory. Less sloppy, more careful, resolves our weird problem with passenger on heroku.