### PR TITLE
Make location headings in footer actual h2's

### DIFF
--- a/app/assets/stylesheets/local/footer.scss
+++ b/app/assets/stylesheets/local/footer.scss
@@ -45,7 +45,10 @@
       color: white;
     }
 
-    strong {
+    h2, strong {
+      color: inherit;
+      margin-bottom: 0;
+      line-height: inherit;
       font-weight: 700;
       font-size: 1.125rem;
     }

--- a/app/views/layouts/_scihist_footer.html.erb
+++ b/app/views/layouts/_scihist_footer.html.erb
@@ -7,7 +7,8 @@
   <div class="footerrow">
     <div class="footeraddresses">
       <div class="firstaddress">
-        <strong>Headquarters</strong><br>315 Chestnut Street<br>Philadelphia, PA 19106<br>215.925.2222<br>
+        <h2>Headquarters</h2>
+        315 Chestnut Street<br>Philadelphia, PA 19106<br>215.925.2222<br>
         <a target="_blank" href="https://www.google.com/maps/dir/''/science+history+institute/data=!4m5!4m4!1m0!1m2!1m1!1s0x89c6c884f0010fd7:0x9fdd2fbe5d2744d3?sa=X&ved=0ahUKEwj_mtuCpbrZAhVLs1kKHSpjAicQ9RcIwgEwCw">
           <i class="fa fa-map-marker"></i> Directions
         </a>
@@ -18,14 +19,15 @@
       </div>
       <div class="secondaddress">
         <div class="mb-4">
-          <strong>West Coast</strong><br>415.798.2104<br>
+          <h2>West Coast</h2>
+          415.798.2104<br>
           <a href="https://www.sciencehistory.org/contact-us#west">
             <i class="fa fa-envelope"></i> Get in Touch
           </a>
         </div>
 
         <div>
-          <strong>Boston/Cambridge</strong><br>
+          <h2>Boston/Cambridge</h2>
           617.500.8668<br>
           <a href="https://sciencehistory.org/contact-us#boston-cambridge"">
             <i class="fa fa-envelope"></i>
@@ -34,7 +36,7 @@
         </div>
       </div>
       <div class="thirdaddress">
-      <strong>Europe</strong><br>
+      <h2>Europe</h2>
       Maison de la Chimie<br>
       28, Rue Saint-Dominique<br>
       75007 Paris<br>


### PR DESCRIPTION
This was suggested by the IBM tool, not sure how it knew. "Check if this text should be marked up as a heading: Headquarters"

But yeah, we do already have an h1 around the Science History Institute in footer, so making these h2's will make them show up nicely in 'outline' views used by assistive tech, so user can easily see the different locations listed.

CSS to leave visually unchanged from before.

Ref WCAG work at #565