### PR TITLE
New default "from" email address

### DIFF
--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -383,6 +383,8 @@ module ScihistDigicoll
 
     # From address:
     define_key :no_reply_email_address, default: "no-reply@sciencehistory.org"
+    define_key :digital_collections_email_address, default: "digital@sciencehistory.org"
+
     # To addresses (these are email lists maintained by IT.)
     define_key :digital_tech_email_address, default: "digital-tech@sciencehistory.org"
     define_key :digital_email_address, default: "digital@sciencehistory.org"

--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -383,7 +383,6 @@ module ScihistDigicoll
 
     # From address:
     define_key :no_reply_email_address, default: "no-reply@sciencehistory.org"
-    define_key :digital_collections_email_address, default: "digital@sciencehistory.org"
 
     # To addresses (these are email lists maintained by IT.)
     define_key :digital_tech_email_address, default: "digital-tech@sciencehistory.org"

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,10 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
   default from: ScihistDigicoll::Env.lookup!(:digital_email_address)
   layout 'mailer'
-
-
-  def hostname
-    ScihistDigicoll::Env.lookup!(:app_url_base)
-  end
-
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: (ScihistDigicoll::Env.lookup(:no_reply_email_address) || "from@example.com")
+  default from: (ScihistDigicoll::Env.lookup(:digital_collections_email_address) || "from@example.com")
   layout 'mailer'
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,10 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: (ScihistDigicoll::Env.lookup(:digital_collections_email_address) || "from@example.com")
+  default from: ScihistDigicoll::Env.lookup!(:digital_email_address)
   layout 'mailer'
+
+
+  def hostname
+    ScihistDigicoll::Env.lookup!(:app_url_base)
+  end
+
 end

--- a/app/mailers/derivative_storage_type_audit_mailer.rb
+++ b/app/mailers/derivative_storage_type_audit_mailer.rb
@@ -20,8 +20,4 @@ class DerivativeStorageTypeAuditMailer < ApplicationMailer
     )
   end
 
-
-  def hostname
-    ScihistDigicoll::Env.lookup!(:app_url_base)
-  end
 end

--- a/app/mailers/derivative_storage_type_audit_mailer.rb
+++ b/app/mailers/derivative_storage_type_audit_mailer.rb
@@ -20,4 +20,8 @@ class DerivativeStorageTypeAuditMailer < ApplicationMailer
     )
   end
 
+
+  def hostname
+    ScihistDigicoll::Env.lookup!(:app_url_base)
+  end
 end

--- a/app/mailers/derivative_storage_type_audit_mailer.rb
+++ b/app/mailers/derivative_storage_type_audit_mailer.rb
@@ -4,18 +4,16 @@ class DerivativeStorageTypeAuditMailer < ApplicationMailer
     raise ArgumentError.new("Required params[:asset_derivative_storage_type_auditor] missing") unless params[:asset_derivative_storage_type_auditor]
     @auditor = params[:asset_derivative_storage_type_auditor]
 
-    from_address = ScihistDigicoll::Env.lookup(:no_reply_email_address)
     to_address = [
         ScihistDigicoll::Env.lookup(:digital_tech_email_address),
         ScihistDigicoll::Env.lookup(:digital_email_address)
       ].compact.join(',')
 
-    unless from_address.present? && to_address.present?
-      raise RuntimeError, 'Cannot send fixity error email; specify at least a "from" and a "to" address.'
+    unless to_address.present?
+      raise RuntimeError, 'Cannot send fixity error email; specify a "to" address.'
     end
 
     mail(
-      from:         from_address,
       to:           to_address,
       subject:      "Digital Collections Warning: #{hostname}: Assets with unexpected derivative_storage_type state found",
       content_type: "text/html",

--- a/app/mailers/fixity_failure_mailer.rb
+++ b/app/mailers/fixity_failure_mailer.rb
@@ -13,6 +13,7 @@ class FixityFailureMailer < ApplicationMailer
     unless to_address.present?
       raise RuntimeError, 'Cannot send fixity error email; specify a "to" address.'
     end
+
     mail(
       to:           to_address,
       subject:      subject,
@@ -22,10 +23,6 @@ class FixityFailureMailer < ApplicationMailer
 
   def subject
     "FIXITY CHECK FAILURE: #{ScihistDigicoll::Env.lookup!(:app_url_base)}, \"#{@asset.title}\" (asset #{@asset.friendlier_id})"
-  end
-
-  def hostname
-    ScihistDigicoll::Env.lookup!(:app_url_base)
   end
 
   def date

--- a/app/mailers/fixity_failure_mailer.rb
+++ b/app/mailers/fixity_failure_mailer.rb
@@ -25,6 +25,10 @@ class FixityFailureMailer < ApplicationMailer
     "FIXITY CHECK FAILURE: #{ScihistDigicoll::Env.lookup!(:app_url_base)}, \"#{@asset.title}\" (asset #{@asset.friendlier_id})"
   end
 
+  def hostname
+    ScihistDigicoll::Env.lookup!(:app_url_base)
+  end
+
   def date
     I18n.l @fixity_check.created_at, format: :admin
   end

--- a/app/mailers/fixity_failure_mailer.rb
+++ b/app/mailers/fixity_failure_mailer.rb
@@ -10,8 +10,8 @@ class FixityFailureMailer < ApplicationMailer
         ScihistDigicoll::Env.lookup(:digital_email_address)
       ].compact.join(',')
 
-    unless from_address.present? && to_address.present?
-      raise RuntimeError, 'Cannot send fixity error email; specify at least a "from" and a "to" address.'
+    unless to_address.present?
+      raise RuntimeError, 'Cannot send fixity error email; specify a "to" address.'
     end
     mail(
       to:           to_address,

--- a/app/mailers/fixity_failure_mailer.rb
+++ b/app/mailers/fixity_failure_mailer.rb
@@ -5,7 +5,6 @@ class FixityFailureMailer < ApplicationMailer
     raise ArgumentError.new("Required params[:fixity_check] missing") unless params[:fixity_check]
     @fixity_check = params[:fixity_check]
     @asset = @fixity_check.asset
-    from_address = ScihistDigicoll::Env.lookup(:no_reply_email_address)
     to_address = [
         ScihistDigicoll::Env.lookup(:digital_tech_email_address),
         ScihistDigicoll::Env.lookup(:digital_email_address)
@@ -15,7 +14,6 @@ class FixityFailureMailer < ApplicationMailer
       raise RuntimeError, 'Cannot send fixity error email; specify at least a "from" and a "to" address.'
     end
     mail(
-      from:         from_address,
       to:           to_address,
       subject:      subject,
       content_type: "text/html",


### PR DESCRIPTION
Suggested by jrochkind; I'm popping this feature out into its own PR so we can deal with it separately.

This PR has any and all email addresses specified in env.rb, and one of them (the one we want, `digital_collections_email_address`) is set as the default in the application_mailer.rb file.

_Furthermore_, even if we were to *not* set the default in env.rb, `application_mailer.rb` would still default to "from@example.com", so I feel we can simplify the three (soon to be 4) outgoing mailers' code. They no longer specify the "from" value at all, and thus default to what's set in `application_mailer.rb`.