### PR TITLE
OHMS Index titles should allow <i> tags

### DIFF
--- a/app/models/oral_history_content/ohms_xml.rb
+++ b/app/models/oral_history_content/ohms_xml.rb
@@ -105,6 +105,12 @@ class OralHistoryContent
           end
         end.compact
       end
+
+      # We want to allow <i> tags, and strip/escape the rest appropriately.
+      def html_safe_title
+        Rails::Html::SafeListSanitizer.new.sanitize(title, tags: ['i']).html_safe
+      end
+
     end
 
     private

--- a/app/views/presenters/_ohms_index.html.erb
+++ b/app/views/presenters/_ohms_index.html.erb
@@ -6,7 +6,7 @@
           <button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#<%= view.accordion_element_id(index) %>" aria-expanded="true" aria-controls="<%= view.accordion_element_id(index) %>">
               <i class="fa fa-plus float-right toggle-icon" aria-hidden="true"></i>
               <i class="fa fa-minus float-right toggle-icon" aria-hidden="true"></i>
-              <span class="mr-3"><%= format_ohms_timestamp(index_point.timestamp) %></span> <%= index_point.title %>
+              <span class="mr-3"><%= format_ohms_timestamp(index_point.timestamp) %></span> <%= index_point.html_safe_title %>
           </button>
         </h3>
       </div>

--- a/spec/models/oral_history_content/ohms_xml_spec.rb
+++ b/spec/models/oral_history_content/ohms_xml_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe OralHistoryContent::OhmsXml do
+  describe OralHistoryContent::OhmsXml::IndexPoint do
+    describe "#html_safe_title" do
+      let(:xml) do
+        <<~EOS
+          <point xmlns="https://www.weareavp.com/nunncenter/ohms">
+            <time>0</time>
+            <title>Title with &lt;i&gt;allowed&lt;/i&gt; and &lt;p&gt;unallowed&lt;/p&gt; tags plus &lt; isolated &gt; internal brackets</title>
+            <title_alt></title_alt>
+            <partial_transcript>CARUSO: Today is the sixth of May, 2013. I'm David Caruso.</partial_transcript>
+            <partial_transcript_alt></partial_transcript_alt>
+            <synopsis>Molina reflects on his childhood and education.</synopsis>
+            <synopsis_alt></synopsis_alt>
+            <keywords>Chemistry sets;Classical music;</keywords><keywords_alt></keywords_alt>
+            <subjects></subjects><subjects_alt></subjects_alt>
+            <gpspoints><gps></gps><gps_zoom></gps_zoom><gps_text></gps_text><gps_text_alt></gps_text_alt></gpspoints>
+            <hyperlinks><hyperlink></hyperlink><hyperlink_text></hyperlink_text><hyperlink_text_alt></hyperlink_text_alt></hyperlinks>
+          </point>"
+        EOS
+      end
+      let(:xml_fragment) { Nokogiri::XML.parse(xml).root }
+      let(:index_point) { OralHistoryContent::OhmsXml::IndexPoint.new(xml_fragment) }
+
+      it "appropriately respects and strips tags" do
+        expect(index_point.title).to eq("Title with <i>allowed</i> and <p>unallowed</p> tags plus < isolated > internal brackets")
+        expect(index_point.html_safe_title).to eq("Title with <i>allowed</i> and unallowed tags plus &lt; isolated &gt; internal brackets")
+      end
+    end
+  end
+end


### PR DESCRIPTION
While still safely stripping or escaping other values.

Actual default OHMS editor/player just lets through ALL html, including things like <p> or <table> tags taht will totally mess up the page, or things like isolated < or > chars that will be illegal but count on browser to handle appropriately. We don't want to just do that. Fortunately the Rails::Html::SafeListSanitizer seems to handle this all pretty well.

Ref #709