### PR TITLE
Clean up OH biographical form

### DIFF
--- a/app/views/admin/works/_oral_history_biography.html.erb
+++ b/app/views/admin/works/_oral_history_biography.html.erb
@@ -32,7 +32,7 @@
       <hr/>
       <div class="row">
         <div class="col-sm">
-          Career
+          Professional Experience
         </div>
         <div class="col-sm">
           <% work.oral_history_content.interviewee_job.sort_by { |hsh| hsh&.start || 0 }.compact.each do |job| %>

--- a/app/views/admin/works/oh_biography_form.html.erb
+++ b/app/views/admin/works/oh_biography_form.html.erb
@@ -29,148 +29,224 @@
     </ul>
     </div>
   <% end %>
+
   <div class="ml-2 form-inputs admin-edit">
     <div class="oral-history-biography">
-      <h4>Birth</h4>
-      <div class="border p-3 mb-3 birth-fields">
-        <%= f.simple_fields_for :interviewee_birth do |birth_form| %>
-          <div class="row ml-2">
-            <div class="col-sm">
-              <%= birth_form.input :date,
-                hint: 'YYYY-MM-DD or YYYY-MM or YYYY',
-                wrapper: :scihist_horizontal_form %>
+      <h2>Birth</h2>
+      <div class="p-3 mb-3 birth-fields">
+        <%= f.simple_fields_for :interviewee_birth do |sub_form| %>
+          <div class="form-row">
+
+            <div class="col-md-2 col-form-label text-right">
+              <%= sub_form.label :date %>
             </div>
-            <div class="col-sm">
-              <%= birth_form.input :city,
+            <div class="col-md-4">
+              <%= sub_form.input :date,
+                hint: 'YYYY-MM-DD or YYYY-MM or YYYY',
+                wrapper: :scihist_no_label_input %>
+            </div>
+            <div class="col-md-2 col-form-label text-right">
+              <%= sub_form.label :city %>
+            </div>
+            <div class="col-md-4">
+              <%= sub_form.input :city,
                 required: false,
-                wrapper: :scihist_horizontal_form  %>
+                wrapper: :scihist_no_label_input  %>
             </div>
           </div>
-          <div class="row ml-2">
-            <div class="col-sm">
-              <%= birth_form.input :state,
+
+          <div class="form-row">
+            <div class="col-md-2 col-form-label text-right">
+              <%= sub_form.label :state %>
+            </div>
+
+            <div class="col-md-4">
+              <%= sub_form.input :state,
                 collection: Work::PlaceLists::US_STATES,
-                hint: 'Leave blank unless USA',
-                wrapper: :scihist_horizontal_form %>
+                hint: 'USA only',
+                wrapper: :scihist_no_label_input %>
             </div>
-            <div class="col-sm">
-              <%= birth_form.input :province,
+
+            <div class="col-md-2 col-form-label text-right">
+              <%= sub_form.label :province %>
+            </div>
+
+            <div class="col-md-4">
+              <%= sub_form.input :province,
                 collection: Work::PlaceLists::CA_PROVINCES,
-                hint: 'Leave blank unless Canada',
+                hint: 'Canada only',
                 required: false,
-                wrapper: :scihist_horizontal_form %>
+                wrapper: :scihist_no_label_input %>
             </div>
-            <div class="col-sm">
-              <%= birth_form.input :country,
+
+            <div class="col-md-2 col-form-label text-right">
+              <%= sub_form.label :country %>
+            </div>
+
+            <div class="col-md-10">
+              <%= sub_form.input :country,
                 collection: Work::PlaceLists::COUNTRIES,
                 required: false,
-                wrapper: :scihist_horizontal_form
+                wrapper: :scihist_no_label_input
               %>
             </div>
           </div>
         <% end %>
       </div>
-      <h4>Death</h4>
-        <div class="border p-3 mb-3 death-fields">
-          <%= f.simple_fields_for :interviewee_death do |death_form| %>
-            <div class="row ml-2">
-              <div class="col-sm">
-                <%= death_form.input :date,
-                  hint: 'YYYY-MM-DD or YYYY-MM or YYYY',
-                  wrapper: :scihist_horizontal_form %>
-              </div>
-              <div class="col-sm">
-                <%= death_form.input :city,
-                  required: false,
-                  wrapper: :scihist_horizontal_form  %>
-              </div>
+
+      <h2>Death</h2>
+      <div class="p-3 mb-3 birth-fields">
+        <%= f.simple_fields_for :interviewee_death do |sub_form| %>
+          <div class="form-row">
+
+            <div class="col-md-2 col-form-label text-right">
+              <%= sub_form.label :date %>
             </div>
-            <div class="row ml-2">
-              <div class="col-sm">
-                <%= death_form.input :state,
-                collection: Work::PlaceLists::US_STATES,
-                hint: 'Leave blank unless USA',
-                wrapper: :scihist_horizontal_form %>
-              </div>
-              <div class="col-sm">
-                <%= death_form.input :province,
-                collection: Work::PlaceLists::CA_PROVINCES,
-                hint: 'Leave blank unless Canada',
-                required: false,
-                wrapper: :scihist_horizontal_form %>
-              </div>
-              <div class="col-sm">
-                <%= death_form.input  :country,
-                collection: Work::PlaceLists::COUNTRIES,
-                required: false,
-                wrapper: :scihist_horizontal_form %>
-               </div>
-            </div>
-          <% end %>
-        </div>
-      <h4>Education</h4>
-      <%= f.repeatable_attr_input(:interviewee_school, simple_form_input_args: { :label => "" }, build: :at_least_one) do |sub_form| %>
-        <div class="border p-3 mb-3">
-          <div class="row ml-2">
-            <div class="col-sm">
+            <div class="col-md-4">
               <%= sub_form.input :date,
                 hint: 'YYYY-MM-DD or YYYY-MM or YYYY',
-                wrapper: :scihist_horizontal_form %>
+                wrapper: :scihist_no_label_input %>
             </div>
-            <div class="col-sm">
-              <%= sub_form.input :institution,  input_html: { data: { "scihist-qa-autocomplete" => qa_search_vocab_path("assign_fast", "corporate")}}, wrapper: :scihist_horizontal_form %>
+            <div class="col-md-2 col-form-label text-right">
+              <%= sub_form.label :city %>
+            </div>
+            <div class="col-md-4">
+              <%= sub_form.input :city,
+                required: false,
+                wrapper: :scihist_no_label_input  %>
             </div>
           </div>
-          <div class="row ml-2">
-            <div class="col-sm">
-              <%= sub_form.input :degree, wrapper: :scihist_horizontal_form %>
+
+          <div class="form-row">
+            <div class="col-md-2 col-form-label text-right">
+              <%= sub_form.label :state %>
             </div>
-            <div class="col-sm">
-             <%= sub_form.input :discipline, wrapper: :scihist_horizontal_form %>
+
+            <div class="col-md-4">
+              <%= sub_form.input :state,
+                collection: Work::PlaceLists::US_STATES,
+                hint: 'USA only',
+                wrapper: :scihist_no_label_input %>
+            </div>
+
+            <div class="col-md-2 col-form-label text-right">
+              <%= sub_form.label :province %>
+            </div>
+
+            <div class="col-md-4">
+              <%= sub_form.input :province,
+                collection: Work::PlaceLists::CA_PROVINCES,
+                hint: 'Canada only',
+                required: false,
+                wrapper: :scihist_no_label_input %>
+            </div>
+
+            <div class="col-md-2 col-form-label text-right">
+              <%= sub_form.label :country %>
+            </div>
+
+            <div class="col-md-10">
+              <%= sub_form.input :country,
+                collection: Work::PlaceLists::COUNTRIES,
+                required: false,
+                wrapper: :scihist_no_label_input
+              %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+      <h2>Education</h2>
+      <%= f.repeatable_attr_input(:interviewee_school, simple_form_input_args: { :label => "" }, build: :at_least_one) do |sub_form| %>
+        <div class="border-bottom pb-3 mb-4">
+          <div class="form-row">
+            <div class="col-md-2 col-form-label text-md-right">
+              <%= sub_form.label :date %>
+            </div>
+            <div class="col-md-4">
+              <%= sub_form.input :date,
+                hint: 'YYYY-MM-DD or YYYY-MM or YYYY',
+                wrapper: :scihist_no_label_input %>
+            </div>
+            <div class="col-md-2 col-form-label text-md-right">
+              <%= sub_form.label :institution %>
+            </div>
+            <div class="col-md-4">
+              <%= sub_form.input :institution,  input_html: { data: { "scihist-qa-autocomplete" => qa_search_vocab_path("assign_fast", "corporate")}}, wrapper: :scihist_no_label_input %>
+            </div>
+          </div>
+          <div class="form-row">
+            <div class="col-md-2 col-form-label text-md-right">
+              <%= sub_form.label :degree %>
+            </div>
+            <div class="col-md-4">
+              <%= sub_form.input :degree, wrapper: :scihist_no_label_input %>
+            </div>
+            <div class="col-md-2 col-form-label text-md-right">
+              <%= sub_form.label :discipline %>
+            </div>
+            <div class="col-md-4">
+             <%= sub_form.input :discipline, wrapper: :scihist_no_label_input %>
             </div>
           </div>
         </div>
       <% end %>
-      <h4>Career</h4>
+
+      <h2>Professional Experience</h2>
       <%= f.repeatable_attr_input(:interviewee_job, simple_form_input_args: { :label => "" }, build: :at_least_one) do |sub_form| %>
-        <div class="border p-3 mb-3">
-          <div class="row ml-2">
-            <div class="col-sm">
-              <%= sub_form.input :start, wrapper: :scihist_horizontal_form,
+        <div class="border-bottom pb-3 mb-4">
+          <div class="form-row">
+            <div class="col-md-2 col-form-label text-md-right">
+              <%= sub_form.label :start %>
+            </div>
+            <div class="col-md-4">
+              <%= sub_form.input :start, wrapper: :scihist_no_label_input,
                 hint: 'YYYY-MM-DD or YYYY-MM or YYYY'%>
             </div>
-            <div class="col-sm">
-              <%= sub_form.input :end, wrapper: :scihist_horizontal_form,
+            <div class="col-md-2 col-form-label text-md-right">
+              <%= sub_form.label :end %>
+            </div>
+            <div class="col-md-4">
+              <%= sub_form.input :end, wrapper: :scihist_no_label_input,
                 hint: 'YYYY-MM-DD or YYYY-MM or YYYY'%>
             </div>
           </div>
-          <div class="row ml-2">
-            <div class="col-sm">
-              <%= sub_form.input :institution,  input_html: { data: { "scihist-qa-autocomplete" => qa_search_vocab_path("assign_fast", "corporate")} }, wrapper: :scihist_horizontal_form %>
+
+          <div class="form-row">
+            <div class="col-md-2 col-form-label text-md-right">
+              <%= sub_form.label :institution %>
             </div>
-            <div class="col-sm">
-              <%= sub_form.input :role, wrapper: :scihist_horizontal_form %>
+
+            <div class="col-md-4">
+              <%= sub_form.input :institution,  input_html: { data: { "scihist-qa-autocomplete" => qa_search_vocab_path("assign_fast", "corporate")} }, wrapper: :scihist_no_label_input %>
+            </div>
+            <div class="col-md-2 col-form-label text-md-right">
+              <%= sub_form.label :role %>
+            </div>
+            <div class="col-md-4">
+              <%= sub_form.input :role, wrapper: :scihist_no_label_input %>
             </div>
           </div>
         </div>
       <% end %>
-      <h4>Honors and awards</h4>
+
+      <h2>Honors</h2>
       <%= f.repeatable_attr_input(:interviewee_honor, simple_form_input_args: { :label => "" }, build: :at_least_one) do |sub_form| %>
         <div class="border-bottom pb-3 mb-4">
           <div class="form-row">
-              <div class="col-sm-2 col-form-label text-right">
+              <div class="col-md-2 col-form-label text-right">
                 <%= sub_form.label :start_date, label: "Start" %>
               </div>
-              <div class="col-sm-4">
+              <div class="col-md-4">
                 <%= sub_form.input :start_date,
                   label: false,
                   hint: 'YYYY-MM-DD or YYYY-MM or YYYY',
                   wrapper: :scihist_no_label_input %>
               </div>
-              <div class="col-form-label col-sm-2 text-right">
+              <div class="col-form-label col-md-2 text-right">
                 <%= sub_form.label :end_date, label: "End" %>
               </div>
-              <div class="col-sm-4">
+              <div class="col-md-4">
                 <%= sub_form.input :end_date,
                   label: false,
                   hint: 'optional, YYYY[-MM[-DD]]',

--- a/app/views/admin/works/oh_biography_form.html.erb
+++ b/app/views/admin/works/oh_biography_form.html.erb
@@ -156,23 +156,33 @@
       <% end %>
       <h4>Honors and awards</h4>
       <%= f.repeatable_attr_input(:interviewee_honor, simple_form_input_args: { :label => "" }, build: :at_least_one) do |sub_form| %>
-        <div class="border p-3 mb-3">
-          <div class="row ml-2">
-            <div class="col-md">
-              <%= sub_form.input :start_date,
-                label: "Start",
-                hint: 'YYYY-MM-DD or YYYY-MM or YYYY' %>
-            </div>
-
-            <div class="col-md">
-              <%= sub_form.input :end_date,
-                label: "End",
-                hint: 'optional, YYYY-MM-DD or YYYY-MM or YYYY' %>
-            </div>
+        <div class="border-bottom pb-3 mb-4">
+          <div class="form-row">
+              <div class="col-sm-2 col-form-label text-right">
+                <%= sub_form.label :start_date, label: "Start" %>
+              </div>
+              <div class="col-sm-4">
+                <%= sub_form.input :start_date,
+                  label: false,
+                  hint: 'YYYY-MM-DD or YYYY-MM or YYYY',
+                  wrapper: :scihist_no_label_input %>
+              </div>
+              <div class="col-form-label col-sm-2 text-right">
+                <%= sub_form.label :end_date, label: "End" %>
+              </div>
+              <div class="col-sm-4">
+                <%= sub_form.input :end_date,
+                  label: false,
+                  hint: 'optional, YYYY[-MM[-DD]]',
+                  wrapper: :scihist_no_label_input %>
+              </div>
           </div>
-          <div class="row ml-2">
-            <div class="col-md">
-              <%= sub_form.input :honor %>
+          <div class="form-row">
+            <div class="col-md-2 col-form-label text-right">
+              <%= sub_form.label :honor %>
+            </div>
+            <div class="col-md-10">
+              <%= sub_form.input :honor, wrapper: :scihist_no_label_input %>
             </div>
           </div>
         </div>

--- a/config/initializers/simple_form_bootstrap_customized.rb
+++ b/config/initializers/simple_form_bootstrap_customized.rb
@@ -44,4 +44,32 @@ SimpleForm.setup do |config|
   end
 
 
+  # For use where we want to lay out the whole form ourselves. It does NOT include a label,
+  # you are responsible for including a label yourself.
+  #
+  # It does include both hint and error UNDER the input.
+  #
+  # Since you are resposible for label, we can't highlight the whole label/input area in red, only
+  # the input itself.
+  #
+  # This was based on the out-of-the-box simple_form bootstrap :inline_form wrapper, but
+  # we don't even want a screen-reader-only label, we're going to do the label ourselves elsewhere.
+  # And we want the hint under the input, because works better for our repeatable sections, even
+  # though it's a bit confusing when the error shows up too.
+  config.wrappers :scihist_no_label_input, tag: 'span', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+
+    b.use :input, class: 'form-control', error_class: 'is-invalid'
+    b.use :error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+    b.optional :hint, wrap_with: { tag: 'small', class: 'form-text text-muted scihist-hint mb-2 mt-0' }
+  end
+
+
+
 end

--- a/spec/system/admin/oral_history_interviewee_bio_spec.rb
+++ b/spec/system/admin/oral_history_interviewee_bio_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Oral History Access Interviewee bio", :logged_in_user, type: :sy
     fill_in('oral_history_content_interviewee_birth_attributes_date', with: '1937-07-1aa')
 
     find('input[name="commit"]').click
-    expect(page).to have_text("Date Must be of format YYYY[-MM-DD]")
+    expect(page).to have_text("Must be of format YYYY[-MM-DD]")
 
 
     fill_in('oral_history_content_interviewee_birth_attributes_date', with: '')


### PR DESCRIPTION
Use more correct bootstrap CSS, with complete control of bootstrap grid, by way of a new simple_form wrapper.

Use form-row for tighter spacing. Generally cleaner.