### PR TITLE
Tools for syncing our local solr config files to a solr cloud instance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,9 @@ gem 'font-awesome-rails', '~> 4.7'
 # intend to merge to master like this.
 gem 'kithe', ">= 2.0.0.beta", "< 3", git: "https://github.com/sciencehistory/kithe.git"
 
+# temporarily using master traject
+gem "traject", github: "traject/traject"
+
 gem 'simple_form', "~> 5.0"
 gem "cocoon"
 

--- a/Gemfile
+++ b/Gemfile
@@ -71,9 +71,7 @@ gem 'font-awesome-rails', '~> 4.7'
 # temporary kithe indexing branch, for scihist_digicoll indexing branch, do not
 # intend to merge to master like this.
 gem 'kithe', ">= 2.0.0.beta", "< 3", git: "https://github.com/sciencehistory/kithe.git"
-
-# temporarily using master traject
-gem "traject", github: "traject/traject"
+gem "traject", ">= 3.5" # to include support for HTTP basic auth in Solr url
 
 gem 'simple_form', "~> 5.0"
 gem "cocoon"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,22 +18,6 @@ GIT
       traject (~> 3.0, >= 3.1.0.rc1)
       tty-command (>= 0.8.2, < 2)
 
-GIT
-  remote: https://github.com/traject/traject.git
-  revision: 9a9bea4d2dce47da2a53686c197319a199dd4a96
-  specs:
-    traject (3.4.0)
-      concurrent-ruby (>= 0.8.0)
-      dot-properties (>= 0.1.1)
-      hashie (>= 3.1, < 5)
-      http (>= 3.0, < 5)
-      httpclient (~> 2.5)
-      marc (~> 1.0)
-      marc-fastxmlwriter (~> 1.0)
-      nokogiri (~> 1.9)
-      slop (~> 4.0)
-      yell
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -582,6 +566,17 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
+    traject (3.5.0)
+      concurrent-ruby (>= 0.8.0)
+      dot-properties (>= 0.1.1)
+      hashie (>= 3.1, < 5)
+      http (>= 3.0, < 5)
+      httpclient (~> 2.5)
+      marc (~> 1.0)
+      marc-fastxmlwriter (~> 1.0)
+      nokogiri (~> 1.9)
+      slop (~> 4.0)
+      yell
     ttfunk (1.6.2.1)
     tty-color (0.6.0)
     tty-command (0.10.0)
@@ -697,7 +692,7 @@ DEPENDENCIES
   solr_wrapper (~> 2.1)
   sprockets (~> 4.0)
   sprockets-rails (>= 2.3.2)
-  traject!
+  traject (>= 3.5)
   uglifier (>= 1.3.0)
   uppy-s3_multipart
   web-console (>= 3.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,22 @@ GIT
       traject (~> 3.0, >= 3.1.0.rc1)
       tty-command (>= 0.8.2, < 2)
 
+GIT
+  remote: https://github.com/traject/traject.git
+  revision: 9a9bea4d2dce47da2a53686c197319a199dd4a96
+  specs:
+    traject (3.4.0)
+      concurrent-ruby (>= 0.8.0)
+      dot-properties (>= 0.1.1)
+      hashie (>= 3.1, < 5)
+      http (>= 3.0, < 5)
+      httpclient (~> 2.5)
+      marc (~> 1.0)
+      marc-fastxmlwriter (~> 1.0)
+      nokogiri (~> 1.9)
+      slop (~> 4.0)
+      yell
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -547,7 +563,7 @@ GEM
       builder (~> 3.0)
     slackistrano (4.0.1)
       capistrano (>= 3.8.1)
-    slop (3.6.0)
+    slop (4.8.2)
     solr_wrapper (2.2.0)
       faraday
       retriable
@@ -566,17 +582,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    traject (3.4.0)
-      concurrent-ruby (>= 0.8.0)
-      dot-properties (>= 0.1.1)
-      hashie (>= 3.1, < 5)
-      http (>= 3.0, < 5)
-      httpclient (~> 2.5)
-      marc (~> 1.0)
-      marc-fastxmlwriter (~> 1.0)
-      nokogiri (~> 1.9)
-      slop (>= 3.4.5, < 4.0)
-      yell
     ttfunk (1.6.2.1)
     tty-color (0.6.0)
     tty-command (0.10.0)
@@ -692,6 +697,7 @@ DEPENDENCIES
   solr_wrapper (~> 2.1)
   sprockets (~> 4.0)
   sprockets-rails (>= 2.3.2)
+  traject!
   uglifier (>= 1.3.0)
   uppy-s3_multipart
   web-console (>= 3.3.0)

--- a/Procfile
+++ b/Procfile
@@ -3,3 +3,6 @@
 web: bundle exec puma -C config/heroku_puma.rb
 
 worker: bundle exec resque-pool
+
+# https://devcenter.heroku.com/articles/release-phase
+release: bundle exec rake db:migrate scihist:solr_cloud:sync_configset

--- a/app/lib/scihist_digicoll/env.rb
+++ b/app/lib/scihist_digicoll/env.rb
@@ -201,6 +201,10 @@ module ScihistDigicoll
       end
     }
 
+    # for legacy reasons this is a solr url WITH a collection name on the end, like
+    # https://example.org/solr/collection_name
+    #
+    # See also solr_base_url and solr_collection_name methods which give you the parts
     define_key :solr_url, default: ->{
       # Note the ports used in dev/test must match ports in .solr_wrapper
       # if you want testing to work right and dev instance to talk to solr-wrapper
@@ -212,6 +216,20 @@ module ScihistDigicoll
       end
       # production we have no default, local env has to supply it
     }
+
+    # config solr_url without collection_name, and without trailing slash
+    def self.solr_base_url
+      @solr_base_url ||= begin
+        parsed = URI.parse(lookup!(:solr_url))
+        parsed.path = parsed.path.gsub(%r{/solr/.*\Z}, "/solr")
+        parsed.to_s
+      end
+    end
+
+    # collection_name taken off the end of config solr_url
+    def self.solr_collection_name
+      @solr_collection_name ||= URI.parse(lookup!(:solr_url)).path.split("/").last
+    end
 
     # If false, we will NOT write to solr on changes to Works/Collections/Assets.
     # Useful for when solr is not present in a testing/staging environment, and we

--- a/app/services/solr_configset_updater.rb
+++ b/app/services/solr_configset_updater.rb
@@ -143,7 +143,7 @@ class SolrConfigsetUpdater
 
   # changes the configName for @collection_name using API
   # /admin/collections?action=MODIFYCOLLECTION&collection=<collection-name>&collection.configName=<newName>
-  def config_name=(new_config_name)
+  def change_config_name(new_config_name)
     http_response = http_client.get("#{solr_uri.to_s}/admin/collections?action=MODIFYCOLLECTION&collection=#{collection_name}&collection.configName=#{new_config_name}")
 
     unless http_response.status.success?
@@ -162,7 +162,7 @@ class SolrConfigsetUpdater
     new_name = configset_timestamp_name
 
     upload(configset_name: new_name)
-    self.config_name = new_name
+    change_config_name(new_name)
     reload
     delete(old_name)
   end
@@ -189,7 +189,7 @@ class SolrConfigsetUpdater
     end
 
     upload(configset_name: new_name)
-    self.config_name = new_name
+    change_config_name(new_name)
     reload
     delete(old_name)
 
@@ -223,20 +223,22 @@ class SolrConfigsetUpdater
     temp_name = "#{current_name}_temp"
 
     self.create(from: current_name, to: temp_name)
-    self.config_name = temp_name
+    self.change_config_name(temp_name)
     self.reload
     self.delete(current_name)
     self.upload(configset_name: current_name)
-    self.config_name = current_name
+    self.change_config_name(current_name)
     self.reload
     self.delete(temp_name)
   end
 
-  # renames a config set, changes collection to use new name, deletes old name.
+  # renames config set used by collection by: copying original configset name to
+  # new name; changing collection to use new name; reloading collection; removing
+  # configset at original name.
   def rename_config_name(to:)
     from = self.config_name
     self.create(from: from, to: to)
-    self.config_name = to
+    self.change_config_name(to)
     self.reload
     self.delete(from)
   end

--- a/app/services/solr_configset_updater.rb
+++ b/app/services/solr_configset_updater.rb
@@ -44,7 +44,7 @@ require 'http'
 # ## Collection API
 #
 #     updater.config_name # configset name set currently set for collection
-#     updater.update_config_name(new_name) # change config set collection uses
+#     updater.change_config_name(new_name) # change config set collection uses
 #     updater.reload # send reload to configured collection
 #     updater.create_collection(configset_name: name) # create a Solr collection using named config set
 #     updater.list_collections # list all collections in Solr instance

--- a/app/services/solr_configset_updater.rb
+++ b/app/services/solr_configset_updater.rb
@@ -1,0 +1,306 @@
+require 'zip'
+require 'http'
+
+# We have our solr configuration files at solr/config. We want to upload
+# the to a solr instance via solr cloud API's:
+#
+#     https://lucene.apache.org/solr/guide/7_4/configsets-api.html#configsets-upload
+#
+# Because prior to Solr 8.7 (released Nov 2020, which we don't have yet), there is no
+# way to overright an existing config-set, we need to do a weird dance to update
+# the config-set in-place without disturbing the existing Solr collections using it.
+# See:
+#
+#     https://dev.lucene.apache.narkive.com/HI7lTF0o/jira-created-solr-12925-configsets-api-should-allow-update-of-existing-configset
+#
+# Meanwhile, SearchStax docs and support encourage us to not use the standard Solr API's like
+# we are using here, but instead to use proprietary SearchStax API's like:
+#     https://www.searchstax.com/docs/staxapi2ZK/#zkcreate
+#
+# However, those proprietary SearchStax API's are actually a lot more painful to use, and
+# of course aren't transferable to non-SearchStax deploys; I can't figure out
+# any reason not to use the standard Solr API's.
+# SearchStax says their use won't be logged By SearchStax (that seems fine?), and that
+# they "aren't secure", but we can access them via the same HTTP Basic Auth credentials
+# we are using anyway (SearchStax solr account with "admin" level access), and they are
+# available there whether we use them or not, it doens't seem a security issue to use them.
+#
+# We are going to assume that the config_set name should match the collection name (Solr's conventional
+# default).
+#
+# https://lucene.apache.org/solr/guide/8_6/configsets-api.html
+# some parts of https://lucene.apache.org/solr/guide/8_6/collection-management.html#collection-management
+class SolrConfigsetUpdater
+  SOLR_CONF_DIRECTORY = "./solr/config"
+
+  attr_reader :collection_name, :conf_dir, :solr_uri, :solr_basic_auth_user, :solr_basic_auth_pass
+
+  # @param solr_url [String] Should be a Solr url ending in /solr, eg
+  #   `https://user:pass@example.org:1234/solr`. As you can see, can optionally
+  #   include user/pass in URI.
+  def initialize(collection_name:, solr_url:, conf_dir: SOLR_CONF_DIRECTORY)
+    @collection_name = collection_name
+    @conf_dir = conf_dir.to_s
+    @solr_uri = URI.parse(solr_url.chomp("/"))
+
+    # take out basic auth user and password into their own variable
+    if @solr_uri.user || @solr_uri.password
+      @solr_basic_auth_user, @solr_basic_auth_pass = @solr_uri.user, @solr_uri.password
+      @solr_uri.user, @solr_uri.password = nil, nil
+    end
+  end
+
+  # scihist_digicoll configuration
+  def self.configured
+    SolrConfigsetUpdater.new(
+        solr_url: ScihistDigicoll::Env.solr_base_url,
+        collection_name: ScihistDigicoll::Env.solr_collection_name,
+        conf_dir: Rails.root + "solr/config"
+      )
+  end
+
+  # simple upload of a "config set" from @conf_dir to solr/zookeeper via API /admin/configs?action=UPLOAD
+  # Will fail if configset_name already exists.
+  #
+  # @param overwrite send overwrite=true if true, only has meaning in Solr 8.7+
+  def upload(configset_name: collection_name, overwrite: false)
+    create_temp_zip_file do |tmp_zip_file|
+      http_response = http_client!.post(
+        "#{solr_uri.to_s}/admin/configs?action=UPLOAD&name=#{configset_name}#{'&overwrite=true' if overwrite}",
+        body: tmp_zip_file.read
+      )
+
+      unless http_response.status.success?
+        raise SolrError.new(http_response.body.to_s)
+      end
+
+      http_response
+    end
+  end
+
+  # lists all config sets from `/admin/configs?action=LIST&omitHeader=true`
+  def list
+    http_response = http_client!.get("#{solr_uri.to_s}/admin/configs?action=LIST&omitHeader=true")
+
+    unless http_response.status.success?
+      raise SolrError.new(http_response.body.to_s)
+    end
+
+    JSON.parse(http_response)["configSets"]
+  end
+
+  # deletes a config set with `/admin/configs?action=DELETE&name=myConfigSet`
+  def delete(configset_name)
+    http_response = http_client!.get("#{solr_uri.to_s}/admin/configs?action=DELETE&name=#{configset_name}&omitHeader=true")
+
+    unless http_response.status.success?
+      raise SolrError.new(http_response.body.to_s)
+    end
+
+    http_response
+  end
+
+  # COPIES an existing config set to a new name, using API
+  # `/admin/configs?action=CREATE&name=myConfigSet&baseConfigSet=predefinedTemplate`
+  def create(from:, to:)
+    http_response = http_client!.get("#{solr_uri.to_s}/admin/configs?action=CREATE&name=#{to}&baseConfigSet=#{from}")
+
+    unless http_response.status.success?
+      raise SolrError.new(http_response.body.to_s)
+    end
+
+    http_response
+  end
+
+  # reloads the @collection_name with /admin/collections?action=RELOAD&name=newCollection
+  # Does not support `async` at present.
+  def reload
+    http_response = http_client!.get("#{solr_uri.to_s}/admin/collections?action=RELOAD&name=#{collection_name}")
+
+    unless http_response.status.success?
+      raise SolrError.new(http_response.body.to_s)
+    end
+
+    http_response
+  end
+
+  # @return [String] current configName set for @collection_name, obtained via
+  #   /admin/collections?action=CLUSTERSTATUS aPI
+  def config_name
+    http_response = http_client!.get("#{solr_uri.to_s}/admin/collections?action=CLUSTERSTATUS&collection=#{collection_name}")
+
+    unless http_response.status.success?
+      raise SolrError.new(http_response.body.to_s)
+    end
+
+    JSON.parse(http_response.body.to_s).dig("cluster", "collections", collection_name, "configName")
+  end
+
+  # changes the configName for @collection_name using API
+  # /admin/collections?action=MODIFYCOLLECTION&collection=<collection-name>&collection.configName=<newName>
+  def config_name=(new_config_name)
+    http_response = http_client!.get("#{solr_uri.to_s}/admin/collections?action=MODIFYCOLLECTION&collection=#{collection_name}&collection.configName=#{new_config_name}")
+
+    unless http_response.status.success?
+      raise SolrError.new(http_response.body.to_s)
+    end
+
+    http_response
+  end
+
+  def replace_configset_timestamped
+    old_name = config_name
+    new_name = configset_timestamp_name
+
+    upload(configset_name: new_name)
+    self.config_name = new_name
+    reload
+    delete(old_name)
+  end
+
+  def configset_timestamp_name
+    "#{collection_name}_#{Time.now.utc.iso8601}"
+  end
+
+  # @return false if no update was needed, else new config_set name.
+  def replace_configset_digest
+    old_name = config_name
+    new_name = configset_digest_name
+
+    if old_name == new_name
+      # we're good, it's already there
+      return false
+    end
+
+    upload(configset_name: new_name)
+    self.config_name = new_name
+    reload
+    delete(old_name)
+
+    return new_name
+  end
+
+  def configset_digest_name
+    "#{collection_name}_#{conf_dir_digest}"
+  end
+
+  # keep the same name by doing a multi-part swap of names, more expensive
+  # than other choices, may leave things in an unexpected state on failure, probably not a great choice,
+  # but does result in a consistent config name.
+  # but doing what Alex Halovic suggests at: https://dev.lucene.apache.narkive.com/HI7lTF0o/jira-created-solr-12925-configsets-api-should-allow-update-of-existing-configset#post4
+  def replace_configset_swap
+    current_name = self.config_name
+    temp_name = "#{current_name}_temp"
+
+    self.create(from: current_name, to: temp_name)
+    self.config_name = temp_name
+    self.reload
+    self.delete(current_name)
+    self.upload(configset_name: current_name)
+    self.config_name = current_name
+    self.reload
+    self.delete(temp_name)
+  end
+
+  # renames a config set, changes collection to use new name, deletes old name.
+  def rename_config_name(to:)
+    from = self.config_name
+    self.create(from: from, to: to)
+    self.config_name = to
+    self.reload
+    self.delete(from)
+  end
+
+  # Uploads @conf_dir as a configset, and then creates a collection using it,
+  # named @collection_name,  via the Solr API
+  # /admin/collections?action=CREATE&name=name
+  #
+  # Useful to bootstrap a brand new collection that wasn't in Solr yet.
+  #
+  # Will use use @collection_name as name, and the configset specified
+  # as @conf_dir.  By default will name the config set same as collection,
+  # or pass something else in, possibly using other methods we have.
+  #
+  # Will error if collection naem or configset_name already exists, you have
+  # to deal with that yourself.
+  #
+  #     updater.create_collection
+  #     updater.create_collection(configset_name: updater.configset_digest_name)
+  #     updater.create_collection(configset_name: updater.configset_digest_name)
+  def upload_and_create_collection(configset_name: collection_name, num_shards: 1)
+    self.upload(configset_name: configset_name)
+
+    http_response = http_client!.get("#{solr_uri.to_s}/admin/collections?action=CREATE&name=#{collection_name}&collection.configName=#{configset_name}&numShards=#{num_shards}")
+
+    unless http_response.status.success?
+      raise SolrError.new(http_response.body.to_s)
+    end
+
+    http_response
+  end
+
+
+
+  class SolrError < StandardError
+    attr_reader :status, :response_body_json
+
+    def initialize(solr_response_str)
+      json_response = JSON.parse(solr_response_str)
+      @status = json_response.dig("responseHeader", "status")
+      @response_body_json = json_response
+      super(json_response.dig("error", "msg") || solr_response_str)
+    rescue JSON::ParserError
+      super(solr_response_str)
+    end
+  end
+
+  protected
+
+  # Returns a digest fingerprint for entire config directory. Uses
+  # SHA-256, truncates to first 7 digits by default, or you can specify.
+  # (git uses 7 digits by default, although from SHA1, I think
+  # should be good enough our purpoes)
+  def conf_dir_digest(truncate: 7)
+    digest = []
+    Dir.glob("#{conf_dir}/**/*").each do |f|
+      digest.push(Digest::SHA1.hexdigest(File.open(f).read)) if File.file?(f)
+    end
+    digest = Digest::SHA1.hexdigest(digest.join(''))
+    if truncate
+      digest = digest[0..truncate-1]
+    end
+    digest
+  end
+
+  # initializes an http-rb client, with basic_auth if specified
+  def http_client!
+    client = HTTP
+    if solr_basic_auth_user || solr_basic_auth_pass
+      client = client.basic_auth(user: solr_basic_auth_user, pass: solr_basic_auth_pass)
+    end
+
+    client
+  end
+
+  # Can be called with a block in which case it will yield a Tempfile, and
+  # then clean it up after block. Or without a block it just returns the Tempfile
+  # and you have to clean it up.
+  def create_temp_zip_file
+    tmp_zip_file = Tempfile.new([self.class.name, ".zip"]).tap { |t| t.binmode }
+    zip = Zip::File.open(tmp_zip_file.path, Zip::File::CREATE) do |zipfile|
+      Dir["#{conf_dir}/**/**"].each do |file|
+        zipfile.add(file.sub("#{conf_dir}/", ''), file)
+      end
+    end
+    # tell the Tempfile to (re)open so it has a file handle open that can see what ruby-zip wrote
+    tmp_zip_file.open
+
+    return tmp_zip_file unless block_given?
+
+    begin
+      yield tmp_zip_file
+    ensure
+      tmp_zip_file.close!
+    end
+  end
+end

--- a/lib/tasks/solr_cloud.rake
+++ b/lib/tasks/solr_cloud.rake
@@ -1,0 +1,31 @@
+namespace :scihist do
+  # some tasks for managing config sets and collections through solr cloud, such as
+  # but not limited to SearchStax-hosted solr.
+  #
+  # Config for solr location and collection name is taken from ScihistDigicoll:Env solr_url
+  #
+  # We use config set names that have a fingerprint digest on the end, so they are unique
+  # for config content.
+  namespace :solr_cloud do
+
+    desc "upload solr config as configset, without attaching it to collection"
+    task :upload_configset => :environment do
+      updater = SolrConfigsetUpdater.configured
+
+      updater.upload(configset_name: updater.configset_digest_name)
+    end
+
+    desc "upload configset and (re-)attach to collection, only if it is not already up to date"
+    task :sync_configset => :environment do
+      updater = SolrConfigsetUpdater.configured
+
+      updated = updater.replace_configset_digest
+
+      if updated
+        puts "sync_configset: updated config set to #{updated}"
+      else
+        puts "sync_configset: no update to config set needed"
+      end
+    end
+  end
+end

--- a/lib/tasks/solr_cloud.rake
+++ b/lib/tasks/solr_cloud.rake
@@ -8,11 +8,11 @@ namespace :scihist do
   # for config content.
   namespace :solr_cloud do
 
-    desc "upload solr config as configset, without attaching it to collection"
-    task :upload_configset => :environment do
+    desc "Create collection using on-disk configuration files, bootstrap on empty solr"
+    task :create_collection => :environment do
       updater = SolrConfigsetUpdater.configured
 
-      updater.upload(configset_name: updater.configset_digest_name)
+      updater.upload_and_create_collection(configset_name: updater.configset_digest_name)
     end
 
     desc "upload configset and (re-)attach to collection, only if it is not already up to date"

--- a/solr/config/README.md
+++ b/solr/config/README.md
@@ -30,7 +30,7 @@ http basic auth)
 
 ...Will sync the solr config directory where you are running it.
 
-For more on SearchStax, see wiki at:
+For more on SearchStax, see our wiki on [Searchstax Solr](https://chemheritage.atlassian.net/l/c/NRZz1d6v)
 
 
 ## History of these config files

--- a/solr/config/README.md
+++ b/solr/config/README.md
@@ -1,7 +1,39 @@
 These are our Solr config files.
 
-They are used directly in dev test, via solr_wrapper, and our `solr:` rake tasks. Due to how solr_wrapper works, if you make changes you may need to run `./bin/rake solr:clean` in development. (And stop/start your dev solr if it was already running).
+They are used directly in dev test, via solr_wrapper, and our `solr:` rake tasks. Due to how solr_wrapper works, if you make changes you may (or may not) need to run `./bin/rake solr:clean` in development. (And stop/start your dev solr if it was already running).
+
+## Self-managed EC2 via Ansible
+
+(Our original deploy infrastructure)
 
 In production, ansible symlinks the host-environment production Solr config to these files. At the time we are writing this, ansible only links schema.xml and solrconfig.xml, so if we need additional local solr core/collection files, we may need to adjust ansible.
 
-These config files originally came from samvera/blacklight generators. They were updated as Solr/Blacklight best practices/requirements changed. Also some updates for local needs, for not using samvera, for using Blacklight non-traditionally, etc.
+Also,
+
+## SearchStax
+
+(deploy infrastructure we are moving to)
+
+The `scihist:solr_cloud:sync_configset` rake task will use Solr Cloud API to
+ensure that Solr identified by our SOLR_URL config is using the current on
+disk config in this directory. It will sync any files in this directory.
+
+It uses a naming pattern that puts a fingerprint digest of the config directory
+at the end of the Solr cloud "config set" name to aid in management.
+
+When on heroku, this rake task is configured to run as part of heroku release phase.
+You can also of course run it manually in any location that has the config files
+on disk you'd like to set, and where SOLR_URL is set properly (likely with
+http basic auth)
+
+    SOLR_URL=https://user:pass@somehost.org/solr/collection_name ./bin/rake scihist:solr_cloud:sync_configset
+
+...Will sync the solr config directory where you are running it.
+
+For more on SearchStax, see wiki at:
+
+
+## History of these config files
+
+These config files originally came from samvera/blacklight generators. They were updated as Solr/Blacklight best practices/requirements changed. Also some updates for local needs, for not using samvera, for using Blacklight non-traditionally, etc.  There may be things in here we inherited
+that are not necessarily intentional or optimal.


### PR DESCRIPTION
Such as via SearchStax, although it will work for any solr cloud instance.

The SolrConfigsetUpdater class has some general purpose tools for working with "config sets" (what Solr Cloud calls a config directory packaged for use with a remote solr cloud instance) via API in a solr cloud instance. It has some good documentation. 

There are a couple new rake tasks that use SolrConfigsetUpdater to do common tasks we need. 

To set up a brand new collection in an empty solr, using our on-disk solr config, there's `scihist:solr_cloud:create_collection`. You might run it on a heroku worker, which should already have config to talk to the desired solr instance:  

    heroku run rake  scihist:solr_cloud:create_collection

Or you could run it locally if you set SOLR_CLOUD via ENV or local_env.yml, it will of course be using whatever solr config is on disk where you are running it. 

    SOLR_URL=https://user:pass@solrhost.searchstax.com/scihist_digicoll ./bin/rake scihist:solr_cloud:create_collection

There is also a task `sync_configset` that will sync the current on-disk solr config to an already existing solr cloud instance. In our ansible-managed EC2 infrastructure, we do something like this on every capistrano deploy, so this is a way to do it with the searchstax infrastructure. 

    heroku run rake scihist:solr_cloud:sync_configset
    SOLR_URL=https://user:pass@solrhost.searchstax.com/scihist_digicoll ./bin/rake scihist:solr_cloud:sync_configset

And in fact we edit the Procfile to use the heroku ["release phase"](https://devcenter.heroku.com/articles/release-phase) to have a solr config sync (as well as a db migrate!) run on every heroku release; our existing capistrano for ansible-managed EC2 release was doing both those things on release, so now we perpetuate that. 

Note also wiki at https://chemheritage.atlassian.net/wiki/spaces/HDC/pages/1372192769/SearchStax+Solr