### PR TITLE
rake task to delete empty interviewee biographies

### DIFF
--- a/app/models/oral_history_content/date_and_place.rb
+++ b/app/models/oral_history_content/date_and_place.rb
@@ -36,6 +36,10 @@ class OralHistoryContent
       ].collect(&:presence).compact
     end
 
+    def blank?
+      displayable_values.blank?
+    end
+
     def to_s
       displayable_values.join(", ")
     end

--- a/app/models/oral_history_content/interviewee_honor.rb
+++ b/app/models/oral_history_content/interviewee_honor.rb
@@ -17,5 +17,9 @@ class OralHistoryContent
         honor
       ].collect(&:presence).compact
     end
+
+    def blank?
+      displayable_values.blank?
+    end
   end
 end

--- a/app/models/oral_history_content/interviewee_job.rb
+++ b/app/models/oral_history_content/interviewee_job.rb
@@ -15,5 +15,9 @@ class OralHistoryContent
         role
       ].collect(&:presence).compact
     end
+
+    def blank?
+      displayable_values.blank?
+    end
   end
 end

--- a/app/models/oral_history_content/interviewee_school.rb
+++ b/app/models/oral_history_content/interviewee_school.rb
@@ -15,5 +15,9 @@ class OralHistoryContent
         discipline
       ].collect(&:presence).compact
     end
+
+    def blank?
+      displayable_values.blank?
+    end
   end
 end

--- a/lib/tasks/data_fixes/remove_empty_interviewee_biographies.rake
+++ b/lib/tasks/data_fixes/remove_empty_interviewee_biographies.rake
@@ -1,0 +1,20 @@
+namespace :scihist do
+  namespace :data_fixes do
+    desc "Remove empty IntervieweeBiography objects"
+    task :remove_empty_biographies => :environment do
+      IntervieweeBiography.find_each do |bio|
+        if (bio.birth.blank? && bio.death.blank? &&
+              (bio.school.blank?  || bio.school.all?(&:blank?)) &&
+              (bio.job.blank?  || bio.job.all?(&:blank?)) &&
+              (bio.honor.blank?  || bio.honor.all?(&:blank?))
+              )
+          if ENV['DRY_RUN']
+            puts "#{bio.id}:#{bio.name}"
+          else
+            bio.destroy!
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[DRY_RUN=true] ./bin/rake scihist:data_fixes:remove_empty_biographies

Has already been run on staging. After merging, needs to be deployed and run on production. 

Ref #1154