### PR TITLE
Some general clean-up of OH views

### DIFF
--- a/app/assets/stylesheets/local/oh_audio.scss
+++ b/app/assets/stylesheets/local/oh_audio.scss
@@ -273,26 +273,6 @@
 
   .other-files {
     border-top: 3px solid $table-border-color;
-
-    .show-member-list-item {
-      display: flex;
-
-      & > div {
-        padding: $table-cell-padding;
-        border-top: $table-border-width solid $table-border-color;
-      }
-
-      .image {
-        width: 54px; // thumb_mini width
-        padding-left: 0;
-      }
-
-      .title {
-        flex-grow: 1;
-        width: 100%;
-        word-break: break-word;
-      }
-    }
   }
 
   .work.chf-attributes {

--- a/app/assets/stylesheets/local/oh_audio.scss
+++ b/app/assets/stylesheets/local/oh_audio.scss
@@ -271,8 +271,8 @@
     }
   }
 
-  .other-files {
-    border-top: 3px solid $table-border-color;
+  .show-member-file-list-item:first-child div {
+    border: none;
   }
 
   .work.chf-attributes {

--- a/app/assets/stylesheets/local/oh_audio.scss
+++ b/app/assets/stylesheets/local/oh_audio.scss
@@ -271,7 +271,7 @@
     }
   }
 
-  .show-member-file-list-item:first-child div {
+  .show-member-file-list-item:first-child > div {
     border: none;
   }
 

--- a/app/assets/stylesheets/local/show-layout.scss
+++ b/app/assets/stylesheets/local/show-layout.scss
@@ -137,6 +137,7 @@
     width: 54px; // thumb_mini width
     padding-left: 0;
     padding-right: 0;
+    flex-shrink: 0;
   }
 
   .title {

--- a/app/assets/stylesheets/local/show-layout.scss
+++ b/app/assets/stylesheets/local/show-layout.scss
@@ -121,26 +121,27 @@
         margin-top: 0 !important;
       }
     }
+  }
+}
 
-    .show-member-file-list-item {
-      display: flex;
+// Yeah, this has no parent selector, it's used on audio page too.
+.show-member-file-list-item {
+  display: flex;
 
-      & > div {
-        padding: $table-cell-padding;
-        border-top: $table-border-width solid $table-border-color;
-      }
+  & > div {
+    padding: $table-cell-padding;
+    border-top: $table-border-width solid $table-border-color;
+  }
 
-      .image {
-        width: 54px; // thumb_mini width
-        padding-left: 0;
-        padding-right: 0;
-      }
+  .image {
+    width: 54px; // thumb_mini width
+    padding-left: 0;
+    padding-right: 0;
+  }
 
-      .title {
-        flex-grow: 1;
-        width: 100%;
-        word-break: break-word;
-      }
-    }
+  .title {
+    flex-grow: 1;
+    width: 100%;
+    word-break: break-word;
   }
 }

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -29,11 +29,14 @@ class WorksController < ApplicationController
   private
 
   def decorator
-    @decorator ||= if @work.is_oral_history? && ! @work.oral_history_content&.available_by_request_off?
-      WorkFileListShowDecorator.new(@work)
-    elsif has_oh_audio_member?
+    @decorator ||= if @work.is_oral_history? && has_oh_audio_member? && @work.oral_history_content&.available_by_request_off?
+      # special OH audio player template
       OhAudioWorkShowDecorator.new(@work)
+    elsif @work.is_oral_history?
+      # OH with no playable audio, either becuae it's by-request or it's not there at all.
+      WorkFileListShowDecorator.new(@work)
     else
+      # standard image-based template.
       WorkShowDecorator.new(@work)
     end
   end

--- a/app/decorators/oh_audio_work_show_decorator.rb
+++ b/app/decorators/oh_audio_work_show_decorator.rb
@@ -40,48 +40,6 @@ class OhAudioWorkShowDecorator < Draper::Decorator
      end
   end
 
-  def asset_details(asset)
-    details = []
-    if asset.original_filename != asset.title
-      details << asset.original_filename
-    end
-    if asset.content_type.present?
-      details << ScihistDigicoll::Util.humanized_content_type(asset.content_type)
-    end
-    if asset.size.present?
-      details << ScihistDigicoll::Util.simple_bytes_to_human_string(asset.size)
-    end
-
-    details.join(" — ")
-  end
-
-  # We have a list of non-audio "Other' files. We expect them to be PDFs,
-  # and we want to link to pdf "view" link -- just direct delivery of the PDF
-  # to the browser, using download controller same as MemberImagePresentation does.
-  #
-  # If it's an image type, we don't expect it here, and don't know what to do with it
-  # here (we're not supporting the Viewer here at present), so just punt and don't make it
-  # a link.
-  #
-  # This method is called with a block for the actual contents of the <a> tag, we use
-  # it on template to wrap an image or a title string.
-  #
-  #     <%= decorator.link_to_non_audio_member(member) do %>
-  #        contents of link
-  #     <% end %>
-  def link_to_non_audio_member(member)
-    if member.content_type&.start_with?("image/")
-      yield
-    else
-      link_to download_path(member.leaf_representative, disposition: :inline),
-        'data-analytics-category' => 'Work',
-        'data-analytics-action' => "view_oral_history_transcript_pdf",
-        'data-analytics-label' => member.parent.friendlier_id do
-        yield
-      end
-    end
-  end
-
   def has_ohms_transcript?
     model&.oral_history_content&.has_ohms_transcript?
   end

--- a/app/decorators/work_file_list_show_decorator.rb
+++ b/app/decorators/work_file_list_show_decorator.rb
@@ -33,19 +33,6 @@ class WorkFileListShowDecorator < Draper::Decorator
     end
   end
 
-  def asset_details(asset)
-    details = []
-
-    if asset.content_type.present?
-      details << ScihistDigicoll::Util.humanized_content_type(asset.content_type)
-    end
-    if asset.size.present?
-      details << ScihistDigicoll::Util.simple_bytes_to_human_string(asset.size)
-    end
-
-    details.join(" — ")
-  end
-
   def available_by_request_summary
     parts = []
 

--- a/app/presenters/download_filename_helper.rb
+++ b/app/presenters/download_filename_helper.rb
@@ -25,9 +25,6 @@ class DownloadFilenameHelper
   # Can do different things for different sorts of Assets, like speical audio file
   # handling.
   def self.filename_for_asset(asset, derivative_key: nil)
-    # audio files use their whole title instead of parents, with the intended
-    # use case of Oral History, our only audio files at present, where archival
-    # title is important.
     base = self.filename_base_for_asset(asset)
 
     if derivative_key && !asset.content_type.start_with?("audio")
@@ -43,11 +40,21 @@ class DownloadFilenameHelper
     self.filename_with_suffix(base, content_type: content_type)
   end
 
+
+  # For image files, the original_filename is pretty opaque, derive
+  # a base filename from first words of title of parent work.
+  #
+  # But for audio and PDF, use original filename with friendlier_id for guaranteed uniqueness.
+  # Intended use case for these is oral history files, where the original filenames
+  # are possibly meaningful to users and usually unique -- but work titles all
+  # begin with "oral history"
+  #
   def self.filename_base_for_asset(asset)
     raise ArgumentError, 'Pass in an asset.' unless asset.is_a? Asset
-    if asset.content_type && asset.content_type.start_with?("audio/")
-      return asset.title
+    if asset.content_type && asset.content_type.start_with?("audio/") || asset.content_type == "application/pdf"
+      return [asset.original_filename, asset.friendlier_id].join("_")
     end
+
     self.filename_base_from_parent(asset)
   end
 

--- a/app/presenters/download_filename_helper.rb
+++ b/app/presenters/download_filename_helper.rb
@@ -52,7 +52,7 @@ class DownloadFilenameHelper
   def self.filename_base_for_asset(asset)
     raise ArgumentError, 'Pass in an asset.' unless asset.is_a? Asset
     if asset.content_type && asset.content_type.start_with?("audio/") || asset.content_type == "application/pdf"
-      return [asset.original_filename, asset.friendlier_id].join("_")
+      return [File.basename(asset.original_filename, ".*"), asset.friendlier_id].join("_")
     end
 
     self.filename_base_from_parent(asset)

--- a/app/presenters/file_list_item_display.rb
+++ b/app/presenters/file_list_item_display.rb
@@ -1,0 +1,98 @@
+class FileListItemDisplay < ViewModel
+  valid_model_type_names "Asset", "Work"
+
+  alias_method :member, :model
+
+  attr_reader :index, :view_link_attributes, :download_original_only
+
+  # @param index [integer] Need index so we know whether to lazy-load
+  #
+  # @param view_link_attributes [Hash] extra attributes to add to title/thumb links
+  #   to item. Used for adding 'data' attributes for analytics to our oral history
+  #   PDF views.
+  #
+  # @param download_original_only [Boolean] default false. If true, instead of the
+  #   download menu component in the action column, there will be a single download
+  #   button to download original.
+  def initialize(member, index:, view_link_attributes: {}, download_original_only: false)
+    super(member)
+    @index = index
+    @view_link_attributes = view_link_attributes
+    @download_original_only = download_original_only
+
+    unless member.association(:parent).loaded?
+      raise ArgumentError.new("parent must be pre-loaded to avoid n+1 queries please, on: #{member}")
+    end
+  end
+
+  def display
+    render "/presenters/file_list_item_display", member: member, view: self
+  end
+
+  # Should we link thumbnail and title to a "view" link?
+  #
+  # Only for PDFs at present, but can expand later. We don't want to do
+  # this for images, not sure about other stuff.
+  #
+  # As we are just linking to our download link with disposition inline,
+  # for PDFs this will be displayed by the browser (for browsers capable of doing
+  # so, which is all popular ones)
+  #
+  # If it's an image type, we're not really planning on using it with this component,
+  # and don't know what to do with it,  here (we're not supporting the Viewer here
+  # at present), so just punt and don't make it a link.
+  #
+  # This method is called with a block for the actual contents of the <a> tag, we use
+  # it on template to wrap an image or a title string.
+  #
+  #     <%= decorator.link_to_non_audio_member(member) do %>
+  #        contents of link
+  #     <% end %>
+  def maybe_view_link_to(member)
+    if member.kind_of?(Asset) && member.content_type&.start_with?("image/")
+      yield
+    else
+      link_to(download_path(member.leaf_representative, disposition: :inline), view_link_attributes) do
+        yield
+      end
+    end
+  end
+
+  # Some metadata about asset, that we will display under the asset.
+  def asset_details(asset)
+    details = []
+
+    if asset.content_type.present?
+      details << ScihistDigicoll::Util.humanized_content_type(asset.content_type)
+    end
+    if asset.size.present?
+      details << ScihistDigicoll::Util.simple_bytes_to_human_string(asset.size)
+    end
+
+    str = details.join(" — ")
+
+    if asset.original_filename != member_label
+      str = safe_join([str, "<br>".html_safe, asset.original_filename])
+    end
+
+    str
+  end
+
+  # Info button for Work.
+  #
+  # For Asset, if we have download_original_only it's a simple download link,
+  # otherwise use download dropdown menu.
+  def action_link
+    if member.kind_of?(Work)
+      link_to "Info", work_path(member), class: "btn btn-primary"
+    elsif download_original_only
+      link_to "Download", download_path(member), class: "btn btn-primary", data: {
+        "analytics-category" => "Work",
+        "analytics-action" => "download_original",
+        "analytics-label"  => member.parent.friendlier_id
+      }
+    else
+      DownloadDropdownDisplay.new(member, display_parent_work: member.parent, use_link:true).display
+    end
+  end
+end

--- a/app/presenters/file_list_item_display.rb
+++ b/app/presenters/file_list_item_display.rb
@@ -29,6 +29,18 @@ class FileListItemDisplay < ViewModel
     render "/presenters/file_list_item_display", member: member, view: self
   end
 
+
+  # use label supplied by "role" if present, otherwise just the asset.title
+  # as usual.
+  def member_label
+    @member_label ||= if member.role.present?
+      t(member.role, scope: "asset_role_label", default: member.role.humanize )
+    else
+      member.title
+    end
+  end
+
+
   # Should we link thumbnail and title to a "view" link?
   #
   # Only for PDFs at present, but can expand later. We don't want to do

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -46,6 +46,11 @@
 
     <dl class="row">
 
+      <% if @asset.role.present? %>
+        <dt class="col-sm-4">Role</dt>
+        <dd class="col-sm-8"><span class="badge badge-info"><%= @asset.role.humanize.downcase %></span></dd>
+      <% end %>
+
       <dt class="col-sm-4">Created</dt>
       <dd class="col-sm-8"><%= l @asset.created_at, format: :admin %></dd>
 

--- a/app/views/presenters/_file_list_item_display.html.erb
+++ b/app/views/presenters/_file_list_item_display.html.erb
@@ -9,7 +9,7 @@
   <div class="title">
     <div>
       <%= view.maybe_view_link_to(member) do %>
-        <%= member.title %>
+        <%= view.member_label %>
       <% end %>
       <% unless member.published? %>
           <span title="Private" class="badge badge-warning">Private</span>

--- a/app/views/presenters/_file_list_item_display.html.erb
+++ b/app/views/presenters/_file_list_item_display.html.erb
@@ -1,0 +1,28 @@
+<div class="show-member-file-list-item" data-member-id="<%= member.friendlier_id %>">
+  <div class="image">
+    <%= view.maybe_view_link_to(member) do %>
+      <%# lazyload all but first 6 images %>
+      <%= ThumbDisplay.new(member.leaf_representative, thumb_size: :mini, lazy: (view.index > 5)).display %>
+    <% end %>
+  </div>
+
+  <div class="title">
+    <div>
+      <%= view.maybe_view_link_to(member) do %>
+        <%= member.title %>
+      <% end %>
+      <% unless member.published? %>
+          <span title="Private" class="badge badge-warning">Private</span>
+      <% end %>
+    </div>
+    <% if member.kind_of?(Asset) %>
+      <div>
+        <small><%= view.asset_details(member) %></small>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="action">
+    <%= view.action_link %>
+  </div>
+</div>

--- a/app/views/works/_show_with_audio_downloads.html.erb
+++ b/app/views/works/_show_with_audio_downloads.html.erb
@@ -5,7 +5,7 @@
     <div class="other-files sans-serif">
       <% decorator.non_audio_members.each_with_index do |member, index| %>
 
-        <div class="show-member-list-item" data-member-id="<%= member.friendlier_id %>">
+        <div class="show-member-file-list-item" data-member-id="<%= member.friendlier_id %>">
           <div class="image">
             <%= decorator.link_to_non_audio_member(member) do %>
               <%# lazyload all but first 6 images %>

--- a/app/views/works/_show_with_audio_downloads.html.erb
+++ b/app/views/works/_show_with_audio_downloads.html.erb
@@ -4,37 +4,15 @@
 
     <div class="other-files sans-serif">
       <% decorator.non_audio_members.each_with_index do |member, index| %>
-
-        <div class="show-member-file-list-item" data-member-id="<%= member.friendlier_id %>">
-          <div class="image">
-            <%= decorator.link_to_non_audio_member(member) do %>
-              <%# lazyload all but first 6 images %>
-              <%= ThumbDisplay.new(member.leaf_representative, thumb_size: :mini, lazy: (index > 5)).display %>
-            <% end %>
-          </div>
-          <div class="title">
-            <div>
-              <%= decorator.link_to_non_audio_member(member) do %>
-                <%= member.title %>
-              <% end %>
-              <% unless member.published? %>
-                  <span title="Private" class="badge badge-warning">Private</span>
-              <% end %>
-            </div>
-            <% if member.kind_of?(Asset) %>
-              <div>
-                <small><%= decorator.asset_details(member) %></small>
-              </div>
-            <% end %>
-          </div>
-          <div class="action">
-            <% if member.kind_of?(Work) %>
-              <%= link_to "Info", work_path(member), class: "btn btn-primary" %>
-            <% else %>
-              <%= DownloadDropdownDisplay.new(member, display_parent_work: @work, use_link:true).display %>
-            <% end %>
-          </div>
-        </div>
+        <%= FileListItemDisplay.new(member,
+              index: index,
+              view_link_attributes: {
+                'data-analytics-category' => 'Work',
+                'data-analytics-action' => "view_oral_history_transcript_pdf",
+                'data-analytics-label' => member.parent.friendlier_id
+              }
+            ).display
+        %>
       <% end %>
       <p><small>The published version of the transcript may diverge from the interview audio due to edits to the transcript made by staff of the Center for Oral History, often at the request of the interviewee, during the transcript review process.</small></p>
     </div>

--- a/app/views/works/_show_with_audio_downloads.html.erb
+++ b/app/views/works/_show_with_audio_downloads.html.erb
@@ -1,7 +1,5 @@
 <% if decorator.non_audio_members.present? %>
   <div class="downloads-pdf">
-    <h2 class="attribute-sub-head">Transcript (Published Version)</h2>
-
     <div class="other-files sans-serif">
       <% decorator.non_audio_members.each_with_index do |member, index| %>
         <%= FileListItemDisplay.new(member,

--- a/app/views/works/work_file_list_show.html.erb
+++ b/app/views/works/work_file_list_show.html.erb
@@ -57,42 +57,7 @@
     </div>
 
     <% decorator.member_list_for_display.each_with_index do |member, index| %>
-        <div class="show-member-file-list-item">
-          <div class="image">
-            <%# lazyload all but first 6 images %>
-            <%= ThumbDisplay.new(member.leaf_representative, thumb_size: :mini, lazy: (index > 5)).display %>
-          </div>
-          <div class="title">
-            <div>
-              <%= link_to_if member.kind_of?(Asset),
-                             member.title,
-                             download_path(member, disposition: :inline) %>
-
-              <% unless member.published? %>
-                  <span title="Private" class="badge badge-warning">Private</span>
-              <% end %>
-            </div>
-            <% if member.kind_of?(Asset) %>
-              <div>
-                <small><%= decorator.asset_details(member) %></small>
-              </div>
-            <% end %>
-          </div>
-          <div class="action">
-            <% if member.kind_of?(Work) %>
-              <%= link_to "Info", work_path(member), class: "btn btn-primary" %>
-            <% else %>
-              <%= link_to "Download",
-                  download_path(member),
-                  class: "btn btn-primary",
-                  data: {
-                    analytics_category: "Work",
-                    analytics_action: "download",
-                    analytics_label: @work.friendlier_id
-                  } %>
-            <% end %>
-          </div>
-        </div>
+      <%= FileListItemDisplay.new(member, index: index, download_original_only: true).display %>
     <% end %>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,3 +76,7 @@ en:
       admin/digitization_queue_item:
         museum_object_id: "Object ID (Past Perfect)"
 
+  asset_role_label:
+    transcript: "Transcript"
+    front_matter: "Front Matter and Index"
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,6 +77,6 @@ en:
         museum_object_id: "Object ID (Past Perfect)"
 
   asset_role_label:
-    transcript: "Transcript"
+    transcript: "Transcript (Published Version)"
     front_matter: "Front Matter and Index"
 

--- a/lib/tasks/data_fixes/assign_oh_roles.rake
+++ b/lib/tasks/data_fixes/assign_oh_roles.rake
@@ -8,6 +8,12 @@ namespace :scihist do
       progress_bar = ProgressBar.create(total: scope.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
 
       scope.find_each do |work|
+
+        if work.members.size == 0
+          # nevermind, we don't care
+          next
+        end
+
         pdfs = work.members.find_all {|a| a.is_a?(Asset) && a.content_type == "application/pdf"}
 
         # only PDF and it's published? Transcript

--- a/lib/tasks/data_fixes/assign_oh_roles.rake
+++ b/lib/tasks/data_fixes/assign_oh_roles.rake
@@ -1,0 +1,39 @@
+namespace :scihist do
+  namespace :data_fixes do
+
+    desc "assign 'role' to legacy Oral History assets"
+    task :assign_oh_roles => :environment do
+      scope = Work.includes(:members).where("json_attributes -> 'genre' ?  'Oral histories'")
+
+      progress_bar = ProgressBar.create(total: scope.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+
+      scope.find_each do |work|
+        pdfs = work.members.find_all {|a| a.is_a?(Asset) && a.content_type == "application/pdf"}
+
+        # only PDF and it's published? Transcript
+        if pdfs.count == 1 && pdfs.first.published?
+          one_pdf = pdfs.first
+          one_pdf.update(role: "transcript")
+
+        # Two pdfs, one is published, and one is by-request? The by-request one is
+        # transccript, the published one is front-matter.
+        elsif pdfs.count == 2 &&
+          transcript = pdfs.find { |a| !a.published? && a.oh_available_by_request? }
+          front_matter = pdfs.find { |a| a.published? }
+
+          if transcript && front_matter
+            transcript.update(role: "transcript")
+            front_matter.update(role: "front_matter")
+          end
+
+        # don't know how to do it!
+        else
+          progress_bar.log "Couldn't figure out what to do with OH work: #{work.friendlier_id}"
+
+        end
+
+        progress_bar.increment
+      end
+    end
+  end
+end

--- a/spec/presenters/download_filename_helper_spec.rb
+++ b/spec/presenters/download_filename_helper_spec.rb
@@ -86,6 +86,19 @@ describe DownloadFilenameHelper, type: :model do
       # note ends with jpeg, not png, cause it's a jpeg derivative
       expect(DownloadFilenameHelper.filename_for_asset(asset, derivative_key: derivative_key)).to eq "plastics_make_the_#{asset.parent.friendlier_id}_12_#{asset.friendlier_id}_#{derivative_key}.jpeg"
     end
-  end
 
+    describe "PDF asset" do
+      let(:asset) { create(:asset_with_faked_file, :pdf) }
+      it "uses original filename plus ID" do
+        expect(DownloadFilenameHelper.filename_for_asset(asset)).to eq("#{File.basename(asset.original_filename, '.*')}_#{asset.friendlier_id}#{File.extname(asset.original_filename)}")
+      end
+    end
+
+    describe "Audio asset" do
+      let(:asset) { create(:asset_with_faked_file, :mp3) }
+      it "uses original filename plus ID" do
+        expect(DownloadFilenameHelper.filename_for_asset(asset)).to eq("#{File.basename(asset.original_filename, '.*')}_#{asset.friendlier_id}#{File.extname(asset.original_filename)}")
+      end
+    end
+  end
 end

--- a/spec/system/oral_history_with_audio_spec.rb
+++ b/spec/system/oral_history_with_audio_spec.rb
@@ -74,7 +74,7 @@ describe "Oral history with audio display", type: :system, js: true do
       # In oh_audio_work_show_decorator.rb we specify that only PDFs should be linked.
 
       #PDF has a link:
-      linked_pdf_transcripts = find_all('.show-member-list-item a').select { |x| x.text == pdf_asset.title }
+      linked_pdf_transcripts = find_all('.show-member-file-list-item a').select { |x| x.text == pdf_asset.title }
       expect(linked_pdf_transcripts.count).to eq 1
       #linked_pdf_transcripts[0]
 
@@ -84,9 +84,9 @@ describe "Oral history with audio display", type: :system, js: true do
       # 3 JPEGS: not linked
 
 
-      expect(find_all('.show-member-list-item a').select { |x| x.text == image_assets[0].title }.count).to eq 0
-      expect(find_all('.show-member-list-item a').select { |x| x.text == image_assets[1].title }.count).to eq 0
-      expect(find_all('.show-member-list-item a').select { |x| x.text == image_assets[2].title }.count).to eq 0
+      expect(find_all('.show-member-file-list-item a').select { |x| x.text == image_assets[0].title }.count).to eq 0
+      expect(find_all('.show-member-file-list-item a').select { |x| x.text == image_assets[1].title }.count).to eq 0
+      expect(find_all('.show-member-file-list-item a').select { |x| x.text == image_assets[2].title }.count).to eq 0
 
       within("*[data-role='audio-playlist-wrapper']") do
         within('.now-playing-container') do
@@ -107,7 +107,7 @@ describe "Oral history with audio display", type: :system, js: true do
         expect(download_links.select{ |x| x.include? 'downloads'}.count).to eq published_audio_assets.count
       end
 
-      non_audio = page.find_all('.other-files .show-member-list-item')
+      non_audio = page.find_all('.other-files .show-member-file-list-item')
 
       # Don't show the unpublished non-audio asset (# 6) to the not-logged-in user.
       # (The + 1 accounts for the PDF, which is not an image but is also not audio.)
@@ -259,7 +259,7 @@ describe "Oral history with audio display", type: :system, js: true do
       # Regular assets:
       # All files are listed, including the unpublished ones:
 
-      other_files = page.find_all('.other-files .show-member-list-item')
+      other_files = page.find_all('.other-files .show-member-file-list-item')
       #  All files = audio files + image files + 1 PDF file.
       expect(other_files.count).to eq image_assets.count + 1
 


### PR DESCRIPTION
Motivated by new asset 'roles' feature. 

1. A rake task to assign roles to legacy OH assets, based on exisitng assumptions in logic
2. We had two different "tabular file listing" displays of assets in the two different OH templates being used. They were copy-paste-changed. We DRY them into a new ViewModel component. So they now both look more consistent, which changes how they look a bit. Also tweaked/improved a few things while doing this. 
3. Since it's DRY now, we can, in one place, make them label files "Transcript" or "Front matter and index" (rather than filename or manual label). 
4. This makes it possible for us to use the file-listing template for OH's with *no* audio files at all, instead of default image-based template which wasn't really working. Ref #985
5. We also change filenames used for downloads to the original_filename for both audio and PDF files. This makes sense, and matches microsite. Eg might be "Molina_M_0896_FULL.pdf" -- actually we might still put the ID on the end for enforced uniqueness.



After this goes live, ingest staff will no longer have to manually assign "label" to Front matter, but *will* have to assign "role" to Front Matter and Transcripts. 