### PR TITLE
deai footer

### DIFF
--- a/app/assets/stylesheets/local/deai_footer.scss
+++ b/app/assets/stylesheets/local/deai_footer.scss
@@ -1,0 +1,20 @@
+.deai-footer {
+  padding-top: ($paragraph-font-size * $paragraph-line-height-long / 2) !important; // matches paragraph margin bottom please
+  padding-left: 1rem;
+  padding-right: 1rem;
+
+
+  color: #050939;
+
+  background-color: $brand-light-grey;
+
+  p {
+
+    max-width: 800px !important; // intended to match site footer, specifically .footeraddress
+    text-align: justify;
+    margin-left: auto;
+    margin-right: auto;
+
+
+  }
+}

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -4,6 +4,8 @@ class WorksController < ApplicationController
   before_action :set_work, :check_auth
 
   def show
+    @show_deai_header = true
+
     respond_to do |format|
       format.html {
         render template: template

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -90,6 +90,15 @@
     </div>
 
     <%= render partial: 'shared/modal' %>
+
+    <% if @show_deai_header || content_for(:show_deai_header) %>
+      <div class="deai-footer">
+        <p>
+          The Science History Institute recognizes there are materials in our collections that may be offensive or harmful, containing racist, sexist, Eurocentric, ableist, or homophobic language or depictions. The history of science is not exempt from beliefs or practices harmful to traditionally marginalized groups. The Institute is engaged in ongoing efforts to responsibly present and address the evidence of oppression and injustice inextricable from the history of science. If you would like to learn more about our ongoing efforts or if you encounter harmful, inaccurate, or insufficient descriptions, please contact us at <a href="mailto:digital@sciencehistory.org">digital@sciencehistory.org</a>.
+        </p>
+      </div>
+    <% end %>
+
     <%= render partial: 'layouts/scihist_footer' %>
     <%= render 'application/accept_cookies_banner' %>
   </body>


### PR DESCRIPTION
Added to general application layout, off by default, with an instance variable switch to turn it on. Only turned on for work detail pages, as requested.

Ref #1340