### PR TITLE
preserve tab selection in url as eg #tab=ohTranscript

### DIFF
--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -83,7 +83,7 @@ class Admin::WorksController < AdminController
   # PATCH/PUT /admin/works/ab2323ac/submit_ohms_xml
   def submit_ohms_xml
     unless params[:ohms_xml].present?
-      redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), flash: { error: "No file received" }
+      redirect_to admin_work_path(@work, anchor: "tab=nav-oral-histories"), flash: { error: "No file received" }
       return
     end
 
@@ -92,10 +92,10 @@ class Admin::WorksController < AdminController
 
     if validator.valid?
       @work.oral_history_content!.update!(ohms_xml_text: xml)
-      redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), notice: "OHMS XML file updated"
+      redirect_to admin_work_path(@work, anchor: "tab=nav-oral-histories"), notice: "OHMS XML file updated"
     else
       Rails.logger.debug("Could not accept invalid OHMS XML for work #{@work.friendlier_id}:\n  #{xml.slice(0, 60).gsub(/[\n\r]/, '')}...\n\n  #{validator.errors.join("\n  ")}")
-      redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), flash: {
+      redirect_to admin_work_path(@work, anchor: "tab=nav-oral-histories"), flash: {
         error: "OHMS XML file was invalid and could not be accepted: #{validator.errors.join('; ')}"
       }
     end
@@ -104,7 +104,7 @@ class Admin::WorksController < AdminController
   # PATCH/PUT /admin/works/ab2323ac/remove_ohms_xml
   def remove_ohms_xml
     @work.oral_history_content!.update!(ohms_xml_text: nil)
-    redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), notice: "OHMS XML file removed."
+    redirect_to admin_work_path(@work, anchor: "tab=nav-oral-histories"), notice: "OHMS XML file removed."
   end
 
   # GET /admin/works/ab2323ac/download_ohms_xml
@@ -117,7 +117,7 @@ class Admin::WorksController < AdminController
   # PATCH/PUT /admin/works/ab2323ac/submit_ohms_xml
   def submit_searchable_transcript_source
     unless params[:searchable_transcript_source].present?
-      redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), flash: { error: "No file received" }
+      redirect_to admin_work_path(@work, anchor: "tab=nav-oral-histories"), flash: { error: "No file received" }
       return
     end
     transcript = params[:searchable_transcript_source].read
@@ -140,9 +140,9 @@ class Admin::WorksController < AdminController
 
     if searchable_transcript_source_error.nil?
       @work.oral_history_content.update!(searchable_transcript_source: transcript)
-      redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), notice: "Full text has been updated."
+      redirect_to admin_work_path(@work, anchor: "tab=nav-oral-histories"), notice: "Full text has been updated."
     else
-      redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), flash: {
+      redirect_to admin_work_path(@work, anchor: "tab=nav-oral-histories"), flash: {
         error: "Transcript not updated: #{searchable_transcript_source_error}",
         searchable_transcript_source_error: "Transcript not updated: #{searchable_transcript_source_error}"
       }
@@ -152,7 +152,7 @@ class Admin::WorksController < AdminController
   # PATCH/PUT /admin/works/ab2323ac/remove_searchable_transcript_source
   def remove_searchable_transcript_source
     @work.oral_history_content!.update!(searchable_transcript_source: nil)
-    redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), notice: "Full text has been removed."
+    redirect_to admin_work_path(@work, anchor: "tab=nav-oral-histories"), notice: "Full text has been removed."
   end
 
   # GET /admin/works/ab2323ac/download_searchable_transcript_source
@@ -169,7 +169,7 @@ class Admin::WorksController < AdminController
   # PATCH/PUT /admin/works/ab2323ac/create_combined_audio_derivatives
   def create_combined_audio_derivatives
     unless CombinedAudioDerivativeCreator.new(@work).available_members?
-      redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), flash: {
+      redirect_to admin_work_path(@work, anchor: "tab=nav-oral-histories"), flash: {
         error: "Combined audio derivatives cannot be created, because this oral history does not have any published audio segments."
       }
       return
@@ -181,7 +181,7 @@ class Admin::WorksController < AdminController
     sidecar.save!
 
     notice = "The combined audio derivative job has been added to the job queue."
-    redirect_to admin_work_path(@work, anchor: "nav-oral-histories"), notice: notice
+    redirect_to admin_work_path(@work, anchor: "tab=nav-oral-histories"), notice: notice
   end
 
   # PUT /admin/works/ab2323ac/update_oh_available_by_request
@@ -193,7 +193,7 @@ class Admin::WorksController < AdminController
         @work.members.find{ |m| m.id == asset_pk}&.update(oh_available_by_request: value)
       end
     end
-    redirect_to admin_work_path(@work, anchor: "nav-oral-histories")
+    redirect_to admin_work_path(@work, anchor: "tab=nav-oral-histories")
   end
 
   # PATCH /admin/works/ab2323ac/update_oral_history_content
@@ -208,7 +208,7 @@ class Admin::WorksController < AdminController
     # OralHistoryContent, so we trigger it here ourselves in controller action.
     @work.update_index
 
-    redirect_to admin_work_path(@work, anchor: "nav-oral-histories")
+    redirect_to admin_work_path(@work, anchor: "tab=nav-oral-histories")
   end
 
   # PATCH/PUT /admin/works/1/publish

--- a/app/javascript/src/js/tab_selection_in_anchor.js
+++ b/app/javascript/src/js/tab_selection_in_anchor.js
@@ -1,22 +1,30 @@
-// Based on https://github.com/twbs/bootstrap/issues/25220
+// Informed by https://github.com/twbs/bootstrap/issues/25220
 //
-// We are using jQuery here, because bootstrap 4 JS for tabs uses/requires
-// it anyway.
+// We will store current tab selection in "anchor" as #tab=[tabID],
+// the query param format in anchor is compatible with storing additional things
+// there too, like timecodes. Then we tag on page load if we see an anchor. This
+// let's user bookmark specific tab selections. Motivated by Oral History Audio navbar.
+//
+// Uses jQuery here only for bootstrap 4 JS tabs which uses/requires it.
 
 import domready from 'domready';
 
 domready(function() {
   // if there's an #anchor in the URL referencing a bootstrap tab, make that tab selected.
   // should we limit to only certain data tags instead of all bootstrap tab links?
-  const anchor = window.location.hash;
+  var anchor = new URLSearchParams(window.location.hash.replace(/^#/, '')).get("tab");
   if (anchor) {
-    $(`*[data-toggle="tab"][href="${anchor}"]`).tab("show")
+    $(`*[data-toggle="tab"][href="#${anchor}"]`).tab("show")
   }
 
   // when showing on a bootstrap tab, put the relevant ID in anchor,
   // without adding to browser history
   $(document).on("show.bs.tab", function(event) {
-    window.history.replaceState(undefined, undefined, event.target.getAttribute("href"));
+    var anchorValues = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+    var tabId = event.target.getAttribute("href").replace(/^#/,"")
+
+    anchorValues.set("tab", tabId);
+    window.history.replaceState(undefined, undefined, "#" + anchorValues.toString());
   });
 });
 

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -38,7 +38,7 @@
               <span class="badge badge-warning">Un-published, but marked available by request</span>
             </span>
               <% if @asset.parent %>
-                More info at <%= link_to "Work Oral History Management", admin_work_path(@asset.parent, anchor: "nav-oral-histories") %>
+                More info at <%= link_to "Work Oral History Management", admin_work_path(@asset.parent, anchor: "tab=nav-oral-histories") %>
               <% end %>
           </div>
         </div>

--- a/app/views/admin/works/oh_biography_form.html.erb
+++ b/app/views/admin/works/oh_biography_form.html.erb
@@ -14,7 +14,7 @@
       </h1>
     </div>
     <div class="form-actions">
-      <%= link_to 'Cancel', admin_work_path(@work, :anchor => "nav-oral-histories"), class: "btn btn-outline-primary my-1" %>
+      <%= link_to 'Cancel', admin_work_path(@work, :anchor => "tab=nav-oral-histories"), class: "btn btn-outline-primary my-1" %>
       <%= submit_tag "Save", class: "btn btn-primary my-1" %>
     </div>
   </div>

--- a/spec/controllers/admin/works_controller_spec.rb
+++ b/spec/controllers/admin/works_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
 
       it "can add valid file" do
         put :submit_ohms_xml, params: { id: work.friendlier_id, ohms_xml: Rack::Test::UploadedFile.new(valid_xml_path, "application/xml")}
-        expect(response).to redirect_to(admin_work_path(work, anchor: "nav-oral-histories"))
+        expect(response).to redirect_to(admin_work_path(work, anchor: "tab=nav-oral-histories"))
         expect(flash[:error]).to be_blank
 
         expect(work.reload.oral_history_content.ohms_xml).to be_present
@@ -87,7 +87,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
           ohms_xml: Rack::Test::UploadedFile.new(StringIO.new("not > xml"), "application/xml", original_filename: "foo.xml")
         }
 
-        expect(response).to redirect_to(admin_work_path(work, anchor: "nav-oral-histories"))
+        expect(response).to redirect_to(admin_work_path(work, anchor: "tab=nav-oral-histories"))
         expect(flash[:error]).to include("OHMS XML file was invalid and could not be accepted")
 
         expect(work.reload.oral_history_content&.ohms_xml).not_to be_present
@@ -110,7 +110,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
           id: work.friendlier_id,
           searchable_transcript_source: Rack::Test::UploadedFile.new(transcript_path, "text/plain")
         }
-        expect(response).to redirect_to(admin_work_path(work, anchor: "nav-oral-histories"))
+        expect(response).to redirect_to(admin_work_path(work, anchor: "tab=nav-oral-histories"))
         expect(flash[:error]).to be_blank
         expect(work.oral_history_content!.searchable_transcript_source).to be_present
       end
@@ -119,7 +119,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
         put :remove_searchable_transcript_source, params: {
           id: work.friendlier_id#,
         }
-        expect(response).to redirect_to(admin_work_path(work, anchor: "nav-oral-histories"))
+        expect(response).to redirect_to(admin_work_path(work, anchor: "tab=nav-oral-histories"))
         expect(flash[:error]).to be_blank
         expect(flash[:notice]).to match /has been removed/
         expect(work.oral_history_content!.searchable_transcript_source).not_to be_present
@@ -158,7 +158,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
       it "kicks off an audio derivatives job" do
         expect(oral_history.members.map(&:stored?)).to match([true, true])
         put :create_combined_audio_derivatives, params: { id: oral_history.friendlier_id }
-        expect(response).to redirect_to(admin_work_path(oral_history, anchor: "nav-oral-histories"))
+        expect(response).to redirect_to(admin_work_path(oral_history, anchor: "tab=nav-oral-histories"))
         expect(CreateCombinedAudioDerivativesJob).to have_been_enqueued
       end
     end
@@ -180,7 +180,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
             "no_such_id" => "true"
           }
         }
-        expect(response).to redirect_to(admin_work_path(work, anchor: "nav-oral-histories"))
+        expect(response).to redirect_to(admin_work_path(work, anchor: "tab=nav-oral-histories"))
 
         expect(work.reload.oral_history_content.available_by_request_mode).to eq("automatic")
         expect(was_false_asset.reload.oh_available_by_request).to be true

--- a/spec/system/admin/oral_history_interviewee_bio_spec.rb
+++ b/spec/system/admin/oral_history_interviewee_bio_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Oral History Access Interviewee bio", :logged_in_user, type: :sy
   end
 
   it "interviewee bio data shows up linked" do
-    visit admin_work_path(work, :anchor => "nav-oral-histories")
+    visit admin_work_path(work, :anchor => "tab=nav-oral-histories")
     section = find("h2", text: "Interviewee biography").ancestor('.card')
     within(section) do
       # have to find hidden select, since it's covered by tom-select.js UI


### PR DESCRIPTION
We add tab selection to URL #anchor on selection, and on page load switch to that tab. This lets tab selection be reflected in the URL, so when you bookmark you get current tab. Oral History audio navbar is the use case, although it's active on all bootstrap tabs.

We were already doing this prior to this PR, but putting the ID of the selected tab in teh anchor as the entire anchor, eg "#ohTranscript"

we now use a key/value format instead, like "#tab=ohTranscript".  This gives us room to store more than one thing in anchor, in particular upcoming planned feature for linking specifically to a timecode, which might look like #tab=ohTranscript&t=1212" where 1212 is a number of seconds.