### PR TITLE
add newrelic_rpm gem for monitoring with new relic service, via heroku.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,11 @@ gem 'lockbox'
 gem 'rails', '~> 6.1.1'
 gem 'webpacker', '~> 5.0'
 
+
+# New Relic monitoring tool
+gem 'newrelic_rpm'
+
+
 # lock blacklight to current MINOR version. While BL minor version releases
 # are theoretically backwards compat, experience shows they often cause problems.
 # So you need to manually change this spec to allow updates when you want

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,6 +369,7 @@ GEM
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)
+    newrelic_rpm (7.2.0)
     nio4r (2.5.7)
     nokogiri (1.11.4)
       mini_portile2 (~> 2.5.0)
@@ -691,6 +692,7 @@ DEPENDENCIES
   kithe (~> 2.0, >= 2.0.2)
   listen (>= 3.0.5, < 3.2)
   lockbox
+  newrelic_rpm
   oai (~> 1.0, >= 1.0.1)
   pdf-reader (~> 2.2)
   pg (>= 0.18, < 2.0)


### PR DESCRIPTION
https://docs.newrelic.com/docs/agents/ruby-agent/installation/ruby-agent-heroku/

The free "Wayne" plan on heroku seems to be free forever. The main things it doens't include is any kind of alerting/notifications. It seems to let us look at what we're going to want to look at to see average response time or dig into the slow responses. I think! It'll be easier to see when we have more data. 

https://elements.heroku.com/addons/newrelic

Hmm, let me deploy this to legacy staging first to make sure the newrelic gem alone without configuration is just no-op.... seems to be fine, without license keys etc configured, I think it just does nothing?

No config file is necessary on heroku, as all minimally necessary new relic config is provided via heroku config vars -- automatically when you turn on new relic as a heroku add-on. 