### PR TITLE
Replace rails_auto_link with rinku

### DIFF
--- a/app/views/layouts/_scihist_footer.html.erb
+++ b/app/views/layouts/_scihist_footer.html.erb
@@ -60,7 +60,7 @@
     <div class="footerprivacycopyright">
       &copy; <%= Time.current.year %>  Science History Institute |
       <a href="https://www.sciencehistory.org/privacy-policy/" >Privacy Policy</a> |
-      <a href="https://www.sciencehistory.org/accessibility">Accessibility
+      <a href="https://www.sciencehistory.org/accessibility">Accessibility</a>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
Also reverting #1359, restoring functionality exactly as it was meant to be originally, but without bug, with test that bug would have tripped, and replacing rails_auto_link with rinku. 

In fact, we realized this is pretty low-value functionality, but oh well. Ref #1360