### PR TITLE
New place for interviewee_biographies content

### DIFF
--- a/app/models/oral_history_content.rb
+++ b/app/models/oral_history_content.rb
@@ -55,6 +55,11 @@ class OralHistoryContent < ApplicationRecord
     succeeded: 'succeeded'
   }
 
+
+  ####
+  # legacy, we are in process of moving away from these direct interviewee attributes, for interviewee_biographies below
+  #
+
   attr_json :interviewee_birth,    OralHistoryContent::DateAndPlace.to_type, default: -> { OralHistoryContent::DateAndPlace.new }
   attr_json :interviewee_death,    OralHistoryContent::DateAndPlace.to_type, default: -> { OralHistoryContent::DateAndPlace.new }
 
@@ -68,6 +73,12 @@ class OralHistoryContent < ApplicationRecord
   attr_json_accepts_nested_attributes_for :interviewee_school
   attr_json_accepts_nested_attributes_for :interviewee_job
   attr_json_accepts_nested_attributes_for :interviewee_honor
+
+  #
+  ######
+
+  # in process to moving to this data model:
+  attr_json :interviewee_biographies, OralHistoryContent::IntervieweeBiography.to_type, array: true, default: -> { [] }
 
   # Some assets marked non-published in this work are still available by request. That feature needs to be turned
   # on here at the work level, in one of two modes:

--- a/app/models/oral_history_content/interviewee_biography.rb
+++ b/app/models/oral_history_content/interviewee_biography.rb
@@ -1,0 +1,16 @@
+class OralHistoryContent
+  class IntervieweeBiography
+    include AttrJson::Model
+
+    attr_json :name, :string
+
+    attr_json :birth,  OralHistoryContent::DateAndPlace.to_type, default: -> { OralHistoryContent::DateAndPlace.new }
+    attr_json :death,  OralHistoryContent::DateAndPlace.to_type, default: -> { OralHistoryContent::DateAndPlace.new }
+
+    attr_json :school,  OralHistoryContent::IntervieweeSchool.to_type, array: true, default: -> {[]}
+    attr_json :job,     OralHistoryContent::IntervieweeJob.to_type,    array: true, default: -> {[]}
+    attr_json :honor,   OralHistoryContent::IntervieweeHonor.to_type,  array: true, default: -> {[]}
+
+    validates_presence_of :name
+  end
+end

--- a/spec/models/oral_history_content_spec.rb
+++ b/spec/models/oral_history_content_spec.rb
@@ -63,6 +63,45 @@ describe OralHistoryContent do
     end
   end
 
+  describe "new interviewee_biographies attribute" do
+    it "name can't be blank" do
+      ohc = work_with_oral_history_content.oral_history_content
+      ohc.interviewee_biographies = [{
+        birth:  OralHistoryContent::DateAndPlace.new(date: '1923', city: 'Place of Birth', state: 'CA', country: 'US'),
+      }]
+
+      expect(ohc.save).to be(false)
+      expect(ohc.errors.full_messages).to include("Interviewee biographies is invalid")
+      expect(ohc.interviewee_biographies.first.errors.full_messages).to include("Name can't be blank")
+    end
+
+    it "can create/save" do
+      ohc = work_with_oral_history_content.oral_history_content
+
+      ohc.interviewee_biographies = [{
+        name: "John Smith",
+        birth:  OralHistoryContent::DateAndPlace.new(date: '1923', city: 'Place of Birth', state: 'CA', country: 'US'),
+        death:  OralHistoryContent::DateAndPlace.new(date: '2223', city: 'Place of Death', province: 'NU', country: 'CA' ),
+        school: [
+          OralHistoryContent::IntervieweeSchool.new(date: "1958", institution: 'Columbia University', degree: 'BA', discipline: 'Chemistry'),
+          OralHistoryContent::IntervieweeSchool.new(date: "1960", institution: 'Harvard University',  degree: 'MS', discipline: 'Physics')
+        ],
+        job: [
+          OralHistoryContent::IntervieweeJob.new({start: "1962", end: "1965", institution: 'Harvard University',  role: 'Junior Fellow, Society of Fellows'}),
+          OralHistoryContent::IntervieweeJob.new( {start: "1965", end: "1968",  institution: 'Cornell University', role: 'Associate Professor, Chemistry'})
+        ],
+        honor: [
+          OralHistoryContent::IntervieweeHonor.new(start_date: "1981", honor: 'Nobel Prize in Chemistry'),
+          OralHistoryContent::IntervieweeHonor.new(start_date: "1998", honor: 'Corresponding Member, Nordrhein-Westfälische Academy of Sciences')
+        ]
+      }]
+
+      ohc.save!
+
+      expect(ohc.interviewee_biographies).to be_present
+    end
+  end
+
   describe "combined_audio_derivatives_job_status" do
     it "sets the date when you change the status" do
       oral_history_content.combined_audio_derivatives_job_status = 'started'


### PR DESCRIPTION
attr_json oral_hisitory_content.inteviewee_biographies, is an embedded attr_json attribute, array of OralHistoryContent::IntervieweeBiography models. Attribute names have changed to no longer have `interviewee_` prefix, since they are embedded in a model named that.

We will be proceeding with trying to change app over to use this data model; doing a separate PR with just the data model so we can work independently on different parts of logic with regard to this. Still possible we will have to give up on this experiment too, or we'll find problems requiring alternate approach to this PR. This PR is a starting point so we can have the data model to both work on.