### PR TITLE
Make heroku release action somewhat more better behaved

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -5,4 +5,4 @@ web: bundle exec puma -C config/heroku_puma.rb
 worker: bundle exec resque-pool
 
 # https://devcenter.heroku.com/articles/release-phase
-release: bundle exec rake db:migrate scihist:solr_cloud:sync_configset
+release: bundle exec rake scihist:heroku:on_release

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -1,0 +1,19 @@
+namespace :scihist do
+  namespace :heroku do
+
+    desc "our custom code for running in heroku release phase"
+    task :on_release do
+      if ENV['DATABASE_URL']
+        Rake::Task["db:migrate"].invoke
+      else
+        $stderr.puts "\n!!! WARNING, no ENV['DATABASE_URL'], not running rake db:migrate as part of heroku release !!!\n\n"
+      end
+
+      if ENV['SOLR_URL']
+        Rake::Task["scihist:solr_cloud:sync_configset"].invoke
+      else
+        $stderr.puts "\n!!! WARNING, no ENV['SOLR_URL'], not running rake scihist:solr_cloud:sync_configset as part of heroku release !!!\n\n"
+      end
+    end
+  end
+end


### PR DESCRIPTION
By removing heroku release action in favor custom rake task

We can only run db:migrate if we have a DATABASE_URL, and solr sync if we have a SOLR_URL. If we don't, just don't try to run them, instead of trying to run them, failing, and cancelling release. 

This results in slightly more "Traditional" heroku behavior and less confusing "background release failures" in some common cases. Such as using `heroku pg:promote` that results in a release with an empty DATABASE_URL!

Later we can put in custom rescue/swallow of more/all errors if we want. 

This all gets very confusing, some write-up at https://bibwild.wordpress.com/2021/06/16/heroku-release-phase-rails-dbmigrate-and-command-failure/

Ref #1203. 