### PR TITLE
make attr_json a direct dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,9 @@ gem 'font-awesome-rails', '~> 4.7'
 # temporary kithe indexing branch, for scihist_digicoll indexing branch, do not
 # intend to merge to master like this.
 gem 'kithe', "~> 2.0", ">= 2.0.2"
+# attr_son is a dependency of kithe, but we want to make sure it gets require'd directly
+# to avoid weird auto-loading issues.
+gem "attr_json", "~> 1.0"
 gem "traject", ">= 3.5" # to include support for HTTP basic auth in Solr url
 
 gem 'simple_form', "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -632,6 +632,7 @@ PLATFORMS
 DEPENDENCIES
   access-granted (~> 1.0)
   activerecord-postgres_enum (~> 1.3)
+  attr_json (~> 1.0)
   aws-sdk-ec2 (>= 1.74)
   blacklight (~> 7.7.0)
   blacklight_range_limit (~> 7.0)


### PR DESCRIPTION
It is a dependency of kithe; but since it's not a direct dependency, it doesn't get automatically loaded on boot. So this can cause weird auto-loading issues if our app tries to use it before it's loaded code from kithe that causes attr_json to get required. Since we use it ourselves directly, we should just express it as a dependency.

I may also respond to this in kithe by making kithe require attr_json on boot.

This should fix the weird auto-loading problem from #1014 among others.