### PR TITLE
Only search for orphaned original files under scihist-digicoll-production-originals/assets

### DIFF
--- a/app/services/orphan_s3_originals.rb
+++ b/app/services/orphan_s3_originals.rb
@@ -26,6 +26,7 @@ class OrphanS3Originals
 
     @s3_iterator = S3PathIterator.new(
       shrine_storage: shrine_storage,
+      extra_prefix: 'asset',
       show_progress_bar: show_progress_bar,
       progress_bar_total: asset_count
     )


### PR DESCRIPTION
Let's only hunt for orphaned original files under `scihist-digicoll-production-originals/asset`.
Fixes #1331 .
Review / merge this first, before #1302 .
