### PR TITLE
link contrast in deai footer passes WCAG

### DIFF
--- a/app/assets/stylesheets/local/deai_footer.scss
+++ b/app/assets/stylesheets/local/deai_footer.scss
@@ -4,9 +4,16 @@
   padding-right: 1rem;
 
 
-  color: #050939;
+  // this is not our standard $body-color, but is a bit more readable contrast on the grey!
+  color: black;
 
   background-color: $brand-light-grey;
+
+  // Our standard link color isn't sufficient WCAG contrast over the dark grey background. :(
+  a {
+    color: $brand-dark-blue;
+    text-decoration: underline !important;
+  }
 
   p {
 


### PR DESCRIPTION
To pass WCAG contrast rules, neither our standard link color, nor white or brand bright green, will do.

We fix it at the brand dark blue, but underlined to make it clear it's a link. It doens't have a different color on hover, because none that look different and meet contrast are avaialable!

While I was looking at this, I changed *standard* deai footer text to plain black instead of dark blue -- it's subtle, and both pass WCAG contrast, but I think the black is actually a lot easier to read. And this may help distinguish the link from the text?

We can still chagne this whole footer to white at a later point, just making the change now to pass WCAG contrast rules with footer as it is!

Ref WCAG work at #565