### PR TITLE
We have to save properly unescaped path to send to AWS SDK to delete, for scheduled ingest deletion

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -77,7 +77,7 @@ class Asset < Kithe::Asset
 
     # schedule it for deletion if needed
     if ingest_bucket_file_url
-      path = URI.parse(ingest_bucket_file_url).path.delete_prefix("/")
+      path = CGI.unescape(URI.parse(ingest_bucket_file_url).path.delete_prefix("/"))
       ScheduledIngestBucketDeletion.create!(path: path, asset: self, delete_after: Time.now + ScheduledIngestBucketDeletion::DELETE_AFTER_WINDOW)
     end
   end


### PR DESCRIPTION
"2003.020.154 Atoms for Peace/2003.020.154_001.tif" not "2003.020.154%20Atoms%20for%20Peace/2003.020.154_001.tif"

This is ONE thing that was going wrong in #1212

Sorry, there were no existing tests for this func and i'm still punting on figuring out good way to test.