### PR TITLE
let reserved resque workers work on other queues when otherwise idle

### DIFF
--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -5,12 +5,12 @@ production:
 
   # "default" queue is mostly ingest-related at present.
 
-  # Prioritize mailers and default, but if you're free it's okay to work on on_demand_derivatives.
-  # Usually more of these than the on_demand_job_worker_count, to make ingest work take priority
-  # if contested.
-  "mailers,default,on_demand_derivatives": <%= ScihistDigicoll::Env.lookup!(:regular_job_worker_count) %>
+  # These will only work on  mailers and default.
+  "mailers,default": <%= ScihistDigicoll::Env.lookup!(:regular_job_worker_count) %>
 
   # Prioritize on_demand_derivatives, but if you're free it's okay to work on mailers and default.
+  # We keep this small though, cause right now on_demand_derivatives jobs can take up a lot
+  # of RAM, we can't afford too many of them at once (depending on particular host size)
   "on_demand_derivatives,mailers,default": <%= ScihistDigicoll::Env.lookup!(:on_demand_job_worker_count)%>
 
   # usually 0 workers, can be used for special temporary purposes.

--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -2,8 +2,19 @@ production:
   # Note: these three settings are
   # *always* defined, with zero as the default.
   # Hence, OK to use lookup!
-  "mailers,default": <%= ScihistDigicoll::Env.lookup!(:regular_job_worker_count) %>
-  "on_demand_derivatives": <%= ScihistDigicoll::Env.lookup!(:on_demand_job_worker_count)%>
+
+  # "default" queue is mostly ingest-related at present.
+
+  # Prioritize mailers and default, but if you're free it's okay to work on on_demand_derivatives.
+  # Usually more of these than the on_demand_job_worker_count, to make ingest work take priority
+  # if contested.
+  "mailers,default,on_demand_derivatives": <%= ScihistDigicoll::Env.lookup!(:regular_job_worker_count) %>
+
+  # Prioritize on_demand_derivatives, but if you're free it's okay to work on mailers and default.
+  "on_demand_derivatives,mailers,default": <%= ScihistDigicoll::Env.lookup!(:on_demand_job_worker_count)%>
+
+  # usually 0 workers, can be used for special temporary purposes.
   "special_jobs": <%= ScihistDigicoll::Env.lookup!(:special_job_worker_count)%>
+
 development:
   "*": 5


### PR DESCRIPTION
Right now in deployment we have 10 workers (regular_job_worker_count) that work ONLY on mailers, default queues, and if those are empty just sit idle.

Then we have 2 workers (on_demand_job_worker_count) that work ONLY on on_demand_derivatives queue, and sit idle if it's empty.

Instead, let's have the regular_job_worker_count willing to work on on_demand_derivatives if otherwise idle -- the resque config means it'll only work on this queue if the ones that are it's higher priority are empty.

And likewise the on_demand_job_worker_count workers should be willing to work on mailers,default if otherwise idle.

If we made this hccange without changing worker counts, we might exceed RAM or other resources, so after this change, we should edit ansible for local_env.yml to make regular_job_worker_count 8 (instead of 10), leaving on_demand_job_worker_count 2. Most of the time there is no on_demand_derivatives work, so we still will usually have 10 workers available for ingest. But in some cases if there's lots of on_demand_derivatives work, there may only be 8.

Overall, this makes more sense -- but it's especially needed on heroku, where we have smaller machines that have less RAM available for workers. A standard-2x dyno can fit 3 workers, so now we can give each one 2 workers that will prioritize default,mailers, and 1 that will prioritize on_demand_derivatives, but without them sitting there idle if their prioritized queues are empty.