### PR TITLE
Force SSL

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = ScihistDigicoll::Env.lookup!(:force_ssl)
+  config.force_ssl = ScihistDigicoll::Env.lookup!(:force_ssl) == "true"
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = ScihistDigicoll::Env.force_ssl
+  config.force_ssl = ScihistDigicoll::Env.lookup!(:force_ssl)
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = ScihistDigicoll::Env.lookup!(:force_ssl) == "true"
+  config.force_ssl = ScihistDigicoll::Env.lookup!(:force_ssl)
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = ScihistDigicoll::Env.force_ssl
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -179,6 +179,8 @@ module ScihistDigicoll
       # it'll just get out of sync.
     }
 
+    define_key :force_ssl, default: Rails.env.production?
+
     define_key :s3_sitemap_bucket, default: -> {
       # for now we keep Google sitemaps in our derivatives bucket
       ScihistDigicoll::Env.lookup(:s3_bucket_derivatives)

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -179,7 +179,7 @@ module ScihistDigicoll
       # it'll just get out of sync.
     }
 
-    define_key :force_ssl, default: Rails.env.production?
+    define_key :force_ssl, default: Rails.env.production?, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM
 
     define_key :s3_sitemap_bucket, default: -> {
       # for now we keep Google sitemaps in our derivatives bucket

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -179,18 +179,7 @@ module ScihistDigicoll
       # it'll just get out of sync.
     }
 
-
-
-    #define_key :force_ssl, default: Rails.env.production?
-
-    # The above failed.
-    define_key :force_ssl, default: -> {
-      if Rails.env.production?
-        true
-      else
-        false
-      end
-    }
+    define_key :force_ssl, default: Rails.env.production?
 
     define_key :s3_sitemap_bucket, default: -> {
       # for now we keep Google sitemaps in our derivatives bucket

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -179,7 +179,18 @@ module ScihistDigicoll
       # it'll just get out of sync.
     }
 
-    define_key :force_ssl, default: Rails.env.production?
+
+
+    #define_key :force_ssl, default: Rails.env.production?
+
+    # The above failed.
+    define_key :force_ssl, default: -> {
+      if Rails.env.production?
+        true
+      else
+        false
+      end
+    }
 
     define_key :s3_sitemap_bucket, default: -> {
       # for now we keep Google sitemaps in our derivatives bucket


### PR DESCRIPTION
[Heroku recommends](https://help.heroku.com/J2R1S4T8/can-heroku-force-an-application-to-use-ssl-tls) turning on `config.force_ssl = true` in `production.rb`.
Works fine on Heroku; I also tested it on our non-Heroku staging environment, and it does not affect the setup on the existing webserver. (Makes sense.)
This won't affect dev or staging.
Ref #1182