### PR TITLE
On the back-end catch bad date range params that trigger Solr error

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -498,7 +498,8 @@ class CatalogController < ApplicationController
     # Make sure it has that shape, or just abort, becuase it is likely to make blacklight_range_limit
     # choke and uncaught excpetion 500.
     #
-    # Additionally, newlines in values cause an error, just reject em too.
+    # Additionally, newlines and other things that aren't just integers can cause an error too,
+    # just insist on \d+ or empty string only.
 
     if params[:range].present?
       unless params[:range].respond_to?(:to_hash)
@@ -506,12 +507,9 @@ class CatalogController < ApplicationController
       end
 
       params[:range].each_pair do |_facet_key, range_limits|
-        unless range_limits.respond_to?(:to_hash) && range_limits[:begin].is_a?(String) && range_limits[:end].is_a?(String)
+        unless range_limits.respond_to?(:to_hash) && range_limits[:begin].is_a?(String) && range_limits[:end].is_a?(String) &&
+          range_limits[:begin] =~ /\A\d*\z/ && range_limits[:end] =~ /\A\d*\z/
           render(plain: "Invalid URL query parameter range=#{param_display.call(params[:range])}", status: 400) && return
-        end
-
-        if range_limits.values.grep(/\n/).present?
-          render(plain: "Invalid URL query parameter (newline) range=#{param_display.call(params[:range])}", status: 400) && return
         end
       end
     end

--- a/spec/requests/bad_blacklight_requests_spec.rb
+++ b/spec/requests/bad_blacklight_requests_spec.rb
@@ -29,6 +29,15 @@ describe CatalogController do
     end
   end
 
+  # This was another one used as some kind of attempt at injection attack, which
+  # was causing a Solr 4xx
+  describe "weird attack in range value" do
+    it "responds with 400" do
+      get "/catalog?range%5Byear_facet_isim%5D%5Bbegin%5D=1989%27,(;))%23-%20--&range%5Byear_facet_isim%5D%5Bend%5D=1989%27,(;))%23-%20--"
+      expect(response.code).to eq("400")
+    end
+  end
+
   # Missing facet ID, e.g.
   #    /collections/gt54kn818/facet
   # https://app.honeybadger.io/projects/58989/faults/80390739


### PR DESCRIPTION
The front-end is already preventing it via #1422.

But someone can still craft a URL that would trigger a Solr error, and show up in our error logs, ala #1415. So we catch that on the back-end too. Becuase it shoudln't be possible for a human using our actual front-end to do this, we can provide the same sort of unfriendly plain-text http 400 error message we do for other similar param validation, it should not be possible for a human using our front-end to see it.