### PR TITLE
Rake task to remove download_* derivatives larger than original

### DIFF
--- a/lib/tasks/data_fixes/remove_upscaled_download_derivatives.rake
+++ b/lib/tasks/data_fixes/remove_upscaled_download_derivatives.rake
@@ -1,0 +1,34 @@
+namespace :scihist do
+  namespace :data_fixes do
+
+    desc "Remove download_* derivatives larger than original, mistakenly created"
+    task :remove_upscaled_download_derivatives => :environment do
+      download_derivatives = [:download_large, :download_medium, :download_small]
+
+      progress_bar = ProgressBar.create(total: Asset.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+
+      Asset.find_each do |asset|
+        removed = []
+
+        download_derivatives.each do |deriv_key|
+          if asset.file_derivatives[deriv_key] && asset.width && asset.width <= asset.file_derivatives[deriv_key].width
+            removed << deriv_key
+          end
+        end
+
+        if removed.present?
+          progress_bar.log("#{asset.friendlier_id} created #{asset.created_at}, width #{asset.width}, removing #{removed.join(',')}")
+
+          # not sure why this is necessary, something weird going on we're not investigating now
+          asset.restore_attributes
+
+          asset.remove_derivatives(*removed)
+
+
+        end
+
+        progress_bar.increment
+      end
+    end
+  end
+end


### PR DESCRIPTION
These are useless and upscaled. We changed code to not create them, but need to go through and delete any previously created before we made that change.

Ref #1246

This has been run on staging -- it actually deleted derivatives from 13,000 assets! (Out of 47,500 total assets, so around 27% of our assets were actually not big enough that they should get a large size download, at least 2880 pixels. Wow, our original asset resolutions really vary a LOT more than we realized! Ramelli originals are like 6000 pixels wide, I thought that was typical, not that other originals would be less than half the resolution!). 

Here's the log of what was deleted: https://gist.github.com/jrochkind/77118d0f8a7e8a5047beab0575bf62ed

The weird restore_attributes line is about some weirdness involving Rails seeing changes to be saved because of default attribute values we added, I just worked around it for now. 

After merge, this needs to be deployed to and run on production.