### PR TITLE
Blank alt tag on homepage featured topics

### DIFF
--- a/app/views/homepage/_featured_topics.html.erb
+++ b/app/views/homepage/_featured_topics.html.erb
@@ -6,7 +6,7 @@
       <% FeaturedTopic.all.each do |ft| %>
           <div class="featured-topic">
             <%= link_to ft.path do %>
-              <%= image_tag ft.thumb_asset_path, class: "featured-topic-image", width: "100%" %>
+              <%= image_tag ft.thumb_asset_path, class: "featured-topic-image", width: "100%", alt: "" %>
               <div class="featured-topic-title-wrapper">
                 <h3 class="featured-topic-title"><%= ft.title.upcase %></h3>
               </div>


### PR DESCRIPTION
The images are non-essential/decorative, for now this seems best, they have the text.

Ref WCAG work at #565