### PR TITLE
should have memoized device_detector in CompactUserAgent

### DIFF
--- a/app/models/compact_user_agent.rb
+++ b/app/models/compact_user_agent.rb
@@ -56,7 +56,7 @@ class CompactUserAgent
   end
 
   def device_detector
-    DeviceDetector.new(user_agent)
+    @device_detector ||= DeviceDetector.new(user_agent)
   end
 
 end


### PR DESCRIPTION
the method is used a bunch of times in calculating the compact string, it should be memoized to avoid instantiating it multiple times, in case it's expensive.