### PR TITLE
Fix accidental duplicate id=description_tab attribute

### DIFF
--- a/app/components/transcription_tabs_component.html.erb
+++ b/app/components/transcription_tabs_component.html.erb
@@ -16,7 +16,7 @@
 
   <% if transcription_texts.present? %>
     <li class="nav-item">
-      <a class="nav-link" id="description-tab" data-toggle="tab" href="#transcription" role="tab" aria-controls="transcription">
+      <a class="nav-link" id="transcription-tab" data-toggle="tab" href="#transcription" role="tab" aria-controls="transcription">
         Transcription
       </a>
     </li>


### PR DESCRIPTION
This was supposed to be transcription_tab, but accidentally copied and pasted description_tab.

Accessibility tool caught it as: "Duplicate id attribute value "description-tab" found on the web page."

In addition to being just illegal HTML, it can be a problem for assistive technology associating the tab with it's content.

Ref WCAG work at #565