### PR TITLE
update overridden shrine method to proper method signature

### DIFF
--- a/app/uploaders/combined_audio_uploader.rb
+++ b/app/uploaders/combined_audio_uploader.rb
@@ -12,12 +12,12 @@ class CombinedAudioUploader < Shrine
     # ie
     #
     #     "9ed358d2-37b9-4cdc-8c3e-bcad4c0aee95/combined_b16f4aa27ec4e7d88fc73c1923ceebfb.mp3"
-    def generate_location(io, context)
+    def generate_location(io, metadata: {}, **options)
       # assumes we're only used with OralHistoryContent model, that has a work_id
-      work_id = context[:record].work_id
+      work_id = options[:record].work_id
       original_uuid = super
 
-      orig_filename = File.basename(context.dig(:metadata, "filename") || "", ".*")
+      orig_filename = File.basename(metadata["filename"] || "", ".*")
       "#{work_id}/#{orig_filename}_#{original_uuid}"
     end
 end


### PR DESCRIPTION
These two are treated equivalently in ruby 2.7 and prior, but in ruby 3.0 with it's changes to separation between keyword arguments and hash data, they aren't the same at all. Shrine updated this signature at some point to be ruby 3 compatible, we need to update to match similarly prior to going to ruby 3 (discovered in running tests under ruby 3), might as well do it now.