### PR TITLE
Reduce view render logging we consider excessive, in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -128,6 +128,12 @@ Rails.application.configure do
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
 
+  # Turn off all action_view logging in production, to give us cleaner more readable
+  # logs. Turns off lines such as:
+  #     Rendering works/index.html.erb within layouts/application
+  #     Rendered works/index.html.erb within layouts/application (2.0ms)
+  config.action_view.logger = nil
+
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 


### PR DESCRIPTION
As I try to monitor the app in heroku, I am finding current logs pretty hard to deal with due to excessive verbosity. A more drastic change to logging could be taken ala #656, but without wanting to take time to figure that out and configure it, for now we can just turn off view/render logging (which is also part of what lograge or semantic_logs would do), which will get us a lot of the way there to less awful logs, or at least we can see how far it gets us.