### PR TITLE
Remove contextual assumptions about ViewComponents

### DIFF
--- a/app/components/work_image_show_component.html.erb
+++ b/app/components/work_image_show_component.html.erb
@@ -1,7 +1,7 @@
 <% provide :page_title, construct_page_title(work.title) %>
 
 <% content_for :head do %>
-  <%= render "meta_tags", work: work  %>
+  <%= render "works/meta_tags", work: work  %>
   <%= tag "link", rel: "alternate", type: "application/xml", title: "OAI-DC metadata in XML", href: work_path(@work, format: "xml") %>
 <% end %>
 
@@ -13,7 +13,7 @@
 
   <div class="show-hero">
     <%= render MemberImageComponent.new(representative_member, size: :large) %>
-    <%= render "rights_and_social", work: work %>
+    <%= render "works/rights_and_social", work: work %>
   </div>
 
   <div class="show-metadata">
@@ -28,7 +28,7 @@
           <%= DescriptionDisplayFormatter.new(work.description).format  %>
         </div>
         <%= render WorkShowInfoComponent.new(work: work) %>
-        <%= render "citation", work: work  %>
+        <%= render "works/citation", work: work  %>
 
       <% end %>
   </div>

--- a/app/views/works/_citation.html.erb
+++ b/app/views/works/_citation.html.erb
@@ -1,10 +1,10 @@
 <h2 class="attribute-sub-head">Cite as</h2>
 <div class="show-sub-head-body">
   <p class="citation long-text-line-height">
-     <%=CitationDisplay.new(@work).display %>
+     <%=CitationDisplay.new(work).display %>
   </p>
   <p class="btn-group" role="group">
-    <%=  link_to(work_path(@work, format: :ris), class: "btn btn-sm btn-primary export-citation") do %>
+    <%=  link_to(work_path(work, format: :ris), class: "btn btn-sm btn-primary export-citation") do %>
       <i class="fa fa-address-card"></i>&nbsp;&nbsp;Export citation (RIS)
     <% end %>
 


### PR DESCRIPTION
We still have a somewhat mixedup world where we use ViewComponents but sometimes use standard partials too. Found a couple view components making assumptions about which controller they were called in, when I went to add some tests that didn't assume that controller.

Adjusting to make slightly fewer assumptions:

* If calling to a traditional template, useit's full name like "works/citation", so it works even if we're not calling from WorksController
* Pass in all arguments to such a template as template locals, the template shouldn't assume controller @instance_variables