### PR TITLE
GH Actions CI, try apt update before apt-get

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
 
         - name: Install apt dependencies
           run: |
+            sudo apt-get update
             sudo apt-get -y install libvips-tools ffmpeg mediainfo
 
         - name: Set up app


### PR DESCRIPTION
Builds were failing trying to install libpulse0, one of the dependencies of the things we tried to install with apt-get. Don't know why it used to work and stopped.

But googling the error got us to this:
https://github.community/t/libpulse0-fails-to-fetch-with-apt-repo-broken/18214/3

Which suggested you use `apt update` first. So we do that, except the `apt-get update` variant, cause we're using `apt-get`. Phew.