### PR TITLE
figcaption is not sufficient or in some cases desirable for accessibility

### DIFF
--- a/app/views/homepage/_hero_image_and_search_form.html.erb
+++ b/app/views/homepage/_hero_image_and_search_form.html.erb
@@ -2,8 +2,8 @@
     <div class="row no-gutters">
         <div class="col-lg">
             <figure class="hero-image">
-                <%= image_tag "hero_image_2x.jpg" %>
-                <figcaption>
+                <%= image_tag "hero_image_2x.jpg", 'aria-labelledby' => "homeHeroCaption" %>
+                <figcaption id="homeHeroCaption">
                     <%
                     hero_image_work = Work.find_by_friendlier_id('w6634363x')
                     hero_image_link = hero_image_work ? work_path(hero_image_work.friendlier_id) : "#"

--- a/app/views/homepage/_recent_items.html.erb
+++ b/app/views/homepage/_recent_items.html.erb
@@ -7,20 +7,11 @@
       <div class="recent-item" data-toggle="tooltip" title="<%= work.title %>" >
         <div class="recent-item-image-matte">
           <%= link_to work_path(work.friendlier_id) do %>
-            <figure>
-              <%= render ThumbComponent.new(
-                work.leaf_representative,
-                thumb_size: :standard,
-                alt_text_override: "#{work.title}")
-              %>
-              <figcaption>
-                <div class="recent-item-title-wrapper">
-                  <p class="recent-item-title">
-                    <%= work.title.truncate(35) %>
-                  </p>
-                </div>
-              </figcaption>
-            </figure>
+            <%= render ThumbComponent.new(
+              work.leaf_representative,
+              thumb_size: :standard,
+              alt_text_override: "#{work.title}")
+            %>
           <%end%>
         </div>
       </div>


### PR DESCRIPTION
Google Lighthouse was flagging the hero image as unlabelled despite figcaption.

It turns out that figcaption isn't actually used to label images by most assistive technology: https://www.powermapper.com/tests/screen-readers/aria/

And additionally figcaption has a different purpose than alt, and usually shouldn't just repeat what is in alt. https://www.scottohara.me/blog/2019/01/21/how-do-you-figure.html

Added appropriate aria technology to hero, but also removed redundant figure/figcaption from the "recent items", where the figcaption ended up hidden and just repeating the alt/title/tooltip text (I think it may have been leftover from an earlier iteration anyway).

Ref WCAG work at #565