### PR TITLE
Link 'Oral histories' in genre list actually to Oral Histories collection

### DIFF
--- a/app/presenters/genre_link_list_display.rb
+++ b/app/presenters/genre_link_list_display.rb
@@ -1,0 +1,25 @@
+# Just displays a list of genres with links, for use on search results and work show page
+class GenreLinkListDisplay < ViewModel
+  valid_model_type_names "Array" # of String names
+
+  alias_method :genre_list, :model
+
+  def display
+    safe_join(
+      genre_list.map { |g| link_to g, link_for_genre(g) },
+      ", "
+    )
+  end
+
+  private
+
+  # Oral histories gets a special collection link, instead of to search results for genre
+  def link_for_genre(genre_str)
+    if genre_str == "Oral histories"
+      collection_path(ScihistDigicoll::Env.lookup!(:oral_history_collection_id))
+    else
+      search_on_facet_path(:genre_facet, genre_str)
+    end
+  end
+
+end

--- a/app/presenters/work_result_display.rb
+++ b/app/presenters/work_result_display.rb
@@ -8,10 +8,7 @@ class WorkResultDisplay < ResultDisplay
   delegate :additional_title
 
   def display_genres
-    @display_genres ||= safe_join(
-      model.genre.map { |g| link_to g, search_on_facet_path(:genre_facet, g) },
-      ", "
-    )
+    @display_genres ||= GenreLinkListDisplay.new(model.genre).display
   end
 
   def display_dates

--- a/app/presenters/work_title_and_dates.rb
+++ b/app/presenters/work_title_and_dates.rb
@@ -11,10 +11,6 @@ class WorkTitleAndDates < ViewModel
   end
 
   def display_genres
-    safe_join(
-      model.genre.map { |g| link_to g, search_on_facet_path(:genre_facet, g) },
-      ", "
-    )
+    GenreLinkListDisplay.new(model.genre).display
   end
-
 end


### PR DESCRIPTION
To do this, we extract genre link list to a VERY simple ViewModel presenter, so we can re-use it in two places.

Ref #988