### PR TITLE
batch publish/unpublish from cart

### DIFF
--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -410,6 +410,41 @@ class Admin::WorksController < AdminController
     redirect_to admin_cart_items_url, notice: "Updated works in Cart"
   end
 
+  def batch_publish_toggle
+    authorize! :publish, Work
+
+    unless params[:publish].in?(["on", "off"])
+      raise ArgumentError.new("Need `in` param to be `on` or off`")
+    end
+
+    publish_value = params[:publish] == "on"
+
+    Work.transaction do
+      current_user.works_in_cart.find_each do |work|
+        work.update!(published: publish_value)
+        if params[:cascade] == 'true'
+          work.all_descendent_members.find_each do |member|
+            member.update!(published: true)
+          end
+        end
+      end
+    end
+
+    message = "#{publish_value ? "Published" : "UN-published"} all items"
+    message += " (and their members)" if params[:cascade]
+
+    redirect_to admin_cart_items_url, notice: message
+  rescue ActiveRecord::RecordInvalid => e
+    # probably because missing a field required for a work to be published, but
+    # could apply to a CHILD work, not just the parent you actually may have clicked 'publish'
+    # on.
+    #
+    # The work we're going to report and redirect to is just the FIRST one we encountered
+    # with an error, there could be more.
+    work = e.record
+    redirect_to admin_cart_items_url, flash: { error: "No changes made due to error: \"#{work.title}\" (#{work.friendlier_id}): #{e.message}" }
+  end
+
 
 
   private

--- a/app/views/admin/cart_items/index.html.erb
+++ b/app/views/admin/cart_items/index.html.erb
@@ -1,9 +1,52 @@
 <h1>Admin Cart</h1>
 
-<p>
-  <%= link_to "Batch Edit", batch_update_admin_works_path, class: "btn btn-primary" %>
-  <%= link_to "Clear Cart", clear_admin_cart_items_path, class: "btn btn-outline-danger", data: { confirm: "Delete all items in cart?"}, method: "delete" %>
-</p>
+<div class="d-flex justify-content-between">
+  <p>
+    <%= link_to "Batch Edit", batch_update_admin_works_path, class: "btn btn-primary" %>
+    <%= link_to "Clear Cart", clear_admin_cart_items_path, class: "btn btn-outline-danger", data: { confirm: "Delete all items in cart?"}, method: "delete" %>
+  </p>
+
+  <% if can?(:publish, Work) %>
+    <div>
+       <div class="btn-group" role="group">
+          <button id="UnpublishButtonGroup" type="button" class="btn btn-outline-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <i class="fa fa-ban" aria-hidden="true"></i>  Unpublish All Items
+          </button>
+
+          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="UnpublishButtonGroup">
+            <%= link_to "Also unpublish all child members of items",
+              batch_publish_toggle_admin_works_path(publish: "off", cascade: "true"),
+              method: "put",
+              class: "dropdown-item"
+            %>
+            <%= link_to "Leave members as they are",
+              batch_publish_toggle_admin_works_path(publish: "off"),
+              method: "put",
+              class: "dropdown-item"
+            %>
+          </div>
+        </div>
+
+        <div class="btn-group" role="group">
+          <button id="publishButtonGroup" type="button" class="btn btn-outline-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <i class="fa fa-eye" aria-hidden="true"></i> Publish All Items
+          </button>
+          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="publishButtonGroup">
+            <%= link_to "Also publish all child members of items",
+              batch_publish_toggle_admin_works_path(publish: "on", cascade: "true"),
+              method: "put",
+              class: "dropdown-item"
+            %>
+            <%= link_to "Leave members as they are",
+              batch_publish_toggle_admin_works_path(publish: "on"),
+              method: "put",
+              class: "dropdown-item"
+            %>
+          </div>
+        </div>
+    </div>
+  <% end %>
+</div>
 
 <%= render PageEntriesInfoComponent.new(@works) %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -214,6 +214,7 @@ Rails.application.routes.draw do
       collection do
         get 'batch_update', to: "works#batch_update_form"
         post 'batch_update'
+        put 'batch_publish_toggle'
       end
     end
 


### PR DESCRIPTION
This is a little bit hacky, I don't love how the WorkController is just getting all these random verbose methods. But it works!

If you publish, there can be an error -- some works arne't publishable. We show just the FIRST work error we encounter, you might have more than one that were unpublishable, but we only show one. If there's an error, we don't make ANY changes, it's all or none -- implemented by wrapping in transaction

Ref #1347