### PR TITLE
Look in more places for redis connection info, including ENV set by heroku redis

### DIFF
--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,1 +1,1 @@
-Resque.redis = ScihistDigicoll::Env.lookup!(:persistent_redis_host)
+Resque.redis = ScihistDigicoll::Env.persistent_redis_connection!


### PR DESCRIPTION
Also properly set up SSL redis connection on heroku per heroku instructions, somewhat outdated info at: https://devcenter.heroku.com/articles/securing-heroku-redis

Backwards compatible with existing EC2 deployment or dev -- the persistent_redis_host key takes priority if set (so should be unset on heroku), and if
heroku ENV isn't set either, still defaults to redis default in dev as before.