### PR TITLE
Add assistive tech labels for navigational thumbnails in viewers

### DIFF
--- a/app/javascript/src/js/scihist_viewer.js
+++ b/app/javascript/src/js/scihist_viewer.js
@@ -432,10 +432,10 @@ ScihistImageViewer.prototype.makeThumbnails = function(json) {
     }
 
     var calcPixelHeight = (_self.thumbWidth / config.thumbAspectRatio).toFixed(1);
-
     container.append(
       '<img class="lazyload viewer-thumb-img"' +
-            ' alt="" tabindex="0" role="button"' +
+            ' alt="Image ' + (index + 1) + '" aria-label="Image ' + (index + 1) + '"' +
+            'tabindex="0" role="button"' +
             ' data-member-id="' + config.memberId + '"' +
             ' data-trigger="change-viewer-source"' +
             ' data-src="' + config.thumbSrc + '"' +


### PR DESCRIPTION
It's not entirely clear what to do with these, even after talking to a friendly person on code4lib slack who knows more than me.

This is my best attempt to hopefully make it better. Those thumbnails used for navigation should have assistive-tech-readable labels like "Image 1", "Image 2" -- becuase that's pretty much all we can say about them, and it's better than nothing at least.

We supply this as both an `alt` attribute and an `aria-label` attribute, becuase of concenrs that existing `role=button` might make assistive tech ignore the alt and want the aria-label. It may depend on the tech. The role=button may or may not actually be a good idea in the first place, but it's our best guess, since these images ARE serving as buttons!  At some point with this stuff I start getting into things where the right answer is not clear to me, depsite limited attempts to research. Doing my best.

Ref WCAG work #565