### PR TITLE
Add 10% of assets to the nightly fixity check

### DIFF
--- a/app/views/admin/assets/fixity_report.html.erb
+++ b/app/views/admin/assets/fixity_report.html.erb
@@ -21,7 +21,7 @@
     <div class="col-md alert alert-info">
       <ul>
         <li>We intend to schedule checks such that every file is checked at least once every <%= pluralize FixityReport::STALE_IN_DAYS, 'day' %>.</li>
-        <li>Fixity checks run <b>nightly</b> at <b><%= ScihistDigicoll::ASSET_CHECK_WHENEVER_CRON_TIME %></b> and will check 1/<%= FixityReport::STALE_IN_DAYS %> of our total assets (~<%= @fixity_report.asset_count / FixityReport::STALE_IN_DAYS %> assets) each night, choosing the assets with missing or most stale checks to run checks on.</li>
+        <li>Fixity checks run <b>nightly</b> at <b><%= ScihistDigicoll::ASSET_CHECK_WHENEVER_CRON_TIME %></b> and will check roughly 1/<%= FixityReport::STALE_IN_DAYS %> of our total assets ( roughly <%= @fixity_report.asset_count / FixityReport::STALE_IN_DAYS %> assets, plus a few extra) each night, choosing the assets with missing or most stale checks to run checks on.</li>
         <li>Can only run fixity checks on assets that are <i>fully ingested</i> and have attached files.</li>
         <li>For assets created within last <%= pluralize FixityReport::EXPECTED_FRESH_IN_DAYS, 'day' %>, we tolerate missing fixity checks, as they may not have run yet.</li>
       </ul>

--- a/lib/tasks/check_fixity.rake
+++ b/lib/tasks/check_fixity.rake
@@ -8,8 +8,8 @@ namespace :scihist do
   To run a full check of all assets with stored files:
     CYCLE_LENGTH=0 bundle exec rake scihist:check_fixity
 
-  To check 1/30th today instea dof 1/7th, checking all every 30 days:
-    CYCLE_LENGTH=30 bundle exec rake scihist:check_fixity
+  To check 1/90th today instead of 1/7th, checking all every 90 days:
+    CYCLE_LENGTH=90 bundle exec rake scihist:check_fixity
 
   To run checks, but leave stale checks around without pruning them:
     SKIP_PRUNE='true'  bundle exec rake scihist:check_fixity


### PR DESCRIPTION
Ref #1136 .

Our current estimate of how many assets to check every night would work perfectly if the number of assets in the collection always stayed the same.

Unfortunately, we are always ingesting new stuff, so that total **increases** over the course of the 90-day check cycle.

Thus, our **current** total is always **less** than the average total over the course of the entire cycle, resulting in a consistent lag.

Let's add 10% more assets to each nightly check to help correct this.