### PR TITLE
Remove section role=main

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -7,9 +7,9 @@ we want the full width of the screen, no margins or padding. %>
 <% content_for(:full_width_layout, true) %>
 
 
-<section role="main">
-    <%= render 'homepage/hero_image_and_search_form' %>
-    <%= render 'homepage/recent_items' %>
-    <%= render 'homepage/featured_topics' %>
-    <%= render 'homepage/featured_collection' %>
-</section>
+
+<%= render 'homepage/hero_image_and_search_form' %>
+<%= render 'homepage/recent_items' %>
+<%= render 'homepage/featured_topics' %>
+<%= render 'homepage/featured_collection' %>
+


### PR DESCRIPTION
We already have a <main> from layout, which was leading to accessibility checker complaining about multiple elements with role=main.

This section element didn't seem to do anything, everything displays just fine if we remove it completely

Ref WCAG work at #565