### PR TITLE
remove duplicate ids search-submit-header

### DIFF
--- a/app/views/collection_show/index.html.erb
+++ b/app/views/collection_show/index.html.erb
@@ -47,7 +47,7 @@
             <label class="sr-only" for="collectionQ"><%= t('collection.search_form.search_field.label') %></label>
 
             <div class="input-group-append">
-              <button type="submit" class="btn btn-emphasis" title="Search" id="search-submit-header">
+              <button type="submit" class="btn btn-emphasis" title="Search">
                 <i class="fa fa-search" aria-hidden="true"></i>
                 <%= t('blacklight.search.form.submit') %>
               </button>

--- a/app/views/collection_show_controllers/oral_history_collection/_splash_page.html.erb
+++ b/app/views/collection_show_controllers/oral_history_collection/_splash_page.html.erb
@@ -43,7 +43,7 @@ we want the full width of the screen, no margins or padding. %>
               <label class="sr-only" for="collectionQ"><%= t('collection.search_form.search_field.label') %></label>
 
               <div class="input-group-append">
-                <button type="submit" class="btn btn-emphasis" title="Search" id="search-submit-header">
+                <button type="submit" class="btn btn-emphasis" title="Search">
                   <i class="fa fa-search" aria-hidden="true"></i>
                   <%= t('blacklight.search.form.submit') %>
                 </button>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -58,7 +58,7 @@
             <label class="sr-only" for="q">Search in</label>
 
             <div class="input-group-append">
-              <button type="submit" class="btn btn-emphasis" title="Search" id="search-submit-header">
+              <button type="submit" class="btn btn-emphasis" title="Search">
                 <i class="fa fa-search" aria-hidden="true"></i>
                 Go
               </button>

--- a/app/views/featured_topic/index.html.erb
+++ b/app/views/featured_topic/index.html.erb
@@ -33,7 +33,7 @@
         %>
         <label class="sr-only" for="collectionQ"><%= t('collection.search_form.search_field.label') %></label>
         <div class="input-group-append">
-          <button type="submit" class="btn btn-emphasis" title="Search" id="search-submit-header">
+          <button type="submit" class="btn btn-emphasis" title="Search">
             <i class="fa fa-search" aria-hidden="true"></i>
             <%= t('blacklight.search.form.submit') %>
           </button>

--- a/app/views/static/oh_legacy_url_not_found.html.erb
+++ b/app/views/static/oh_legacy_url_not_found.html.erb
@@ -38,7 +38,7 @@
             <label class="sr-only" for="collectionQ"><%= t('collection.search_form.search_field.label') %></label>
 
             <div class="input-group-append">
-              <button type="submit" class="btn btn-emphasis" title="Search" id="search-submit-header">
+              <button type="submit" class="btn btn-emphasis" title="Search">
                 <i class="fa fa-search" aria-hidden="true"></i>
                 <%= t('blacklight.search.form.submit') %>
               </button>


### PR DESCRIPTION
One of the accessibility checkers caught it, in some cases we had more than one id=search-submit-header on page, which is illegal HTML.

It doesn't look like we're USING this id for anything, I don't think it needs to be there at all. Removing from all except main search form.

Ref WCAG work #565