### PR TITLE
rake scihist:checks_fixity:complete_overdue

### DIFF
--- a/lib/tasks/check_fixity.rake
+++ b/lib/tasks/check_fixity.rake
@@ -60,7 +60,32 @@ namespace :scihist do
     unless ENV['SHOW_PROGRESS_BAR'] == 'true'
       Rails.logger.info(info)
     end
+  end
 
+  namespace :check_fixity do
+    desc "find any assets marked as overdue for fixity check, and check them"
+    task :complete_overdue => :environment do
+      reporter = FixityReport.new
 
+      # default no progress bar for scheduled job, but optionally can add it...
+      if ENV['SHOW_PROGRESS_BAR'] == 'true'
+        progress_bar =  ProgressBar.create(total: reporter.not_recent_with_no_checks_or_stale_checks, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+      end
+
+      count_of_items_checked = 0;
+
+      reporter.need_checks_assets_relation.find_each do |asset|
+        if asset.stored?
+          checker = FixityChecker.new(asset)
+          new_check = checker.check
+          FixityCheckFailureService.new(new_check).send if new_check&.failed?
+          count_of_items_checked = count_of_items_checked + 1
+        end
+        progress_bar.increment if progress_bar
+      end
+      if count_of_items_checked > 0
+        puts "complete_stale_checks: found and checked #{count_of_items_checked} stale assets!"
+      end
+    end
   end
 end

--- a/spec/models/fixity_report_spec.rb
+++ b/spec/models/fixity_report_spec.rb
@@ -150,6 +150,13 @@ describe FixityReport do
       # old_asset was ingested more than a day ago but it hasn't been checked for over a week.
       # Sound the alarm!
       expect(report.not_recent_with_no_checks_or_stale_checks).to eq 1
+
+      # and can we fetch the actual assets that correspond, with this other method?
+      found = []
+      report.need_checks_assets_relation.each do |asset|
+        found << asset
+      end
+      expect(found.length).to eq 1
     end
   end
 


### PR DESCRIPTION
Refactor/add method to FixityReport so we can get the actual list of assets, not just the count, that are displayed in dashboard as problematic. FixityReport is a little bit messy, all those existing methods probably should have had a name making it clear they were returning a count. Oh well.

Addresses part of #1136 

Then add rake task that uses this to just... check them. Since planning on doing from a scheduled job, no progress bar. Just outputs to log if we found any stale ones and checked em... where we will see that it happened only if we go looking for it. Does it need any other kind of alerting? Not sure.

Tried running this on staging -- looked like it would take around 2 hours to complete for the ~2400 overdue assets. So haven't completed it yet, so can't say for sure that it gets that report number down to 0, but it should?

After merging and deploying, we just need to change the Scheduler line that says `bundle exec rake scihist:check_fixity` to say `bundle exec rake scihist:check_fixity scihist:check_fixity:complete_overdue`, and then every night after doing it's usual 1/90th, it will ALSO do any extra that are overdue. Or at least that's the intent. 

So if we merge on production without running manually, the first night it's live the nightly fixity check job will take an extra 1-2 hours.