### PR TITLE
Switch to puma5, and use some experimental features in puma5 that may reduce memory use

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "draper", "~> 4.0", ">= 4.0.1" # "decorators", which we use as view models
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
 # Use Puma as the app server
-gem 'puma', '~> 4.3'
+gem 'puma', '~> 5.0'
 
 # resque+redis being used for activejob, maybe later for Rails.cache
 # resque-pool currently does not support resque 2.0 alas.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -390,7 +390,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.6)
-    puma (4.3.5)
+    puma (5.0.2)
       nio4r (~> 2.0)
     qa (5.4.0)
       activerecord-import
@@ -674,7 +674,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   prawn (~> 2.2)
   pry-byebug
-  puma (~> 4.3)
+  puma (~> 5.0)
   qa (~> 5.2)
   rails (~> 6.0.0)
   rails-controller-testing

--- a/config/heroku_puma.rb
+++ b/config/heroku_puma.rb
@@ -11,6 +11,7 @@ threads threads_count, threads_count
 
 # https://github.com/puma/puma/blob/master/5.0-Upgrade.md
 nakayoshi_fork
+fork_worker
 
 preload_app!
 

--- a/config/heroku_puma.rb
+++ b/config/heroku_puma.rb
@@ -9,6 +9,9 @@ workers Integer(ENV['WEB_CONCURRENCY'] || 1)
 threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
 threads threads_count, threads_count
 
+# https://github.com/puma/puma/blob/master/5.0-Upgrade.md
+nakayoshi_fork
+
 preload_app!
 
 rackup      DefaultRackup


### PR DESCRIPTION
We don't currently deploy to production with puma. This will upgrade puma used in dev, but probably won't matter. Mainly we are doing this for heroku testing, the experimental puma5 features are only enabled in the config we use with heroku.