### PR TITLE
Don't try to restart/reload solr on deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -174,5 +174,8 @@ namespace :scihist do
       end
     end
   end
-  after "deploy:log_revision", "scihist:restart_or_reload_solr"
+
+  # Disable cap flow to restart/reload our EC2 solr, because it won't work with the
+  # production searchstax we are trying to swap in as an emergency measure.
+  #after "deploy:log_revision", "scihist:restart_or_reload_solr"
 end


### PR DESCRIPTION
Our existing restart/reload code wouldn't work with searchstax -- and we're trying to switch to searchstax in production as part of emergency recovery measures.

We do have a rake task to send current solr config to searchstax solr. But we're not trying to wire it up to cap deploy in this PR. Instead, we just disable the function.

The rake task is `scihist:solr_cloud:sync_configset`.  Once we have production EC2 using searchstax solr, if you know you have a solr config change that needs to be sync'd, you should be able to ssh to an EC2, say, jobs server, and from there run `./bin/rake scihist:solr_cloud:sync_configset`.