### PR TITLE
Add oral history projects redirect

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
       "#{ScihistDigicoll::Env.lookup!("app_url_base")}/collections/#{ScihistDigicoll::Env.lookup!("oral_history_collection_id")}?q=#{path_params[:query]}"
     }
 
+    get '/oral-histories/projects', to: redirect { 'https://www.sciencehistory.org/oral-history-projects' }
 
     # Does it match one of our OH_LEGACY_REDIRECTS? Then redirect it!
     get '*path', constraints: ->(req) { OH_LEGACY_REDIRECTS.has_key?(req.path.downcase) }, to: redirect { |params, req|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
       "#{ScihistDigicoll::Env.lookup!("app_url_base")}/collections/#{ScihistDigicoll::Env.lookup!("oral_history_collection_id")}?q=#{path_params[:query]}"
     }
 
-    get '/oral-histories/projects', to: redirect { "https://#{ ScihistDigicoll::Env.lookup!("institute_main_site_hostname") }/#{ ScihistDigicoll::Env.lookup!("institute_main_site_projects_page") }" }
+    get '/oral-histories/projects', to: redirect { 'https://www.sciencehistory.org/oral-history-projects' }
 
     # Does it match one of our OH_LEGACY_REDIRECTS? Then redirect it!
     get '*path', constraints: ->(req) { OH_LEGACY_REDIRECTS.has_key?(req.path.downcase) }, to: redirect { |params, req|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
       "#{ScihistDigicoll::Env.lookup!("app_url_base")}/collections/#{ScihistDigicoll::Env.lookup!("oral_history_collection_id")}?q=#{path_params[:query]}"
     }
 
-    get '/oral-histories/projects', to: redirect { 'https://sciencehistory.org/oral-history-projects' }
+    get '/oral-histories/projects', to: redirect('https://sciencehistory.org/oral-history-projects')
 
     # Does it match one of our OH_LEGACY_REDIRECTS? Then redirect it!
     get '*path', constraints: ->(req) { OH_LEGACY_REDIRECTS.has_key?(req.path.downcase) }, to: redirect { |params, req|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
       "#{ScihistDigicoll::Env.lookup!("app_url_base")}/collections/#{ScihistDigicoll::Env.lookup!("oral_history_collection_id")}?q=#{path_params[:query]}"
     }
 
-    get '/oral-histories/projects', to: redirect { 'https://www.sciencehistory.org/oral-history-projects' }
+    get '/oral-histories/projects', to: redirect { 'https://sciencehistory.org/oral-history-projects' }
 
     # Does it match one of our OH_LEGACY_REDIRECTS? Then redirect it!
     get '*path', constraints: ->(req) { OH_LEGACY_REDIRECTS.has_key?(req.path.downcase) }, to: redirect { |params, req|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
       "#{ScihistDigicoll::Env.lookup!("app_url_base")}/collections/#{ScihistDigicoll::Env.lookup!("oral_history_collection_id")}?q=#{path_params[:query]}"
     }
 
-    get '/oral-histories/projects', to: redirect { 'https://www.sciencehistory.org/oral-history-projects' }
+    get '/oral-histories/projects', to: redirect { "https://#{ ScihistDigicoll::Env.lookup!("institute_main_site_hostname") }/#{ ScihistDigicoll::Env.lookup!("institute_main_site_projects_page") }" }
 
     # Does it match one of our OH_LEGACY_REDIRECTS? Then redirect it!
     get '*path', constraints: ->(req) { OH_LEGACY_REDIRECTS.has_key?(req.path.downcase) }, to: redirect { |params, req|

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -99,9 +99,6 @@ module ScihistDigicoll
       end
     }
 
-    define_key :institute_main_site_hostname, default: "www.sciencehistory.org"
-    define_key :institute_main_site_projects_page, default: "oral-history-projects"
-
     # Sometimes we need the individual parts of the app_base_url, returns a URI object
     # they can be obtained from.
     def self.app_url_base_parsed

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -99,6 +99,9 @@ module ScihistDigicoll
       end
     }
 
+    define_key :institute_main_site_hostname, default: "www.sciencehistory.org"
+    define_key :institute_main_site_projects_page, default: "oral-history-projects"
+
     # Sometimes we need the individual parts of the app_base_url, returns a URI object
     # they can be obtained from.
     def self.app_url_base_parsed


### PR DESCRIPTION
Includes two config settings, so we can change the URL easily if there's a website rename or redesign.
Ref #1011  .
This is the last URL we know about.