### PR TITLE
ActiveJob retry_on to retry ALL failed jobs once, still with resque

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,17 @@
 class ApplicationJob < ActiveJob::Base
+  # All our jobs should be idempotent, let's automatically retry them all for any
+  # error.
+  #
+  # This can for instance automatically take care of long-running jobs interupted by a host restart.
+  #
+  # Resque, which we ae are using at the moment, by default doesn't support
+  # future-scheduled jobs, so we retry just once, immediately. Could have
+  # a more sophisticated retry pattern with a back-end that supports future-scheduling.
+  retry_on StandardError, attempts: 2, wait: 0
+
+
 end
+
+
+
+

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -8,10 +8,4 @@ class ApplicationJob < ActiveJob::Base
   # future-scheduled jobs, so we retry just once, immediately. Could have
   # a more sophisticated retry pattern with a back-end that supports future-scheduling.
   retry_on StandardError, attempts: 2, wait: 0
-
-
 end
-
-
-
-

--- a/config/initializers/activejob_retry_logging.rb
+++ b/config/initializers/activejob_retry_logging.rb
@@ -15,8 +15,6 @@
 #   https://github.com/roidrage/lograge/blob/1729eab7956bb95c5992e4adab251e4f93ff9280/lib/lograge.rb#L119
 # * An example of adding a notification/log line a different way:
 #
-
-
 class LocalActiveJobLogSubscriber < ActiveJob::LogSubscriber
   def enqueue_retry(event)
     job = event.payload[:job]
@@ -34,7 +32,6 @@ class LocalActiveJobLogSubscriber < ActiveJob::LogSubscriber
       end
     end
   end
-
 
   def retry_stopped(event)
     job = event.payload[:job]
@@ -85,5 +82,3 @@ ActiveJob::LogSubscriber.detach_from :active_job
 # for some reason API makes us specify inherit_all: true to make sure we
 # get existing event-handling events we weren't overriding!
 LocalActiveJobLogSubscriber.attach_to :active_job, inherit_all: true
-
-

--- a/config/initializers/activejob_retry_logging.rb
+++ b/config/initializers/activejob_retry_logging.rb
@@ -1,0 +1,89 @@
+# ActiveJob default logging around retry events is missing a lot of info that IS
+# included in other events, including "tags" (Rails tagged logging) for ActiveJob and job-id.
+#
+# We want to customize it to make retry/discard log events more similar to other ActiveJob log events,
+# so we can more easily see and monitor what's going on.
+#
+# The ActiveSupport::Subscriber archirtecture doesn't make this super easy.
+# After delving into Rails code, we make our own subclass of ActiveJob::LogSubscriber, override
+# the methods with log lines we want to change.
+#
+# Then we subscribe our custom one, and UNSUBSCRIBE the original one.
+#
+# Some background that didn't end up too useful:
+# * how lograge unsubscribes things:
+#   https://github.com/roidrage/lograge/blob/1729eab7956bb95c5992e4adab251e4f93ff9280/lib/lograge.rb#L119
+# * An example of adding a notification/log line a different way:
+#
+
+
+class LocalActiveJobLogSubscriber < ActiveJob::LogSubscriber
+  def enqueue_retry(event)
+    job = event.payload[:job]
+    ex = event.payload[:error]
+    wait = event.payload[:wait]
+
+    Rails.logger.tagged(*_needed_additional_tags(job.job_id)) do
+      # default logs this one at 'info', let's change to 'warn'
+      warn do
+        if ex
+          "Retrying #{job.class} (Job ID: #{job.job_id}) after #{job.executions} attempts in #{wait.to_i} seconds, due to a #{ex.class} (#{ex.message})."
+        else
+          "Retrying #{job.class} (Job ID: #{job.job_id}) after #{job.executions} attempts in #{wait.to_i} seconds."
+        end
+      end
+    end
+  end
+
+
+  def retry_stopped(event)
+    job = event.payload[:job]
+    ex = event.payload[:error]
+
+
+    Rails.logger.tagged(*_needed_additional_tags(job.job_id)) do
+      error do
+        "Stopped retrying #{job.class} (Job ID: #{job.job_id}) after #{job.executions} attempts, due to a #{ex.class} (#{ex.message})."
+      end
+    end
+  end
+
+  def discard(event)
+    job = event.payload[:job]
+    ex = event.payload[:error]
+
+    Rails.logger.tagged(*_needed_additional_tags(job.job_id)) do
+      error do
+        "Discarded #{job.class} (Job ID: #{job.job_id}) due to a #{ex.class} (#{ex.message})."
+      end
+    end
+  end
+
+  private
+
+  def _needed_additional_tags(job_id)
+    tags = []
+
+    unless logger.formatter.current_tags.include?("ActiveJob")
+      tags << "ActiveJob"
+    end
+
+    unless logger.formatter.current_tags.include?(job_id)
+      tags << job_id
+    end
+
+    tags
+  end
+
+end
+
+# Unsubscribe default ActiveJob logging
+ActiveJob::LogSubscriber.detach_from :active_job
+
+# Subsribe ours with custom overrides.
+#
+# for some reason API makes us specify inherit_all: true to make sure we
+# get existing event-handling events we weren't overriding!
+LocalActiveJobLogSubscriber.attach_to :active_job, inherit_all: true
+
+

--- a/config/initializers/patch_resque_for_scheduled_at_now.rb
+++ b/config/initializers/patch_resque_for_scheduled_at_now.rb
@@ -1,0 +1,22 @@
+
+
+# monkey patch resque adapter to be willing to enqueue_at NOW,
+# to let us use ActiveJob retry_on with wait: 0. Resque
+# can't enqueue in the future without resque-scheduler,
+# but we can enqueue at wait:0/NOW.
+
+
+module AllowResqueEnqueueAtNow
+  def enqueue_at(job, timestamp) #:nodoc:de
+    if !Resque.respond_to?(:enqueue_at_with_queue) && timestamp.to_i <= Time.now.to_i
+      # we don't have resque-scheduler, but it's asking for it to run now anyway,
+      # just enqueue as usual.
+      enqueue(job)
+    else
+      super
+    end
+  end
+end
+
+ActiveJob::QueueAdapters::ResqueAdapter.prepend(AllowResqueEnqueueAtNow)
+

--- a/config/initializers/patch_resque_for_scheduled_at_now.rb
+++ b/config/initializers/patch_resque_for_scheduled_at_now.rb
@@ -1,11 +1,10 @@
 
-
+#
 # monkey patch resque adapter to be willing to enqueue_at NOW,
 # to let us use ActiveJob retry_on with wait: 0. Resque
 # can't enqueue in the future without resque-scheduler,
 # but we can enqueue at wait:0/NOW.
-
-
+#
 module AllowResqueEnqueueAtNow
   def enqueue_at(job, timestamp) #:nodoc:de
     if !Resque.respond_to?(:enqueue_at_with_queue) && timestamp.to_i <= Time.now.to_i
@@ -19,4 +18,3 @@ module AllowResqueEnqueueAtNow
 end
 
 ActiveJob::QueueAdapters::ResqueAdapter.prepend(AllowResqueEnqueueAtNow)
-


### PR DESCRIPTION
Ref #607 

* retry once for StandardError (basically any error) in ApplicationJob super-class of all our jobs. The intent is that any failure should be re-enqueued for a retry ONCE, immediately, before giving up. This should resolve intermittent errors or errors caused by the Job dyno being shut down mid-job.

* Basic resque isn't able to schedule future jobs. Patch the resque adapter so it IS willing to `retry_on` with `wait:0`, just by doing an ordinary job enqueue.

* Retry logging is not great. Customize the ActiveJob retry logging by making a custom rails log subscriber for ActiveJob (based on the default one, by subclass), and using our custom one in place of the default one.