### PR TITLE
CONSIDERATION: Oral history audio player, scroll to media sync button

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -28,5 +28,6 @@ import '../src/js/audio/ohms_search.js';
 import '../src/js/audio/ohms_footnotes.js';
 import '../src/js/audio/accordion_open_on_screen.js';
 import '../src/js/audio/navbar_tabs.js';
+import '../src/js/audio/jump_to_text.js';
 
 

--- a/app/javascript/src/js/audio/jump_to_text.js
+++ b/app/javascript/src/js/audio/jump_to_text.js
@@ -1,0 +1,102 @@
+ // OK, but now if audio is playing, and we're on transcript or ToC tab, we actually want to
+// scroll to relevant portion...
+
+
+document.body.addEventListener("click", function (event) {
+  if (event.target.matches("*[data-trigger='ohms-jump-to-text']")) {
+    var player = document.querySelector("audio[data-role=ohms-audio-elem]");
+    var timeCodeSeconds = player.currentTime;
+    var activeTab = getActiveTab();
+
+    if (activeTab.id == "ohTocTab") {
+      var collapsible = findTocCollapsibleSection(timeCodeSeconds);
+      if (collapsible) {
+        if (collapsible.classList.contains("collapse")) {
+          $(collapsible).collapse("show");
+        }
+        // And scroll to the
+        scrollToElement(collapsible.closest(".card").querySelector(".card-header"));
+      }
+    } else if (activeTab) {
+      // if we have anything else, jump to transcript point, activating
+      // transcript tab first if needed.
+      if (activeTab.id != "ohTranscriptTab") {
+        $('*[data-toggle="tab"][href="#ohTranscript"]').tab("show");
+      }
+
+      var element = findTranscriptAnchor(timeCodeSeconds);
+      if (element) {
+        scrollToElement(element);
+      }
+    }
+  }
+});
+
+
+
+
+
+
+  //   if (tabId == "ohTranscriptTab") {
+  //     var anchor = findTranscriptAnchor(timeCodeSeconds);
+
+  //     if (anchor) {
+  //       scrollToElement(anchor);
+  //     }
+  //   } else if (tabId == "ohTocTab") {
+  //     var collapsible = findTocCollapsibleSection(timeCodeSeconds);
+  //     if (collapsible) {
+  //       if (collapsible.classList.contains("collapse")) {
+  //         $(collapsible).collapse("show");
+  //       }
+  //       // And scroll to the
+  //       scrollToElement(collapsible.closest(".card").querySelector(".card-header"));
+  //     }
+  //   }
+  // }
+
+
+
+
+
+function findTranscriptAnchor(timeInSeconds) {
+  return findOhmsTimestampElementIncluding(timeInSeconds, "a")
+}
+
+function findOhmsTimestampElementIncluding(timeInSeconds, baseSelector) {
+  var previousEl = undefined;
+  for (element of document.querySelectorAll(baseSelector + "[data-ohms-timestamp-s]")) {
+    if (element.getAttribute("data-ohms-timestamp-s") > timeInSeconds) {
+      return previousEl;
+    }
+    previousEl = element;
+  }
+  return undefined;
+}
+
+// Returns an element that you can call boostrap element.collapse()
+// on, for ToC section corresponding to timecode.
+function findTocCollapsibleSection(timeInSeconds) {
+  var button = findOhmsTimestampElementIncluding(timeInSeconds, "button");
+
+  // need to find it's parent collapsible
+  return button && button.closest("*[data-parent='#ohmsIndexAccordionParent']")
+}
+
+// What makes this slightly less than completely simple is allowing for
+// the fixed navbar on top; built-in browser functions will often wind
+// up scrolling it top of window, under navbar.
+//
+function scrollToElement(element) {
+  var targetDocumentXPosition = element.getBoundingClientRect().top + window.scrollY;
+  var navbarHeight = document.querySelector("#ohmsAudioNavbar").offsetHeight;
+
+  window.scrollTo({top: (targetDocumentXPosition - navbarHeight)});
+}
+
+// returns dom element for tab (the button that triggers the tab, that you can
+// call tab() on).
+function getActiveTab() {
+  var content = document.querySelector("#ohmsScrollable .tab-pane.active");
+  return content && document.querySelector(`*[data-toggle="tab"][href="#${content.id}"]`);
+}

--- a/app/javascript/src/js/audio/navbar_tabs.js
+++ b/app/javascript/src/js/audio/navbar_tabs.js
@@ -33,21 +33,25 @@ $(document).on("hide.bs.tab", ".work-show-audio", function(event) {
   }
 });
 
-
-// Restore tab position on a tab when we switch back to it, or else try to get
+// Scroll position on tab change:
+//
+// 1) Normally, restore tab position on a tab when we switch back to it, or else try to get
 // us at the "top" of the tab, so you don't wind up looking at the footer on a short tab.
 // A bit hard to get right.
+//
+// 2) but if Audio is playing, scroll to corresponding position in transcript or ToC tab.
 $(document).on("shown.bs.tab", ".work-show-audio", function(event) {
   // restore scroll position, or move to a reasonable starting point if first time on this tab.
 
+  var tabId = event.target.id;
   var navbarIsFixed = (document.getElementById("ohmsAudioNavbar").getBoundingClientRect().top == 0);
-  var saved = tabScrollPositions[event.target.id];
+  var saved = tabScrollPositions[tabId];
 
   if (saved) {
     window.scrollTo({top: saved})
   } else if (! navbarIsFixed) {
     // navbar isn't fixed to top anyway, don't worry about it, too weird if we try.
-    return;
+    // no-op.
   } else {
     // we don't have a saved position, but we're in position with fixed navbar at
     // top of page -- move to top of fixed navbar at top of page in new tab.
@@ -60,3 +64,5 @@ $(document).on("shown.bs.tab", ".work-show-audio", function(event) {
     document.getElementById("ohmsAudioNavbar").scrollIntoView({behavior: "auto", block: "start"});
   }
 });
+
+

--- a/app/views/works/oh_audio_work_show.html.erb
+++ b/app/views/works/oh_audio_work_show.html.erb
@@ -14,10 +14,15 @@
           <%= @work.title %>
         </h1>
         <% if decorator.combined_mp3_audio.present? && decorator.derivatives_up_to_date? %>
-          <audio controls controlsList="nodownload" data-role="ohms-audio-elem" >
-              <source src="<%= decorator.combined_mp3_audio%>"  type="audio/mpeg"/>
-              <source src="<%= decorator.combined_webm_audio%>"  type="audio/webm"/>
-          </audio>
+          <div class="d-flex" style="align-items: center">
+            <audio controls controlsList="nodownload" data-role="ohms-audio-elem" >
+                <source src="<%= decorator.combined_mp3_audio%>"  type="audio/mpeg"/>
+                <source src="<%= decorator.combined_webm_audio%>"  type="audio/webm"/>
+            </audio>
+            <div class="pl-3">
+              <button class="btn btn-emphasis btn-sm text-nowrap" data-trigger="ohms-jump-to-text">Scroll to media</button>
+            </div>
+          </div>
         <% else %>
           <div class="alert alert-warning" role="alert" data-role="no-audio-alert">
              This oral history is not properly prepared for the audio player. (Staff: please create a combined derivative.)


### PR DESCRIPTION
Possible solution to #696. But we might try an "auto-scroll" instead. 

@lsberry16 did confirm this is already probably preferable to what's speced in #696

Still some outstanding concern about what the button is labelled, currently "scroll to media".