### PR TITLE
Revert "Merge pull request #889 from sciencehistory/avoid_double_members_fetch"

### DIFF
--- a/app/decorators/oh_audio_work_show_decorator.rb
+++ b/app/decorators/oh_audio_work_show_decorator.rb
@@ -11,8 +11,7 @@ class OhAudioWorkShowDecorator < Draper::Decorator
 
 
 
-  # Cache the total list of published members, in other methods we'll search
-  # through this in-memory to get members for various spots on the page.
+  # The list of tracks for the playlist.
   def all_members
     @all_members ||= begin
       members = model.members.includes(:leaf_representative)
@@ -22,12 +21,12 @@ class OhAudioWorkShowDecorator < Draper::Decorator
   end
 
   # We don't want the leaf_representative, we want the direct representative member
-  # to pass to MemberImagePresenter.
+  # to pass to MemberImagePresenter. But instead of following the `representative`
+  # association, let's find it from the `members`, to avoid an extra fetch.
+  #
+  # Does assume your representative is one of your members, otherwise it won't find it.
   def representative_member
-    # memoize with a value that could be nil....
-    return @representative_member if defined?(@representative_member)
-
-    @representative_member = all_members.find { |m| m.id == model.representative_id }
+    @representative_member ||= model.members.find { |m| m.id == model.representative_id }
   end
 
   def audio_members

--- a/app/decorators/work_show_decorator.rb
+++ b/app/decorators/work_show_decorator.rb
@@ -24,12 +24,11 @@ class WorkShowDecorator < Draper::Decorator
   end
 
   # We don't want the leaf_representative, we want the direct representative member
-  # to pass to MemberImagePresenter. This will be an additional SQL fetch to
-  # member_list_for_display, but a small targetted one-result one.
+  # to pass to MemberImagePresenter. But instead of following the `representative`
+  # association, let's find it from the `members`, to avoid an extra fetch.
+  #
+  # Does assume your represnetative is one of your members, otherwise it won't find it.
   def representative_member
-    # memoize with a value that could be nil....
-    return @representative_member if defined?(@representative_member)
-
-    @representative_member = model.representative
+    @representative_member ||= model.members.find { |m| m.id == model.representative_id }
   end
 end


### PR DESCRIPTION
This ended up causing performance problems of it's own, mainly triggering:

```
Calling Work#member_content_types without pre-loading members => leaf_representative may be dangerous to performance
  CACHE Kithe::Model Load (0.0ms)  SELECT "kithe_models".* FROM "kithe_models" WHERE "kithe_models"."id" = $1 LIMIT $2  [["id", "bf0d487e-fb6a-4375-b977-25f89a85e584"], ["LIMIT", 1]]
  ↳ app/models/work.rb:157:in `block in member_content_types'
  CACHE Kithe::Model Load (0.0ms)  SELECT "kithe_models".* FROM "kithe_models" WHERE "kithe_models"."id" = $1 LIMIT $2  [["id", "ba213170-6783-4955-87fc-b22661a6f72c"], ["LIMIT", 1]]
  ↳ app/models/work.rb:157:in `block in member_content_types'
  CACHE Kithe::Model Load (0.0ms)  SELECT "kithe_models".* FROM "kithe_models" WHERE "kithe_models"."id" = $1 LIMIT $2  [["id", "ba23681a-bb11-4d64-9dd5-55673919d517"], ["LIMIT", 1]]
  ↳ app/models/work.rb:157:in `block in member_content_types'
  CACHE Kithe::Model Load (0.0ms)  SELECT "kithe_models".* FROM "kithe_models" WHERE "kithe_models"."id" = $1 LIMIT $2  [["id", "15037510-f2ad-4c16-92cc-5e764d3e4a18"], ["LIMIT", 1]]
  ↳ app/models/work.rb:157:in `block in member_content_types'

[…]
```

I'll have to spend more time with this. Avoiding n+1 fetches or extra fetches with ActiveRecord can be tricky. 

This reverts commit 60d2d6a1d929d047bcffbec72667f8600707f44d, reversing
changes made to 11f1399d14fc0ba893d257982919f34c3af6eb49.