### PR TITLE
Put DEIA footer in a <footer> element.

### DIFF
--- a/app/views/layouts/_scihist_footer.html.erb
+++ b/app/views/layouts/_scihist_footer.html.erb
@@ -1,7 +1,7 @@
-<footer id="footer" role="contentinfo">
+<footer id="footer" role="contentinfo" aria-labelledby="footerTitle">
 
   <div class="footerrow">
-    <h1 class="footer-title"> <%= link_to "Science History Institute", "https://www.sciencehistory.org" %> </h1>
+    <h1 class="footer-title" id="footerTitle"> <%= link_to "Science History Institute", "https://www.sciencehistory.org" %> </h1>
   </div>
 
   <div class="footerrow">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -92,11 +92,11 @@
     <%= render partial: 'shared/modal' %>
 
     <% if @show_deai_header || content_for(:show_deai_header) %>
-      <div class="deai-footer">
+      <footer class="deai-footer" aria-label="Statement on Harmful or Offensive Content">
         <p>
           The Science History Institute recognizes there are materials in our collections that may be offensive or harmful, containing racist, sexist, Eurocentric, ableist, or homophobic language or depictions. The history of science is not exempt from beliefs or practices harmful to traditionally marginalized groups. The Institute is engaged in ongoing efforts to responsibly present and address the evidence of oppression and injustice inextricable from the history of science. If you would like to learn more about our ongoing efforts or if you encounter harmful, inaccurate, or insufficient descriptions, please contact us at <a href="mailto:digital@sciencehistory.org">digital@sciencehistory.org</a>.
         </p>
-      </div>
+      </footer>
     <% end %>
 
     <%= render partial: 'layouts/scihist_footer' %>


### PR DESCRIPTION
With labelling to distinguish from site-wide footer.

I think this will aid assistive tech accessibility

Ref WCAG work at #565