### PR TITLE
Clearer error message when WorkPDFCreator doesn't have any images

### DIFF
--- a/app/services/work_pdf_creator.rb
+++ b/app/services/work_pdf_creator.rb
@@ -16,6 +16,8 @@ require 'open-uri'
 # DEPENDS ON `pdfunite` command-line utility, which is installed with `poppler` which was a dependency
 # for our vips use anyway.
 class WorkPdfCreator
+  class PdfCreationFailure < RuntimeError ; end
+
   PAGE_WIDTH = 612
   PAGE_HEIGHT = 792
 
@@ -98,7 +100,7 @@ class WorkPdfCreator
       end
 
       if chunk_filepaths.empty?
-        raise "#{self.class.name}: No PDF files to join; are there no suitable images in work? work: #{work.friendlier_id}; total_page_count: #{total_page_count}"
+        raise PdfCreationFailure, "#{self.class.name}: No PDF files to join; are there no suitable images in work? work: #{work.friendlier_id}; total_page_count: #{total_page_count}"
       end
 
       # Now we gotta combine all our separate PDF files into one big one, which pdfunite

--- a/spec/services/work_pdf_creator_spec.rb
+++ b/spec/services/work_pdf_creator_spec.rb
@@ -128,7 +128,7 @@ describe WorkZipCreator do
     it "raises on create" do
       expect{
         WorkPdfCreator.new(work).create
-      }.to raise_error(RuntimeError, /No PDF files to join/)
+      }.to raise_error(WorkPdfCreator::PdfCreationFailure, /No PDF files to join/)
     end
   end
 


### PR DESCRIPTION
Avoid making a failed attempt to call pdfunite. Have a clearer error message in our logs for what actually the failure was.

Clean up the tempfile while we're at it. (Not a big deal, as ruby will clean it up eventually, but we can help the GC).

Ref: #1283

see also #1168 for one context in which this condition can occur; there could be others though at least hypothetically, like bots caching a URL for a work that used to be PDF-able but isn't anymore?