### PR TITLE
Close accidentally un-closed link

### DIFF
--- a/app/views/layouts/_scihist_footer.html.erb
+++ b/app/views/layouts/_scihist_footer.html.erb
@@ -60,7 +60,7 @@
     <div class="footerprivacycopyright">
       &copy; <%= Time.current.year %>  Science History Institute |
       <a href="https://www.sciencehistory.org/privacy-policy/" >Privacy Policy</a> |
-      <a href="https://www.sciencehistory.org/accessibility">Accessibility
+      <a href="https://www.sciencehistory.org/accessibility">Accessibility</a>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
Although browsers we test with recovered from it fine, this was technically incorrect. And it was confusing some of the automated WCAG checkers by being invalid HTML (don't know if it was also an accessibility problem of it's own, could be).

Ref #565