### PR TITLE
Make this rescue logic a bit safer

### DIFF
--- a/app/services/work_pdf_creator.rb
+++ b/app/services/work_pdf_creator.rb
@@ -46,8 +46,10 @@ class WorkPdfCreator
     return tempfile
   rescue StandardError => e
     # if we raised, clean up the tempfile first
-    tempfile.close
-    tempfile.unlink
+    if tempfile
+      tempfile.close
+      tempfile.unlink
+    end
 
     # re-raise
     raise e


### PR DESCRIPTION
Worst thing is when your rescue itself raises! Maybe the raise we're rescuing prevented the tempfile from even being created.