### PR TITLE
Adding "Translator" role to our "additional credit" field

### DIFF
--- a/app/models/work/additional_credit.rb
+++ b/app/models/work/additional_credit.rb
@@ -2,8 +2,9 @@ class Work
   class AdditionalCredit
     include AttrJson::Model
 
-    ROLES = ['photographed_by']
+    ROLES = ['photographed_by', 'translator']
     NAMES = [
+      'Jocelyn R. McDaniel',
       'Douglas Lockard',
       'Gregory Tobias',
       'Mark Backrath',
@@ -26,6 +27,7 @@ class Work
     attr_json :name, :string
 
     def display_as
+      return "Translator: #{name}" if role == 'translator'
       "#{role.humanize} #{name}"
     end
   end

--- a/app/models/work/additional_credit.rb
+++ b/app/models/work/additional_credit.rb
@@ -27,7 +27,7 @@ class Work
     attr_json :name, :string
 
     def display_as
-      return "Translator: #{name}" if role == 'translator'
+      return "Translated by #{name}" if role == 'translator'
       "#{role.humanize} #{name}"
     end
   end

--- a/app/models/work/additional_credit.rb
+++ b/app/models/work/additional_credit.rb
@@ -2,11 +2,11 @@ class Work
   class AdditionalCredit
     include AttrJson::Model
 
-    ROLES = ['photographed_by', 'translator']
+    ROLES = ['photographed_by', 'translated_by']
     NAMES = [
-      'Jocelyn R. McDaniel',
       'Douglas Lockard',
       'Gregory Tobias',
+      'Jocelyn R. McDaniel',
       'Mark Backrath',
       'Penn School of Medicine',
       'Will Brown'
@@ -27,7 +27,6 @@ class Work
     attr_json :name, :string
 
     def display_as
-      return "Translated by #{name}" if role == 'translator'
       "#{role.humanize} #{name}"
     end
   end

--- a/config/locales/work.en.yml
+++ b/config/locales/work.en.yml
@@ -23,7 +23,7 @@ en:
       # https://guides.rubyonrails.org/i18n.html#translations-for-active-record-models
       work/additional_credit/role:
         photographed_by: "Photographed by"
-        translator: "Translated by"
+        translated_by: "Translated by"
 
 
 

--- a/config/locales/work.en.yml
+++ b/config/locales/work.en.yml
@@ -23,7 +23,7 @@ en:
       # https://guides.rubyonrails.org/i18n.html#translations-for-active-record-models
       work/additional_credit/role:
         photographed_by: "Photographed by"
-        translator: "Translator:"
+        translator: "Translated by"
 
 
 

--- a/config/locales/work.en.yml
+++ b/config/locales/work.en.yml
@@ -23,6 +23,7 @@ en:
       # https://guides.rubyonrails.org/i18n.html#translations-for-active-record-models
       work/additional_credit/role:
         photographed_by: "Photographed by"
+        translator: "Translator:"
 
 
 

--- a/spec/factories/work_factory.rb
+++ b/spec/factories/work_factory.rb
@@ -151,7 +151,7 @@ FactoryBot.define do
         [
           Work::AdditionalCredit.new({"name"=>"Douglas Lockard", "role"=>"photographed_by"}),
           Work::AdditionalCredit.new({"name"=>"Mark Backrath",   "role"=>"photographed_by"}),
-          Work::AdditionalCredit.new({"name"=>"Jocelyn R. McDaniel",   "role"=>"translator"})
+          Work::AdditionalCredit.new({"name"=>"Jocelyn R. McDaniel",   "role"=>"translated_by"})
         ]
       }
       physical_container {

--- a/spec/factories/work_factory.rb
+++ b/spec/factories/work_factory.rb
@@ -150,7 +150,7 @@ FactoryBot.define do
       additional_credit {
         [
           Work::AdditionalCredit.new({"name"=>"Douglas Lockard", "role"=>"photographed_by"}),
-          Work::AdditionalCredit.new({"name"=>"Mark Backrath",   "role"=>"photographed_by"})
+          Work::AdditionalCredit.new({"name"=>"Mark Backrath",   "role"=>"photographed_by"}),
           Work::AdditionalCredit.new({"name"=>"Jocelyn R. McDaniel",   "role"=>"translator"})
         ]
       }

--- a/spec/factories/work_factory.rb
+++ b/spec/factories/work_factory.rb
@@ -150,8 +150,7 @@ FactoryBot.define do
       additional_credit {
         [
           Work::AdditionalCredit.new({"name"=>"Douglas Lockard", "role"=>"photographed_by"}),
-          Work::AdditionalCredit.new({"name"=>"Mark Backrath",   "role"=>"photographed_by"}),
-          Work::AdditionalCredit.new({"name"=>"Jocelyn R. McDaniel",   "role"=>"translated_by"})
+          Work::AdditionalCredit.new({"name"=>"Mark Backrath",   "role"=>"photographed_by"})
         ]
       }
       physical_container {

--- a/spec/factories/work_factory.rb
+++ b/spec/factories/work_factory.rb
@@ -151,6 +151,7 @@ FactoryBot.define do
         [
           Work::AdditionalCredit.new({"name"=>"Douglas Lockard", "role"=>"photographed_by"}),
           Work::AdditionalCredit.new({"name"=>"Mark Backrath",   "role"=>"photographed_by"})
+          Work::AdditionalCredit.new({"name"=>"Jocelyn R. McDaniel",   "role"=>"translator"})
         ]
       }
       physical_container {


### PR DESCRIPTION
This is batch-editable (at least when it comes to *adding* a translator to multiple works, which is the main use case.)

And yes, adding a translator does not make anything disappear. It just appends a "Translated by" line to the metadata.

Ref #1193 