### PR TITLE
link to ToC segment and timecode in OHMS

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -28,5 +28,6 @@ import '../src/js/audio/ohms_search.js';
 import '../src/js/audio/ohms_footnotes.js';
 import '../src/js/audio/accordion_open_on_screen.js';
 import '../src/js/audio/navbar_tabs.js';
+import '../src/js/audio/timecode_in_url.js';
 
 

--- a/app/javascript/src/js/audio/accordion_open_on_screen.js
+++ b/app/javascript/src/js/audio/accordion_open_on_screen.js
@@ -6,8 +6,11 @@
 // We detect that condition, and scroll to reveal it, after calculating
 // the #ohmsAudioNavbar height to know how much space to leave.
 //
+// We also scroll if the target is off the BOTTOM of the page after opening,
+// which can mainly happen if we switched to specific segment on page load due
+// to #anchor.
+//
 // Only within an .ohms-index-container, not affecting all bootstrap collapse/accordions.
-
 $(document).on("shown.bs.collapse", ".ohms-index-container", function(event) {
   var indexSection = $(event.target).closest(".ohms-index-point").get(0);
 
@@ -16,7 +19,7 @@ $(document).on("shown.bs.collapse", ".ohms-index-container", function(event) {
   var targetViewportXPosition = indexSection.getBoundingClientRect().top;
   var navbarHeight = $("#ohmsAudioNavbar").height();
 
-  if (targetViewportXPosition <= navbarHeight) {
+  if (targetViewportXPosition <= navbarHeight || targetViewportXPosition > window.innerHeight) {
     window.scrollTo({top: window.scrollY - (navbarHeight - targetViewportXPosition), behavior: "smooth"});
   }
 });

--- a/app/javascript/src/js/audio/timecode_in_url.js
+++ b/app/javascript/src/js/audio/timecode_in_url.js
@@ -1,6 +1,8 @@
 // Allow timecodes to be in urls in fragment identifier, like #t=[number of seconds]
 //
 // And we'll jump to that timecode in our OH audio player.
+// Or #t=[seconds]&toc=true
+//   Will find a Table of Contents (toc) segment that starts with that timecode if possible, and expand to it too.
 //
 // This is influenced by w3c media fragment standard. https://www.w3.org/TR/media-frags/
 //
@@ -9,7 +11,8 @@
 //
 // * Note we also use `#`` fragment identifiers in somewhat inconsistent way, at `tab_selection_in_anchor.js`. `
 //
-// This file avoids using jQuery.
+// This file tries to avoid using jQuery, but has to for bootstrap accordion and tab controls
+// in bootstrap 4, caues they are jquery based.
 
 import domready from 'domready';
 
@@ -39,6 +42,20 @@ domready(function() {
       playPromise.catch(error => {
         console.log("Could not autoplay audio: " + error);
       });
+
+      if (hashParams["toc"] == "true") {
+        // try to find the ToC segment and open it up please
+        var button = document.querySelector('*[data-ohms-timestamp-s="' + hashParams["t"] + '"]');
+        var collapse = button && button.closest(".collapse");
+
+        if (collapse) {
+          // move to tab
+          $('*[href="#ohToc"]').tab("show");
+
+          // open section
+          $(collapse).collapse("show");
+        }
+      }
 
     }
   }

--- a/app/javascript/src/js/audio/timecode_in_url.js
+++ b/app/javascript/src/js/audio/timecode_in_url.js
@@ -1,0 +1,45 @@
+// Allow timecodes to be in urls in fragment identifier, like #t=[number of seconds]
+//
+// And we'll jump to that timecode in our OH audio player.
+//
+// This is influenced by w3c media fragment standard. https://www.w3.org/TR/media-frags/
+//
+// * Note we also have a different mechanism of jumping to a timecode in `play_at_timecode.js`.
+// We could rationalize them in the future?
+//
+// * Note we also use `#`` fragment identifiers in somewhat inconsistent way, at `tab_selection_in_anchor.js`. `
+//
+// This file avoids using jQuery.
+
+import domready from 'domready';
+
+domready(function() {
+  const anchor = window.location.hash;
+
+  if (anchor && anchor.includes('=')) {
+
+    // parse out #t=1212&maybeother=thing
+    var pairs = anchor.substring(1).split("&");
+    var hashParams = {};
+    for (var i = 0; i < pairs.length; i++) {
+        var pair = pairs[i].split('=');
+        hashParams[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1] || '');
+    }
+
+    var html5Audio = document.querySelector("*[data-role=now-playing-container] audio");
+
+    if (hashParams["t"] && html5Audio) {
+      var seconds = hashParams["t"];
+      html5Audio.currentTime = seconds;
+
+      // Chrome and maybe other browsers don't let us play audio
+      // on load anymore. User has to press play. But we'll try if the browser lets us.
+      // https://developers.google.com/web/updates/2017/09/autoplay-policy-changes
+      var playPromise = html5Audio.play();
+      playPromise.catch(error => {
+        console.log("Could not autoplay audio: " + error);
+      });
+
+    }
+  }
+});

--- a/app/javascript/src/js/tab_selection_in_anchor.js
+++ b/app/javascript/src/js/tab_selection_in_anchor.js
@@ -8,8 +8,11 @@ import domready from 'domready';
 domready(function() {
   // if there's an #anchor in the URL referencing a bootstrap tab, make that tab selected.
   // should we limit to only certain data tags instead of all bootstrap tab links?
+  //
+  // If there is an `=` in the anchor, we assume it's being used for some kind of query-param
+  // style thing, and not for this.
   const anchor = window.location.hash;
-  if (anchor) {
+  if (anchor && !anchor.includes('=')) {
     $(`*[data-toggle="tab"][href="${anchor}"]`).tab("show")
   }
 

--- a/app/presenters/ohms_transcript_display.rb
+++ b/app/presenters/ohms_transcript_display.rb
@@ -121,7 +121,7 @@ class OhmsTranscriptDisplay < ViewModel
     content_tag(
       "a",
       format_ohms_timestamp(tc[:seconds]),
-      href: "#",
+      href: "#t=#{tc[:seconds]}",
       class: "ohms-transcript-timestamp",
       data: { "ohms_timestamp_s" => tc[:seconds]}
     )

--- a/app/views/presenters/_ohms_index.html.erb
+++ b/app/views/presenters/_ohms_index.html.erb
@@ -13,9 +13,9 @@
 
       <div id="<%= view.accordion_element_id(index) %>" class="collapse card-body ohms-index-list long-text-line-height" aria-labelledby="<%= view.accordion_header_id(index) %>" data-parent="#ohmsIndexAccordionParent">
           <p>
-            <button type="button" class="btn btn-secondary" data-ohms-timestamp-s="<%= index_point.timestamp %>">
+            <%= link_to(url_for({anchor: "t=#{index_point.timestamp}"}), class:"btn btn-secondary", "data-ohms-timestamp-s" => index_point.timestamp) do %>
               <i class="fa fa-play-circle mr-1" aria-hidden="true"></i> Play segment
-            </button>
+            <% end %>
           </p>
 
           <% if index_point.synopsis.present? %>

--- a/app/views/presenters/_ohms_index.html.erb
+++ b/app/views/presenters/_ohms_index.html.erb
@@ -16,6 +16,18 @@
             <%= link_to(url_for({anchor: "t=#{index_point.timestamp}"}), class:"btn btn-secondary", "data-ohms-timestamp-s" => index_point.timestamp) do %>
               <i class="fa fa-play-circle mr-1" aria-hidden="true"></i> Play segment
             <% end %>
+
+            <button class="btn btn-outline-secondary" type="button"
+              data-toggle="collapse" data-target="<%= "#collapseSegmentLink#{index}" %>"
+              aria-expanded="false" aria-controls="<%= "#collapseSegmentLink#{index}" %>">
+
+              <i class="fa fa-link mr-1" aria-hidden="true"></i> Link to segment
+            </button>
+
+            <div class="collapse alert alert-info" id="<%= "collapseSegmentLink#{index}" %>">
+              <h3 class="h4 alert-heading">Direct segment link</h3>
+              <%= link_to url_for(anchor: "t=#{index_point.timestamp}", only_path: false), url_for(anchor: "t=#{index_point.timestamp}", only_path: false), class: "alert-link" %>
+            </div>
           </p>
 
           <% if index_point.synopsis.present? %>

--- a/app/views/presenters/_ohms_index.html.erb
+++ b/app/views/presenters/_ohms_index.html.erb
@@ -13,7 +13,7 @@
 
       <div id="<%= view.accordion_element_id(index) %>" class="collapse card-body ohms-index-list long-text-line-height" aria-labelledby="<%= view.accordion_header_id(index) %>" data-parent="#ohmsIndexAccordionParent">
           <p>
-            <%= link_to(url_for({anchor: "t=#{index_point.timestamp}"}), class:"btn btn-secondary", "data-ohms-timestamp-s" => index_point.timestamp) do %>
+            <%= link_to(url_for({anchor: "t=#{index_point.timestamp}&toc=true"}), class:"btn btn-secondary", "data-ohms-timestamp-s" => index_point.timestamp) do %>
               <i class="fa fa-play-circle mr-1" aria-hidden="true"></i> Play segment
             <% end %>
 
@@ -26,7 +26,7 @@
 
             <div class="collapse alert alert-info" id="<%= "collapseSegmentLink#{index}" %>">
               <h3 class="h4 alert-heading">Direct segment link</h3>
-              <%= link_to url_for(anchor: "t=#{index_point.timestamp}", only_path: false), url_for(anchor: "t=#{index_point.timestamp}", only_path: false), class: "alert-link" %>
+              <%= link_to url_for(anchor: "t=#{index_point.timestamp}&toc=true", only_path: false), url_for(anchor: "t=#{index_point.timestamp}&toc=true", only_path: false), class: "alert-link" %>
             </div>
           </p>
 


### PR DESCRIPTION
Ref #655

Among other issues to consider:

* When we link directly to ToC segment, there can be no SHI branding at all, cause it scrolled off screen! Oops. Consequence of our design. 

* No tests at present, this is not easy behavior to test. 

* Not sure about using #fragmentIdentifier vs ?queryString

* We have implemented ability to link directly to a given timecode in seconds, but have no UI for getting those links yet. (Other than right-click copy-link on a transcript timecode, that works presently)