### PR TITLE
Pay more attention to aria role and labels for main content area

### DIFF
--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -11,5 +11,7 @@
 <% content_for(:sidebar) do %>
   <%= render 'search_sidebar' %>
 <% end %>
+<% content_for(:sidebar_aria_label) { t('blacklight.search.documents.aria.limit_search')  } %>
+<% content_for(:content_aria_label) { t('blacklight.search.documents.aria.search_results')  } %>
 
 <%= render 'search_results' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,7 +60,7 @@
     <%# Blacklight put a search form here, we include our own local one in scihist_masthead instead,
         integrated into the masthead -%>
 
-    <div id="mainContainer" class="container-fluid">
+    <main id="mainContainer" class="container-fluid">
       <%= content_for(:container_header) %>
       <%= render 'flash_message_display' %>
       <% if content_for? :full_width_layout %>
@@ -69,10 +69,14 @@
       <% else %>
         <div class="row">
           <% if content_for? :sidebar %>
-            <section id="content" role="main" class="order-last">
+            <section id="content" class="order-last"
+              <%= %Q{aria-label="#{content_for(:content_aria_label)}"}.html_safe if content_for(:content_aria_label) %>
+            >
               <%= yield %>
             </section>
-            <section id="sidebar" class="page-sidebar order-first">
+            <section id="sidebar" class="page-sidebar order-first"
+                <%= %Q{aria-label="#{content_for(:sidebar_aria_label)}"}.html_safe if content_for(:sidebar_aria_label) %>
+            >
               <%= content_for(:sidebar) %>
             </section>
           <% else %>
@@ -82,7 +86,7 @@
           <% end %>
         </div>
       <% end %>
-    </div>
+    </main>
 
     <%= render partial: 'shared/modal' %>
 


### PR DESCRIPTION
Some of this was improved in Blacklight after we 'forked' from the blacklight layout, and we looked at that. But didn't hard-code certain semantics to sidebar/main area, instead provide those with content_for

Ref WCAG work at #565