### PR TITLE
Removing acl and owner info from preservation logical (sql) backup

### DIFF
--- a/lib/tasks/copy_database_to_s3.rake
+++ b/lib/tasks/copy_database_to_s3.rake
@@ -38,7 +38,7 @@ namespace :scihist do
         storage_class: "STANDARD_IA",
         metadata: { "backup_time" => Time.now.utc.to_s}
       ) do |write_stream|
-      cmd.run('pg_dump', '-w', '--clean', ENV['DATABASE_URL']) do |out, err|
+      cmd.run('pg_dump', '--no-owner', '--no-acl', '--clean', ENV['DATABASE_URL']) do |out, err|
         write_stream << out.force_encoding('UTF-8') if out
       end
     end


### PR DESCRIPTION
Per Jonathan's suggestion, let's make the sql backup more portable by not including owner and ACL info in the backup file.