### PR TITLE
Email "from" addresses

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,10 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: ScihistDigicoll::Env.lookup!(:digital_email_address)
+  # Note that for delivery TO sciencehistory.org email addresses, if the email
+  # is also FROM a @sciencehistory.org address, it needs to be allow-listed
+  # by IT to avoid their anti-phishing measures.
+  #
+  # So be careful with "from" email addresses on Amazon SES-sent emails.
+  default from: ScihistDigicoll::Env.lookup!(:no_reply_email_address)
+
   layout 'mailer'
 end

--- a/app/mailers/oral_history_delivery_mailer.rb
+++ b/app/mailers/oral_history_delivery_mailer.rb
@@ -1,4 +1,6 @@
 class OralHistoryDeliveryMailer < ApplicationMailer
+  default from: ScihistDigicoll::Env.lookup!(:oral_history_email_address)
+
 
   def oral_history_delivery_email
     raise ArgumentError.new("Required params[:request] missing") unless request.present?

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -440,6 +440,7 @@ module ScihistDigicoll
 
     # From address:
     define_key :no_reply_email_address, default: "no-reply@sciencehistory.org"
+    define_key :oral_history_email_address, default: "oralhistory@sciencehistory.org"
 
     # To addresses (these are email lists maintained by IT.)
     define_key :digital_tech_email_address, default: "digital-tech@sciencehistory.org"

--- a/spec/mailers/oral_history_delivery_spec.rb
+++ b/spec/mailers/oral_history_delivery_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe OralHistoryDeliveryMailer, :type => :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq("Science History Institute: files from Oral history interview with William John Bailey")
       expect(mail.to).to eq(["patron@institution.com"])
-      expect(mail.from).to eq(["digital@sciencehistory.org"])
+      expect(mail.from).to eq(["oralhistory@sciencehistory.org"])
     end
 
     it "renders the body; does not send items that are already publicly accessible" do


### PR DESCRIPTION
default changed back to no-reply@sciencehistory.org

OH delivery specifially from oralhistory@sciencehistory.org

Those are currently the only two email addresses allow-listed to get through anti-phishing measures to be delivered to sciencehistory email boxes, when they have @sciencehistory.org "from" addresses but are being sent by an external system.