### PR TITLE
Hide thumbnail link in search results from assistive technology

### DIFF
--- a/app/components/search_result/base_component.html.erb
+++ b/app/components/search_result/base_component.html.erb
@@ -2,7 +2,9 @@
 
 
     <div class="scihist-results-list-item-thumb">
-      <%= link_to link_to_href do %>
+      <%#  hide redundant thumb link from assitive tech
+           https://www.sarasoueidan.com/blog/keyboard-friendlier-article-listings/.  -%>
+      <%= link_to link_to_href, tabindex: "-1", "aria-hidden" => "true" do %>
         <%= thumbnail_html %>
       <% end %>
       <%= display_num_children %>


### PR DESCRIPTION
It duplicates the link right next to it on the title, and should be hidden. We have no good alt text for img, so really the whole area should be hidden.

https://www.sarasoueidan.com/blog/keyboard-friendlier-article-listings/