### PR TITLE
Don't throw a 500 error when the Blacklight controller receives an accept: application/json request

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -7,6 +7,7 @@ class CatalogController < ApplicationController
   before_action :redirect_hash_facet_params, only: :index
   before_action :redirect_legacy_query_urls, only: :index
   before_action :swap_range_limit_params_if_needed, only: :index
+  before_action :catch_bad_request_headers, only: :index
 
   include BlacklightRangeLimit::ControllerOverride
   # Blacklight wanted Blacklight::Controller included in ApplicationController,
@@ -409,6 +410,22 @@ class CatalogController < ApplicationController
     # eg &f=expect%3A%2F%2Fdir
     if params[:f] && !params[:f].respond_to?(:to_hash)
       render plain: "Invalid URL query parameter f=#{params[:f].to_param}", status: 400
+    end
+  end
+
+
+  # Out of the box, Blacklight allows for search results
+  # to be requested as (and served as) JSON.
+  # That feature is not working, and we have no plans to fix it,
+  # but as a courtesy (and to avoid noisy 500 errors) we're providing an actual
+  # 406 error message, consistent with the behavior on other controllers
+  # on our app that don't handle JSON requests.
+  # See discussion at:
+  # https://github.com/sciencehistory/scihist_digicoll/issues/201
+  # https://github.com/sciencehistory/scihist_digicoll/issues/924
+  def catch_bad_request_headers
+    if request.headers["accept"] == "application/json"
+      render plain: "Invalid request header: we do not provide a JSON version of our search results.", status: 406
     end
   end
 

--- a/spec/requests/catalog_search_spec.rb
+++ b/spec/requests/catalog_search_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+describe CatalogController, type: :request, solr: true, queue_adapter: :test, indexable_callbacks: true do
+  describe "blacklight controller" do
+    it "returns a 406 Not Acceptable if you request json" do
+      get search_catalog_path(), :headers => { "accept" => "application/json" }
+      expect(response.code).to eq "406"
+    end
+  end
+end

--- a/spec/requests/catalog_search_spec.rb
+++ b/spec/requests/catalog_search_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 describe CatalogController, type: :request, solr: true, queue_adapter: :test, indexable_callbacks: true do
-  describe "blacklight controller" do
-    it "returns a 406 Not Acceptable if you request json" do
-      get search_catalog_path(), :headers => { "accept" => "application/json" }
-      expect(response.code).to eq "406"
-    end
+  it "returns a 406 Not Acceptable if you request json" do
+    get search_catalog_path(), :headers => { "accept" => "application/json" }
+    expect(response.code).to eq "406"
   end
 end


### PR DESCRIPTION
Fail with a 406 and a friendly text error message.

Such requests were causing a series of annoying 500 errors for a problem we don't intend to fix in the short term, and this bandaid will eliminate the problem.

Ref #924 