### PR TITLE
Fix image bug

### DIFF
--- a/bin/oh_microsite_export/queries/image.sql
+++ b/bin/oh_microsite_export/queries/image.sql
@@ -1,25 +1,32 @@
 select
     field_data_field_interviewee_name.entity_id interview_entity_id,
     field_data_field_interview_number.field_interview_number_value interview_number,
-    field_interviewee_name_value as interviewee_name,
+    field_data_field_interviewee_name.field_interviewee_name_value interviewee_name,
+    image.field_image_fid image_fid,
     image_metadata.filename filename,
     REPLACE(image_metadata.uri,'public://','https://oh.sciencehistory.org/sites/default/files/') url,
     image_title.field_file_image_title_text_value title,
     image_alt.field_file_image_alt_text_value alt,
     image_caption.field_image_caption_value caption
-    -- ,
-    -- image_metadata.status image_published,
-    -- image.field_image_fid as image_fid,
-    -- published.status published
 from
-    field_data_field_interviewee_name,
     field_data_field_interview_number,
+    field_data_field_interviewee_name
+    LEFT JOIN
+        field_data_field_image_caption          image_caption
+        ON
+        field_data_field_interviewee_name.entity_id = image_caption.entity_id
+        AND
+        field_data_field_interviewee_name.revision_id = image_caption.revision_id,
     field_data_field_image image,
-    file_managed image_metadata,
-    field_data_field_file_image_title_text  image_title,
-    field_data_field_file_image_alt_text    image_alt,
-    field_data_field_image_caption          image_caption,
-    node published
+    file_managed image_metadata
+    LEFT JOIN
+        field_data_field_file_image_title_text image_title
+        ON
+        image_title.entity_id = image_metadata.fid
+    LEFT JOIN
+        field_data_field_file_image_alt_text    image_alt
+        ON
+        image_alt.entity_id = image_metadata.fid
 WHERE
     field_data_field_interviewee_name.entity_id =  field_data_field_interview_number.entity_id
 AND
@@ -29,16 +36,4 @@ AND
 AND
     field_data_field_interviewee_name.revision_id = image.revision_id
 AND
-    published.nid = field_data_field_interviewee_name.entity_id
-AND
     image.field_image_fid = image_metadata.fid
-AND
-    image_title.entity_id = image_metadata.fid
-AND
-    image_alt.entity_id = image_metadata.fid
-AND
-    field_data_field_interviewee_name.entity_id = image_caption.entity_id
-AND
-    field_data_field_interviewee_name.revision_id = image_caption.revision_id
-ORDER BY
-    field_data_field_interview_number.field_interview_number_value

--- a/lib/scihist_digicoll/oh_microsite_import_utilities/interviewee_portrait_uploader.rb
+++ b/lib/scihist_digicoll/oh_microsite_import_utilities/interviewee_portrait_uploader.rb
@@ -29,31 +29,28 @@ module OhMicrositeImportUtilities
     # If the portrait already exists, update its metadata
     def maybe_update_metadata
       return if portrait_asset.nil?
-      portrait_asset['file_data']['metadata']['filename'] = @filename
       portrait_asset.title = @title
       portrait_asset.alt_text = DescriptionSanitizer.new.sanitize(@alt_text)
       portrait_asset.caption = DescriptionSanitizer.new.sanitize(@caption)
-      # note = []
-      # note << "Original microsite title: \"#{@title}\""          if @title.present?
-      # note << "Downloaded from microsite URL: \"#{@url}\""  if @url.present?
-      # note << "Alt text: \"#{@alt_text}\""    if @alt_text.present?
-      # note << "Caption: \"#{@caption}\""      if @caption.present?
-      # portrait_asset.admin_note = note
       portrait_asset.save!
     end
 
     def new_portrait
       portrait = Asset.new(
-        title: @title,
-        position: next_open_position,
-        parent_id: @work.id,
-        published: @work.published,
-        role: 'portrait',
+          title: @title,
+          alt_text: DescriptionSanitizer.new.sanitize(@alt_text),
+          caption: DescriptionSanitizer.new.sanitize(@caption),
+          position: next_open_position,
+          parent_id: @work.id,
+          published: @work.published,
+          role: 'portrait'
         )
         portrait.file_attacher.set_promotion_directives(promote: "inline")
         portrait.file_attacher.set_promotion_directives(create_derivatives: "inline")
         begin
-          portrait.file = { "id" => @url, "storage" => "remote_url" }
+          file_settings =  { "id" => @url, "storage" => "remote_url"}
+          file_settings['metadata'] = { "filename" => @filename} if @filename.present?
+          portrait.file = file_settings
         rescue Shrine::Error => shrine_error
           puts("Shrine error: #{shrine_error}")
         end


### PR DESCRIPTION
The query we were using to extract images from the microsite DB didn't deal properly with missing image metadata.
Also fixed how that metadata gets applied in the actual import.
Finally, the "original filename" for these portraits now shows up in its proper place on the asset metadata page.
Ref  #1108 and #1114.
