### PR TITLE
Robots.txt to try to avoid some especially useless search-adjacent utility pages

### DIFF
--- a/app/views/application/robots.txt.erb
+++ b/app/views/application/robots.txt.erb
@@ -1,10 +1,22 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 
 <% if ScihistDigicoll::Env.production? %>
-# No restrictions at present
-
 # Link to sitemap
 Sitemap: https://s3.amazonaws.com/<%= ScihistDigicoll::Env.lookup("s3_sitemap_bucket") %>/<%= ScihistDigicoll::Env.lookup("sitemap_path") %>sitemap.xml.gz
+
+# Disallow some sort of search 'extra' that there is really no reason to be web crawling.
+# Both from /catalog, and off various /collections/$collection_id pages.
+User-agent: *
+# "more facets"
+Disallow: /catalog/facet/
+Disallow: /collections/*/facet/
+# range-limit page normally only requested by AJAX for loading range limit info.
+Disallow: /catalog/range_limit
+Disallow: /collections/*/range_limit
+# "View larger" link for range limit.
+Disallow: /catalog/range_limit_panel
+Disallow: /collections/*/range_limit_panel
+
 
 
 <% else %>
@@ -16,5 +28,4 @@ Disallow:
 
 User-agent: *
 Disallow: /
-
 <% end %>


### PR DESCRIPTION
This is part of #1306

Details of pages in comments in robots.txt

this probably  won't reduce our search volume by more than 10-15% or so (based on our Sep 6 one-hour-sample of logs), but it doesn't hurt, and there's no reason for crawlers to spend time crawling these. 