### PR TITLE
Tell Honeybadger to ignore invalid MIME errors

### DIFF
--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -8,5 +8,8 @@ user_informer:
   info: "Error ID: {{error_id}}"
 breadcrumbs:
   enabled: true
+exceptions:
+  ignore:
+    - 'ActionDispatch::Http::MimeNegotiation::InvalidType'
 
 # http://docs.honeybadger.io/ruby/gem-reference/configuration.html


### PR DESCRIPTION
Rails 6.1 finally uses a specific identifiable class for this, so we can add it the ignore list.