### PR TITLE
bootstrap tablist markup needs role=presentation on li

### DIFF
--- a/app/components/transcription_tabs_component.html.erb
+++ b/app/components/transcription_tabs_component.html.erb
@@ -8,14 +8,14 @@
 %>
 
 <ul class="nav nav-tabs mt-4 mb-2" data-trigger="responsive-tabs-lg" role="tablist">
-  <li class="nav-item">
+  <li class="nav-item" role="presentation">
     <a class="nav-link active" id="description-tab" data-toggle="tab" href="#description" role="tab" aria-controls="description" aria-selected="true">
       Description
     </a>
   </li>
 
   <% if transcription_texts.present? %>
-    <li class="nav-item">
+    <li class="nav-item" role="presentation">
       <a class="nav-link" id="transcription-tab" data-toggle="tab" href="#transcription" role="tab" aria-controls="transcription">
         Transcription
       </a>
@@ -23,7 +23,7 @@
   <% end %>
 
   <% if translation_texts.present? %>
-    <li class="nav-item">
+    <li class="nav-item" role="presentation">
       <a class="nav-link" id="translation-tab" data-toggle="tab" href="#translation" role="tab" aria-controls="translation" aria-selected="true">
         English Translation
       </a>

--- a/app/components/work_oh_audio_show_component.html.erb
+++ b/app/components/work_oh_audio_show_component.html.erb
@@ -32,14 +32,14 @@
         <% end %>
 
         <ul class="nav ohms-nav-tabs" role="tablist">
-          <li class="nav-item">
+          <li class="nav-item" role="presentation">
             <a class="nav-link active btn btn-emphasis" id="ohDescriptionTab" data-toggle="tab" href="#ohDescription" role="tab" aria-controls="home" aria-selected="true">
               Description
             </a>
           </li>
 
           <% if has_ohms_index? %>
-            <li class="nav-item">
+            <li class="nav-item" role="presentation">
               <a class="nav-link btn btn-emphasis" id="ohTocTab" data-toggle="tab" href="#ohToc" role="tab" aria-controls="profile" aria-selected="false">
                 Table of Contents <span data-ohms-hitcount="index"></span>
               </a>
@@ -47,14 +47,14 @@
           <% end %>
 
           <% if has_ohms_transcript? %>
-            <li class="nav-item">
+            <li class="nav-item" role="presentation">
               <a class="nav-link btn btn-emphasis" id="ohTranscriptTab" data-toggle="tab" href="#ohTranscript" role="tab" aria-controls="home" aria-selected="false">
                 Transcript <span data-ohms-hitcount="transcript"></span>
               </a>
             </li>
           <% end %>
 
-          <li class="nav-item">
+          <li class="nav-item" role="presentation">
             <a class="nav-link btn btn-emphasis" id="ohDownloadsTab" data-toggle="tab" href="#ohDownloads" role="tab" aria-controls="contact" aria-selected="false">Downloads</a>
           </li>
         </ul>


### PR DESCRIPTION
in between the role=tablist and the role=tab.

This is what bootstrap sample markup shows: https://getbootstrap.com/docs/5.0/components/navs-tabs/#javascript-behavior

And is necessary to avoid an error from lighthouse accessibility check

Ref WCAG work #565 