### PR TITLE
need to sort Dir.glob output for reproducible digest value

### DIFF
--- a/app/services/solr_configset_updater.rb
+++ b/app/services/solr_configset_updater.rb
@@ -371,7 +371,7 @@ class SolrConfigsetUpdater
   # should be good enough our purpoes)
   def conf_dir_digest(truncate: 7)
     digest = []
-    Dir.glob("#{conf_dir}/**/*").each do |f|
+    Dir.glob("#{conf_dir}/**/*").sort.each do |f|
       digest.push(Digest::SHA1.hexdigest(File.open(f).read)) if File.file?(f)
     end
     digest = Digest::SHA1.hexdigest(digest.join(''))


### PR DESCRIPTION
If Dir.glob returns in a different order, then the calculated digest will be different even though underlying files haven't changed. On heroku, Dir.glob order differs from execution to execution (and from what it is on our development machines). So digest was different even when no underlying changes, Ref #1203.

Sorting the Dir.glob results should make digest actually reproducibly the same when file contents have not changed