### PR TITLE
Revert "Reduce view render logging we consider excessive, in production"

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -128,12 +128,6 @@ Rails.application.configure do
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
 
-  # Turn off all action_view logging in production, to give us cleaner more readable
-  # logs. Turns off lines such as:
-  #     Rendering works/index.html.erb within layouts/application
-  #     Rendered works/index.html.erb within layouts/application (2.0ms)
-  config.action_view.logger = nil
-
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 


### PR DESCRIPTION
This reverts commit 3fefd46eeb457a2d278b5d31690b2c294514a42e.

This caused a problem for us, https://github.com/projectblacklight/blacklight/issues/2379