### PR TITLE
Redirect legacy OH content

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -10,4 +10,23 @@ class StaticController < ApplicationController
 
   def policy
   end
+
+  def oh_legacy_url_not_found
+    Rails.logger.warn("Unknown legacy oral histories url: #{request.url}; referer: #{request.referer} ")
+
+    @original_url = request.url
+    @original_referer = request.referer
+
+    subject = ERB::Util.url_encode('Missing oral history URL on digital collections')
+    body = ERB::Util.url_encode("url: #{@original_url}\nreferrer: #{@original_referrer}")
+    @report_mailto = "mailto:#{ScihistDigicoll::Env.lookup!(:oral_history_email_address)}?subject=#{subject}&body=#{body}"
+
+    render status: 404
+  end
+
+  # our oh_legacy action can be displayed via the old oh.sciencehistory.org host, make
+  # sure rendered links are to our actual preferred host.
+  def default_url_options
+    { host: ScihistDigicoll::Env.lookup!(:app_url_base) }
+  end
 end

--- a/app/views/application/_search_form.html.erb
+++ b/app/views/application/_search_form.html.erb
@@ -10,7 +10,7 @@
       the extra search options may be always visible.
 %>
 
-<%= form_tag search_catalog_path, method: :get, class: "search-form", role: "search" do %>
+<%= form_tag search_catalog_url, method: :get, class: "search-form", role: "search" do %>
   <%= hidden_field_tag :search_field, 'all_fields' %>
 
 

--- a/app/views/layouts/_scihist_masthead.html.erb
+++ b/app/views/layouts/_scihist_masthead.html.erb
@@ -22,7 +22,7 @@ do `content_for(:suppress_masthead_search, true)`
       </a>
 
 
-      <h1 class="masthead-title small-masthead-only"><%= link_to "Digital Collections", root_path %></h1>
+      <h1 class="masthead-title small-masthead-only"><%= link_to "Digital Collections", root_url %></h1>
 
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#top-navbar-collapse" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
@@ -32,12 +32,12 @@ do `content_for(:suppress_masthead_search, true)`
 
     <div class="collapse navbar-collapse" id="top-navbar-collapse" role="navigation">
       <div class="masthead-right">
-        <h1 class="masthead-title large-masthead-only"><%= link_to "Digital Collections", root_path %></h1>
+        <h1 class="masthead-title large-masthead-only"><%= link_to "Digital Collections", root_url %></h1>
 
         <ul class="nav navbar-nav navbar-right">
-          <li class="navbar-item"><%= link_to "About", about_path, class: "nav-link" %></li>
-          <li class="navbar-item"><%= link_to "FAQ", faq_path, class: "nav-link" %></li>
-          <li class="navbar-item"><%= link_to "Contact", contact_path, class: "nav-link" %></li>
+          <li class="navbar-item"><%= link_to "About", about_url, class: "nav-link" %></li>
+          <li class="navbar-item"><%= link_to "FAQ", faq_url, class: "nav-link" %></li>
+          <li class="navbar-item"><%= link_to "Contact", contact_url, class: "nav-link" %></li>
         </ul>
 
         <% unless content_for(:suppress_masthead_search) %>

--- a/app/views/static/oh_legacy_url_not_found.html.erb
+++ b/app/views/static/oh_legacy_url_not_found.html.erb
@@ -1,0 +1,51 @@
+<div class="branded-body-font text-page collection-show">
+
+  <h1 class='h2 error-headline'>
+    <i class="fa fa-warning" aria-hidden="true"></i>
+    Sorry, we couldn't find that oral history content
+  </h1>
+
+  <p>There have been some changes to our website. <b>We probably still have the content you are looking for</b>, but not at this location.</p>
+
+  <p>We'd love to help you find what you're looking for. Feel free to email the Center for Oral History at
+    <%= link_to(ScihistDigicoll::Env.lookup!(:oral_history_email_address), @report_mailto) %>, or you could try searching within our oral history collection:</p>
+
+
+    <div class="collection-search-form">
+        <h2 class="search-title">
+              Search within the Oral History Collection
+        </h2>
+
+        <%= form_tag collection_url(ScihistDigicoll::Env.lookup!(:oral_history_collection_id)), method: :get do |f| %>
+         <div class="input-group">
+            <%= search_field_tag :q, '', class: "q form-control",
+                id: "collectionQ",
+                autocomplete: "off",
+                placeholder: t("collection.search_form.search_field.placeholder"),
+                :"aria-label" => t('collection.search_form.search_field.label')
+            %>
+
+            <label class="sr-only" for="collectionQ"><%= t('collection.search_form.search_field.label') %></label>
+
+            <div class="input-group-append">
+              <button type="submit" class="btn btn-emphasis" title="Search" id="search-submit-header">
+                <i class="fa fa-search" aria-hidden="true"></i>
+                <%= t('blacklight.search.form.submit') %>
+              </button>
+            </div>
+          </div>
+
+          <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>
+        <% end %>
+
+    </div>
+
+
+  <p>You tried to visit:</p>
+  <pre><%= @original_url %></pre>
+
+  <% if @original_referer.present? %>
+    <p>Referred from:</p>
+    <pre><%= @original_referer %></pre>
+  <% end %>
+</div>

--- a/app/views/static/oh_legacy_url_not_found.html.erb
+++ b/app/views/static/oh_legacy_url_not_found.html.erb
@@ -1,7 +1,16 @@
+<!-- getting our fontawesome icon font to show up on the oh.sciencehistory.org domain
+     is way harder than it's worth, because of CORS issues, that quickly have complciated
+     interactions with our deploy setup. We'll just take the easy way out and suppress font-awesome
+     icons, for this kind of odd 404 page. -->
+<style>
+  .fa {
+    display: none !important;
+  }
+</style>
+
 <div class="branded-body-font text-page collection-show">
 
   <h1 class='h2 error-headline'>
-    <i class="fa fa-warning" aria-hidden="true"></i>
     Sorry, we couldn't find that oral history content
   </h1>
 

--- a/app/views/static/oh_legacy_url_not_found.html.erb
+++ b/app/views/static/oh_legacy_url_not_found.html.erb
@@ -8,7 +8,8 @@
   <p>There have been some changes to our website. <b>We probably still have the content you are looking for</b>, but not at this location.</p>
 
   <p>We'd love to help you find what you're looking for. Feel free to email the Center for Oral History at
-    <%= link_to(ScihistDigicoll::Env.lookup!(:oral_history_email_address), @report_mailto) %>, or you could try searching within our oral history collection:</p>
+    <%= link_to(ScihistDigicoll::Env.lookup!(:oral_history_email_address), @report_mailto) %>, or you could try searching within our
+    <%= link_to "oral history collection", collection_path(ScihistDigicoll::Env.lookup!(:oral_history_collection_id)) %>:</p>
 
 
     <div class="collection-search-form">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -85,4 +85,9 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # in development, allow the app to respond to our legacy oral history
+  # hostname, by default oh.sciencehistory.org. You might use /etc/hosts
+  # locally to test our legacy redirect functionality.
+  config.hosts << ScihistDigicoll::Env.lookup!(:oral_history_legacy_host)
 end

--- a/config/oral_history_legacy_redirects.yml
+++ b/config/oral_history_legacy_redirects.yml
@@ -1,0 +1,7 @@
+# TODO this is a placeholder, before we shut down the OH microsite we need to replace
+# this with complete real data.
+
+# KEY is old path on Oral History, VALUE is new path on Digital Collections for same work
+
+"/oral-histories/adams-alison-e-m": "/works/3417dff"
+"/oral-histories/pauling-linus-c": "/works/5h73px42w"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,26 @@ Rails.application.routes.draw do
     end
   end
 
+
+
+  # Oral History legacy redirects, come first in routes file so they'll match first
+  # for requests to old oral history host oh.sciencehistory.org
+  OH_LEGACY_REDIRECTS = YAML.load_file(Rails.root + "config/oral_history_legacy_redirects.yml").freeze
+  constraints host: ScihistDigicoll::Env.lookup!(:oral_history_legacy_host) do
+    # OH home page, send to new OH collection page
+    root as: false, to: redirect { "#{ScihistDigicoll::Env.lookup!("app_url_base")}/collections/#{ScihistDigicoll::Env.lookup!("oral_history_collection_id")}"  }
+
+    # Does it match one of our OH_LEGACY_REDIRECTS? Then redirect it!
+    get '*path', constraints: ->(req) { OH_LEGACY_REDIRECTS.has_key?(req.path) }, to: redirect { |params, req|
+      "#{ScihistDigicoll::Env.lookup!("app_url_base")}#{OH_LEGACY_REDIRECTS[req.path]}"
+    }
+
+    # Is Oral history host but we don't recognize it? Give them the customly helpful
+    # legacy OH 404
+    get "*path", to: "static#oh_legacy_url_not_found"
+  end
+
+
   root 'homepage#index'
 
   match 'oai', to: "oai_pmh#index", via: [:get, :post], as: :oai_provider
@@ -301,5 +321,4 @@ Rails.application.routes.draw do
   %w(about contact faq policy).each do |page_label|
     get page_label, controller: 'static', action: page_label, as: page_label
   end
-
 end

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -440,6 +440,9 @@ module ScihistDigicoll
     # Used to trigger custom controllers/UI for specific known collections
     define_key :oral_history_collection_id, default: "gt54kn818"
 
+    # hostname for legacy Oral History microsite, we catch requests to this
+    # and redirect appropriately.
+    define_key :oral_history_legacy_host, default: "oh.sciencehistory.org"
 
     # OUTGOING EMAIL:
 

--- a/spec/requests/oh_legacy_redirects.rb
+++ b/spec/requests/oh_legacy_redirects.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe "Oral history legacy site redirects" do
+  let(:legacy_host) { ScihistDigicoll::Env.lookup!(:oral_history_legacy_host) }
+  let(:standard_base_url) { ScihistDigicoll::Env.lookup!(:app_url_base) }
+
+  let(:redirects) { YAML.load_file(Rails.root + "config/oral_history_legacy_redirects.yml") }
+  let(:known_item_source_path) { redirects.keys.first }
+  let(:known_item_target_path) { redirects.values.first }
+
+  before do
+    # send all requests to this host, our legacy OH host
+    host! legacy_host
+  end
+
+  it "redirects the homepage to OH collection" do
+    get "/"
+    expect(response).to have_http_status(301) # moved permanently
+    expect(response).to redirect_to("#{standard_base_url}/collections/#{ScihistDigicoll::Env.lookup!(:oral_history_collection_id)}")
+  end
+
+  it "redirects a known item" do
+    get known_item_source_path
+    expect(response).to have_http_status(301) # moved permanently
+    expect(response).to redirect_to("#{standard_base_url}#{known_item_target_path}")
+  end
+
+  it "handles unrecognized with a nice 404" do
+    get "/some_url/never_heard_of_it"
+    expect(response).to have_http_status(:not_found)
+    expect(response).to render_template("static/oh_legacy_url_not_found")
+  end
+end


### PR DESCRIPTION
Ref #1011 but this does NOT close that ticket, because we still need to actually generate the old-url->new-url mappings. There are a couple placeholders in the config file at present, that are proof of concept and show the format. 

This assumes we will point oh.sciencehistory.org at the app -- now the app has routing to recognize requests to thathost, and try to handle them. 

1. requests to home page will be redirected with a permanent redirect code to the Oral History Collection page, in digital collections at normal host. 
2. Request to known item URLs in our mapping file wil be redirected to those known items in digital collections at normal host. 
3. OTHERWISE requests to oh.sciencehistory.org not recognized will get a 404 page, with some custom helpful HTML. 

Case 3 is not a redirect, it's actually delivering content at the alternate host. I knew that was possible, but had never done it before. It ended up having all sorts of gotchas. I considered abanodning it, but, it is a neat solution, and it seems to work out okay for this simple page. Had to suppress all font-awesome icons (which ends up effecting footer), to avoid having to fight with CORS in this case, which was going to be hard to do reliably it ends up very deployment-specific config.