### PR TITLE
let Rails log_level be set by Env (including Heroku config var)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,10 @@ module ScihistDigicoll
     # but still want to require it for rails app too.
     require 'scihist_digicoll/asset_check_whenever_cron_time'
 
+    if ScihistDigicoll::Env.lookup("rails_log_level")
+      config.log_level = ScihistDigicoll::Env.lookup("rails_log_level")
+    end
+
     # Initialize configuration defaults for originally generated Rails version,
     # or Rails version we have upgraded to and verified for new defaults.
     config.load_defaults 6.1

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,10 +48,6 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # :info is one step less info than :debug, it's still a fairly large amount of info, including
-  # all requests. We're trying this in production for now.
-  config.log_level = :info
-
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
 

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -56,6 +56,14 @@ module ScihistDigicoll
       @production ||= lookup(:service_level) == "production"
     end
 
+    define_key :rails_log_level, default: -> {
+      # :info is one step less info than :debug, it's still a fairly large amount of info, including
+      # all requests. We're trying this as default in production.
+      #
+      # For non-production environments, we don't by default override Rails default.
+      :info if Rails.env.production?
+    }, system_env_transform: ->(str) { str.to_sym }
+
 
     # what env for honeybadger to log, if not given we'll use the `service_level` value
     # (staging/production), or if that's not there either, just Rails.env (development, testing)


### PR DESCRIPTION
Convenient to be able to switch this without a code change/deploy, just in env! We think this patch leaves the defautls just as they were -- :info in Rails env production, and Rails default (which is :debug) otherwise.