### PR TITLE
Check newly-ingested files' fixity right away -- don't wait until the nightly fixity check job.

### DIFF
--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -12,6 +12,13 @@ describe Asset do
     end
   end
 
+  describe "initial checksum creation", queue_adapter: :inline do
+    let!(:asset) { create(:asset, :inline_promoted_file) }
+    it "checks the asset after storing it" do
+      expect(asset.fixity_checks.count).to eq 1
+    end
+  end
+
   describe "restricted derivatives", queue_adapter: :inline do
     let(:sample_file_location) {  Rails.root + "spec/test_support/images/20x20.png" }
     let(:asset) { create(:asset, derivative_storage_type: "restricted") }

--- a/spec/serializers/viewer_member_info_serializer_spec.rb
+++ b/spec/serializers/viewer_member_info_serializer_spec.rb
@@ -8,7 +8,7 @@ describe ViewerMemberInfoSerializer, type: :decorator do
 
   let(:serializer) { ViewerMemberInfoSerializer.new(work) }
 
-  it "serializes" do
+  it "serializes", queue_adapter: :inline do
     serialized = serializer.as_hash
 
     expect(serialized).to be_kind_of(Array)

--- a/spec/services/work_combined_audio_creator_spec.rb
+++ b/spec/services/work_combined_audio_creator_spec.rb
@@ -19,7 +19,7 @@ describe "Combined Audio" do
 
   let(:cmd) { cmd = TTY::Command.new(printer: :null)}
 
-  it "creates combined audio derivatives" do
+  it "creates combined audio derivatives", queue_adapter: :inline do
     expect(work.members.map(&:stored?)).to match([true, true])
     combined_audio_info = CombinedAudioDerivativeCreator.new(work).generate
     expect(combined_audio_info.start_times.count).to eq 2

--- a/spec/system/catalog_search_spec.rb
+++ b/spec/system/catalog_search_spec.rb
@@ -7,7 +7,7 @@ require 'rails_helper'
 # trust that future versions of Blacklight wouldn't break our unit tests assumptions, a
 # full integration test on UI is safest and easiest.
 describe CatalogController, solr: true, indexable_callbacks: true do
-  describe "general smoke test with lots of features" do
+  describe "general smoke test with lots of features", queue_adapter: :inline do
     let!(:work1) do
       create(:public_work,
         description: 'priceless work',


### PR DESCRIPTION
A first step in fixing ref #1136, after an in-depth conversation on Slack this morning.