### PR TITLE
Try to robots.txt most catalog search results

### DIFF
--- a/app/views/application/robots.txt.erb
+++ b/app/views/application/robots.txt.erb
@@ -17,6 +17,13 @@ Disallow: /collections/*/range_limit
 Disallow: /catalog/range_limit_panel
 Disallow: /collections/*/range_limit_panel
 
+# OK, let's try to disallow any search results that include facet limits,
+# to try to prevent these crawlers from tree-walking every possible
+# facet limit combination. 'nofollow' on the links would be my first choice
+# instead of this, but waiting on PR to Blacklight for that.
+# https://github.com/sciencehistory/scihist_digicoll/issues/1306
+Disallow: /catalog/*f%5B
+Disallow: /collections/*f%5B
 
 
 <% else %>


### PR DESCRIPTION
Specifically those including any facet limits.

Trick is getting the syntax right to disallow what we want, and NOT accidentally disallowing collection landing pages, which are actually high-priority to be indexed! I think this will work.

My ideal first try solution would not be this, but instead `nofollow` on the facet limit links, but waiting for a Blacklight PR-merge-release for that.

Ref: #1306