### PR TITLE
OAI-pmh must allow that there may be no representative set

### DIFF
--- a/app/serializers/work_oai_dc_serialization.rb
+++ b/app/serializers/work_oai_dc_serialization.rb
@@ -218,11 +218,27 @@ class WorkOaiDcSerialization
   # We are using a pretty big URL, thumb_large_2X (1050px; facebook recommends 1200px upload!)
   # our largest "thumb" type URL -- even PDFs get thumb-size derivatives.
   def appropriate_thumb_url
-    @appropriate_thumb_url ||= "#{ScihistDigicoll::Env.lookup!(:app_url_base)}/downloads/#{work.leaf_representative.friendlier_id}/thumb_large_2X?disposition=inline"
+    unless defined?(@appropriate_thumb_url)
+      @appropriate_thumb_url = if work.leaf_representative
+        "#{ScihistDigicoll::Env.lookup!(:app_url_base)}/downloads/#{work.leaf_representative.friendlier_id}/thumb_large_2X?disposition=inline"
+      else
+        nil
+      end
+    end
+
+    @appropriate_thumb_url
   end
 
   def full_jpg_url
-    @full_jpg_url ||= "#{ScihistDigicoll::Env.lookup!(:app_url_base)}/downloads/#{work.leaf_representative.friendlier_id}/download_full?disposition=inline"
+    unless defined?(@full_jpg_url)
+      @full_jpg_url = if work.leaf_representative
+        "#{ScihistDigicoll::Env.lookup!(:app_url_base)}/downloads/#{work.leaf_representative.friendlier_id}/download_full?disposition=inline"
+      else
+        nil
+      end
+    end
+
+    @full_jpg_url
   end
 
   def xmlns_attribs

--- a/spec/models/work/work_all_descendent_members_spec.rb
+++ b/spec/models/work/work_all_descendent_members_spec.rb
@@ -9,6 +9,6 @@ describe "Work#all_descendent_members" do
   let!(:unrelated_work){ FactoryBot.create(:work, title: "unrelated") }
 
   it "finds all" do
-    expect(work.all_descendent_members.to_a.collect(&:id)).to match([intermediate_work.id, asset.id])
+    expect(work.all_descendent_members.to_a.collect(&:id)).to match_array([intermediate_work.id, asset.id])
   end
 end

--- a/spec/system/oai_pmh_spec.rb
+++ b/spec/system/oai_pmh_spec.rb
@@ -3,77 +3,106 @@ require 'rails_helper'
 # Because creating real data is so slow, and feature tests pretty slow too,
 # we try to do everything in one test, even though that's not great test design.
 RSpec.feature "OAI-PMH feed", js: false do
-
-  let!(:representative_asset) { create(:asset_with_faked_file) }
-
-  # This one should be in feed:
-  let!(:work) { create(:work, :with_complete_metadata,
-    published: true,
-    creator: [
-      {
-        category: "creator_of_work",
-        value: "John Lennon"
-      },
-      {
-        category: "editor",
-        value: "G. Henle Verlag"
-      }
-    ],
-    representative: representative_asset,
-    members: [representative_asset]
-  )}
-
-  # Should not be in feed, unpublished:
-  let!(:unpublished_work) { create(:work, :with_complete_metadata, title: "unpublished", published: false) }
-
-  # Should not be in feed, a collection:
-  let!(:collection) { create(:collection, published: true) }
-
   # We use this to validate OAI-pmh:
   let(:oai_pmh_xsd_path) { Rails.root + "spec/fixtures/xsd/OAI-PMH.xsd" }
 
-  let(:public_work_url) { work_url(work) }
-  let(:work_thumb_url) { download_derivative_url(work.leaf_representative, "thumb_large_2X", disposition: :inline) }
-  let(:work_full_url) { download_derivative_url(work.leaf_representative, "download_full", disposition: :inline) }
+  describe "smoke test" do
+    let!(:representative_asset) { create(:asset_with_faked_file) }
 
-  it "renders feed with just work" do
-    visit(oai_provider_path(verb: "ListRecords", metadataPrefix: "oai_dc"))
+    # This one should be in feed:
+    let!(:work) { create(:work, :with_complete_metadata,
+      published: true,
+      creator: [
+        {
+          category: "creator_of_work",
+          value: "John Lennon"
+        },
+        {
+          category: "editor",
+          value: "G. Henle Verlag"
+        }
+      ],
+      representative: representative_asset,
+      members: [representative_asset]
+    )}
 
-    expect(page.status_code).to eq 200
+    # Should not be in feed, unpublished:
+    let!(:unpublished_work) { create(:work, :with_complete_metadata, title: "unpublished", published: false) }
 
-    # parse strict, so we get an exception if it's not well-formed XML
-    xml = Nokogiri::XML(page.body) { |config| config.strict }
+    # Should not be in feed, a collection:
+    let!(:collection) { create(:collection, published: true) }
 
-    # validate XSD
-    schema = Nokogiri::XML::Schema(File.read(oai_pmh_xsd_path))
-    errors = schema.validate(xml)
-    expect(errors.count == 0)
+    let(:public_work_url) { work_url(work) }
+    let(:work_thumb_url) { download_derivative_url(work.leaf_representative, "thumb_large_2X", disposition: :inline) }
+    let(:work_full_url) { download_derivative_url(work.leaf_representative, "download_full", disposition: :inline) }
 
-    # includes one item, which is the work, not the collection, not the non-published work.
-    records = xml.xpath("//oai:record", oai: "http://www.openarchives.org/OAI/2.0/")
-    expect(records.count).to eq (1)
-    record = records.first
+    it "renders feed with just work" do
+      visit(oai_provider_path(verb: "ListRecords", metadataPrefix: "oai_dc"))
 
-    dc_contributors = record.xpath("//dc:contributor", dc:"http://purl.org/dc/elements/1.1/").children.map(&:to_s)
-    expect(dc_contributors.map).to include("G. Henle Verlag")
+      expect(page.status_code).to eq 200
 
-    dc_creators = record.xpath("//dc:contributor", dc:"http://purl.org/dc/elements/1.1/").children.map(&:to_s)
-    expect(dc_contributors.map).to include("G. Henle Verlag")
+      # parse strict, so we get an exception if it's not well-formed XML
+      xml = Nokogiri::XML(page.body) { |config| config.strict }
 
-    record_id = record.at_xpath("./oai:header/oai:identifier", oai: "http://www.openarchives.org/OAI/2.0/")
-    expect(record_id.text).to eq("oai:sciencehistoryorg:#{work.friendlier_id}")
+      # validate XSD
+      schema = Nokogiri::XML::Schema(File.read(oai_pmh_xsd_path))
+      errors = schema.validate(xml)
+      expect(errors.count == 0)
 
-    dc_identifiers = record.xpath("//dc:identifier", dc:"http://purl.org/dc/elements/1.1/").collect(&:text)
-    expect(dc_identifiers).to include(public_work_url)
+      # includes one item, which is the work, not the collection, not the non-published work.
+      records = xml.xpath("//oai:record", oai: "http://www.openarchives.org/OAI/2.0/")
+      expect(records.count).to eq (1)
+      record = records.first
 
-    # Thumb in edm:preview
-    expect(record.xpath("//edm:preview", edm: "http://www.europeana.eu/schemas/edm/").collect(&:text)).to eq([work_thumb_url])
+      dc_contributors = record.xpath("//dc:contributor", dc:"http://purl.org/dc/elements/1.1/").children.map(&:to_s)
+      expect(dc_contributors.map).to include("G. Henle Verlag")
 
-    expect(record.at_xpath("//edm:object", edm: "http://www.europeana.eu/schemas/edm/")&.text).to eq work_full_url
+      dc_creators = record.xpath("//dc:contributor", dc:"http://purl.org/dc/elements/1.1/").children.map(&:to_s)
+      expect(dc_contributors.map).to include("G. Henle Verlag")
 
-    # And make sure thumb_url is actually visitable -- it may result in a redirect to S3 or underlying
-    # storage but should be 200 eventually. Also this may be different in test mock. :(
-    visit work_thumb_url
-    expect(page.status_code).to eq 200
+      record_id = record.at_xpath("./oai:header/oai:identifier", oai: "http://www.openarchives.org/OAI/2.0/")
+      expect(record_id.text).to eq("oai:sciencehistoryorg:#{work.friendlier_id}")
+
+      dc_identifiers = record.xpath("//dc:identifier", dc:"http://purl.org/dc/elements/1.1/").collect(&:text)
+      expect(dc_identifiers).to include(public_work_url)
+
+      # Thumb in edm:preview
+      expect(record.xpath("//edm:preview", edm: "http://www.europeana.eu/schemas/edm/").collect(&:text)).to eq([work_thumb_url])
+
+      expect(record.at_xpath("//edm:object", edm: "http://www.europeana.eu/schemas/edm/")&.text).to eq work_full_url
+
+      # And make sure thumb_url is actually visitable -- it may result in a redirect to S3 or underlying
+      # storage but should be 200 eventually. Also this may be different in test mock. :(
+      visit work_thumb_url
+      expect(page.status_code).to eq 200
+    end
+  end
+
+  # should not create an error, as long as it's possible in DB
+  describe "work with no representative" do
+    let!(:work_with_no_representative) { create(:work, :with_complete_metadata, title: "no representative", published: true) }
+
+    it "renders" do
+      visit(oai_provider_path(verb: "ListRecords", metadataPrefix: "oai_dc"))
+
+      expect(page.status_code).to eq 200
+
+      # parse strict, so we get an exception if it's not well-formed XML
+      xml = Nokogiri::XML(page.body) { |config| config.strict }
+
+      # validate XSD
+      schema = Nokogiri::XML::Schema(File.read(oai_pmh_xsd_path))
+      errors = schema.validate(xml)
+      expect(errors.count == 0)
+
+      records = xml.xpath("//oai:record", oai: "http://www.openarchives.org/OAI/2.0/")
+      expect(records.count).to eq (1)
+
+      record = records.first
+
+      # no image so no edm:object or edm:preview tags, that have thumbs/images
+      expect(record.xpath("//edm:object", edm: "http://www.europeana.eu/schemas/edm/")).not_to be_present
+      expect(record.xpath("//edm:preview", edm: "http://www.europeana.eu/schemas/edm/")).not_to be_present
+    end
   end
 end


### PR DESCRIPTION
if it's legal in the DB, it can happen!  Was happening, and crashing oai-pmh export. Ref #1319