### PR TITLE
Raise Rack::Utils.key_space_limit

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -85,5 +85,14 @@ module ScihistDigicoll
     config.hide_accept_cookies_banner = false
 
 
+    # Default 65K limit was getting in the way of large ingests.
+    #
+    # https://github.com/sciencehistory/scihist_digicoll/issues/888
+    #
+    # We don't believe this limit actually does anything useful anyway,
+    # should be fine to set it to something absurdly large, we'll go with 10 megs
+    #
+    # https://github.com/rack/rack/pull/1487
+    Rack::Utils.key_space_limit = 10.megabytes.to_i
   end
 end


### PR DESCRIPTION
To handle #888

We don't believe this limit was providing any useful security or other purpose anyway, just raise it to something really large.