### PR TITLE
Allow config variable to bypass automatic SOLR indexing on callbacks

### DIFF
--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -179,7 +179,7 @@ module ScihistDigicoll
       # production we have no default, local env has to supply it
     }
 
-    define_key :solr_indexing, default: true
+    define_key :solr_indexing, default: "true"
 
     # Supplied only on production servers, should have form 'UA-XXXXX-Y'
     define_key :google_analytics_property_id

--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -179,6 +179,8 @@ module ScihistDigicoll
       # production we have no default, local env has to supply it
     }
 
+    define_key :solr_indexing, default: true
+
     # Supplied only on production servers, should have form 'UA-XXXXX-Y'
     define_key :google_analytics_property_id
 

--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -179,6 +179,9 @@ module ScihistDigicoll
       # production we have no default, local env has to supply it
     }
 
+    # If false, we will NOT write to solr on changes to Works/Collections/Assets.
+    # Useful for when solr is not present in a testing/staging environment, and we
+    # want to make it still possible to do admin work.
     define_key :solr_indexing, default: "true"
 
     # Supplied only on production servers, should have form 'UA-XXXXX-Y'

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -5,7 +5,9 @@
 # automatically deletes the thumb (which automatically deletes the stored file)
 class Collection < Kithe::Collection
   # automatic Solr indexing on save
-  self.kithe_indexable_mapper = CollectionIndexer.new
+  if ScihistDigicoll::Env.lookup(:solr_indexing) == 'true'
+    self.kithe_indexable_mapper = CollectionIndexer.new
+  end
 
   validates :related_url, array_inclusion: {
     proc: ->(v) { ScihistDigicoll::Util.valid_url?(v) } ,

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1,7 +1,9 @@
 class Work < Kithe::Work
   # will trigger automatic solr indexing in callbacks
-  self.kithe_indexable_mapper = WorkIndexer.new
 
+  if ScihistDigicoll::Env.lookup(:solr_indexing) == 'true'
+    self.kithe_indexable_mapper = WorkIndexer.new
+  end
 
   belongs_to :digitization_queue_item, optional: true, class_name: "Admin::DigitizationQueueItem"
 


### PR DESCRIPTION
For testing Heroku background jobs even without SOLR present.