### PR TITLE
Handle completely nil user-agent in user-agent reporting code

### DIFF
--- a/app/models/compact_user_agent.rb
+++ b/app/models/compact_user_agent.rb
@@ -19,7 +19,7 @@ class CompactUserAgent
     ].collect(&:presence).compact.join("/").yield_self do |str|
       if str.presence == nil
         # if we couldn't parse, give em first 15 chars of thing, no spaces.
-        user_agent&.slice(0, 50).gsub(" ", "_")
+        user_agent&.slice(0, 50)&.gsub(" ", "_")
       else
         str
       end

--- a/spec/models/compact_user_agent_spec.rb
+++ b/spec/models/compact_user_agent_spec.rb
@@ -17,6 +17,11 @@ describe CompactUserAgent do
     it { is_expected.to eq "a_quite_very_long_and_terrible_user_agent_that_is_" }
   end
 
+  describe "nil user agent" do
+    let(:user_agent) { nil }
+    it { is_expected.to eq nil }
+  end
+
   describe "googlebot mobile" do
     let(:user_agent) { %q{Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)} }
     it { is_expected.to eq "bot:Googlebot/Chrome Mobile-41/Android-6.0/Nexus 5X"}


### PR DESCRIPTION
https://app.honeybadger.io/projects/58989/faults/81492268

Not sure why something/someone following the link from our email newsletter had completely no user-agent, but that should not make the app 500!

(GET https://digital.sciencehistory.org/works/o2sfuyr?utm_source=newsletter&utm_medium=email&utm_campaign=092021)