### PR TITLE
log a compacted version of user-agent with lograge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,7 @@ gem 'jquery-rails', "~> 4.3"
 gem 'font-awesome-rails', '~> 4.7'
 
 gem "lograge", "< 2"
+gem "device_detector", "~> 1.0" # user-agent parsing we use for logging
 
 # temporary kithe indexing branch, for scihist_digicoll indexing branch, do not
 # intend to merge to master like this.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,7 @@ GEM
     declarative (0.0.20)
     deprecation (1.1.0)
       activesupport
+    device_detector (1.0.5)
     devise (4.8.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -680,6 +681,7 @@ DEPENDENCIES
   csl-styles (~> 1.0)
   database_cleaner (~> 2.0)
   db-query-matchers (< 2.0)
+  device_detector (~> 1.0)
   devise (~> 4.5)
   draper (~> 4.0, >= 4.0.1)
   factory_bot_rails

--- a/app/models/compact_user_agent.rb
+++ b/app/models/compact_user_agent.rb
@@ -19,7 +19,7 @@ class CompactUserAgent
     ].collect(&:presence).compact.join("/").yield_self do |str|
       if str.presence == nil
         # if we couldn't parse, give em first 15 chars of thing,
-        user_agent&.slice(0, 15)
+        user_agent&.slice(0, 20)
       else
         str
       end

--- a/app/models/compact_user_agent.rb
+++ b/app/models/compact_user_agent.rb
@@ -1,0 +1,62 @@
+# Tries to parse the user-agent to make a much more compact representation of what we'd
+# eally want to know from it, to keep our logs shorter
+#
+# Currently implemented with device_detector gem.
+
+class CompactUserAgent
+  attr_reader :user_agent
+
+  def initialize(user_agent)
+    @user_agent = user_agent
+  end
+
+  def compact
+    @compact ||= [
+      bot,
+      application,
+      os,
+      device
+    ].collect(&:presence).compact.join("/").yield_self do |str|
+      if str.presence == nil
+        # if we couldn't parse, give em first 15 chars of thing,
+        user_agent&.slice(0, 15)
+      else
+        str
+      end
+    end
+  end
+
+
+  private
+
+  # empty, or eg `"bot:GoogleBot"
+  def bot
+    "bot:#{device_detector.bot_name}" if device_detector.bot?
+  end
+
+  # Can be empty, otherwise something like "Chrome-13" or just "Chrome"
+  def application
+    [
+      device_detector.name,
+      device_detector.full_version&.split(".")&.first&.presence
+    ].compact.join("-")
+  end
+
+  # Can be empty, otherwise something like "Android-6.3" or just "Android"
+  def os
+    [
+      device_detector.os_name,
+      device_detector.os_full_version&.split(".")&.slice(0,2)&.join(".")
+    ].compact.join("-")
+  end
+
+  # Can be empty, otherwise someting like "Nexus 5X"
+  def device
+    device_detector.device_name
+  end
+
+  def device_detector
+    DeviceDetector.new(user_agent)
+  end
+
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -165,12 +165,13 @@ Rails.application.configure do
     # URL in there eg `/catalog?q=foo`, so we override. Alternately, you could
     # of course add this as `fullpath` to have both.
     # https://bibwild.wordpress.com/2021/08/04/logging-uri-query-params-with-lograge/
+    #
+    # Also we include some user-agent info, but compressed with device_detector gem
     {
-      path: controller.request.filtered_path
+      path: controller.request.filtered_path,
+      ua: CompactUserAgent.new(controller.request.user_agent).compact
     }
   end
-
-
 
   # This default Rails log config probably doesn't do anything if we're using
   # lograge anyway, but we leave it here in case we turn lograge off again,

--- a/spec/models/compact_user_agent_spec.rb
+++ b/spec/models/compact_user_agent_spec.rb
@@ -14,7 +14,7 @@ describe CompactUserAgent do
   describe "long bad user agent" do
     let(:user_agent) { "a quite very long and terrible user agent that is very very long" }
     # truncates
-    it { is_expected.to eq "a quite very lo" }
+    it { is_expected.to eq "a quite very long an" }
   end
 
   describe "googlebot mobile" do

--- a/spec/models/compact_user_agent_spec.rb
+++ b/spec/models/compact_user_agent_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+# using rspec "subject" one-liner shortcut which normally I hate, but it just saved
+# so much typing here, where it's simple.
+
+describe CompactUserAgent do
+  subject { CompactUserAgent.new(user_agent).compact }
+
+  describe "bad user agent" do
+    let(:user_agent) { "bad user agent" }
+    it { is_expected.to eq "bad user agent" }
+  end
+
+  describe "long bad user agent" do
+    let(:user_agent) { "a quite very long and terrible user agent that is very very long" }
+    # truncates
+    it { is_expected.to eq "a quite very lo" }
+  end
+
+  describe "googlebot mobile" do
+    let(:user_agent) { %q{Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)} }
+    it { is_expected.to eq "bot:Googlebot/Chrome Mobile-41/Android-6.0/Nexus 5X"}
+  end
+
+  describe "yandex bot" do
+    let(:user_agent) { %q{Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)} }
+    it { is_expected.to eq "bot:Yandex Bot"}
+  end
+
+  describe "baidu bot" do
+    let(:user_agent) { %q{Mozilla/5.0 (compatible; Baiduspider/2.0;+http://www.baidu.com/search/spider.html)} }
+    it { is_expected.to eq "bot:Baidu Spider"}
+  end
+
+  describe "IE" do
+    let(:user_agent) { %q{Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; FSL 7.0.6.01001)} }
+    it { is_expected.to eq "Internet Explorer-6/Windows-XP" }
+  end
+
+  describe "linux firefox" do
+    let(:user_agent) { %q{Mozilla/5.0 (X11; U; Linux x86_64; de; rv:1.9.2.8) Gecko/20100723 Ubuntu/10.04 (lucid) Firefox/3.6.8} }
+    it { is_expected.to eq "Firefox-3/Ubuntu-10.04"}
+  end
+
+  describe "MacOS safari" do
+    let(:user_agent) { %q{ Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Safari/605.1.15} }
+    it { is_expected.to eq "Safari-14/Mac-10.15" }
+  end
+
+  describe "iOS safari" do
+    let(:user_agent) { %q{Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1} }
+    it { is_expected.to eq "Mobile Safari-14/iOS-14.7/iPhone"}
+  end
+
+  describe "Opera Samsung" do
+    let(:user_agent) { %q{Mozilla/5.0 (Linux; Android 10; SM-G970F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.62 Mobile Safari/537.36 OPR/63.3.3216.58675} }
+    it {is_expected.to eq "Opera Mobile-63/Android-10/GALAXY S10e"}
+  end
+
+  describe "Edge Windows" do
+    let(:user_agent) { %q{Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36 Edg/93.0.961.38} }
+    it { is_expected.to eq "Microsoft Edge-93/Windows-10" }
+  end
+end


### PR DESCRIPTION
Another part of #1306 

Pro: Much less bytes than actual user-agent string, also a lot more intelligible than the cryptic manipulative real user-agents

Con: Opportunity for there to be a bug in our code or the device_detector gem we're using (in worst case, bug that 500 errors, I tried to write defensively); we could miss logging something we actually want from user-agent; could be a performance hit to parse it on every request

But seems worth trying -- we really want user-agent info, especially whether something is a bot or not, and we can't afford the bytes to papertrail. 

We could log EVEN LESS than this, like only if it's a bot or not and what bot; but seemed good to try to log browser, OS and, device too, to have mostly complete picture of what you want from user-agent, but in fewer bytes.

Check out the spec for examples of what gets logged. 