### PR TITLE
Add net_http_connect_on_start to WebMock calls

### DIFF
--- a/lib/scihist_digicoll/spec_util.rb
+++ b/lib/scihist_digicoll/spec_util.rb
@@ -6,7 +6,7 @@ module ScihistDigicoll
     # disable to our standard settings again.
     #
     #    begin
-    #       WebMock.allow_net_connect!
+    #       ScihistDigicoll::SpecUtil.allow_net_connect!
     #       # ...
     #    ensure
     #      ScihistDigicoll::SpecUtil.disable_net_connect!
@@ -16,7 +16,28 @@ module ScihistDigicoll
       # https://github.com/titusfortner/webdrivers/issues/4
       #
       # solr_wrapper wants to use 127.0.0.1 instead of localhost.
-      WebMock.disable_net_connect!(allow_localhost: true, allow: ['127.0.0.1', 'chromedriver.storage.googleapis.com'])
+      #
+      # net_http_connect_on_start needed for reasons I don't totally understand
+      # for "too many open files" error in capybara test that should be passing.
+      # * https://stackoverflow.com/questions/59632283/chromedriver-capybara-too-many-open-files-socket2-for-127-0-0-1-port-951
+      # * https://github.com/teamcapybara/capybara#gotchas
+      # * https://github.com/bblimke/webmock/blob/master/README.md#connecting-on-nethttpstart
+
+      WebMock.disable_net_connect!(allow_localhost: true, allow: ['127.0.0.1', 'chromedriver.storage.googleapis.com'], net_http_connect_on_start: true)
     end
+
+
+    # Calls WebMock.disable_net_connect! with our desired exceptions.
+    #
+    # Extracted into utility so we can make sure we do it consistently.
+    def self.allow_net_connect!
+      # net_http_connect_on_start needed for reasons I don't totally understand
+      # for "too many open files" error in capybara test that should be passing.
+      # * https://stackoverflow.com/questions/59632283/chromedriver-capybara-too-many-open-files-socket2-for-127-0-0-1-port-951
+      # * https://github.com/teamcapybara/capybara#gotchas
+      # * https://github.com/bblimke/webmock/blob/master/README.md#connecting-on-nethttpstart
+      WebMock.allow_net_connect!(net_http_connect_on_start: true)
+    end
+
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -156,7 +156,7 @@ RSpec.configure do |config|
           $test_solr_started = false
         }
 
-        WebMock.allow_net_connect!
+        ScihistDigicoll::SpecUtil.allow_net_connect!
         ScihistDigicoll::SolrWrapperUtil.start_with_collection(SolrWrapper.instance)
 
         $test_solr_started = true
@@ -171,7 +171,7 @@ RSpec.configure do |config|
   end
 
   if ENV["WEBMOCK_ALLOW_CONNECT"] == "true"
-    WebMock.allow_net_connect!
+    ScihistDigicoll::SpecUtil.allow_net_connect!
   end
 
   # RSpec Rails can automatically mix in different behaviours to your tests


### PR DESCRIPTION
There's a weird problem with WebMock that it looks like we're not alone in running into only in ruby 2.7, although there's no techniccal reason it shouldn't have effected earlier ruby. It's also unclear why it only effects us sometimes seemingly non-determinstically -- not happening in master, but was happening in my blacklight upgrading branch.

Also honestly unclear to me why WebMock isn't doing this config by default since it's such a weird gotcha! Links to more info such as I could find it are included in comments by relevant code.

Anyway, we'll just get it into master now, to avoid future headaches, doesn't seem to hurt anything and fixes things for me in my present in-progress work.