### PR TITLE
Remove aria-label from cookie "I accept" button

### DIFF
--- a/app/views/application/_accept_cookies_banner.html.erb
+++ b/app/views/application/_accept_cookies_banner.html.erb
@@ -16,7 +16,7 @@
 
         <div class="col-md-2 i-accept-button-div text-center">
             <a href="#" class="i-accept-link"
-                aria-label="dismiss cookie message" role="button"
+                role="button"
                 tabindex="0">I Accept</a>
         </div>
 


### PR DESCRIPTION
It has visible text, it doesn't need an aria-label, and shouldn't have one that doens't match visible text for no reason.

Ref WCAG work #565