### PR TITLE
use custom logger formatter to avoid logging things heroku is adding in anyway

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+require 'scihist_digicoll/logger_formatter'
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -129,7 +131,11 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
+  #config.log_formatter = ::Logger::Formatter.new
+  #
+  # Use our custom logging formatter, that includes only log level and message,
+  # not a bunch of things we don't need on heroku/paperclip.
+  config.log_formatter = ScihistDigicoll::LoggerFormatter.new
 
   # Use a different logger for distributed setups.
   # require 'syslog/logger'

--- a/lib/scihist_digicoll/logger_formatter.rb
+++ b/lib/scihist_digicoll/logger_formatter.rb
@@ -1,0 +1,23 @@
+
+module ScihistDigicoll
+  # custom sub-class to log a bit less than ruby standard logger formatter.
+  #
+  # * We don't need timestamp because heroku is going to add it
+  # * We don't need the log level reported two different ways
+  # * We don't need the process # ($$), doesn't do anything we care about on heroku.
+  # * We don't need progname, it seems to weirdly be empty r just a colon
+  #
+  # Which actually leaves nothing but severity... maybe we don't even really need
+  # that? But it's convenient to be able to search for just FAIL or WARN, so we'll
+  # leave it. (Papertrail thinks it knows severity out of band, but it dooesn't, on
+  # heroku it thinks everything is 'INFO')
+  #
+  # You can see original at eg https://github.com/ruby/ruby/blob/v2_7_4/lib/logger/formatter.rb
+  class LoggerFormatter < ::Logger::Formatter
+    def call(severity, time, progname, msg)
+      # could be `severity[0..0]` if we only wanted eg `I` or `W`, but I like `INFO` or `WARN` for
+      # easier visibility/grep-ability.
+      "%s: %s\n" % [severity, msg2str(msg)]
+    end
+  end
+end


### PR DESCRIPTION
or things that are irrelevant/unintelligible on heroku. Help reduce our log data, for things like papertrail that have paid plans baesd on log data.

In fact, all we're adding with the formatter is log level (info, debug, etc) -- maybe we don't even need that, and could use no log formatter at all, but I like seeing it and being able to search on it, so we'll leave it for now.