### PR TITLE
REMOVE alt tag

### DIFF
--- a/app/views/homepage/_hero_image_and_search_form.html.erb
+++ b/app/views/homepage/_hero_image_and_search_form.html.erb
@@ -2,7 +2,7 @@
     <div class="row no-gutters">
         <div class="col-lg">
             <figure class="hero-image">
-                <%= image_tag "hero_image_2x.jpg", alt: "" %>
+                <%= image_tag "hero_image_2x.jpg" %>
                 <figcaption>
                     <%
                     hero_image_work = Work.find_by_friendlier_id('w6634363x')


### PR DESCRIPTION
This has a figcaption tag which serves as image description, don't need to accidentally cover it up with an empty alt tag

Ref WCAG work at #565