### PR TITLE
Adding the correct packages for brandoncc's version of heroku-buildpack-vips

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,5 +1,12 @@
 mediainfo
 imagemagick
+
+# These three packages are required
+# by https://github.com/brandoncc/heroku-buildpack-vips
 libglib2.0-0
 libglib2.0-dev
 libpoppler-glib8
+
+# `poppler-utils` is not installed as a dependency of libpoppler-glib8,
+# and we need it for  `pdfunite`, which we use for on-demand PDF derivatives:
+poppler-utils

--- a/Aptfile
+++ b/Aptfile
@@ -1,14 +1,5 @@
-# Removing libvips-tools
-# in favor of https://github.com/machinio/heroku-buildpack-vips
-# which gives us vips 8.10.2 .
-# We may want to switch back to libvips-tools
-# in the future and remove the buildpack.
-# libvips-tools
-
 mediainfo
 imagemagick
-
-# poppler-utls was probably already getting installed as a dependency
-# of above anyway, but we need `pdfunite` command line util from it, so we'll
-# list it explicitly.
-poppler-utils
+libglib2.0-0
+libglib2.0-dev
+libpoppler-glib8


### PR DESCRIPTION
Ref #1264
This assumes:

`heroku buildpacks`
returns
```
1. heroku-community/apt
2. https://github.com/brandoncc/heroku-buildpack-vips
3. heroku/ruby
```
and will install `vips-8.10.6`, which is great.

I'm sure this could have been working a long time ago, but I misread the installation instructions for the buildpack and assumed this buildpack was a non-starter until @jrochkind pointed out I had never correctly modified the Aptfile as described in the documentation.

All's well that ends well: with this PR we go from 8.10.2 to 8.10.6 and yes, all derivatives work great.
