### PR TITLE
Avoid double fetch of all work members

### DIFF
--- a/app/decorators/oh_audio_work_show_decorator.rb
+++ b/app/decorators/oh_audio_work_show_decorator.rb
@@ -11,7 +11,8 @@ class OhAudioWorkShowDecorator < Draper::Decorator
 
 
 
-  # The list of tracks for the playlist.
+  # Cache the total list of published members, in other methods we'll search
+  # through this in-memory to get members for various spots on the page.
   def all_members
     @all_members ||= begin
       members = model.members.includes(:leaf_representative)
@@ -21,12 +22,12 @@ class OhAudioWorkShowDecorator < Draper::Decorator
   end
 
   # We don't want the leaf_representative, we want the direct representative member
-  # to pass to MemberImagePresenter. But instead of following the `representative`
-  # association, let's find it from the `members`, to avoid an extra fetch.
-  #
-  # Does assume your representative is one of your members, otherwise it won't find it.
+  # to pass to MemberImagePresenter.
   def representative_member
-    @representative_member ||= model.members.find { |m| m.id == model.representative_id }
+    # memoize with a value that could be nil....
+    return @representative_member if defined?(@representative_member)
+
+    @representative_member = all_members.find { |m| m.id == model.representative_id }
   end
 
   def audio_members

--- a/app/decorators/work_show_decorator.rb
+++ b/app/decorators/work_show_decorator.rb
@@ -24,11 +24,12 @@ class WorkShowDecorator < Draper::Decorator
   end
 
   # We don't want the leaf_representative, we want the direct representative member
-  # to pass to MemberImagePresenter. But instead of following the `representative`
-  # association, let's find it from the `members`, to avoid an extra fetch.
-  #
-  # Does assume your represnetative is one of your members, otherwise it won't find it.
+  # to pass to MemberImagePresenter. This will be an additional SQL fetch to
+  # member_list_for_display, but a small targetted one-result one.
   def representative_member
-    @representative_member ||= model.members.find { |m| m.id == model.representative_id }
+    # memoize with a value that could be nil....
+    return @representative_member if defined?(@representative_member)
+
+    @representative_member = model.representative
   end
 end


### PR DESCRIPTION
What had been intended as an optimization ended up a de-optimization!

No new tests, instead refactor with preserved behavior all tests still passing.

This is worth understanding what's going on, to avoid making a similar mistake (this one was my mistake!). Happy to discuss it if needed.

This was found in exploring why so much memory for heroku; this was PART of it, but isn't a solution or anything.

The #representative_member method was fetching ALL members, and then filtering through it in-memory to find the representative member. Originally the author (uh me) thought this wouldn't be a double-fetch, because #members would already be in memory. But the implementation of #member_list_for_display was changed so it didn't actually load #members. And then the result was we ended up fetching ALL members (could be hundreds of items) TWICE.  This was way WORSE than if we had just used the existing #representative association to fetch the SINGLE representative object.

While there would be a way to actually do it in one fetch -- fetch all members, then split them into "represnetative" and "all but representative" -- instead we do a smaller refactor to just use the #representative association. This is good enough! By trying to be clever, we opened ourselves up to a bug that made it worse. Let's not be clever.

Here we actually can more easily avoid two fetches, fine, we will. While most importantly still avoiding a second fetch of ALL members to filter in-memory to find representative.