### PR TITLE
automated accessibility testing in CI with axe-core-rspec

### DIFF
--- a/app/controllers/collection_show_controllers/bredig_collection_controller.rb
+++ b/app/controllers/collection_show_controllers/bredig_collection_controller.rb
@@ -1,0 +1,14 @@
+# A sub-class of collection show controller that is specifically for the Oral History
+# collection -- it's routed to for that collection in our routes.rb
+#
+# It lets us override configuration and views.
+#
+# index view is overridden to use splash page template for splash_page_only?
+module CollectionShowControllers
+  class BredigCollectionController < CollectionShowController
+    configure_blacklight do |config|
+      # A specialty facet just for this collection. Possibly temporary.
+      config.add_facet_field "bredig_feature_facet", label: "Features", limit: 5
+    end
+  end
+end

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -179,6 +179,13 @@ class WorkIndexer < Kithe::Indexer
       acc.concat get_string_from_each_member(rec, :transcription) if rec.language != ['en']
     end
 
+    # add a 'translation' token in bredig_feature_facet if we have any translations
+    to_field "bredig_feature_facet" do |rec, acc|
+      if rec.members.any? {|m| m.is_a?(Asset) && m.english_translation.present? }
+        acc << "English Translation"
+      end
+    end
+
     # for oral histories, get biographical data. Some to same field as subject (text3_tesim), some
     # to our general-purpose "text_no_boost_tesim"
     each_record do |rec, context|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,15 @@ Rails.application.routes.draw do
     end
   end
 
+
+  # and a special controller for bredig, that at least initially only has customized facets
+  if ScihistDigicoll::Env.lookup(:bredig_collection_id)
+    constraints(collection_id: ScihistDigicoll::Env.lookup(:bredig_collection_id)) do
+      concerns :collection_showable, controller: "collection_show_controllers/bredig_collection"
+    end
+  end
+
+
   # and our default collection show page routing
   concerns :collection_showable
 

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -453,6 +453,7 @@ module ScihistDigicoll
     # SPECIFIC COLLECTION IDS
     # Used to trigger custom controllers/UI for specific known collections
     define_key :oral_history_collection_id, default: "gt54kn818"
+    define_key :bredig_collection_id, default: "qfih5hl"
 
     # hostname for legacy Oral History microsite, we catch requests to this
     # and redirect appropriately.


### PR DESCRIPTION
Ref #1391 and WCAG overall ticket at #565

https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md

Using the [axe tool from Deque](https://www.deque.com/axe/) to do some automated accessibility checking as part of our system tests.  This definitely doens't ensure accessibility, it's just one level of check, but it's good to have that level of check happening for future work we do, so it can warn us of things we might want to fix, or take a closer look at and ultimately tell the tool to ignore in some cases. 

We picked several major pages to incorporate an axe check in. If we add additional system tests for new kinds of pages in the future, we should add axe checks in them!

Note this PR will not currently pass becuase of unmerged #1408. Once that's merged, this one can be rebased/merged with master, and it should be green. In the meantime, it gives you an opportunity to see what axe failures look like in CI?

Note also that our axe tests in this PR have some "ignore these things" configured:

* For a Blacklight issue we can't easily fix, need it to be fixed in BL. https://github.com/projectblacklight/blacklight/pull/2491
* In OH transcript page, footnotes issue at #1411
* in OH transcript page, our audio navbar actually fails contrast test, with bright green on dark grey. :( Setting this aside for now, I'm not sure how to redesign it, we're kind of out of colors.