### PR TITLE
Adding rescue_rake: true

### DIFF
--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -11,5 +11,6 @@ breadcrumbs:
 exceptions:
   ignore:
     - 'ActionDispatch::Http::MimeNegotiation::InvalidType'
+  rescue_rake: true
 
 # http://docs.honeybadger.io/ruby/gem-reference/configuration.html


### PR DESCRIPTION
See conversation at ref #931 about 
`HONEYBADGER_EXCEPTIONS_RESCUE_RAKE`.

@jrochkind figured out that we were trying to configure HB in a very roundabout way via an env variable set in `config/schedule.rb`, and appended as a prefix to every scheduled task run by `whenever`. `whenever` is going away, so we're taking the opportunity to do this (hopefully) the right way.

See also:
- https://github.com/honeybadger-io/honeybadger-ruby/issues/258
- https://docs.honeybadger.io/lib/ruby/gem-reference/configuration.html