### PR TITLE
Add date range validation to range_limit

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -496,7 +496,7 @@ class CatalogController < ApplicationController
   def screen_params_for_range_limit
     if (params['range_end'].nil?) ||
       (params['range_start'].nil?) ||
-      (params['range_start'].to_i < params['range_end'].to_i)
+      (params['range_start'].to_i > params['range_end'].to_i)
         render plain: "Calls to range_limit should have a range_start " +
           "and a range_end parameter, and range_start " +
           "should be before range_end.", status: 406

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -8,6 +8,8 @@ class CatalogController < ApplicationController
   before_action :redirect_legacy_query_urls, only: :index
   before_action :swap_range_limit_params_if_needed, only: :index
 
+  before_action :fail_if_bad_params, only: :range_limit
+
   include BlacklightRangeLimit::ControllerOverride
   # Blacklight wanted Blacklight::Controller included in ApplicationController,
   # we do it just here instead.
@@ -485,5 +487,14 @@ class CatalogController < ApplicationController
 
     params['range']['year_facet_isim']['begin'] = end_date
     params['range']['year_facet_isim']['end']   = start_date
+  end
+
+  # When a user (in practice, a bot) makes a call directly to /catalog/range_limit
+  # rather than the usual /catalog?q=&range, this bypasses the preprocessing normally
+  # performed by the `before_action` methods for #index, which supplies a
+  # range_start and range_end parameter and ensures they are in the correct order.
+  def fail_if_bad_params
+    # puts params['range_start']
+    # puts params['range_end']
   end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -492,7 +492,8 @@ class CatalogController < ApplicationController
   # When a user (in practice, a bot) makes a call directly to /catalog/range_limit
   # rather than the usual /catalog?q=&range, this bypasses the preprocessing normally
   # performed by the `before_action` methods for #index, which supplies a
-  # range_start and range_end parameter and ensures they are in the correct order.
+  # range_start and range_end parameter and ensures they are in the correct order,
+  # then makes a second request to #range_limit .
   def screen_params_for_range_limit
     if (params['range_end'].nil?) ||
       (params['range_start'].nil?) ||

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -8,7 +8,7 @@ class CatalogController < ApplicationController
   before_action :redirect_legacy_query_urls, only: :index
   before_action :swap_range_limit_params_if_needed, only: :index
 
-  before_action :fail_if_bad_params, only: :range_limit
+  before_action :screen_params_for_range_limit, only: :range_limit
 
   include BlacklightRangeLimit::ControllerOverride
   # Blacklight wanted Blacklight::Controller included in ApplicationController,
@@ -493,8 +493,13 @@ class CatalogController < ApplicationController
   # rather than the usual /catalog?q=&range, this bypasses the preprocessing normally
   # performed by the `before_action` methods for #index, which supplies a
   # range_start and range_end parameter and ensures they are in the correct order.
-  def fail_if_bad_params
-    # puts params['range_start']
-    # puts params['range_end']
+  def screen_params_for_range_limit
+    if (params['range_end'].nil?) ||
+      (params['range_start'].nil?) ||
+      (params['range_start'].to_i < params['range_end'].to_i)
+        render plain: "Calls to range_limit should have a range_start " +
+          "and a range_end parameter, and range_start " +
+          "should be before range_end.", status: 406
+    end
   end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe CatalogController, solr: true, type: :controller do
     end
   end
 
-  describe "bad URL params  passed to range_limit -- should not happen under normal use." do
+  describe "bad URL params  passed to range_limit; should not happen under normal use" do
     describe "range end missing" do
       let(:out_of_order_range_params) do
         {
@@ -94,7 +94,7 @@ RSpec.describe CatalogController, solr: true, type: :controller do
 
       it "fails gracefully - no 500 error from blacklight" do
         get :range_limit, params: out_of_order_range_params
-        expect(response.status).to eq(422) # or some other similar status
+        expect(response.status).to eq(406)
       end
     end
   end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -81,4 +81,21 @@ RSpec.describe CatalogController, solr: true, type: :controller do
       end
     end
   end
+
+  describe "bad URL params  passed to range_limit -- should not happen under normal use." do
+    describe "range end missing" do
+      let(:out_of_order_range_params) do
+        {
+          "f"=>{"creator_facet"=>["Beckman, Arnold O."]},
+          "range_field"=>"year_facet_isim",
+          "range_start"=>"1931"
+        }
+      end
+
+      it "fails gracefully - no 500 error from blacklight" do
+        get :range_limit, params: out_of_order_range_params
+        expect(response.status).to eq(422) # or some other similar status
+      end
+    end
+  end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -82,20 +82,37 @@ RSpec.describe CatalogController, solr: true, type: :controller do
     end
   end
 
-  describe "bad URL params  passed to range_limit; should not happen under normal use" do
-    describe "range end missing" do
-      let(:out_of_order_range_params) do
-        {
-          "f"=>{"creator_facet"=>["Beckman, Arnold O."]},
-          "range_field"=>"year_facet_isim",
-          "range_start"=>"1931"
-        }
-      end
-
-      it "fails gracefully - no 500 error from blacklight" do
-        get :range_limit, params: out_of_order_range_params
-        expect(response.status).to eq(406)
-      end
+  describe "bad URL params passed to range_limit (should not happen under normal use)" do
+    let(:no_start_params) do
+      {
+        "range_field"=>"year_facet_isim",
+        "range_start"=>"1931"
+      }
+    end
+    let(:no_end_params) do
+      {
+        "range_field"=>"year_facet_isim",
+        "range_start"=>"1931"
+      }
+    end
+    let(:end_before_start_params) do
+      {
+        "range_field"=>"year_facet_isim",
+        "range_start"=>"1940",
+        "range_end"=>"1930"
+      }
+    end
+    it "throws 406 unless start param is present" do
+      get :range_limit, params: no_start_params
+      expect(response.status).to eq(406)
+    end
+    it "throws 406 unless end param is present" do
+      get :range_limit, params: no_end_params
+      expect(response.status).to eq(406)
+    end
+    it "throws 406 if params out of order" do
+      get :range_limit, params: end_before_start_params
+      expect(response.status).to eq(406)
     end
   end
 end


### PR DESCRIPTION
Ref #945 

In regular operation, calls to `CatalogController#range_limit` are first processed by `CatalogController#index`, which checks the dates and fixes them, if necessary, before making a second request to `CatalogController#range_limit`.

However, if you know the URL, it's still possible to make a request directly to `CatalogController#range_limit` with bad dates. We have a very enthusiastic generator of such requests living at IP `13.66.139.128`.  `HTTP_USER_AGENT` is always `Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)`. This is resulting in over a hundred 500 errors a day, logged dutifully by Honeybadger : see https://app.honeybadger.io/projects/58989/faults/56829566/ .

This adds a second validation step in `range_limit` and throws a 406 error instead of a 500. This means the parameters are checked twice, so it's not a particularly elegant solution.