### PR TITLE
Custom front-page for Oral History collection specifically

### DIFF
--- a/app/controllers/collection_show_controllers/oral_history_collection_controller.rb
+++ b/app/controllers/collection_show_controllers/oral_history_collection_controller.rb
@@ -1,0 +1,9 @@
+# A sub-class of collection show controller that is specifically for the Oral History
+# collection -- it's routed to for that collection in our routes.rb
+#
+# It lets us override configuration and views.
+module CollectionShowControllers
+  class OralHistoryCollectionController < CollectionShowController
+
+  end
+end

--- a/app/controllers/collection_show_controllers/oral_history_collection_controller.rb
+++ b/app/controllers/collection_show_controllers/oral_history_collection_controller.rb
@@ -25,6 +25,18 @@ module CollectionShowControllers
 
       # Some facets we don't use generally but we do want to use here.
       config.add_facet_field "interviewer_facet", label: "Interviewer", limit: 5
+
+      # to change order of keys in hash we basically need to hackily make a new
+      # hash.
+      key_order = config.facet_fields.keys
+
+      # make interviewer_facet second one
+      key_order.insert(1, "interviewer_facet") if key_order.delete("interviewer_facet")
+
+      # and "rights" facet last
+      key_order.insert(-1, "rights_facet") if key_order.delete("rights_facet")
+
+      config.facet_fields = config.facet_fields.slice(*key_order)
     end
   end
 end

--- a/app/controllers/collection_show_controllers/oral_history_collection_controller.rb
+++ b/app/controllers/collection_show_controllers/oral_history_collection_controller.rb
@@ -5,5 +5,26 @@
 module CollectionShowControllers
   class OralHistoryCollectionController < CollectionShowController
 
+    # Add and remove some facet fields from inherited default configuration
+    configure_blacklight do |config|
+
+      # Remove some facets we don't want, not relevant in this specific collection search
+      config.facet_fields.delete("genre_facet")
+      config.facet_fields.delete("place_facet")
+      config.facet_fields.delete("department_facet")
+      config.facet_fields.delete("creator_facet") # we're going ot use Interviewer specifically instead
+
+      # re-label "date" per stakeholder request
+      config.facet_fields["year_facet_isim"].label = "Interview Date"
+
+      # Make "Rights" staff-only, at least fo rnow, with label matching
+      config.facet_fields["rights_facet"].tap do |facet_config|
+        facet_config.if = :current_user
+        facet_config.label = "Rights (Staff-only)"
+      end
+
+      # Some facets we don't use generally but we do want to use here.
+      config.add_facet_field "interviewer_facet", label: "Interviewer", limit: 5
+    end
   end
 end

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -18,6 +18,12 @@ class WorkIndexer < Kithe::Indexer
 
     to_field ["text3_tesim", "subject_facet"], obj_extract("subject")
 
+    # Interviewer out of creator facet for use specifically for Oral History collection
+    to_field "interviewer_facet" do |record, acc|
+      acc.concat record.creator.find_all { |creator| creator.category == "interviewer"}.collect(&:value)
+    end
+
+
     to_field "text4_tesim", obj_extract("description")
     to_field "text4_tesim", obj_extract("provenance")
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,8 +77,10 @@ Rails.application.routes.draw do
   # Rails routing constraints feature to say if collection_id is a specific one, use
   # this other controller.
 
-  constraints(collection_id: "gt54kn818") do
-    concerns :collection_showable, controller: "collection_show_controllers/oral_history_collection"
+  if ScihistDigicoll::Env.lookup(:oral_history_collection_id)
+    constraints(collection_id: ScihistDigicoll::Env.lookup(:oral_history_collection_id)) do
+      concerns :collection_showable, controller: "collection_show_controllers/oral_history_collection"
+    end
   end
 
   # and our default collection show page routing

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -436,6 +436,11 @@ module ScihistDigicoll
     define_key :special_job_worker_count, default: 0
 
 
+    # SPECIFIC COLLECTION IDS
+    # Used to trigger custom controllers/UI for specific known collections
+    define_key :oral_history_collection_id, default: "gt54kn818"
+
+
     # OUTGOING EMAIL:
 
     # From address:

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -23,9 +23,17 @@ describe WorkIndexer do
     end
   end
 
-  describe "with oral history transcript" do
-    let(:work) { create(:work, oral_history_content: oral_history_content) }
+  describe "oral history" do
+    let(:work) { create(:oral_history_work) }
 
+    it "indexes interviewer_facet" do
+      output_hash = WorkIndexer.new.map_record(work)
+      expect(output_hash["interviewer_facet"]).not_to eq(nil)
+    end
+  end
+
+  describe "with oral history transcript" do
+    let(:work) { create(:oral_history_work, oral_history_content: oral_history_content) }
 
     describe "ohms xml with missing transcript" do
       # this one has missing transcript...


### PR DESCRIPTION
There are a couple ways we could have done this. We *could* have put some conditional logic in the existing CollectionShowController that tried to configure it differently when it recognized a specific collection. 

But instead, I sub-classed the CollectionShowController into namespaced CollectionShowControllers::OralHistoryCollectionController.  Then I used some kind of convoluted tricks in routes.rb to route to that controller *instead* of the default CollectionShowController, when the collectionId for Oral History was noticed. 

It's a bit hacky -- too much sub-classing especially of Rails controllers can get messy to understand/debug. But I think it was going to be messy no matter what, i decided this seemed the cleanest, especially because we are probably going to want to customize the whole "home page" too (views), not just some config. 

For now, all we're customizing is the facet-related configuration. 

This was done using a pattern that can easily be extended to other specific collections, should we want to customize other specific collection landing pages too.  See routes.rb, we just put in a route constrained by other collection IDs and routing to other special-purpose sub-classes.