### PR TITLE
Use nav instead of div[role=navigation]

### DIFF
--- a/app/views/layouts/_scihist_masthead.html.erb
+++ b/app/views/layouts/_scihist_masthead.html.erb
@@ -30,7 +30,7 @@ do `content_for(:suppress_masthead_search, true)`
 
     </div>
 
-    <div class="collapse navbar-collapse" id="top-navbar-collapse" aria-role="navigation" aria-label="Site-wide Navigation">
+    <nav class="collapse navbar-collapse" id="top-navbar-collapse" aria-label="Site-wide Navigation">
       <div class="masthead-right">
         <h1 class="masthead-title large-masthead-only"><%= link_to "Digital Collections", root_url %></h1>
 
@@ -46,5 +46,5 @@ do `content_for(:suppress_masthead_search, true)`
           <!-- </div> -->
         <% end %>
       </div>
-    </div>
+    </nav>
 </header>


### PR DESCRIPTION
Google Lighthouse accessibility checker really didn't like the later, and was fine with the former. Not sure if it matters, but doens't hurt.

Ref WCAG work at #565