### PR TITLE
Add /focus search results to robots.txt

### DIFF
--- a/app/views/application/robots.txt.erb
+++ b/app/views/application/robots.txt.erb
@@ -10,12 +10,15 @@ User-agent: *
 # "more facets"
 Disallow: /catalog/facet/
 Disallow: /collections/*/facet/
+Disallow: /focus/*/facet
 # range-limit page normally only requested by AJAX for loading range limit info.
 Disallow: /catalog/range_limit
 Disallow: /collections/*/range_limit
+Disallow: /focus/*/range_limit
 # "View larger" link for range limit.
 Disallow: /catalog/range_limit_panel
 Disallow: /collections/*/range_limit_panel
+Disallow: /focus/*/range_limit_panel
 
 # OK, let's try to disallow any search results that include facet limits,
 # to try to prevent these crawlers from tree-walking every possible
@@ -27,8 +30,10 @@ Disallow: /collections/*/range_limit_panel
 # google robots.txt-validator suggests no, so we'll list both.
 Disallow: /catalog*f%5B
 Disallow: /catalog*f[
-Disallow: /collections*f%5B
-Disallow: /collections*f[
+Disallow: /collections/*f%5B
+Disallow: /collections/*f[
+Disallow: /focus/*f%5B
+Disallow: /focus/*f[
 
 
 <% else %>


### PR DESCRIPTION
Looking at actual logs, I realize we have another variant URL for search results, our featured topic "focus" urls. Include those variants in robots.txt too.

Ref #1306 

FWIW, googleboth does seem to have stopped requeting "infinite facet permuation" urls (although it's possible it would have gotten tired anyway); other bots like Ahrefs continue, possibly they haven't updated robots.txt yet. 

All bots continue to give us lots of traffic on URLs we do want, like individual works, images, collections, etc.