### PR TITLE
phrase boost higher

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -121,7 +121,7 @@ class CatalogController < ApplicationController
     config.default_solr_params = {
       rows: 25,
       qf: "text1_tesim^1000 text2_tesim^500 text3_tesim^100 text4_tesim^50 text_no_boost_tesim^10 friendlier_id_ssi id^10 searchable_fulltext^0.5",
-      pf: "text1_tesim^1000 text2_tesim^500 text3_tesim^100 text4_tesim^50 text_no_boost_tesim^10 friendlier_id_ssi id^10 searchable_fulltext^5",
+      pf: "text1_tesim^1500 text2_tesim^1200 text3_tesim^600 text4_tesim^120 text_no_boost_tesim^55 friendlier_id_ssi id^55 searchable_fulltext^12",
 
 
       # HIGHLIGHTING-related params, full snippets from fulltext matches


### PR DESCRIPTION
Phrase matches were not beating non-phrase matches to the extent we expected them to

Ref #1127

It was actually performing pretty decently. But automatic phrase boost had to be made higher for things like entering phrase <university of washington> without quotes to work well. 

Did not end up modifying omitNorms -- still not sure if it's a good idea or not!

Re-discovered that relevancy is complicated, if we want to get serious about it we're going to need to create a 'program' with normalized means of measurement/QA etc.