### PR TITLE
OH without OHMS but with PDF can embed PDF in a tab

### DIFF
--- a/app/assets/stylesheets/local/oh_audio.scss
+++ b/app/assets/stylesheets/local/oh_audio.scss
@@ -198,9 +198,16 @@
     }
   }
 
-  .tab-content {
+  .tab-pane:not(.pdf-transcript) {
     // hacky, match attribute-table width
     max-width: ($max-readable-width / 0.67);
+  }
+
+  .pdf-transcript object {
+    // try to make the embed <object> tag kind of take up a lot of space,
+    // full page of PDF, full screen, sort of kind of.
+    width: 100%;
+    height: 120vh;
   }
 
   // When we're two column, add more spacer than default

--- a/app/decorators/oh_audio_work_show_decorator.rb
+++ b/app/decorators/oh_audio_work_show_decorator.rb
@@ -30,6 +30,11 @@ class OhAudioWorkShowDecorator < Draper::Decorator
     @representative_member = all_members.find { |m| m.id == model.representative_id }
   end
 
+  def pdf_transcript_member
+    # For now we're just assuming the first PDF found is it, which is not quite right. TODO.
+    @pdf_transcript_member = all_members.find { |m| m.leaf_representative&.content_type&.start_with?("application/pdf") }
+  end
+
   def audio_members
     @audio_members ||= all_members.select { |m| m.leaf_representative&.content_type&.start_with?("audio/") }
   end

--- a/app/views/works/oh_audio_work_show.html.erb
+++ b/app/views/works/oh_audio_work_show.html.erb
@@ -45,6 +45,12 @@
                 Transcript <span data-ohms-hitcount="transcript"></span>
               </a>
             </li>
+          <% elsif decorator.pdf_transcript_member.present? %>
+            <li class="nav-item">
+              <a class="nav-link btn btn-emphasis" id="ohTranscriptPdfTab" data-toggle="tab" href="#ohTranscriptPdf" role="tab" aria-controls="home" aria-selected="false">
+                Transcript
+              </a>
+            </li>
           <% end %>
 
           <li class="nav-item">
@@ -113,7 +119,17 @@
           <div class="tab-pane long-text-line-height" id="ohTranscript" role="tabpanel" aria-labelledby="ohTranscriptTab">
             <%= OhmsTranscriptDisplay.new(decorator.oral_history_content.ohms_xml).display %>
           </div>
+        <% elsif decorator.pdf_transcript_member.present? %>
+          <div class="tab-pane pdf-transcript" id="ohTranscriptPdf" role="tabpanel" aria-labelledby="ohTranscriptPdfTab">
+            <object data="<%= decorator.pdf_transcript_member.file.url %>" type="application/pdf">
+              <%# content of object tag only shows up if browser can't do object tag for this content type %>
+              <p>Sorry, this transcript is in PDF format, and your browser does not support displaying PDF. You can download the Transcript PDF on the Downloads tab.</p>
+            </object>
+          </div>
         <% end %>
+
+
+
 
         <div class="tab-pane downloads" id="ohDownloads" role="tabpanel" aria-labelledby="ohDownloadsTab">
           <%= render 'show_with_audio_downloads', decorator: decorator %>


### PR DESCRIPTION
Experiment, needs evaluation. 

- [ ] needs some kind of testing

There are two main reasons I think this needs evaluation:

1. The UI is a bit weird. It's the best I could figure out, but the scrollbar-within-a-scrollbar of asking the browser to embed a PDF makes it kind of confusing in some cases. 

2. Right now, the software architecture has no way to know which is the "transcript PDF". It only knows "here are the members whihc are PDFs". Current logic for this feature just takes the first PDF found, and assumes it's the transcript. For the actual current use cases we plan to use this template, that assupmption should be valid, there should only BE one PDF. (For OH's, we currently have two PDF's only for non-immediate-access, which... we think don't use this template). 

But it's kind of fragile and easy for that assumption to become untrue in the future maybe, and then this won't do the right thing. 

Should we add an architectural component to give a work member a "role"?  This isn't the first time that woudl be convenient, in OH's specifically. Transcript, front matter (which could then be automatically labelled), portrait, etc. 

That would potentially require staff to do more work on ingest, assigning roles to some members, so we'd need to discuss this. But it might be time to consider that architectural enhancement, even though it exceeds the boundaries of the "PCDM" model a bit.