### PR TITLE
fix aria-controls on tabs

### DIFF
--- a/app/components/work_oh_audio_show_component.html.erb
+++ b/app/components/work_oh_audio_show_component.html.erb
@@ -33,14 +33,14 @@
 
         <ul class="nav ohms-nav-tabs" role="tablist">
           <li class="nav-item" role="presentation">
-            <a class="nav-link active btn btn-emphasis" id="ohDescriptionTab" data-toggle="tab" href="#ohDescription" role="tab" aria-controls="home" aria-selected="true">
+            <a class="nav-link active btn btn-emphasis" id="ohDescriptionTab" data-toggle="tab" href="#ohDescription" role="tab" aria-controls="ohDescription" aria-selected="true">
               Description
             </a>
           </li>
 
           <% if has_ohms_index? %>
             <li class="nav-item" role="presentation">
-              <a class="nav-link btn btn-emphasis" id="ohTocTab" data-toggle="tab" href="#ohToc" role="tab" aria-controls="profile" aria-selected="false">
+              <a class="nav-link btn btn-emphasis" id="ohTocTab" data-toggle="tab" href="#ohToc" role="tab" aria-controls="ohToc" aria-selected="false">
                 Table of Contents <span data-ohms-hitcount="index"></span>
               </a>
             </li>
@@ -48,14 +48,14 @@
 
           <% if has_ohms_transcript? %>
             <li class="nav-item" role="presentation">
-              <a class="nav-link btn btn-emphasis" id="ohTranscriptTab" data-toggle="tab" href="#ohTranscript" role="tab" aria-controls="home" aria-selected="false">
+              <a class="nav-link btn btn-emphasis" id="ohTranscriptTab" data-toggle="tab" href="#ohTranscript" role="tab" aria-controls="ohTranscript" aria-selected="false">
                 Transcript <span data-ohms-hitcount="transcript"></span>
               </a>
             </li>
           <% end %>
 
           <li class="nav-item" role="presentation">
-            <a class="nav-link btn btn-emphasis" id="ohDownloadsTab" data-toggle="tab" href="#ohDownloads" role="tab" aria-controls="contact" aria-selected="false">Downloads</a>
+            <a class="nav-link btn btn-emphasis" id="ohDownloadsTab" data-toggle="tab" href="#ohDownloads" role="tab" aria-controls="ohDownloads" aria-selected="false">Downloads</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
The values were accidentally copied and pasted from bootstrap example without being changed to what is on this page. aria-controls just needs to match the href but without # I guess.
https://getbootstrap.com/docs/4.0/components/navs/#javascript-behavior

Ref WCAG work at #565