### PR TITLE
README link to heroku developer setup doc in wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Start a development Solr instance with `./bin/rake solr:start`.
 
 Run app with `./rails server`, it will be available at `http://localhost:3000`.
 
+To interact with our deployment infrastructure on [heroku](heroku.com), see [Heroku Developer Setup](https://chemheritage.atlassian.net/l/c/FsTqq6DV) in our wiki.
+
 ### To use githoooks in repo
 
 There's a pre-commit hook in the repo to try and **catch you from accidentally


### PR DESCRIPTION
Check out the wiki doc too eddie! You don't *have* to do things this way, but I think it makes sense, and will probably write other docs intended for developers using the `-r staging` and `-r production` options that are set up thusly. (Also I think it makes sense to make the defualt staging, rather than production, to minimize accidents).