### PR TITLE
Add aria-label to footer social media icons

### DIFF
--- a/app/views/layouts/_scihist_footer.html.erb
+++ b/app/views/layouts/_scihist_footer.html.erb
@@ -47,13 +47,36 @@
 
   <div class="footerrow">
     <div class="footersocialicons">
-      <div class="footersocialicon"><a href="https://facebook.com/scihistoryorg" target="_blank"><i class="fa fa-facebook-square" aria-hidden="true"></i></a>
+      <div class="footersocialicon">
+        <a href="https://facebook.com/scihistoryorg" target="_blank" aria-label="Facebook">
+          <i class="fa fa-facebook-square" aria-hidden="true"></i>
+        </a>
       </div>
-      <div class="footersocialicon"><a href="https://twitter.com/scihistoryorg" target="_blank"><i class="fa fa-twitter" aria-hidden="true"></i></a></div>
-        <div class="footersocialicon"><a href="https://www.instagram.com/scihistoryorg/" target="_blank"><i class="fa fa-instagram" aria-hidden="true"></i></a></div>
-      <div class="footersocialicon"><a href="https://www.youtube.com/c/ScienceHistoryInstitute" target="_blank"><i class="fa fa-youtube-play" aria-hidden="true"></i></a></div>
-      <div class="footersocialicon"><a href="https://www.linkedin.com/company/scihistoryorg/" target="_blank"><i class="fa fa-linkedin" aria-hidden="true"></i></a></div>
-      <div class="footersocialicon"><a href="https://vimeo.com/scihistoryorg " target="_blank"><i class="fa fa-vimeo" aria-hidden="true"></i></a></div>
+      <div class="footersocialicon">
+        <a href="https://twitter.com/scihistoryorg" target="_blank" aria-label="Twitter">
+          <i class="fa fa-twitter" aria-hidden="true"></i>
+        </a>
+      </div>
+      <div class="footersocialicon">
+        <a href="https://www.instagram.com/scihistoryorg/" target="_blank" aria-label="Instagram">
+          <i class="fa fa-instagram" aria-hidden="true"></i>
+        </a>
+      </div>
+      <div class="footersocialicon">
+        <a href="https://www.youtube.com/c/ScienceHistoryInstitute" target="_blank" aria-label="YouTube">
+          <i class="fa fa-youtube-play" aria-hidden="true"></i>
+        </a>
+      </div>
+      <div class="footersocialicon">
+        <a href="https://www.linkedin.com/company/scihistoryorg/" target="_blank" aria-label="LinkedIn">
+          <i class="fa fa-linkedin" aria-hidden="true"></i>
+        </a>
+      </div>
+      <div class="footersocialicon">
+        <a href="https://vimeo.com/scihistoryorg " target="_blank" aria-label="Vimeo">
+          <i class="fa fa-vimeo" aria-hidden="true"></i>
+        </a>
+      </div>
     </div>
   </div>
   <div class="footerrow">


### PR DESCRIPTION
As the links are on only images, and lack text. Fixes accessibiltiy warning:

> Anchor element found with a valid href attribute, but no link content has been supplied.

Ref WCAG main issue #565