### PR TITLE
Add alt_text and caption attributes to asset

### DIFF
--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -129,7 +129,8 @@ class Admin::AssetsController < AdminController
   private
 
   def asset_params
-    allowed_params = [:title, :derivative_storage_type, :alt_text, :role, {admin_note_attributes: []}]
+    allowed_params = [:title, :derivative_storage_type, :alt_text, :caption,
+      :role, {admin_note_attributes: []}]
     allowed_params << :published if can?(:publish, @asset)
 
     asset_params = params.require(:asset).permit(*allowed_params)

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -129,7 +129,7 @@ class Admin::AssetsController < AdminController
   private
 
   def asset_params
-    allowed_params = [:title, :derivative_storage_type, :role, {admin_note_attributes: []}]
+    allowed_params = [:title, :derivative_storage_type, :alt_text, :role, {admin_note_attributes: []}]
     allowed_params << :published if can?(:publish, @asset)
 
     asset_params = params.require(:asset).permit(*allowed_params)

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -26,6 +26,10 @@ class Asset < Kithe::Asset
   # Set rails_attribute true so we get rails dirty tracking.
   attr_json :derivative_storage_type, :string, default: "public", rails_attribute: true
 
+  # alt_text was added for Oral Histories portraits and migrating existing data,
+  # but can be used for any asset.
+  attr_json :alt_text, :string
+
   validates :derivative_storage_type, inclusion: { in: ["public", "restricted"] }
 
   DERIVATIVE_STORAGE_TYPE_LOCATIONS = {

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -30,6 +30,10 @@ class Asset < Kithe::Asset
   # but can be used for any asset.
   attr_json :alt_text, :string
 
+  # Caption also motivated by Oral Histories data migration, and is not
+  # really anticipated for any other use.
+  attr_json :caption, :string
+
   validates :derivative_storage_type, inclusion: { in: ["public", "restricted"] }
 
   DERIVATIVE_STORAGE_TYPE_LOCATIONS = {

--- a/app/presenters/thumb_display.rb
+++ b/app/presenters/thumb_display.rb
@@ -111,6 +111,10 @@ class ThumbDisplay < ViewModel
       }
     }
 
+    if asset.alt_text.present?
+      img_attributes[:alt] = asset.alt_text
+    end
+
     if lazy?
       # tell lazysizes.js to load with class, and put src/srcset only in
       # data- attributes, so the image will not be loaded immediately, but lazily

--- a/app/views/admin/assets/edit.html.erb
+++ b/app/views/admin/assets/edit.html.erb
@@ -33,6 +33,8 @@
 
     <%= f.input :alt_text %>
 
+    <%= f.input :caption %>
+
     <%= f.repeatable_attr_input(:admin_note, build: :at_least_one) do |input_name, value| %>
       <div class="form-group">
         <%= f.input_field :admin_note, name: input_name, value: value, as: :text, class: "form-control", rows: 4 %>

--- a/app/views/admin/assets/edit.html.erb
+++ b/app/views/admin/assets/edit.html.erb
@@ -31,6 +31,8 @@
 
     <%= f.input :role, collection: Asset.roles.values.collect { |v| [v.humanize.downcase, v] }, include_blank: "[unspecified]" %>
 
+    <%= f.input :alt_text %>
+
     <%= f.repeatable_attr_input(:admin_note, build: :at_least_one) do |input_name, value| %>
       <div class="form-group">
         <%= f.input_field :admin_note, name: input_name, value: value, as: :text, class: "form-control", rows: 4 %>

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -60,6 +60,9 @@
       <dt class="col-sm-4">Orig. Filename</dt>
       <dd class="col-sm-8"><%= @asset&.file&.metadata.try { |h| h["filename"]} %></dd>
 
+      <dt class="col-sm-4">Alt text</dt>
+      <dd class="col-sm-8"><%= @asset.alt_text %></dd>
+
       <%if @asset.stored? && Shrine.storages[:store].try('bucket').try('name') %>
         <dt class="col-sm-4">File in s3</dt>
         <dd class="col-sm-8"><%= link_to @asset.file.url(public: true).split('/').last, S3ConsoleUri.new(@asset.file.url(public: true)).console_uri %></dd>

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -63,6 +63,10 @@
       <dt class="col-sm-4">Alt text</dt>
       <dd class="col-sm-8"><%= @asset.alt_text %></dd>
 
+      <dt class="col-sm-4">Caption</dt>
+      <dd class="col-sm-8"><%= @asset.caption %></dd>
+
+
       <%if @asset.stored? && Shrine.storages[:store].try('bucket').try('name') %>
         <dt class="col-sm-4">File in s3</dt>
         <dd class="col-sm-8"><%= link_to @asset.file.url(public: true).split('/').last, S3ConsoleUri.new(@asset.file.url(public: true)).console_uri %></dd>

--- a/app/views/works/oh_audio_work_show.html.erb
+++ b/app/views/works/oh_audio_work_show.html.erb
@@ -99,6 +99,9 @@
             <% if decorator.portrait_asset.present? %>
               <div class="oh-portrait">
                 <%= ThumbDisplay.new(decorator.portrait_asset).display %>
+                <% if decorator.portrait_asset.caption.present? %>
+                  <span class="text-muted"><%= decorator.portrait_asset.caption %></span>
+                <% end %>
               </div>
             <% end %>
 

--- a/app/views/works/work_file_list_show.html.erb
+++ b/app/views/works/work_file_list_show.html.erb
@@ -13,8 +13,11 @@
     <%# up here so it stays above request button in single-column mode %>
     <div class="work-description long-text-line-height">
       <% if decorator.portrait_asset.present? %>
-        <div class="oh-portrait">
+        <div class="card oh-portrait">
           <%= ThumbDisplay.new(decorator.portrait_asset).display %>
+          <% if decorator.portrait_asset.caption.present? %>
+            <div class="card-body"><div class="card-text text-muted"><%= decorator.portrait_asset.caption %></div></div>
+          <% end %>
         </div>
       <% end %>
 

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -14,6 +14,11 @@ en:
       interviewer_profile:
         profile: "Allowed HTML tags: b, i, cite, a."
         name: 'Recommend "Lastname, First I.", but legacy data may not match.'
+      asset:
+        alt_text: "Alternative textual description for when asset can't be viewed directly, has accessibility uses."
+    labels:
+      asset:
+        alt_text: "Alt(ernative) text"
 
     # Examples
     # labels:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -16,6 +16,7 @@ en:
         name: 'Recommend "Lastname, First I.", but legacy data may not match.'
       asset:
         alt_text: "Alternative textual description for when asset can't be viewed directly, has accessibility uses."
+        caption: "Used at present with role portrait on oral histories"
     labels:
       asset:
         alt_text: "Alt(ernative) text"

--- a/spec/presenters/thumb_display_spec.rb
+++ b/spec/presenters/thumb_display_spec.rb
@@ -48,6 +48,17 @@ describe ThumbDisplay do
     end
   end
 
+  describe "with alt_text" do
+    let(:alt_text) { "This is alt text" }
+    let(:argument) { build(:asset_with_faked_file, alt_text: alt_text) }
+
+    it "renders alt attribute from model alt_text" do
+      img_tag = rendered.at_css("img")
+      expect(img_tag).to be_present
+      expect(img_tag["alt"]).to eq(alt_text)
+    end
+  end
+
   describe "specified placeholder image" do
     let(:argument) { build(:asset) }
     let(:instance) { ThumbDisplay.new(argument, placeholder_img_url: specified_img_url) }


### PR DESCRIPTION
Motivated by oral histories data migration. 

Alt_text  can be generally useful. If present on an asset, will be output with any thumbnail of that asset.

caption is really more just for OH, shown next to role=portrait images. 

Ref #1060, #1031