### PR TITLE
Hide rights statement icon from assistive technology consistently

### DIFF
--- a/app/components/rights_icon_component.rb
+++ b/app/components/rights_icon_component.rb
@@ -23,7 +23,7 @@ class RightsIconComponent < ApplicationComponent
   # one line, all a link
   def display_dropdown_item
     link_to(rights_url, target: "_blank", class: ['rights-statement', mode.to_s.dasherize, layout_class]) do
-      image_tag(rights_category_icon_src, class: "rights-statement-logo", alt: RightsTerms.label_for(work.rights)) +
+      image_tag(rights_category_icon_src, class: "rights-statement-logo", alt: "", "aria-hidden" => true) +
       " ".html_safe +
       content_tag("span",
                   (RightsTerms.short_label_inline_for(work.rights) || "").html_safe,
@@ -70,18 +70,18 @@ class RightsIconComponent < ApplicationComponent
 
   def large_graphical_element
     if rights_category == "creative_commons"
-      images =  [image_tag(rights_category_icon_src, class: "rights-statement-logo", alt: "")]
+      images =  [image_tag(rights_category_icon_src, class: "rights-statement-logo", alt: "", "aria-hidden" => true)]
 
       (RightsTerms.metadata_for(work.rights)["pictographs"] || []).each do |pictograph_image|
-        images << image_tag("cc_pictographs/#{pictograph_image}", class: "rights-statement-logo", alt: "")
+        images << image_tag("cc_pictographs/#{pictograph_image}", class: "rights-statement-logo", alt: "", "aria-hidden" => true)
       end
 
-      link_to rights_url, target: "_blank", alt: RightsTerms.label_for(work.rights), title: RightsTerms.label_for(work.rights) do
+      link_to rights_url, target: "_blank", title: RightsTerms.label_for(work.rights) do
         safe_join images
       end
     else
       # just the category icon
-      image_tag(rights_category_icon_src, class: "rights-statement-logo", alt: RightsTerms.icon_alt_for(work.rights))
+      image_tag(rights_category_icon_src, class: "rights-statement-logo", alt: "", "aria-hidden" => true)
     end
   end
 

--- a/spec/components/rights_icon_component_spec.rb
+++ b/spec/components/rights_icon_component_spec.rb
@@ -55,7 +55,7 @@ describe RightsIconComponent, type: :component do
     end
   end
 
-  describe "needs alt attr in large render" do
+  describe "should not have alt attr in large render either" do
     let(:work) { build(:work, rights: "http://rightsstatements.org/vocab/InC-EDU/1.0/")}
     let(:rendered) { render_inline(RightsIconComponent.new(work: work, mode: :large)) }
 
@@ -66,7 +66,8 @@ describe RightsIconComponent, type: :component do
       expect(container.inner_text.strip).to eq("EducationalUse Permitted") # weird test value cause there's a BR tag in there that inner_text eliminates
 
       img = container.at_css("img")
-      expect(img["alt"]).to eq("In Copyright")
+      expect(img["alt"]).to eq("")
+      expect(img["aria-hidden"]).to eq "true"
     end
   end
 


### PR DESCRIPTION
The text next to it is sufficient, the icon can be hidden.

We were doing that somewhat inconsistently, we switch to doing it consistently, with blank `alt` attriute AND aria-hidden=true on all of them -- both large format and compact format.

From getting advice on code4lib slack, I _think_ this is the right thing to do in all of these circumstances. Doing my best!

Ref WCAG work at #565