### PR TITLE
have to properly escape/encode params on legacy Oral History search redirect

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,10 +29,10 @@ Rails.application.routes.draw do
     # Links to search results in legacy OH site should redirct to search of OH collection.
     # We only support basic query term, not fielded search or facets.
     get "search/site/*query", to: redirect { |path_params, req|
-      "#{ScihistDigicoll::Env.lookup!("app_url_base")}/collections/#{ScihistDigicoll::Env.lookup!("oral_history_collection_id")}?q=#{path_params[:query]}"
+      "#{ScihistDigicoll::Env.lookup!("app_url_base")}/collections/#{ScihistDigicoll::Env.lookup!("oral_history_collection_id")}?q=#{URI.encode_www_form_component(path_params[:query]).gsub("+", "%20")}"
     }
     get "search/oh/*query", to: redirect { |path_params, req|
-      "#{ScihistDigicoll::Env.lookup!("app_url_base")}/collections/#{ScihistDigicoll::Env.lookup!("oral_history_collection_id")}?q=#{path_params[:query]}"
+      "#{ScihistDigicoll::Env.lookup!("app_url_base")}/collections/#{ScihistDigicoll::Env.lookup!("oral_history_collection_id")}?q=#{URI.encode_www_form_component(path_params[:query]).gsub("+", "%20")}"
     }
 
     get '/oral-histories/projects', to: redirect('https://sciencehistory.org/oral-history-projects')

--- a/spec/requests/oh_legacy_redirects_spec.rb
+++ b/spec/requests/oh_legacy_redirects_spec.rb
@@ -51,6 +51,12 @@ describe "Oral history legacy site redirects" do
       expect(response).to have_http_status(301) # moved permanently
       expect(response).to redirect_to("#{standard_base_url}/collections/#{ScihistDigicoll::Env.lookup!(:oral_history_collection_id)}?q=new\%20york")
     end
+
+    it "properly escapes redirect" do
+      get '/search/oh/Poun%C3%A9%20Saberi'
+      expect(response).to have_http_status(301)
+      expect(response).to redirect_to("#{standard_base_url}/collections/#{ScihistDigicoll::Env.lookup!(:oral_history_collection_id)}?q=Poun\%C3\%A9\%20Saberi")
+    end
   end
 
 


### PR DESCRIPTION
Amazing this was working before at all, it wasn't right, but some things (Rails, browsers) rescued us anyway.  But not for on non-ascii. 

Ref #1389