### PR TITLE
Avoid warning on routes.rb reload

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
 
   # Oral History legacy redirects, come first in routes file so they'll match first
   # for requests to old oral history host oh.sciencehistory.org
-  OH_LEGACY_REDIRECTS = YAML.load_file(Rails.root + "config/oral_history_legacy_redirects.yml").freeze
+  OH_LEGACY_REDIRECTS ||= YAML.load_file(Rails.root + "config/oral_history_legacy_redirects.yml").freeze
   constraints host: ScihistDigicoll::Env.lookup!(:oral_history_legacy_host) do
     # OH home page, send to new OH collection page
     root as: false, to: redirect { "#{ScihistDigicoll::Env.lookup!("app_url_base")}/collections/#{ScihistDigicoll::Env.lookup!("oral_history_collection_id")}"  }


### PR DESCRIPTION
The routes.rb file can be reloaded sometimes, it turns out the devise gem does that by default in production mode.

When it is, we were getting warnings:

```
/app/config/routes.rb:24: warning: already initialized constant OH_LEGACY_REDIRECTS
/app/config/routes.rb:24: warning: previous definition of OH_LEGACY_REDIRECTS was here
```

Make the constant load `OH_LEGACY_REDIRECTS ||=` just to avoid the warning.