### PR TITLE
make copy_data capistrano task more tolerant of missing S3 files to copy

### DIFF
--- a/app/models/copy_staging/restore_work.rb
+++ b/app/models/copy_staging/restore_work.rb
@@ -136,6 +136,8 @@ module CopyStaging
 
         remote_file = Shrine::UploadedFile.new(derivative_uploaded_file.data.merge("storage" => REMOTE_DERIVATIVES_STORAGE_KEY))
         Shrine.storages[:kithe_derivatives].upload(remote_file, derivative_uploaded_file.id)
+      rescue Aws::S3::Errors::NoSuchKey => e
+        puts "   ERROR: Could not find file to copy `#{remote_file.id}` on #{Shrine.storages[REMOTE_DERIVATIVES_STORAGE_KEY].then {|s| [s.bucket&.name, s.prefix].compact.join('/')}}"
       end
     end
 


### PR DESCRIPTION
When trying to use ./bin/cap staging copy_data[ym8smcv] to copy helen murray free, I was getting an error, when it tried to copy derivatives for a asset with UUID 0e649ec8-2157-477b-a6ea-f97a6c2421b8, and couldn't find them. I'm not sure what's going wrong -- maybe we sync'd the database from prod to staging, but didn't sync S3?

So there's something wrong with our prod=>staging sync, but anyway, this task should print out an error message and otherwise be willing to complete the copy instead of just aborting, and that's now what it can do.