### PR TITLE
Correct item count on Featured Topic page.

### DIFF
--- a/app/controllers/featured_topic_controller.rb
+++ b/app/controllers/featured_topic_controller.rb
@@ -42,7 +42,23 @@ class FeaturedTopicController < CatalogController
   end
 
   def total_count
-    @response.total_count
+    @total_count ||= begin
+      # We need to fight with Blacklight a bit to get the results which have been
+      # limited by our "slug", but EXCLUDING any current search query or facet limits.
+      #
+      # This is based on reverse-engineering of the very abstracted stuff BL is
+      # doing, and is probably kind of fragile, sorry. :(
+
+      empty_search_state = search_state_class.new(params.slice(:controller, :action, :slug), blacklight_config, self)
+
+      # In future BL versions you may need to remove .to_h, just `search_service.search_builder.with(empty_search_state)`
+      builder = search_service.search_builder.with(empty_search_state.to_h)
+      builder.rows = 0 # we don't want any actual results back, just search metadata
+
+      response = search_service.repository.search(builder)
+
+      response.total_count
+    end
   end
   helper_method :total_count
 

--- a/spec/system/featured_topic_spec.rb
+++ b/spec/system/featured_topic_spec.rb
@@ -33,4 +33,14 @@ describe "Featured Topic show page", type: :system, js: false, solr:true, indexa
     expect(page).to have_content("lithographs")
     expect(page).not_to have_content("machinery")
   end
+
+  it "searches, and keeps total count accurate" do
+    visit featured_topic_path(topic_id.to_s.dasherize, q: "artillery")
+
+    expect(page).to have_text("2 items")
+    expect(page).to have_text("1 entry found")
+
+    expect(page).to have_content("artillery")
+    expect(page).not_to have_content("lithographs")
+  end
 end

--- a/spec/system/featured_topic_spec.rb
+++ b/spec/system/featured_topic_spec.rb
@@ -9,9 +9,11 @@ describe "Featured Topic show page", type: :system, js: false, solr:true, indexa
     ]
   end
 
-  it "smoke tests" do
+  let(:topic_id) { :instruments_and_innovation }
+
+  before do
     fake_definition =  {
-        instruments_and_innovation: {
+        topic_id => {
         title: "Instruments & Innovation",
         genre: ["Scientific apparatus and instruments", "Lithographs"],
         subject: ["Artillery", "Machinery", "Chemical apparatus"],
@@ -20,7 +22,10 @@ describe "Featured Topic show page", type: :system, js: false, solr:true, indexa
       }
     }
     allow(FeaturedTopic).to receive(:definitions).and_return(fake_definition)
-    visit featured_topic_path('instruments-and-innovation')
+  end
+
+  it "smoke tests" do
+    visit featured_topic_path(topic_id.to_s.dasherize)
     expect(page).to have_title "Instruments & Innovation"
     expect(page).to have_selector("h1", text: 'Instruments & Innovation')
     expect(page).to have_selector("p", text: 'Fireballs')


### PR DESCRIPTION
Closes #279

Have to reverse engineer Blacklight a bit to get at the parts that will let us query solr in a way that is restricted to just this 'featured topic' using the mechanisms we've already set up, but without any current query or other additional limits. A bit difficult to get at these parts, and BL tends to change them frequently, so it's possible the code will break in future versions. But I think it's something not too crazy, I think it's the best we can do.