### PR TITLE
add tom-select.js filtered multi-select for large-element association select inputs

### DIFF
--- a/app/javascript/packs/admin.js
+++ b/app/javascript/packs/admin.js
@@ -11,3 +11,5 @@ import '../src/js/admin/simple_uppy_file_input';
 import '../src/js/admin/uppy_dashboard.js';
 import '../src/js/admin/qa_autocomplete.js';
 import '../src/js/admin/queue_status_submit.js';
+
+import '../src/js/admin/tom_select.js' // has CSS

--- a/app/javascript/src/js/admin/tom_select.js
+++ b/app/javascript/src/js/admin/tom_select.js
@@ -1,0 +1,31 @@
+// use https://tom-select.js.org/ for fancy auto-complete text/select boxes.
+
+// tom-select does not require JQuery, and we use no JQuery in this file.
+
+import 'tom-select/dist/css/tom-select.bootstrap4.min.css';
+
+// Not sure how I figured out these paths to load tom-select base and then selected plugins
+// from npm tom-select... but here it is. See: https://github.com/orchidjs/tom-select/issues/57
+import TomSelect from 'tom-select/dist/esm/tom-select'; // tom-select base
+import 'tom-select/dist/esm/plugins/remove_button/plugin'; // specific desired plugin(s)
+
+import domready from 'domready';
+
+domready(function() {
+
+  // We're just going to add a standard tom-select to any select input that has data-tom-select=true
+  // It will not do any AJAX loads, just turn an in-page <select> input into a dynamic tom-select.
+  //
+  // For now, this is good enough. Later, we could add more functionality in data- attributes,
+  // or even just select certain things like "#specificSelect" to configure in certain TomSelect ways.
+
+  document.querySelectorAll('select[data-tom-select]').forEach(function(item) {
+    new TomSelect(item,{
+      //openOnFocus: false,
+      placeholder: "type to filter",
+      hidePlaceholder: true,
+      closeAfterSelect:  true,
+      plugins: ['remove_button']
+    });
+  });
+});

--- a/app/views/admin/works/_oral_history_biography.html.erb
+++ b/app/views/admin/works/_oral_history_biography.html.erb
@@ -2,7 +2,7 @@
   <h2 class="card-header h3">Interviewee biography</h2>
   <div class="card-body">
     <%= simple_form_for(@work.oral_history_content, url: update_oral_history_content_admin_work_path(@work)) do |f| %>
-      <%= f.association :interviewee_biographies, collection: IntervieweeBiography.order(:name), hint: "Multiple select, hold down command on MacOS or control on Windows to select and deselect" %>
+      <%= f.association :interviewee_biographies, collection: IntervieweeBiography.order(:name), input_html: { "data-tom-select": "true" } %>
       <%= submit_tag "Save Changes", class: "btn btn-primary mb-3" %>
     <% end %>
   </div>

--- a/app/views/admin/works/_oral_history_biography.html.erb
+++ b/app/views/admin/works/_oral_history_biography.html.erb
@@ -1,7 +1,7 @@
 <div class="card bg-light mb-3">
   <h2 class="card-header h3">Interviewee biography</h2>
   <div class="card-body">
-    <%= simple_form_for(@work.oral_history_content, url: update_oral_history_content_admin_work_path(@work)) do |f| %>
+    <%= simple_form_for(@work.oral_history_content, url: update_oral_history_content_admin_work_path(@work), html: { id: :oh_interviewee_biographies}) do |f| %>
       <%= f.association :interviewee_biographies, collection: IntervieweeBiography.order(:name), input_html: { "data-tom-select": "true" } %>
       <%= submit_tag "Save Changes", class: "btn btn-primary mb-3" %>
     <% end %>

--- a/app/views/admin/works/_work_fields.html.erb
+++ b/app/views/admin/works/_work_fields.html.erb
@@ -123,4 +123,4 @@
       </div>
     <% end %>
 
-    <%= f.association :contained_by, collection: Collection.all.to_a.sort_by { |c| c.title.downcase } %>
+    <%= f.association :contained_by, collection: Collection.all.to_a.sort_by { |c| c.title.downcase }, input_html: { "data-tom-select": "true "} %>

--- a/app/views/admin/works/show.html.erb
+++ b/app/views/admin/works/show.html.erb
@@ -151,7 +151,7 @@
         <h2 class="card-header h3">Interviewer Profiles</h2>
         <div class="card-body">
 
-        <%= simple_form_for(@work.oral_history_content, url: update_oral_history_content_admin_work_path(@work)) do |f| %>
+        <%= simple_form_for(@work.oral_history_content, url: update_oral_history_content_admin_work_path(@work), html: { id: :oh_interviewer_profiles}) do |f| %>
           <%= f.association :interviewer_profiles, collection: InterviewerProfile.order(:name), input_html: { "data-tom-select": "true" } %>
           <%= submit_tag "Save Changes", class: "btn btn-primary mb-3" %>
         <% end %>

--- a/app/views/admin/works/show.html.erb
+++ b/app/views/admin/works/show.html.erb
@@ -152,7 +152,7 @@
         <div class="card-body">
 
         <%= simple_form_for(@work.oral_history_content, url: update_oral_history_content_admin_work_path(@work)) do |f| %>
-          <%= f.association :interviewer_profiles, collection: InterviewerProfile.order(:name), hint: "Multiple select, hold down command on MacOS or control on Windows to select and deselect" %>
+          <%= f.association :interviewer_profiles, collection: InterviewerProfile.order(:name), input_html: { "data-tom-select": "true" } %>
           <%= submit_tag "Save Changes", class: "btn btn-primary mb-3" %>
         <% end %>
       </div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -38,11 +38,14 @@
     <%# lazysizes gets it's own "pack", loaded early without 'defer', per lazysizes doc suggestion %>
     <%= javascript_pack_tag 'lazysizes' %>
 
+    <%# sprockets 'application' js and css %>
     <%= stylesheet_link_tag    'application', media: 'all' %>
-
     <%= javascript_include_tag 'application', defer: true %>
+
+    <%# webpacker 'application' js, and 'admin' js and css %>
     <%= javascript_pack_tag 'application', defer: true %>
     <%= javascript_pack_tag 'admin', defer: true %>
+    <%= stylesheet_pack_tag "admin" %>
 
   </head>
 

--- a/config/locales/work.en.yml
+++ b/config/locales/work.en.yml
@@ -73,4 +73,4 @@ en:
         file_creator: "Select the individual, group, or organization responsible for producing the digital representation of the work, such as the digitizing agent or file author. If a desired entry is not available, contact the Digital Collections and Metadata Librarian. Recommended."
         admin_note: "Use for any internal notes about the digital object or physical work, such as copyright concerns, digitization errors, legacy metadata, etc. Record first initial, last name, and date with the note in case a follow-up is necessary."
         representative: "Select the file with media that represents this Work and is used as a thumbnail."
-        contained_by: "Select the named collection that the work is part of, if applicable. If a desired entry is not available, contact the Digital Collections and Metadata Librarian. To deselect a collection, use Ctrl-click or ⌘-click."
+        contained_by: "Select the named collection that the work is part of, if applicable. If a desired entry is not available, contact the Digital Collections and Metadata Librarian."

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "mdn-polyfills": "^5.15.0",
     "openseadragon": "^2.4.1",
     "promise-polyfill": "^8.1.3",
+    "tom-select": "^1.4.3",
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -101,6 +101,9 @@ RSpec.configure do |config|
     end
   end
 
+  require './spec/test_support/rspec_helper/tom_select'
+  config.include RspecHelper::TomSelect, type: :system
+
   # Get current_user to work in decorator (draper) specs when there is no logged in user,
   # where #current_user should be nil. Weird workaround with Draper.
   # https://github.com/drapergem/draper/issues/857

--- a/spec/system/admin/oral_history_interviewee_bio_spec.rb
+++ b/spec/system/admin/oral_history_interviewee_bio_spec.rb
@@ -72,7 +72,8 @@ RSpec.describe "Oral History Access Interviewee bio", :logged_in_user, type: :sy
     visit admin_work_path(work, :anchor => "nav-oral-histories")
     section = find("h2", text: "Interviewee biography").ancestor('.card')
     within(section) do
-      expect(find("select").value).to match_array(work.oral_history_content.interviewee_biographies.collect(&:id).collect(&:to_s))
+      # have to find hidden select, since it's covered by tom-select.js UI
+      expect(find("select", visible: :all).value).to match_array(work.oral_history_content.interviewee_biographies.collect(&:id).collect(&:to_s))
     end
   end
 end

--- a/spec/system/work/edit_work_metadata_spec.rb
+++ b/spec/system/work/edit_work_metadata_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe "Edit work metadata form", :logged_in_user, type: :system, js: tr
   it "edits work" do
     visit edit_admin_work_path(work)
 
-    # Set collection to a new thing, unselect old thing
     original_collection = work.contained_by.first
-    find("#work_contained_by_ids option[value='#{original_collection.id}']").unselect_option
-    find("#work_contained_by_ids option[value='#{new_collection.id}']").select_option
+
+    # Set collection to a new thing only, using special tom_select helper
+    tom_select("#work_contained_by_ids", option_id: new_collection.id)
 
     # Set representative to a new thing
     new_representative = work.members.find {|m| m.id != work.representative_id}

--- a/spec/system/work/new_work_spec.rb
+++ b/spec/system/work/new_work_spec.rb
@@ -164,7 +164,8 @@ RSpec.describe "New Work form", :logged_in_user, type: :system, js: true do
     end
 
     # Collection membership
-    find("#work_contained_by_ids option[value='#{collection.id}']").select_option
+    # have to use special tom_select helper
+    tom_select("#work_contained_by_ids", option_id: collection.id)
 
     click_button "Create Work"
 

--- a/spec/test_support/rspec_helper/tom_select.rb
+++ b/spec/test_support/rspec_helper/tom_select.rb
@@ -1,0 +1,20 @@
+module RspecHelper
+  module TomSelect
+
+    # A helper for Capyabara tests that need to set values from a tom-select.js input.
+    #
+    # This is a really hacky approach using execute_javascript, but it works. Not sure if there's
+    # a better way, we could try actually interacting with the on-screen tom-select-provided UI,
+    # but we're taking the easy way out for now.
+    #
+    # @param option_id can be the `id` value of an option in the select, OR for select multiple inputs,
+    #   can be an array of such IDs.
+    #
+    # @example tom_select("#select_id", option_id: "2")
+    # @example tom_select("#select_id", option_id: ["2", "10"]) # `multiple` input.
+    def tom_select(select_selector, option_id:)
+      js_str = %Q(document.querySelector("#{select_selector}").tomselect.setValue(#{option_id.inspect}))
+      execute_script(js_str)
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -7286,9 +7286,9 @@ toidentifier@1.0.0:
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
 tom-select@^1.4.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/tom-select/-/tom-select-1.4.3.tgz#d4167e0ad52e0ea478c5d39d282d372f2d09e23b"
-  integrity sha512-0/cRGSz0t3P/3p3MmuRjuWMGcQUTh9488yrICWD7eMGpB/pFCchNsXKWWO/c0R32IBucHivj00qU+e8pNN8Oeg==
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/tom-select/-/tom-select-1.5.0.tgz#a51212bee410d4375176f957dc116bd63f6ad0f1"
+  integrity sha512-6nv/dGswJNkyLVnzUwYF2+EeQXF9uy769paw6njk5DhG815+rlA8xHn4BLsbuOsGvemcNwl8mPi2QKs/hZINbQ==
 
 tough-cookie@~2.5.0:
   version "2.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7285,6 +7285,11 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+tom-select@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/tom-select/-/tom-select-1.4.3.tgz#d4167e0ad52e0ea478c5d39d282d372f2d09e23b"
+  integrity sha512-0/cRGSz0t3P/3p3MmuRjuWMGcQUTh9488yrICWD7eMGpB/pFCchNsXKWWO/c0R32IBucHivj00qU+e8pNN8Oeg==
+
 tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"


### PR DESCRIPTION
Ref #1076 

tom-select JS and CSS added via npm/webpacker, in the "admin" pack that's added only to admin layout.

For the moment, we are NOT doing any AJAX loading here (although tom-select supports it) -- we are still loading all select options in delivered HTML, just using tom-select for a much nicer UI for it.

Used for:

* Work: select collection
* Work/Oral History: select linked interviewer profile
* Work/Oral History: select linked interviewee biography