### PR TITLE
aria-expanded should start out false for collapsed collapsibles

### DIFF
--- a/app/views/presenters/_ohms_index.html.erb
+++ b/app/views/presenters/_ohms_index.html.erb
@@ -3,7 +3,7 @@
     <div class="ohms-index-point card" id="<%= view.accordion_wrapper_id(index) %>">
       <div class="card-header" id="<%= view.accordion_header_id(index) %>">
         <h3 class="ohms-index-point-title mb-0">
-          <button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#<%= view.accordion_element_id(index) %>" aria-expanded="true" aria-controls="<%= view.accordion_element_id(index) %>">
+          <button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#<%= view.accordion_element_id(index) %>" aria-expanded="false" aria-controls="<%= view.accordion_element_id(index) %>">
               <i class="fa fa-plus float-right toggle-icon" aria-hidden="true"></i>
               <i class="fa fa-minus float-right toggle-icon" aria-hidden="true"></i>
               <span class="mr-3"><%= format_ohms_timestamp(index_point.timestamp) %></span> <%= index_point.html_safe_title %>


### PR DESCRIPTION
Noticed this was wrong when working on some stuff in this area.