### PR TITLE
Hide link on thumbnail from assistive technology

### DIFF
--- a/app/components/file_list_item_component.rb
+++ b/app/components/file_list_item_component.rb
@@ -55,7 +55,11 @@ class FileListItemComponent < ApplicationComponent
     if member.kind_of?(Asset) && member.content_type&.start_with?("image/")
       yield
     else
-      link_to(download_path(member.leaf_representative, disposition: :inline), view_link_attributes) do
+      # image thumb is in a link, but right next to filename with same link.
+      # Suppress image thumb from assistive technology to avoid un-useful double
+      # link. https://www.sarasoueidan.com/blog/keyboard-friendlier-article-listings/
+      link_to(download_path(member.leaf_representative, disposition: :inline),
+              view_link_attributes.merge("aria-hidden" => "true", "tabindex" => -1)) do
         yield
       end
     end


### PR DESCRIPTION
It's redundant to link on title right next to it, and we have no good alt label for image that wouldn't just lead to two identical links in a row. https://www.sarasoueidan.com/blog/keyboard-friendlier-article-listings/

Ref WCAG work at #565