### PR TITLE
Display warning to those using IE

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,7 @@ gem 'html_aware_truncation', '~> 1.0'
 gem "prawn", "~> 2.2" # creating PDFs
 gem "pdf-reader", "~> 2.2" # simple metadata extraction from pdfs
 gem 'rubyzip', '~> 2.0'
+gem 'browser', '~> 5.0' # browser user-agent detection, maybe only for IE-unsupported warning.
 
 
 # Until oai 1.0 is released...

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,7 @@ GEM
       ruby-box
       signet (~> 0.8)
       typhoeus
+    browser (5.3.0)
     builder (3.2.4)
     byebug (11.1.3)
     capistrano (3.15.0)
@@ -638,6 +639,7 @@ DEPENDENCIES
   bootstrap (~> 4.3)
   bootstrap4-kaminari-views
   browse-everything (~> 1.0)
+  browser (~> 5.0)
   capistrano (~> 3.8)
   capistrano-bundler (~> 1.2)
   capistrano-maintenance (~> 1.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,4 +25,10 @@ class ApplicationController < ActionController::Base
     end
   end
 
+
+  def show_ie_unsupported_warning?
+    # #browser method comes from `browser` gem
+    browser.ie? && !cookies[:ieWarnDismiss]
+  end
+  helper_method :show_ie_unsupported_warning?
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -22,7 +22,6 @@ import '../src/js/custom_google_analytics_events.js';
 import '../src/js/cart_control.js';
 import '../src/js/date_range_render_workaround.js';
 import '../src/js/tab_selection_in_anchor';
-import '../src/js/ie_warning_dismiss_remember.js';
 
 import '../src/js/audio/play_at_timecode.js';
 import '../src/js/audio/ohms_search.js';

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -22,10 +22,12 @@ import '../src/js/custom_google_analytics_events.js';
 import '../src/js/cart_control.js';
 import '../src/js/date_range_render_workaround.js';
 import '../src/js/tab_selection_in_anchor';
+import '../src/js/ie_warning_dismiss_remember.js';
 
 import '../src/js/audio/play_at_timecode.js';
 import '../src/js/audio/ohms_search.js';
 import '../src/js/audio/ohms_footnotes.js';
 import '../src/js/audio/accordion_open_on_screen.js';
 import '../src/js/audio/navbar_tabs.js';
+
 

--- a/app/javascript/src/js/ie_warning_dismiss_remember.js
+++ b/app/javascript/src/js/ie_warning_dismiss_remember.js
@@ -1,6 +1,0 @@
-$( document ).ready(function() {
-  $('#ieWarning').on('close.bs.alert', function () {
-    // Set a cookie so we can now not to show the warning again
-    document.cookie = "ieWarnDismiss=1";
-  })
-});

--- a/app/javascript/src/js/ie_warning_dismiss_remember.js
+++ b/app/javascript/src/js/ie_warning_dismiss_remember.js
@@ -1,0 +1,6 @@
+$( document ).ready(function() {
+  $('#ieWarning').on('close.bs.alert', function () {
+    // Set a cookie so we can now not to show the warning again
+    document.cookie = "ieWarnDismiss=1";
+  })
+});

--- a/app/views/application/_ie_unsupported_warning.html.erb
+++ b/app/views/application/_ie_unsupported_warning.html.erb
@@ -1,0 +1,10 @@
+<%# navbar that is shown at very top of page in "front-end" end-user-accessible
+    pages, if admin is logged in. May use it in admin pages too? Maybe change
+    name if so. %>
+<div class="alert alert-dismissible alert-warning mb-0" id="ieWarning" role="alert">
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i>&nbsp;&nbsp;
+ It looks like you are using the Internet Explorer browser. We can not guarantee all functions of this website will work, we recommend installing a more recent browser.
+ <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+  <span aria-hidden="true">&times;</span>
+</button>
+</div>

--- a/app/views/application/_ie_unsupported_warning.html.erb
+++ b/app/views/application/_ie_unsupported_warning.html.erb
@@ -1,10 +1,7 @@
 <%# navbar that is shown at very top of page in "front-end" end-user-accessible
     pages, if admin is logged in. May use it in admin pages too? Maybe change
     name if so. %>
-<div class="alert alert-dismissible alert-warning mb-0" id="ieWarning" role="alert">
+<div class="alert alert-warning mb-0" id="ieWarning" role="alert">
 <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>&nbsp;&nbsp;
  It looks like you are using the Internet Explorer browser. We can not guarantee all functions of this website will work, we recommend installing a more recent browser.
- <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-  <span aria-hidden="true">&times;</span>
-</button>
 </div>

--- a/app/views/application/_ie_unsupported_warning.html.erb
+++ b/app/views/application/_ie_unsupported_warning.html.erb
@@ -3,5 +3,5 @@
     name if so. %>
 <div class="alert alert-warning mb-0" id="ieWarning" role="alert">
 <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>&nbsp;&nbsp;
- It looks like you are using the Internet Explorer browser. We can not guarantee all functions of this website will work, we recommend installing a more recent browser.
+ It looks like you are using the Internet Explorer browser. We can not guarantee all functions of this website will work. We recommend installing a more recent browser.
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,6 +52,10 @@
   </head>
 
   <body class="<%= render_body_class %> scihist-main-layout">
+    <% if show_ie_unsupported_warning? %>
+      <%= render 'ie_unsupported_warning' %>
+    <% end %>
+
     <% if current_user %>
       <%= render 'front_end_admin_navbar' %>
     <% end %>


### PR DESCRIPTION
Closes #642 

The first implementation here is server-side, the logic checks user-agent server-side and then includes an extra element at top of page. 

One problem with this is that it makes the page no longer globally cacheable, since different people get differnet pages. If in the future we wanted to cache at a CDN for instance. To do that, all users need to get the same page delivered from server. JS can customize once it's in the browser though. 

We could try to replace this with a purely client-side solution. Does it matter?