### PR TITLE
disable WebMock to allow SolrBuilder to download the Solr package

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -22,4 +22,4 @@ collection:
   persist: <%= Rails.env.test? ? "false" : "true" %>
   dir: solr/config
   name: scihist_digicoll_<%= Rails.env %>
-version: 8.5.2
+version: 8.6.3

--- a/lib/scihist_digicoll/solr_wrapper_util.rb
+++ b/lib/scihist_digicoll/solr_wrapper_util.rb
@@ -3,8 +3,18 @@ module ScihistDigicoll
     # Pass in a solr_wrapper instance, we'll start it, AND create a collection
     # if specified in solr_wrapper config.
     def self.start_with_collection(instance)
+      # oy, since we're in test env, WebMock is enabled, and WebMock breaks http-rb's ability to
+      # do streaming, which SolrBuilder tries to use to download Solr. It can result in an inability
+      # to download a Solr, with error "body has already been consumed"".
+      #
+      # This is such a mess, we have to know to disable WebMock for downloading.
+      WebMock.disable! if defined?(WebMock)
+
       instance.start
       instance.create(instance.config.collection_options)
+
+    ensure
+      WebMock.enable! if defined?(WebMock)
     end
 
     # Pass in a solr_wrapper instance, we'll stop it, AND delete the collection

--- a/lib/scihist_digicoll/solr_wrapper_util.rb
+++ b/lib/scihist_digicoll/solr_wrapper_util.rb
@@ -7,14 +7,18 @@ module ScihistDigicoll
       # do streaming, which SolrBuilder tries to use to download Solr. It can result in an inability
       # to download a Solr, with error "body has already been consumed"".
       #
-      # This is such a mess, we have to know to disable WebMock for downloading.
-      WebMock.disable! if defined?(WebMock)
+      # This is such a mess, we have to know to disable WebMock for downloading. But we only want to
+      # do that, and only re-enable it again, if we are actually in the middle of rspec right now!
+      #
+      # It turns out this is a prickly part of us trying to automatically bring up test solr
+      # when a test requires it. We'll try making sure WebMock and Rspec are actually loaded...
+      WebMock.disable! if defined?(WebMock) && defined?(RSpec) && defined?(SCIHIST_WEBMOCK_USED)
 
       instance.start
       instance.create(instance.config.collection_options)
 
     ensure
-      WebMock.enable! if defined?(WebMock)
+      WebMock.enable! if defined?(WebMock) && defined?(RSpec) && defined?(SCIHIST_WEBMOCK_USED)
     end
 
     # Pass in a solr_wrapper instance, we'll stop it, AND delete the collection

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'webmock/rspec'
 
+SCIHIST_WEBMOCK_USED = true
 
 # Have WebMock disable outgoing http connections, except for some locally configured
 # exceptions.


### PR DESCRIPTION
And update our solr_wrapper Solr version to the version we are currently using in production.