### PR TITLE
Do not include PDF/ZIP on-demand whole-work downloads for non-published works

### DIFF
--- a/app/presenters/download_dropdown_display.rb
+++ b/app/presenters/download_dropdown_display.rb
@@ -226,13 +226,19 @@ class DownloadDropdownDisplay < ViewModel
     RightsIconDisplay.new(display_parent_work, mode: :dropdown_item).display
   end
 
-  # have a parent work, with more than 1 child, and AT LEAST ONE of it's children are images,
+  # have a PUBLISHED parent work, with more than 1 child, and AT LEAST ONE of it's children are images,
   # provide multi-image downloads. These are the only whole-work-download options we provide at present.
+  #
+  # (Our current PDF and Zip creators only create for published items, they can't create
+  # for non-published items. But we don't have an easy way to efficiently access
+  # number of published child items, we just use the parent being unpublished as a proxy
+  # for "not ready")
   #
   # NOTE: We had been checking to make sure ALL members were images, but that was FAR
   # too resource intensive, it destroyed ramelli. Checking just one is okay though.
   def has_work_download_options?
     display_parent_work &&
+    display_parent_work.published? &&
     display_parent_work.member_count > 1 &&
     display_parent_work.member_content_types(mode: :query).all? {|t| t.start_with?("image/")}
   end

--- a/spec/presenters/download_dropdown_display_spec.rb
+++ b/spec/presenters/download_dropdown_display_spec.rb
@@ -113,7 +113,7 @@ describe DownloadDropdownDisplay do
       end
 
       let(:parent_work) do
-        create(:work, members: [asset, build(:asset_with_faked_file), build(:asset_with_faked_file)])
+        create(:public_work, members: [asset, build(:asset_with_faked_file), build(:asset_with_faked_file)])
       end
 
       it "renders whole-work download options" do
@@ -136,6 +136,21 @@ describe DownloadDropdownDisplay do
         expect(pdf_option["data-analytics-category"]).to eq "Work"
         expect(pdf_option["data-analytics-action"]).to eq "download_pdf"
         expect(pdf_option["data-analytics-label"]).to eq parent_work.friendlier_id
+      end
+
+      describe "unpublished parent work" do
+        let(:parent_work) do
+          create(:work, published: false, members: [asset, build(:asset_with_faked_file), build(:asset_with_faked_file)])
+        end
+
+        # whole work download options are cached publically, they only include public
+        # members, and don't make sense on non-public work, and sometimes create errors
+        # if clicked there.
+        it "does not include whole-work download options" do
+          expect(div).not_to have_selector(".dropdown-header", text: "Download all 3 images")
+          expect(div).not_to have_selector("a.dropdown-item:contains('ZIP')")
+          expect(div).not_to have_selector("a.dropdown-item:contains('PDF')")
+        end
       end
 
       describe "template_only" do


### PR DESCRIPTION
Part of #1168

Just suppresses those options from download menu for non-published work. This will prevent staff from clicking on those options when they result in an error. It may not prevent the error entirely, if bots are somehow finding the bg job trigger URLs by guessing or something.

Would be nice to make controller return error before starting bg job too.