### PR TITLE
More ingest bucket scheduled cleanup

### DIFF
--- a/app/models/scheduled_ingest_bucket_deletion.rb
+++ b/app/models/scheduled_ingest_bucket_deletion.rb
@@ -3,7 +3,7 @@
 # with a `delete_after` timestamp, so we can run a scheduled task
 # to delete stuff from the ingest bucket.
 class ScheduledIngestBucketDeletion < ApplicationRecord
-  DELETE_AFTER_WINDOW = 7.days
+  DELETE_AFTER_WINDOW = 24.hours
 
   belongs_to :asset
 end

--- a/lib/tasks/scheduled_ingest_bucket_deletions.rake
+++ b/lib/tasks/scheduled_ingest_bucket_deletions.rake
@@ -1,17 +1,25 @@
 namespace :scihist do
   desc "Delete files from ingest_bucket that have been scheduled"
   task :scheduled_ingest_bucket_delete => :environment do
+    client = Aws::S3::Client.new(
+      access_key_id:     ScihistDigicoll::Env.lookup(:aws_access_key_id),
+      secret_access_key: ScihistDigicoll::Env.lookup(:aws_secret_access_key),
+      region:            ScihistDigicoll::Env.lookup(:aws_region)
+    )
+    bucket = Aws::S3::Bucket.new(name: ScihistDigicoll::Env.lookup!(:ingest_bucket), client: client)
+
     ScheduledIngestBucketDeletion.where("delete_after < ?", Time.now).find_each do |scheduled|
-        client = Aws::S3::Client.new(
-          access_key_id:     ScihistDigicoll::Env.lookup(:aws_access_key_id),
-          secret_access_key: ScihistDigicoll::Env.lookup(:aws_secret_access_key),
-          region:            ScihistDigicoll::Env.lookup(:aws_region)
-        )
-        bucket = Aws::S3::Bucket.new(name: ScihistDigicoll::Env.lookup!(:ingest_bucket), client: client)
-
         bucket.object(scheduled.path).delete
-
         scheduled.destroy!
+    end
+
+    # now delete ALL placeholder directory objects, they aren't needed for anything,
+    # they just wind up sticking around after we've deleted their contents. But it's
+    # fine to delete placeholder obj when contents are still there too.
+    bucket.objects.each do |obj|
+      if obj.key.end_with?('/') && obj.size == 0
+        obj.delete
+      end
     end
   end
 end


### PR DESCRIPTION
Ref #1212, more parts of that

   Remove all S3 "folder" placeholder objects on every nightly ingest bucket
   cleanup

   change ScheduledIngestBucketDeletion::DELETE_AFTER_WINDOW to 24.hours
   instead of 7.days