### PR TITLE
Enable using Cloudfront CDN to serve static assets

### DIFF
--- a/app/assets/html/404.html.erb
+++ b/app/assets/html/404.html.erb
@@ -16,7 +16,7 @@
       <a id="logo" href="https://www.sciencehistory.org" data-no-turbolink="true">
           <%= image_tag "partial-mark-75rotate-80.png", class: "small-masthead-only masthead-logo-small", alt: "Science History Institute" %>
           <%= image_tag "sci_logo-webheader_1x.png",
-              srcset:  "#{image_url 'sci_logo-webheader_1x.png'} 1x, #{image_url 'sci_logo-webheader_2x.png'} 2x",
+              srcset:  "#{image_path 'sci_logo-webheader_1x.png'} 1x, #{image_path 'sci_logo-webheader_2x.png'} 2x",
               class: "large-masthead-only masthead-logo-large",
               alt: "Science History Institute" %>
       </a>

--- a/app/assets/html/500.html.erb
+++ b/app/assets/html/500.html.erb
@@ -16,7 +16,7 @@
       <a id="logo" href="https://www.sciencehistory.org" data-no-turbolink="true">
           <%= image_tag "partial-mark-75rotate-80.png", class: "small-masthead-only masthead-logo-small", alt: "Science History Institute" %>
           <%= image_tag "sci_logo-webheader_1x.png",
-              srcset:  "#{image_url 'sci_logo-webheader_1x.png'} 1x, #{image_url 'sci_logo-webheader_2x.png'} 2x",
+              srcset:  "#{image_path 'sci_logo-webheader_1x.png'} 1x, #{image_path 'sci_logo-webheader_2x.png'} 2x",
               class: "large-masthead-only masthead-logo-large",
               alt: "Science History Institute" %>
       </a>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,7 +34,9 @@ Rails.application.configure do
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.asset_host = ScihistDigicoll::Env.app_url_base_parsed.to_s
+  if ScihistDigicoll::Env.lookup(:rails_asset_host).present?
+    config.asset_host = ScihistDigicoll::Env.lookup(:rails_asset_host)
+  end
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,8 +40,15 @@ Rails.application.configure do
 
   # CORS headers for fonts served on seperate asset_host
   config.public_file_server.headers = {
-    'Access-Control-Allow-Origin' => ScihistDigicoll::Env.lookup(:app_url_base).chomp('/'),
-    'Vary' => "Origin",
+    # Difficult getting this to work properly, can't really support multiple specifically
+    # allowed hostnames via the statis public_file_server.headers , and I don't think
+    # actually necessary for any kind of security:
+    #
+    # 'Access-Control-Allow-Origin' => ScihistDigicoll::Env.lookup(:app_url_base).chomp('/'),
+    # 'Vary' => "Origin",
+    #
+    # Instead we just:
+    'Access-Control-Allow-Origin' => "*",
     'Cache-Control' => 'public, max-age=31536000' # 1 year, max accepted value. Assets are timestamped so cacheable forever.
   }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,7 +41,8 @@ Rails.application.configure do
   # CORS headers for fonts served on seperate asset_host
   config.public_file_server.headers = {
     'Access-Control-Allow-Origin' => ScihistDigicoll::Env.lookup(:app_url_base).chomp('/'),
-    'Vary' => "Origin"
+    'Vary' => "Origin",
+    'Cache-Control' => 'public, max-age=31536000' # 1 year, max accepted value. Assets are timestamped so cacheable forever.
   }
 
   # Specifies the header that your server uses for sending files.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,6 +38,12 @@ Rails.application.configure do
     config.asset_host = ScihistDigicoll::Env.lookup(:rails_asset_host)
   end
 
+  # CORS headers for fonts served on seperate asset_host
+  config.public_file_server.headers = {
+    'Access-Control-Allow-Origin' => ScihistDigicoll::Env.lookup(:app_url_base).chomp('/'),
+    'Vary' => "Origin"
+  }
+
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -473,6 +473,8 @@ module ScihistDigicoll
     define_key :smtp_password
     define_key :smtp_host
 
+    define_key :rails_asset_host
+
     ##
     #
     # feature flags: We can use Env to be a place where feature flags that hide under-development


### PR DESCRIPTION
Ref #874 

Extensive write-up at https://bibwild.wordpress.com/2021/06/23/notes-on-cloudfront-in-front-of-rails-assets-on-heroku-with-cors/

Also documented Cloudfront as a thing in our wiki [Operational Components Overview](https://chemheritage.atlassian.net/l/c/JtRn0Ydb). 

I honestly don't entirely understand why I had to change the helper methods in the custom 404/500 implementation. But I DID test the changes don't break anything in legacy environemnt -- we can merge this into master, and deploy on legacy ansible/EC2, and it doens't break our custom 404/500, they still work after this PR.  The custom 404/500 implementation is a bit too clever, see #1221