### PR TITLE
Make Collection search results screen more compact

### DIFF
--- a/app/assets/stylesheets/local/collection_show.scss
+++ b/app/assets/stylesheets/local/collection_show.scss
@@ -5,6 +5,11 @@
 
   .collection-top {
     display: flex;
+
+    .show-title h1 a {
+      color: inherit; // underline is enough, the bright blue is too much
+    }
+
     .collection-desc {
       flex-grow: 1;
       flex-shrink: 1;

--- a/app/assets/stylesheets/local/collection_show.scss
+++ b/app/assets/stylesheets/local/collection_show.scss
@@ -6,7 +6,7 @@
   .collection-top {
     display: flex;
 
-    .show-title h1 a {
+    a.title-link {
       color: inherit; // underline is enough, the bright blue is too much
     }
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -11,11 +11,11 @@ class CatalogController < ApplicationController
 
   before_action :screen_params_for_range_limit, only: :range_limit
 
-  include BlacklightRangeLimit::ControllerOverride
   # Blacklight wanted Blacklight::Controller included in ApplicationController,
   # we do it just here instead.
   include Blacklight::Controller
   include Blacklight::Catalog
+  include BlacklightRangeLimit::ControllerOverride
 
   # Not totally sure why we need this, instead of Rails loading all helpers automatically
   helper LocalBlacklightHelpers

--- a/app/views/collection_show/index.html.erb
+++ b/app/views/collection_show/index.html.erb
@@ -2,91 +2,95 @@
 
 <div itemscope itemtype="http://schema.org/CollectionPage" class="collection-show">
 
-  <% if can? :update, collection %>
-    <div class="show-admin">
-      <%= link_to "Edit", edit_admin_collection_path(collection), class: "btn btn-outline-primary" %>
-    </div>
-  <% end %>
 
   <div class="collection-top">
     <div class="collection-desc clearfix">
       <div class="show-title">
         <header>
           <div class="show-genre"><%= link_to "Collections", collections_path %></div>
-          <h1><%= presenter.title %> <%= publication_badge(presenter) %></h1>
+          <h1>
+            <%= presenter.title %> <%= publication_badge(presenter) %>
+            <% if can? :update, collection %>
+              <%= link_to "Edit", edit_admin_collection_path(collection), class: "btn btn-outline-primary" %>
+            <% end %>
+          </h1>
         </header>
       </div>
 
-      <div class="show-metadata">
-        <% if current_staff_user? %>
-          <p class="show-item-count">
-            <%= "#{number_with_delimiter(presenter.public_count)} public #{'item'.pluralize(presenter.public_count)}, #{number_with_delimiter(presenter.all_count)} total" %>
-          </p>
-        <% else %>
-          <p class="show-item-count"><%= "#{number_with_delimiter(presenter.public_count)} #{'item'.pluralize(presenter.public_count)}" %></p>
-        <% end %>
-
-        <div class="collection-description long-text-line-height">
-          <%= DescriptionDisplayFormatter.new(presenter.description).format %>
-        </div>
-
-        <table class="collection-attributes chf-attributes">
-          <% presenter.opac_urls.each do |url| %>
-            <tr>
-              <td colspan="2"><%= link_to "View in library catalog", url %></td>
-            </tr>
+      <% unless has_search_parameters? %>
+        <div class="show-metadata">
+          <% if current_staff_user? %>
+            <p class="show-item-count">
+              <%= "#{number_with_delimiter(presenter.public_count)} public #{'item'.pluralize(presenter.public_count)}, #{number_with_delimiter(presenter.all_count)} total" %>
+            </p>
+          <% else %>
+            <p class="show-item-count"><%= "#{number_with_delimiter(presenter.public_count)} #{'item'.pluralize(presenter.public_count)}" %></p>
           <% end %>
 
-          <% if presenter.related_urls.present? %>
-            <tr>
-              <th>Related URL</th>
-              <td>
-                <ul>
-                  <% presenter.related_urls.each do |url| %>
-                    <li class="attribute"><%= ExternalLinkDisplay.new(url).display %></li>
-                  <% end %>
-                </ul>
-              </td>
-            </tr>
-          <% end %>
-        </table>
-      </div>
-
-    </div>
-
-    <div class="collection-thumb">
-      <%= ThumbDisplay.new(presenter.leaf_representative, thumb_size: :collection_page, placeholder_img_url: asset_path("default_collection.svg")).display %>
-    </div>
-  </div>
-
-  <div class="collection-search-form">
-      <h2 class="search-title">
-            Search within the <%= presenter.title %>
-      </h2>
-
-      <%= form_tag "", method: :get do |f| %>
-       <div class="input-group">
-          <%= search_field_tag :q, '', class: "q form-control",
-              id: "collectionQ",
-              autocomplete: "off",
-              placeholder: t("collection.search_form.search_field.placeholder"),
-              :"aria-label" => t('collection.search_form.search_field.label')
-          %>
-
-          <label class="sr-only" for="collectionQ"><%= t('collection.search_form.search_field.label') %></label>
-
-          <div class="input-group-append">
-            <button type="submit" class="btn btn-emphasis" title="Search" id="search-submit-header">
-              <i class="fa fa-search" aria-hidden="true"></i>
-              <%= t('blacklight.search.form.submit') %>
-            </button>
+          <div class="collection-description long-text-line-height">
+            <%= DescriptionDisplayFormatter.new(presenter.description).format %>
           </div>
+
+          <table class="collection-attributes chf-attributes">
+            <% presenter.opac_urls.each do |url| %>
+              <tr>
+                <td colspan="2"><%= link_to "View in library catalog", url %></td>
+              </tr>
+            <% end %>
+
+            <% if presenter.related_urls.present? %>
+              <tr>
+                <th>Related URL</th>
+                <td>
+                  <ul>
+                    <% presenter.related_urls.each do |url| %>
+                      <li class="attribute"><%= ExternalLinkDisplay.new(url).display %></li>
+                    <% end %>
+                  </ul>
+                </td>
+              </tr>
+            <% end %>
+          </table>
         </div>
-
-        <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>
       <% end %>
+    </div>
 
+    <% unless has_search_parameters? %>
+      <div class="collection-thumb">
+        <%= ThumbDisplay.new(presenter.leaf_representative, thumb_size: :collection_page, placeholder_img_url: asset_path("default_collection.svg")).display %>
+      </div>
+    <% end %>
   </div>
+
+  <% unless has_search_parameters? %>
+    <div class="collection-search-form">
+        <h2 class="search-title">
+              Search within the <%= presenter.title %>
+        </h2>
+
+        <%= form_tag "", method: :get do |f| %>
+         <div class="input-group">
+            <%= search_field_tag :q, '', class: "q form-control",
+                id: "collectionQ",
+                autocomplete: "off",
+                placeholder: t("collection.search_form.search_field.placeholder"),
+                :"aria-label" => t('collection.search_form.search_field.label')
+            %>
+
+            <label class="sr-only" for="collectionQ"><%= t('collection.search_form.search_field.label') %></label>
+
+            <div class="input-group-append">
+              <button type="submit" class="btn btn-emphasis" title="Search" id="search-submit-header">
+                <i class="fa fa-search" aria-hidden="true"></i>
+                <%= t('blacklight.search.form.submit') %>
+              </button>
+            </div>
+          </div>
+
+          <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>
+        <% end %>
+    </div>
+  <% end %>
 
 
   <%= render 'catalog/constraints' %>

--- a/app/views/collection_show/index.html.erb
+++ b/app/views/collection_show/index.html.erb
@@ -9,7 +9,7 @@
         <header>
           <div class="show-genre"><%= link_to "Collections", collections_path %></div>
           <h1>
-            <%= link_to presenter.title, collection_path(collection) %> <%= publication_badge(presenter) %>
+            <%= link_to presenter.title, collection_path(collection), class: "title-link" %> <%= publication_badge(presenter) %>
             <% if can? :update, collection %>
               <%= link_to "Edit", edit_admin_collection_path(collection), class: "btn btn-outline-primary" %>
             <% end %>

--- a/app/views/collection_show/index.html.erb
+++ b/app/views/collection_show/index.html.erb
@@ -9,7 +9,7 @@
         <header>
           <div class="show-genre"><%= link_to "Collections", collections_path %></div>
           <h1>
-            <%= presenter.title %> <%= publication_badge(presenter) %>
+            <%= link_to presenter.title, collection_path(collection) %> <%= publication_badge(presenter) %>
             <% if can? :update, collection %>
               <%= link_to "Edit", edit_admin_collection_path(collection), class: "btn btn-outline-primary" %>
             <% end %>


### PR DESCRIPTION
Don't repeat collection description on the results screen, just show a brief header and results. Ref #1045. 

This is complete, and can be code reviewed, but shouldn't be merged until we get stakeholder feedback. Will leave in 'draft' until then.