### PR TITLE
Slight tweak to lograge param logging, respect Rails feature for sensitive parameter filtering

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -166,7 +166,7 @@ Rails.application.configure do
     # of course add this as `fullpath` to have both.
     # https://bibwild.wordpress.com/2021/08/04/logging-uri-query-params-with-lograge/
     {
-      path: controller.request.fullpath
+      path: controller.request.filtered_path
     }
   end
 


### PR DESCRIPTION
We aren't using this Rails feature now, but might as well write it right, so if we configured any URL params as sensitive, they would correctly be omitted from where we are logging. This was pointed out by a user on reddit when I blogged this. https://www.reddit.com/r/ruby/comments/oy0h58/logging_uri_query_params_with_lograge/h7pu626/

Revision to #1256