### PR TITLE
aria-label on next/previous viewer buttons

### DIFF
--- a/app/views/scihist_image_viewer/_scihist_viewer_modal.html.erb
+++ b/app/views/scihist_image_viewer/_scihist_viewer_modal.html.erb
@@ -34,8 +34,8 @@
           <div class="viewer-content">
             <div class="viewer-image-and-navbar" data-alert-container>
               <div class="viewer-image" id="openseadragon-container">
-                <button href="#" id="viewer-left" class="viewer-image-prev" data-trigger="viewer-prev" tabindex="0"><i class="fa fa-chevron-left" title="Previous"></i></button>
-                <button href="#" id="viewer-right" class="viewer-image-next" data-trigger="viewer-next" tabindex="0"><i class="fa fa-chevron-right" title="Next"></i></button>
+                <button href="#" id="viewer-left" class="viewer-image-prev" data-trigger="viewer-prev" aria-label="Previous image" tabindex="0"><i class="fa fa-chevron-left" title="Previous"></i></button>
+                <button href="#" id="viewer-right" class="viewer-image-next" data-trigger="viewer-next" aria-label="Next image" tabindex="0"><i class="fa fa-chevron-right" title="Next"></i></button>
               </div>
 
               <%= render "scihist_image_viewer/scihist_viewer_navbar", work: work %>


### PR DESCRIPTION
They are graphic-only buttons, so need a label, which aria-label suffices. Accessibilty checker says:

> This element has role of "button" but does not have a name available to an accessibility API. Valid names are: element content, aria-label undefined, aria-labelledby undefined.

Ref WCAG at #565