### PR TITLE
Fix nil error.

### DIFF
--- a/app/decorators/work_file_list_show_decorator.rb
+++ b/app/decorators/work_file_list_show_decorator.rb
@@ -52,7 +52,7 @@ class WorkFileListShowDecorator < Draper::Decorator
   end
 
   def available_by_request_audio_count
-    @available_by_request_audio_count ||= available_by_request_assets.find_all { |asset| asset.content_type.start_with?("audio/") }.count
+    @available_by_request_audio_count ||= available_by_request_assets.find_all { |asset| asset.content_type&.start_with?("audio/") }.count
   end
 
   def multiple_files?


### PR DESCRIPTION
When audio is still in process of being ingested (or ingest fails), it may have a nil content_type. Make sure our code doesn't bomb then, a nil content type means it's not an audio file.

Ref #995