### PR TITLE
Redirect some existing legacy OH microsite search result links

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,17 @@ Rails.application.routes.draw do
     # OH home page, send to new OH collection page
     root as: false, to: redirect { "#{ScihistDigicoll::Env.lookup!("app_url_base")}/collections/#{ScihistDigicoll::Env.lookup!("oral_history_collection_id")}"  }
 
+
+    # Links to search results in legacy OH site should redirct to search of OH collection.
+    # We only support basic query term, not fielded search or facets.
+    get "search/site/*query", to: redirect { |path_params, req|
+      "#{ScihistDigicoll::Env.lookup!("app_url_base")}/collections/#{ScihistDigicoll::Env.lookup!("oral_history_collection_id")}?q=#{path_params[:query]}"
+    }
+    get "search/oh/*query", to: redirect { |path_params, req|
+      "#{ScihistDigicoll::Env.lookup!("app_url_base")}/collections/#{ScihistDigicoll::Env.lookup!("oral_history_collection_id")}?q=#{path_params[:query]}"
+    }
+
+
     # Does it match one of our OH_LEGACY_REDIRECTS? Then redirect it!
     get '*path', constraints: ->(req) { OH_LEGACY_REDIRECTS.has_key?(req.path.downcase) }, to: redirect { |params, req|
       "#{ScihistDigicoll::Env.lookup!("app_url_base")}#{OH_LEGACY_REDIRECTS[req.path.downcase]}"

--- a/spec/requests/oh_legacy_redirects_spec.rb
+++ b/spec/requests/oh_legacy_redirects_spec.rb
@@ -39,6 +39,20 @@ describe "Oral history legacy site redirects" do
     end
   end
 
+  describe "search results link" do
+    it "redirects from /search/site/" do
+      get '/search/site/new%20york'
+      expect(response).to have_http_status(301) # moved permanently
+      expect(response).to redirect_to("#{standard_base_url}/collections/#{ScihistDigicoll::Env.lookup!(:oral_history_collection_id)}?q=new\%20york")
+    end
+
+    it "redirects from /search/oh/" do
+      get '/search/oh/new%20york'
+      expect(response).to have_http_status(301) # moved permanently
+      expect(response).to redirect_to("#{standard_base_url}/collections/#{ScihistDigicoll::Env.lookup!(:oral_history_collection_id)}?q=new\%20york")
+    end
+  end
+
 
   it "handles unrecognized with a nice 404" do
     get "/some_url/never_heard_of_it"


### PR DESCRIPTION
Only bothering with the main searches, not fielded searches. Will catch things like the search form on main sciencehistory.org website, if it's left as is. Final decision hasn't been made wrt what to do with OH search on main site; but it's so cheap/easy to do this redirect, let's do it anyway, just for completeness in redirects. Either it'll be used or it won't, doesn't hurt anything by being there.

Maybe i just think setting up redirects in the routing file is fun.

Ref #1123