### PR TITLE
Update method call for ruby 3 in work_pdf_creator_spec

### DIFF
--- a/spec/services/work_pdf_creator_spec.rb
+++ b/spec/services/work_pdf_creator_spec.rb
@@ -41,9 +41,9 @@ describe WorkZipCreator do
       work.members.each do |member|
         if member.kind_of?(Asset)
           member.remove_derivatives(:download_small, :download_medium, :download_large)
-          member.update_derivatives(
+          member.update_derivatives({
             download_full: create(:stored_uploaded_file)
-          )
+          })
         end
       end
     end


### PR DESCRIPTION
Another example where ruby 3's more careful distinction between hash arguments and keyword arguments require a differnece in how the method is called, we need to use curly braces `{}` to make it clear we are passing a hash as the first argument to match method signature. Required in ruby 3, works fine either way in ruby 2.7. Let's get ready for 3.

With this and the last change, the branch with upgraded blacklight passes tests in ruby 3, wow!