### PR TITLE
DRY up our pagination status info

### DIFF
--- a/app/presenters/page_entries_info_display.rb
+++ b/app/presenters/page_entries_info_display.rb
@@ -1,0 +1,24 @@
+# Displays the "1 - 10 of 123" message.
+#
+# Similar to kaminari's #page_entries_info, I forget why we didn't just use that, maybe
+# we wanted somewhat different functionality that we didn't know how to theme.
+#
+# https://github.com/kaminari/kaminari/blob/master/README.md#the-page_entries_info-helper-method
+#
+# Pass in a kaminari-paginated array.
+class PageEntriesInfoDisplay < ViewModel
+  def display
+    return "" unless should_display?
+
+    content_tag("p") do
+      "#{model.offset_value + 1} - #{model.offset_value + model.count} of #{model.total_count}"
+    end
+  end
+
+  protected
+
+  def should_display?
+    model.total_count > 0
+  end
+
+end

--- a/app/views/admin/cart_items/index.html.erb
+++ b/app/views/admin/cart_items/index.html.erb
@@ -5,12 +5,7 @@
   <%= link_to "Clear Cart", clear_admin_cart_items_path, class: "btn btn-outline-danger", data: { confirm: "Delete all items in cart?"}, method: "delete" %>
 </p>
 
-<% if @works.total_count > 0 %>
-  <p>
-    <%= @works.offset_value + 1 %> - <%= @works.offset_value + @works.count %> of <%= @works.total_count %>
-  </p>
-<% end %>
-
+<%= PageEntriesInfoDisplay.new(@works).display %>
 
 <table class="table admin-list">
   <thead>

--- a/app/views/admin/digitization_queue_items/index.html.erb
+++ b/app/views/admin/digitization_queue_items/index.html.erb
@@ -40,12 +40,8 @@
   <% end %>
 </div>
 
-<% if @admin_digitization_queue_items.total_count > 0 %>
-  <p>
-    <%= @admin_digitization_queue_items.offset_value + 1 %> - <%= @admin_digitization_queue_items.offset_value + @admin_digitization_queue_items.count %> of <%= @admin_digitization_queue_items.total_count %>
-  </p>
-<% end %>
 
+<%= PageEntriesInfoDisplay.new(@admin_digitization_queue_items).display %>
 
 <div class="table-responsive">
   <table class="table" style="table-layout: fixed; font-size: 90%; min-width: 55rem; word-break: break-word;">

--- a/app/views/admin/r_and_r_items/index.html.erb
+++ b/app/views/admin/r_and_r_items/index.html.erb
@@ -64,11 +64,7 @@
 </div>
 
 
-<% if @admin_r_and_r_items.total_count > 0 %>
-  <p>
-    <%= @admin_r_and_r_items.offset_value + 1 %> - <%= @admin_r_and_r_items.offset_value + @admin_r_and_r_items.count %> of <%= @admin_r_and_r_items.total_count %>
-  </p>
-<% end %>
+<%= PageEntriesInfoDisplay.new(@admin_r_and_r_items).display %>
 
 <div class="table-responsive">
   <table class="table">

--- a/app/views/admin/works/index.html.erb
+++ b/app/views/admin/works/index.html.erb
@@ -63,12 +63,7 @@
   </div>
 <% end %>
 
-
-<% if @works.total_count > 0 %>
-  <p>
-    <%= @works.offset_value + 1 %> - <%= @works.offset_value + @works.count %> of <%= @works.total_count %>
-  </p>
-<% end %>
+<%= PageEntriesInfoDisplay.new(@works).display %>
 
 <table class="table admin-list">
   <thead>


### PR DESCRIPTION
I noticed when adding admin page for interviewer profiles that this code was copy-pasted in several places, makes sense to DRY it up into one of our presenter viewmodels.

Theoretically we could be using kaminari functionality for this (kaminari is the gem for pagination), by theming it to be how we wanted. Not sure why we didn't, but not looking into that, just taking the code that was there and DRYing it.