### PR TITLE
Stop adding extra # in URL manipulation

### DIFF
--- a/app/javascript/src/js/scihist_viewer.js
+++ b/app/javascript/src/js/scihist_viewer.js
@@ -251,7 +251,6 @@ ScihistImageViewer.prototype.setLocationUrl = function() {
   } else {
     newPath = currentPath + '/viewer/' + encodeURIComponent(selectedID);
   }
-
   history.replaceState({}, "", this.locationWithNewPath(newPath));
 };
 
@@ -268,7 +267,7 @@ ScihistImageViewer.prototype.locationWithNewPath = function(newPath) {
     newUrl += '?' + location.query;
   }
   if (location.hash) {
-    newUrl += '#' + location.hash;
+    newUrl += location.hash;
   }
   return newUrl;
 };


### PR DESCRIPTION
Every time we tried to edit the URL on opening or closing viewer, we were adding an extra "#" in, because location.hash already includes a leading "#".

This resulted in URLs in the browser that ended up looking like eg https://digital.sciencehistory.org/works/dqao8vj###tab=transcription

Which actually broke the "auto-select tab on page load" functionality from working too!

This fixes that.