### PR TITLE
Keep long title from pushing 'search' box to next line on full width layout

### DIFF
--- a/app/assets/stylesheets/local/oh_audio.scss
+++ b/app/assets/stylesheets/local/oh_audio.scss
@@ -51,6 +51,7 @@
 
         @include media-breakpoint-up(lg) {
           padding: 0 1rem 0 0;
+          max-width: 66%;
         }
 
         .title {


### PR DESCRIPTION
This CSS is a bit convoluted! But this seemed to fix it. Tested at multiple widths and compared to production to make sure it didn't seem to mess up anything else. 

before:
![Screen Shot 2021-04-28 at 11 02 24 AM](https://user-images.githubusercontent.com/149304/116429214-ae79e080-a813-11eb-989f-574e497f3a19.png)



after:

![Screen Shot 2021-04-28 at 11 19 51 AM](https://user-images.githubusercontent.com/149304/116429236-b33e9480-a813-11eb-9f64-85147f57f0d8.png)
