### PR TITLE
Use mirror url to keep CI tests from being blocked by

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -23,3 +23,10 @@ collection:
   dir: solr/config
   name: scihist_digicoll_<%= Rails.env %>
 version: 8.5.2
+
+# Use mirror url to keep CI tests from being blocked by
+# apache for too many solr downloads. We try to have CI cache
+# solr download, but something still sometimes goes weird for
+# reaosns we haven't figured out, maybe this will help?
+
+mirror_url: http://lib-solr-mirror.princeton.edu/dist/

--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -22,7 +22,7 @@ collection:
   persist: <%= Rails.env.test? ? "false" : "true" %>
   dir: solr/config
   name: scihist_digicoll_<%= Rails.env %>
-version: 8.5.2
+version: 8.6.3
 
 # Use mirror url to keep CI tests from being blocked by
 # apache for too many solr downloads. We try to have CI cache

--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -30,3 +30,7 @@ version: 8.5.2
 # reaosns we haven't figured out, maybe this will help?
 
 mirror_url: http://lib-solr-mirror.princeton.edu/dist/
+# Will validate_false help, is it still insisting on getting checksum direct from apache?
+# That was supposed to be fixed in solr_wrapper, but it's somehow not in master
+# https://github.com/cbeer/solr_wrapper/commit/eaab9cd5bba2b5d3bc94f33c15cee089462089ae
+validate: false


### PR DESCRIPTION
apache for too many solr downloads. We try to have CI cache
solr download, but something still sometimes goes weird for
reaosns we haven't figured out, maybe this will help?