### PR TITLE
Fix attempt to do Jquery-style 'on' delegation without Jquery

### DIFF
--- a/app/javascript/src/js/admin/uppy_dashboard.js
+++ b/app/javascript/src/js/admin/uppy_dashboard.js
@@ -16,6 +16,8 @@
 // If we actually had it as a dependency in webpacker, we'd want:
 //import Uppy from 'uppy';
 
+import delegateEvent from '../lib/delegate_event.js';
+
 
 function kithe_createFileUploader(container) {
   // Some variables that can be taken from data- attributes, or defaults.
@@ -168,12 +170,24 @@ function kithe_createFileUploader(container) {
   });
 
   // Make the remove button work on the cached file rows
-  cachedFileTableEl.addEventListener('click', function(event) {
-    if (event.target.getAttribute("data-cached-file-remove")) {
-      row = closest(event.target, function(el) { return el.tagName.toLowerCase() == "tr" });
-      row.parentNode.removeChild(row);
-    }
+  delegateEvent(cachedFileTableEl, "click", "*[data-cached-file-remove]", function(event) {
+    var row = closest(event.target, function(el) { return el.tagName.toLowerCase() == "tr" });
+    row.parentNode.removeChild(row);
   });
+
+
+
+
+//   // Make the remove button work on the cached file rows
+//   cachedFileTableEl.addEventListener('click', function(event) {
+// debugger;
+//     if (event.target.getAttribute("data-cached-file-remove]",
+
+//       ) {
+//       row = closest(event.target, function(el) { return el.tagName.toLowerCase() == "tr" });
+//       row.parentNode.removeChild(row);
+//     }
+//   });
 
   var handleDirectoryInput = function() {
     var fileList = this.files;

--- a/app/javascript/src/js/lib/delegate_event.js
+++ b/app/javascript/src/js/lib/delegate_event.js
@@ -1,0 +1,35 @@
+/*
+
+   We want something like JQuery 'on', but without JQuery:
+       https://api.jquery.com/on/
+
+   This is a bit tricky to get right. We cribbed this implementation from:
+
+  https://stackoverflow.com/a/25248515/
+
+
+  If in JQuery you'd do:
+
+     $(document).on("click", <selector>, handler)
+
+  Now do something like:
+
+    import delegateEvent from './lib/delegate_event.js';
+
+    delegateEvent(document, "click", <selector>, handler);
+
+ALL ARGS ARE REQUIRED for now.
+
+*/
+
+export default function delegateEvent(container, event, selectorStr, handler) {
+  container.addEventListener(event, function(e) {
+      for (var target=e.target; target && target!=container; target=target.parentNode) {
+      // loop parent nodes from the target to the delegation node
+          if (target.matches(selectorStr)) {
+              handler.call(target, e);
+              break;
+          }
+      }
+  }, false);
+};


### PR DESCRIPTION
Previous attempt failed when the click was a *child* of the delegations selector. Turns out this is a bit trickier than totally naive. But not that much. Copied an implementation from StackOverflow. It's a bit hacky, but it works, to resolve the problem in #1017

Still don't totally understand how to keep my JS files and imports organized well, not sure this is quite right... but it works.