### PR TITLE
Remove vips from aptfile; we're using machinio buildpack instead

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,6 +1,13 @@
-libvips-tools
+# Removing libvips-tools
+# in favor of https://github.com/machinio/heroku-buildpack-vips
+# which gives us vips 8.10.2 .
+# We may want to switch back to libvips-tools
+# in the future and remove the buildpack.
+# libvips-tools
+
 mediainfo
 imagemagick
+
 # poppler-utls was probably already getting installed as a dependency
 # of above anyway, but we need `pdfunite` command line util from it, so we'll
 # list it explicitly.


### PR DESCRIPTION
Removing vips from the Aptfile and instead adding the machinio vips buildpack by running:
`heroku buildpacks:set https://github.com/machinio/heroku-buildpack-vips
`
results in vips 8.10.2 getting installed on Heroku.
This is not the latest version (we currently have 8.10.5 installed in production on s3 boxes), but it does fix the grayscale thumbnail problem described in ref #942.

