### PR TITLE
Avoid expensive/extra loading of #members association on standard Work show page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -145,6 +145,8 @@ group :test do
   gem "db-query-matchers", "< 2.0"
   # Used for Cap deployment to auto-lookup hosts from EC2 tags.
   gem 'aws-sdk-ec2', '>=1.74'
+
+  gem 'rails-controller-testing'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -423,6 +423,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 6.0.3.3)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -673,6 +677,7 @@ DEPENDENCIES
   puma (~> 4.3)
   qa (~> 5.2)
   rails (~> 6.0.0)
+  rails-controller-testing
   rails_autolink (~> 1.0)
   ransack (~> 2.1)
   resque (~> 2.0)

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -132,30 +132,61 @@ class Work < Kithe::Work
 
   # @returns [Array] of IANA/MIME content types from any members.
   #
-  # It will collect these by visiting each actual member, and then uniquing. Results are then
-  # _cached_, so subsequent calls will _not_ reflect any changes you've made to members or
-  # their content types -- unless you pass in `reset:false`.
+  # For children that are Works themselves, only includes the content-type of the single
+  # represnetative of that work, does not completely descend the hieararchy tree.
   #
-  # The Work model is a kind of architectural unfortunate place to put this, but it worked
-  # for being easily accessible from the DownloadDropdownDisplay, which is what this method
-  # is intended for. Multiple DownloadDropdownDisplays needed to get this value for the same
-  # work without re-calculating it. See https://github.com/sciencehistory/scihist_digicoll/pull/334
+  # This is something we need frequently, but is hard to do efficiently! This method provides
+  # two modes to do it, you need to choose the mode explicity.
   #
-  # Note that for this to be most performant, you have to have members => leaf_representatives
-  # eager-loaded, so it doesn't lead to an n+1 problem.
-  def member_content_types(reset: false)
-    @member_content_types = nil if reset
-    @member_content_types ||= begin
-      warned = false
+  # @option mode [Symbol], :query or :associaiton.
+  #
+  # :query will go to the database to execute a single relatievly efficient query to collect
+  # these. Great if you are doing it for a single Work, and does not require loading
+  # all #members and their #leaf_representatives into memory -- but would be an n+1 query
+  # problem if using this mode on a page of works.
+  #
+  # :association will do an in-memory scan of all #members and their #leaf_representatives.
+  # Find if you already have those associations in-memory, but will a terrible n+1
+  # (or even n^2+1) query if you don't. :association mode will actually raise a TypeError
+  # if you try using it WITHOUT associations pre-loaded, to avoid the dangerous mistake.
+  # That is, it wants you to have done: `Work.where(something).includes(members: :leaf_representative)`
+  #
+  # In either case, answer is memoized/cached on this Work instance, unless you call
+  # with `reset: true` to re-fetchc/re-calculate.
+  #
+  # This is kind of a complicated mess; and the Work model is kind of an architecturally
+  # unfortunate place to put this complicated mess, better to segregate in a decorator
+  # or something? But this worked for being easily accessible from the various places
+  # that needed it (and memoizing it in common), avoiding having to pass it down as
+  # an argument along a nested call-chain. Eg DownloadDropdownDisplay needs it.
+  def member_content_types(mode:, reset: false)
+    raise ArgumentError.new("mode must be :query or :association") unless [:query, :association].include?(mode)
 
-      members.collect do |member|
-        unless warned || member.association(:leaf_representative).loaded?
-          Rails.logger.warn("Calling Work#member_content_types without pre-loading members => leaf_representative may be dangerous to performance")
-          warned = true
+    if reset
+      @member_content_types = nil
+    end
+
+    @member_content_types ||= begin
+      if mode == :association
+        unless members.loaded?
+          raise TypeError.new("Calling member_content_types with mode: :association without pre-loaded members, performance problem")
         end
 
-        member.leaf_representative&.content_type
-      end.compact.uniq
+        members.collect do |member|
+          unless member.association(:leaf_representative).loaded?
+            raise TypeError.new("Calling member_content_types with mode: :association without pre-loaded members.leaf_representative, performance problem")
+          end
+
+          member.leaf_representative&.content_type
+        end.compact.uniq
+      else # mode == :query
+        self.members.
+          includes(:leaf_representative).
+          references(:leaf_representative).
+          pluck(Arel.sql("
+            DISTINCT leaf_representatives_kithe_models.file_data -> 'metadata' -> 'mime_type', kithe_models.file_data -> 'metadata' -> 'mime_type'"
+          )).flatten.compact.uniq
+      end
     end
   end
 
@@ -170,6 +201,11 @@ class Work < Kithe::Work
     @member_count = nil if reset
     @member_count ||= members.size
   end
+
+  # def members
+  #   byebug if $debugging
+  #   super
+  # end
 
   # We have enough checks for special treatment of oral history, it makes
   # sense to make a method to encapsulate it.

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -202,11 +202,6 @@ class Work < Kithe::Work
     @member_count ||= members.size
   end
 
-  # def members
-  #   byebug if $debugging
-  #   super
-  # end
-
   # We have enough checks for special treatment of oral history, it makes
   # sense to make a method to encapsulate it.
   def is_oral_history?

--- a/app/presenters/download_dropdown_display.rb
+++ b/app/presenters/download_dropdown_display.rb
@@ -234,7 +234,7 @@ class DownloadDropdownDisplay < ViewModel
   def has_work_download_options?
     display_parent_work &&
     display_parent_work.member_count > 1 &&
-    display_parent_work.member_content_types.all? {|t| t.start_with?("image/")}
+    display_parent_work.member_content_types(mode: :query).all? {|t| t.start_with?("image/")}
   end
 
   def whole_work_download_options

--- a/app/presenters/download_dropdown_display.rb
+++ b/app/presenters/download_dropdown_display.rb
@@ -181,7 +181,7 @@ class DownloadDropdownDisplay < ViewModel
     end
 
     if has_work_download_options?
-      elements << "<h3 class='dropdown-header'>Download all #{display_parent_work.members.length} images</h3>".html_safe
+      elements << "<h3 class='dropdown-header'>Download all #{display_parent_work.member_count} images</h3>".html_safe
       whole_work_download_options.each do |download_option|
         elements << format_download_option(download_option)
       end

--- a/app/presenters/work_show_info.rb
+++ b/app/presenters/work_show_info.rb
@@ -29,14 +29,8 @@ class WorkShowInfo < ViewModel
     )
   end
 
-  # Like chf_sufia, it only looks at content types from direct Asset children, it
-  # won't go down levels. That has been good enough.
   def humanized_content_types
-    @humanized_content_types ||= model.members.
-      find_all { |m| m.kind_of?(Asset) }.
-      map(&:content_type).
-      map { |a| ScihistDigicoll::Util.humanized_content_type(a) }.
-      uniq
+    @humanized_content_types ||= model.member_content_types(mode: :query).uniq.map { |a| ScihistDigicoll::Util.humanized_content_type(a) }
   end
 
   def related_urls_filtered

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -9,12 +9,13 @@ require 'rails_helper'
 RSpec.describe WorksController, type: :controller do
   context "smoke tests" do
     context "standard work" do
-      let(:work){ create(:public_work, :published, members: [create(:asset)]) }
+      render_views
+
+      let(:work){ create(:public_work, :published, members: [create(:asset_with_faked_file), create(:asset_with_faked_file)]) }
 
       before do
         work.representative = work.members.first
         work.save
-        allow(work.members.first).to receive(:content_type).and_return("audio/mpeg")
       end
 
 

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -13,15 +13,14 @@ RSpec.describe WorksController, type: :controller do
 
       let(:work){ create(:public_work, :published, members: [create(:asset_with_faked_file), create(:asset_with_faked_file)]) }
 
-      before do
-        work.representative = work.members.first
-        work.save
-      end
-
-
       it "shows the work as expected" do
         get :show, params: { id: work.friendlier_id }, as: :html
         expect(response.status).to eq(200)
+
+        # We don't intend to ever actually load work.members, instead doing
+        # special purpose stuff in the decorator. It's too easy to load too
+        # much. let's test to make sure we don't.
+        expect(assigns[:work].members.loaded?).to be(false)
       end
 
       it 'allows user to download RIS citation' do

--- a/spec/factories/work_factory.rb
+++ b/spec/factories/work_factory.rb
@@ -10,6 +10,13 @@ FactoryBot.define do
       ]
     end
 
+    # Automatically set a representative if needed and possible
+    after(:build) do |work|
+      if work.representative.nil? && work.members.loaded?
+        work.representative = work.members.first
+      end
+    end
+
     trait :published do
       published { true }
       department { "Library" }

--- a/spec/models/work/work_member_content_types_spec.rb
+++ b/spec/models/work/work_member_content_types_spec.rb
@@ -11,7 +11,38 @@ describe "Work#member_content_types" do
     ])
   end
 
-  it "finds" do
-    expect(work.member_content_types).to match(["image/tiff", "application/pdf", "audio/mpeg"])
+  describe "mode: :association" do
+    describe "pre-loaded" do
+      let(:preloaded_work) { Work.where(id: work.id).includes(members: :leaf_representative).first }
+      it "finds" do
+        expect(preloaded_work.member_content_types(mode: :association)).to match_array(["image/tiff", "application/pdf", "audio/mpeg"])
+      end
+    end
+
+    describe "none pre-loaded" do
+      let(:not_preloaded_work) { Work.where(id: work.id).first }
+
+      it "raises" do
+        expect {
+          not_preloaded_work.member_content_types(mode: :association)
+        }.to raise_error(TypeError)
+      end
+    end
+
+    describe "partially pre-loaded" do
+      let(:partially_preloaded_work) { Work.where(id: work.id).includes(:members).first }
+
+      it "raises" do
+        expect {
+          partially_preloaded_work.member_content_types(mode: :association)
+        }.to raise_error(TypeError)
+      end
+    end
+  end
+
+  describe "mode: :query" do
+    it "finds" do
+      expect(work.member_content_types(mode: :query)).to match_array(["image/tiff", "application/pdf", "audio/mpeg"])
+    end
   end
 end

--- a/spec/models/work/work_member_content_types_spec.rb
+++ b/spec/models/work/work_member_content_types_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+# in a separate spec file because we likely want to extract to kithe
+describe "Work#member_content_types" do
+  let(:work) do
+    create(:work, members: [
+      create(:asset_with_faked_file, faked_content_type: "image/tiff"),
+      create(:asset_with_faked_file, faked_content_type: "application/pdf"),
+      create(:work, members: [create(:asset_with_faked_file, faked_content_type: "audio/mpeg")]),
+      create(:work, members: [create(:asset_with_faked_file, faked_content_type: "image/tiff")]),
+    ])
+  end
+
+  it "finds" do
+    expect(work.member_content_types).to match(["image/tiff", "application/pdf", "audio/mpeg"])
+  end
+end


### PR DESCRIPTION
When dealing with works that can have hundreds of memberes, loading all #members can be expensive. Worse is doing it more than once, or doing it in a way that causes an "n+1 query" problem, with an extra SQL query per member. We had two main problems/categories of problem discovered here:

1. To actually load the members for display, WorkShowDecorator#member_list_for_display constructs a query with SQL WHERE limits and ORDER BY clause, that does NOT end up memoized/cached in #members. So any subsequent calls to `work#members` will end up loading all members AGAIN a second time. It was expensive enough the first time, we don't want to do this. In most cases we want to replace it by a targetted SQL query getting the aggregate info we wanted -- since it's a work#show page, we can do one query per main work displayed -- there's only one main work displayed. Doing a few queries to get a few different pieces of info is okay, and better than loading #members to do it in-memory. 

2. One thing we want in a couple places is the mime types of all members. This is tricky to get! The previous implementation of work#member_content_types loaded #members and then looked at them in-memory to calculate. In some cases, if members hadn't been pre-loaded properly, this would result in an n+1 query problem. The previous implementation recognized that, and printed a warning to logs -- but we never noticed that, it was deployed to production with the warning!  The new implementation won't just warn, it will raise refusing to do it. BUT ALSO provides a different mode, where instead of looking at #members in-memory, it actually goes to database with another query. Either could be disastrously expensive depending on circumstances; the caller needs to decide which mode they want.  (Ref #895)


This is all a bit hacky, and I do worry it's easy to have a performance regression where it gets slow again when we write new code. But it's just part of how it goes I think. We also put a check in a controller spec that ensures work#members actually was NOT loaded! Can protect against some things, but not everything. 

Some attempt at measuring what effect this has on performance coming in a comment.

