### PR TITLE
enable hirefire worker autoscaling, and other worker tune-up for heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,6 +119,14 @@ gem 'sane_patch', '< 2.0' # time-limited monkey patches
 gem 'activerecord-postgres_enum', '~> 1.3' # can record postgres enums in schema.rb dump
 
 
+# For autoscaling on heroku via hirefire.io service, but hopefully won't cause any problems
+# when running not on heroku.
+#
+# https://help.hirefire.io/article/53-job-queue-ruby-on-rails
+# https://help.hirefire.io/article/49-logplex-queue-time
+# https://github.com/hirefire/hirefire-resource
+gem "hirefire-resource"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'pry-byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'puma', '~> 5.3'
 # https://github.com/nevans/resque-pool/issues/170
 gem "resque", "~> 2.0"
 gem "resque-pool"
+gem "resque-heroku-signals" # gah, weirdly needed for graceful shutdown on heroku. https://github.com/resque/resque#heroku
 
 gem 'honeybadger', '~> 4.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,6 +277,7 @@ GEM
     hashdiff (1.0.1)
     hashery (2.1.2)
     hashie (4.1.0)
+    hirefire-resource (0.9.0)
     honeybadger (4.7.3)
     html_aware_truncation (1.0.0)
       nokogiri (~> 1.0)
@@ -679,6 +680,7 @@ DEPENDENCIES
   factory_bot_rails
   faster_s3_url (< 2)
   font-awesome-rails (~> 4.7)
+  hirefire-resource
   honeybadger (~> 4.0)
   html_aware_truncation (~> 1.0)
   jbuilder (~> 2.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -488,6 +488,8 @@ GEM
       redis-namespace (~> 1.6)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
+    resque-heroku-signals (2.0.0)
+      resque (= 2.0.0)
     resque-pool (0.7.1)
       rake (>= 10.0, < 14.0)
       resque (>= 1.22, < 3)
@@ -701,6 +703,7 @@ DEPENDENCIES
   rails_autolink (~> 1.0)
   ransack (~> 2.1)
   resque (~> 2.0)
+  resque-heroku-signals
   resque-pool
   rsolr (>= 1.0, < 3)
   rspec-rails (~> 4.0)

--- a/config/initializers/hirefire_resource.rb
+++ b/config/initializers/hirefire_resource.rb
@@ -1,0 +1,22 @@
+# The hirefire_resource gem has our app providing some info to hirefire.io for
+# heroku autoscaling.
+#
+# Let's only configure it to do anything if we're actually on heroku with HIREFIRE_TOKEN
+# configured. This config  won't be operative in dev or CI, OR if/when we're still
+# deploying to non-heroku infrastructure, hopefully minimizing any performance
+# impact on non-heroku.
+
+if ENV['HIREFIRE_TOKEN']
+  HireFire::Resource.configure do |config|
+
+    # https://help.hirefire.io/article/53-job-queue-ruby-on-rails
+    # https://github.com/hirefire/hirefire-resource
+    config.dyno(:worker) do
+      HireFire::Macro::Resque.queue
+    end
+
+    # for queue time-based web dyno scaling, if we choose to use that.
+    # https://help.hirefire.io/article/49-logplex-queue-time
+    # config.log_queue_metrics = true
+  end
+end

--- a/config/initializers/resque_patch.rb
+++ b/config/initializers/resque_patch.rb
@@ -1,0 +1,25 @@
+# Monkey-patching an apparent bug in resque.
+#
+# Bug exhibited on heroku as OpenSSL::SSL::SSLError: SSL_read: sslv3 alert bad record mac
+#
+# This stackoverflow: https://stackoverflow.com/questions/50228454/why-am-i-getting-opensslsslsslerror-ssl-read-sslv3-alert-bad-record-mac
+#
+# Led us to this unmerged resque PR: https://github.com/resque/resque/pull/1739
+#
+# Which we are trying as a monkey-patch, redefining the Resque::DataStore#reconnect method.
+#
+# We'll refuse to run and require manual review if resque is more than 2.0.0 -- maybe
+# resque will have fixed this itself, or changed in a way that makes the monkey-patch not work.
+SanePatch.patch('resque', '2.0.0') do
+  Resque::DataStore
+
+  module Resque
+    class DataStore
+      # Force a reconnect to Redis without closing the connection in the parent
+      # process after a fork.
+      def reconnect
+        @redis._client.connect
+      end
+    end
+  end
+end

--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -15,3 +15,20 @@ task 'resque:pool:setup' do
     Resque.redis.client.reconnect
   end
 end
+
+
+namespace :scihist do
+  namespace :resque do
+    desc "prune workers resque knows haven't sent a heartbeat in a while"
+    # resque is supposed to do this itself sometimes, but doesn't always.
+    task :prune_expired_workers do
+      expired = Resque::Worker.all_workers_with_expired_heartbeats
+      if expired.present?
+        $stderr.puts "pruning: #{expired}"
+        expired.each { |w| w.unregister_worker }
+      else
+        $stderr.puts "None found"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ref #1195, but we are only auto-scaling workers here, not yet web. 

# 1. hirefire-resource gem

required for integration with hirefire.io, the main thing it does is provide a URL endpoint hirefire can access to get the current job queue count, so it knows if it wants to scale. 

We don't have hirefire web scaling turned on yet. #1180 

The HIREFIRE_TOKEN needs to be set in heroku config in order for connection to work. 

# 2. resque-heroku-signals gem

Provides a monkey-patch to resque, to make it work properly with how heroku tries to shut down dynos. We want our dynos to shut down somewhat gracefully, and it turns out resque gem needed a patch for that, which resque itself hasn't merged. :( This applies to hirefire downscaling, but also to any worker dyno restart, when a worker dyno may be busy -- from code deploys, heroku's automatic nightly restarts, whatever. 

https://github.com/resque/resque/issues/1559

Heroku config vars that we set to effect graceful shut down (https://github.com/resque/resque#heroku):
* TERM_CHILD=1 : Switches resque to a different shutdown mode that respects the following vars....
* RESQUE_PRE_SHUTDOWN_TIMEOUT=20: After getting the signal to shut down from heroku, give busy workers 20 seconds to finish their work, then tell them they better really abort
* RESQUE_TERM_TIMEOUT=8; after telling them they better really abort, give them another 8 seconds to stop and clean up (for instance register as 'failed' with resque) before really killing them hard. 

In testing, this seemed to mostly work. If a job isn't finished in the 20 seconds, it will wind up in the resque 'failed' queue. 

Trying this repeatedly, in *some* cases a worker dies and the resque admin dashboard doesn't know it's dead, see below. 

# 3. another local patch to heroku

When testing heroku dyno restarts and scaling, I was getting intermittent mysterious errors from resque workers:

    OpenSSL::SSL::SSLError: SSL_read: sslv3 alert bad record mac

Googling, I found that someone else had this problem (on heroku too; not sure why it might only effect heroku) and thought they had diagnosed and fixed it. The PR remains unreviewed/merged in resque though. https://github.com/resque/resque/pull/1739

So we patch it in in our app instead, it's a simple patch. 

# Trimming phantom workers

In my tests of restarting worker dynos from heroku, sometimes resque ended up with "phantom" workers in it's list. Workers that didn't really exist anymore, but resque thought they did, so maybe resque thought there were 10 active workers, but really there were only 8, two were phantom. The phantom ones resque might think are idle, or busy. 

Resque code looks like it's *supposed* to trim these now and then, noticing a worker that hasn't sent a "heartbeat" in a while and deciding it's dead. But that didn't seem to be happenign in my observation. 

But running some simple resque code somehow did succesfully prune them, resque is capable of knowing they are dead, it just wasn't pruning them! I dunno, resque is in a bit of a maintenance abandonment. :( 

    
    Resque::Worker.all_workers_with_expired_heartbeats.each { |w| w.unregister_worker }

I made a rake task to do that too:

    heroku run rake scihist:resque:prune_expired_workers

If a phantom worker is believed to be busy, and gets pruned -- it'll get recorded as 'failed'. In some cases it may be recorded as failed even though it really succeeded -- this is one reason we try to make sure our tasks are idempotent! 