### PR TITLE
error handling pages should handle ANY formats

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -9,6 +9,7 @@ class ErrorsController < ApplicationController
      respond_to do |format|
        format.html { render status: 404, layout: false }
        format.json { render json: { error: "Resource not found" }, status: 404 }
+       format.any  { render plain: "Resource not found", status: 404 }
      end
    end
 
@@ -16,6 +17,7 @@ class ErrorsController < ApplicationController
      respond_to do |format|
        format.html { render status: 422, layout: false }
        format.json { render json: { error: "Params unacceptable" }, status: 422 }
+       format.any  { render plain: "Params unacceptable", status: 422 }
      end
    end
 
@@ -23,6 +25,7 @@ class ErrorsController < ApplicationController
      respond_to do |format|
        format.html { render status: 500, layout: false }
        format.json { render json: { error: "Internal server error" }, status: 500 }
+       format.any  { render plain: "Internal server error", status: 500 }
      end
    end
 end


### PR DESCRIPTION
With just a plain text response I guess. If error happens in some format we haven't explicitly enumerated, still do something other than an error. Without this, the error handling itself ends up raising a ActionController::UnknownFormat, which triggers Rails failsafe exception handling. And results in eg a 500 in what should be a 404.

This triggered #1362

Tested in staging showed this does resolve #1362