### PR TITLE
Changes to work and asset controllers to prevent published works w/o a representative

### DIFF
--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -11,7 +11,8 @@ class Admin::WorksController < AdminController
            :remove_ohms_xml, :submit_searchable_transcript_source, :download_searchable_transcript_source,
            :remove_searchable_transcript_source, :create_combined_audio_derivatives, :update_oh_available_by_request,
            :update_oral_history_content]
-
+  before_action :prevent_deleting_parent_representative, only: [:destroy]
+  
   # GET /admin/works
   # GET /admin/works.json
   def index
@@ -219,6 +220,17 @@ class Admin::WorksController < AdminController
   # recursive CTE so it'll be efficient-ish.
   def publish
     authorize! :publish, @work
+    
+    if @work.representative.nil?
+      prevent_publication_because_no_representative && return
+    end
+    
+    # If you only want to publish the work and not its members,
+    # make sure it already has a published representative
+    if params[:cascade] != 'true' && !@work.representative.published?
+      prevent_publication_because_no_published_representative && return
+    end
+
     @work.class.transaction do
       @work.update!(published: true)
       if params[:cascade] == 'true'
@@ -250,6 +262,10 @@ class Admin::WorksController < AdminController
   # recursive CTE so it'll be efficient-ish.
   def unpublish
     authorize! :publish, @work
+    if would_remove_representative?(@work.parent)
+      render_refused_remove_representative("Can't unpublish '#{@work.title}'") && return
+    end
+
     @work.class.transaction do
       @work.update!(published: false)
       if params[:cascade] == 'true'
@@ -258,7 +274,6 @@ class Admin::WorksController < AdminController
         end
       end
     end
-
     redirect_to admin_work_url(@work)
   end
 
@@ -266,7 +281,9 @@ class Admin::WorksController < AdminController
   # DELETE /works/1.json
   def destroy
     authorize! :destroy, @work
-
+    if would_remove_representative?(@work.parent)
+      render_refused_remove_representative("Can't delete '#{@work.title}'") && return
+    end
     @work.destroy
     respond_to do |format|
       format.html { redirect_to cancel_url, notice: "Work '#{@work.title}' was successfully destroyed." }
@@ -453,6 +470,17 @@ class Admin::WorksController < AdminController
       @work = Work.includes(:leaf_representative).find_by_friendlier_id!(params[:id])
     end
 
+    def prevent_deleting_parent_representative
+      if @work.parent.present? && @work.parent.representative == @work && @work.parent.published?
+        respond_to do |format|
+          notice = "Could not destroy work '#{@work.title}'. '#{@work.parent.title}' is published and this is its representative."
+          format.html { redirect_to admin_work_path(@work.friendlier_id, anchor: "tab=nav-members"), notice: notice }
+          format.json { render json: { error: notice }, status: 422 }
+        end
+      end
+    end
+
+
     # only allow whitelisted params through (TODO, we're allowing all work params!)
     # Plus sanitization or any other mutation.
     #
@@ -567,5 +595,28 @@ class Admin::WorksController < AdminController
     end
     helper_method :cancel_url
 
+    def prevent_publication_because_no_representative
+      @work.errors.add(:base, "Can't publish '#{@work.title}': choose a published representative first.")
+      respond_to do |format|
+        format.html { render :edit }
+        format.json { render json: @work.errors, status: :unprocessable_entity }
+      end
+    end
+
+    def prevent_publication_because_no_published_representative
+      @work.errors.add(:base, "Can't publish '#{@work.title}': publish its representative #{@work.representative.title} first.")
+      respond_to do |format|
+        format.html { render :edit }
+        format.json { render json: @work.errors, status: :unprocessable_entity }
+      end
+    end
+
+    def would_remove_representative?(parent)
+      parent&.published? && parent.representative == @work
+    end
+
+    def render_refused_remove_representative(message)
+      redirect_to admin_work_path(@work), alert:  "#{message}: '#{parent.title}' is published and would be left without a representative. Unpublish '#{parent.title}' first."  
+    end
 
 end

--- a/spec/controllers/admin/assets_controller_spec.rb
+++ b/spec/controllers/admin/assets_controller_spec.rb
@@ -38,6 +38,30 @@ RSpec.describe Admin::AssetsController, :logged_in_user, type: :controller do
         expect(parent_work.members).to be_present
         expect(parent_work.members.all? { |m| m.published? }).to be true
       end
+      
+      context "asset is the representative of the published parent", logged_in_user: :admin do
+        let(:asset_child) { create(:asset_with_faked_file, published: true) }
+        let(:unpublished_asset_child) { create(:asset_with_faked_file, published: false) }
+        let!(:parent_work) { create(:work, :published, members:[asset_child, unpublished_asset_child], representative:asset_child) }
+        it "can't be removed" do
+          put :destroy, params: { id: asset_child.friendlier_id}
+          expect(response).to redirect_to(admin_work_path(parent_work, anchor: "tab=nav-members"))
+          expect(flash[:notice]).to match /Could not delete.*Its parent is published and this is its representative./
+          expect(asset_child.reload).to be_present
+          expect(parent_work.reload.representative).to eq asset_child
+        end
+        it "can't be unpublished" do
+          put :update, params: { id: asset_child.friendlier_id, "asset"=>{"published"=>"0"}}
+          expect(response).not_to have_http_status(:redirect)
+          expect(asset_child.reload.published?).to be true
+          expect(parent_work.reload.representative).to eq asset_child
+        end
+        it "non-representative asset can still be published" do
+          put :update, params: { id: unpublished_asset_child.friendlier_id, "asset"=>{"published"=>"1"}}
+          expect(response).to have_http_status(:redirect)
+          expect(unpublished_asset_child.reload.published?).to be true
+        end
+      end
     end
   end
 end

--- a/spec/controllers/admin/works_controller_spec.rb
+++ b/spec/controllers/admin/works_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
         end
       end
 
-      context "becuase it has multiple assets" do
+      context "because it has multiple assets" do
         let(:parent_work) { FactoryBot.create(:work) }
         let(:work) { FactoryBot.create(:work, :with_assets, asset_count: 5, parent: parent_work)}
 
@@ -108,7 +108,8 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
   end
 
   context "#batch_publish_toggle", logged_in_user: :admin do
-    let(:publishable_work) { create(:work, :with_complete_metadata, published: false) }
+    let(:representative) {  build(:asset_with_faked_file, published: true)}
+    let(:publishable_work) { create(:work, :with_complete_metadata, published: false, members: [representative], representative: representative) }
     let(:unpublishable_work) { create(:work, published: false) }
 
     context "unpublishable works" do
@@ -207,24 +208,24 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
     end
 
     context "create audio derivatives",  logged_in_user: :admin do
-      let!(:oral_history) { FactoryBot.create(
-        :work,
-        :published,      # with the metadata necessary to publish it...
-        published: false, # but not actually published.
-        genre: ["Oral histories"],
-        title: "Oral history with two interview audio segments")
-      }
+
       let!(:audio_asset_1)  { create(:asset, :inline_promoted_file,
           position: 1,
-          parent_id: oral_history.id,
+          title: "Audio asset 1",
           file: File.open((Rails.root + "spec/test_support/audio/ice_cubes.mp3"))
         )
       }
       let!(:audio_asset_2)  { create(:asset, :inline_promoted_file,
           position: 2,
-          parent_id: oral_history.id,
+          title: "Audio asset 2",
           file: File.open((Rails.root + "spec/test_support/audio/double_ice_cubes.mp3"))
         )
+      }      
+      let!(:oral_history) { FactoryBot.create(
+        :work,
+        genre: ["Oral histories"],
+        members: [audio_asset_1, audio_asset_2],
+        title: "Oral history with two interview audio segments")
       }
 
       it "kicks off an audio derivatives job" do
@@ -317,12 +318,17 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
       # works that have the necessary metadata to be published, but aren't actually published yet
       let(:work_child) { build(:work, :published, published: false) }
       let(:asset_child) { build(:asset, published: false) }
-      let(:work) { create(:work, :published, published: false, members: [asset_child, work_child]) }
+      let(:work) do
+        create(:work, :published).tap do |w|
+          w.members += [asset_child, work_child]
+          w.published = false
+          w.save!
+        end
+      end
 
       it "can publish, and publishes children" do
         put :publish, params: { id: work.friendlier_id, cascade: 'true' }
         expect(response.status).to redirect_to(admin_work_path(work))
-
         work.reload
         expect(work.published?).to be true
         expect(work.members.all? {|m| m.published?}).to be true
@@ -334,6 +340,64 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
         work.reload
         expect(work.published?).to be true
         expect(work.members.all? {|m| m.published?}).to be false
+      end
+
+      context "works without a published representative" do
+        context "work with nil representative" do
+          before do
+            work.update(representative: nil, published: false)
+          end
+          it "can't be published" do
+            put :publish, params: {
+              id: work.friendlier_id,
+            }
+            work.reload
+            expect(work.published?).to be false
+            expect(work.members.all? {|m| m.published?}).to be false
+          end
+        end
+
+        context "work with an unpublished asset representative" do
+          before do
+            work.update({representative: asset_child, published: false})
+            asset_child.update({published: false})
+          end
+          it "can't be published" do
+            put :publish, params: {
+              id: work.friendlier_id,
+            }
+            work.reload
+            expect(work.published?).to be false
+            expect(work.members.all? {|m| m.published?}).to be false
+          end
+        end
+
+        context "work with an unpublished child work representative" do
+          before do
+            work.update(representative: work_child, published: false)
+            work_child.update(published: false)
+          end
+          it "can't be published" do
+            put :publish, params: {
+              id: work.friendlier_id,
+            }
+            work.reload
+            expect(work.published?).to be false
+            expect(work.members.all? {|m| m.published?}).to be false
+          end
+        end
+      end
+
+      context "child work that is the representative of a published parent" do        
+        let!(:parent_work) { create(:work, :published, members:[child_work], representative:child_work, title: "Parent") }
+        let(:child_work) { create(:work, :published, title: "Representative") }
+        it "can't be removed" do
+          put :destroy, params: { id: child_work.friendlier_id}
+          expect(response).to redirect_to(admin_work_path(child_work, anchor: "tab=nav-members"))
+          expect(flash[:notice]).to match /Could not destroy work 'Representative'. 'Parent' is published and this is its representative./
+          expect(child_work.reload).to be_present
+          expect(parent_work.reload.representative).to eq child_work
+        end
       end
 
       it "can delete, and deletes children" do
@@ -349,7 +413,8 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
       context "work missing required fields for publication" do
         render_views
 
-        let(:work) { create(:private_work, rights: nil, format: nil, genre: nil, department: nil, date_of_work: nil) }
+        let(:representative) {  build(:asset_with_faked_file, published: true)}
+        let(:work) { create(:private_work, rights: nil, format: nil, genre: nil, department: nil, date_of_work: nil, members: [representative], representative: representative)}
 
         it "can not publish, displaying proper error and work form" do
           put :publish, params: { id: work.friendlier_id, cascade: 'true' }
@@ -364,8 +429,14 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
         end
 
         describe "child work missing required fields" do
-          let(:work_child) { build(:private_work) }
-          let(:work) { create(:work, :published, published: false, members: [work_child]) }
+          let(:work_child) { build(:private_work, title: "the_child_work_title") }
+          let(:work) do
+            create(:work, :published).tap do |w|
+              w.members << work_child
+              w.published = false
+              w.save!
+            end
+          end
 
           it "can not publish, displaing proper error for child work" do
             put :publish, params: { id: work.friendlier_id, cascade: 'true'}

--- a/spec/factory_specs/work_factory_spec.rb
+++ b/spec/factory_specs/work_factory_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe "work factory" do
+  describe "published work" do
+    let(:work) { build(:work, :published) }
+
+    it "is valid" do
+      expect(work).to be_valid
+    end
+
+    it "is published" do
+      expect(work).to be_published
+    end
+
+    it "creates with representative" do
+      expect(work.representative).to be_present
+    end
+  end
+
+  describe "oral history work" do
+    describe "published oral history work" do
+      let(:work) { build(:oral_history_work, :published) }
+
+      it "is genre oral history" do
+        expect(work.genre).to eq ["Oral histories"]
+      end
+
+      it "is valid" do
+        expect(work).to be_valid
+      end
+
+      it "is published" do
+        expect(work).to be_published
+      end
+
+      it "has representative" do
+        expect(work.representative).to be_present
+      end
+    end
+  end
+end

--- a/spec/mailers/oral_history_delivery_spec.rb
+++ b/spec/mailers/oral_history_delivery_spec.rb
@@ -2,23 +2,26 @@ require "rails_helper"
 
 RSpec.describe OralHistoryDeliveryMailer, :type => :mailer do
   describe "Sends out the items" do
+    let(:representative) do
+      create(:asset_with_faked_file, :pdf, published: true, title: "Preview PDF", position: 1) 
+    end
+    
     let(:members) do
       [
+        representative,
         create(:asset_with_faked_file, :mp3, published: false,
-          oh_available_by_request: true, title: "Protected mp3", position: 0),
+          oh_available_by_request: true, title: "Protected mp3", position: 2),
         create(:asset_with_faked_file, :pdf, published: false,
-          oh_available_by_request: true,  title: "Protected PDF", position: 1),
-        create(:asset_with_faked_file, :pdf, published: true,
-          title: "Preview PDF", position: 2),
+          oh_available_by_request: true,  title: "Protected PDF", position: 3),
         create(:asset_with_faked_file, :pdf, published: false,
-          title: "We will get sued if you send this out.", position: 3)
+          title: "We will get sued if you send this out.", position: 4)
       ]
     end
 
     let!(:work) do
-      create(:oral_history_work, published: true).tap do |work|
+      create(:oral_history_work, :published).tap do |work|
         work.members = members
-        work.representative =  members[2]
+        work.representative =  representative
         work.save!
         work.oral_history_content!.update(available_by_request_mode: :automatic)
       end

--- a/spec/presenters/child_count_display_fetcher_spec.rb
+++ b/spec/presenters/child_count_display_fetcher_spec.rb
@@ -24,7 +24,7 @@ describe ChildCountDisplayFetcher do
     end
 
     describe "with no members" do
-      let(:item) { create(:public_work) }
+      let(:item) { build(:public_work, members: []) }
 
       it "returns zero" do
         expect(item_counter.member_count_for_friendlier_id(item.friendlier_id)).to eq(0)

--- a/spec/services/work_pdf_creator_spec.rb
+++ b/spec/services/work_pdf_creator_spec.rb
@@ -121,9 +121,9 @@ describe WorkZipCreator do
   end
 
   describe "with no available published images" do
-    let(:work) {
-      create(:public_work, members: [create(:asset_with_faked_file, published: false)])
-    }
+    let(:work) do
+      build(:public_work, members: [create(:asset_with_faked_file, published: false)])
+    end
 
     it "raises on create" do
       expect{

--- a/spec/system/admin/oral_history_interviewee_bio_spec.rb
+++ b/spec/system/admin/oral_history_interviewee_bio_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 RSpec.describe "Oral History Access Interviewee bio", :logged_in_user, type: :system, queue_adapter: :test  do
-  let(:work) { create(:oral_history_work, published: true) }
+  let(:work) { create(:oral_history_work, :published) }
 
   it "can add an Interviewee Biography" do
     visit admin_interviewee_biographies_path

--- a/spec/system/oai_pmh_spec.rb
+++ b/spec/system/oai_pmh_spec.rb
@@ -78,9 +78,8 @@ RSpec.feature "OAI-PMH feed", js: false do
     end
   end
 
-  # should not create an error, as long as it's possible in DB
   describe "work with no representative" do
-    let!(:work_with_no_representative) { create(:work, :with_complete_metadata, title: "no representative", published: true) }
+    let!(:work_with_no_representative) { create(:work, :published, :with_complete_metadata, title: "no representative", members: [], representative: nil) }
 
     it "renders" do
       visit(oai_provider_path(verb: "ListRecords", metadataPrefix: "oai_dc"))

--- a/spec/system/oral_history_by_request_spec.rb
+++ b/spec/system/oral_history_by_request_spec.rb
@@ -12,15 +12,7 @@ describe "Oral History with by-request delivery", type: :system, js: true, queue
 
   context "When you visit an OH with protected by request, automatic delivery assets" do
     let!(:work) do
-      create(:oral_history_work, published: true).tap do |work|
-        work.members << preview_pdf
-        work.members << protected_pdf
-        work.members << protected_mp3
-        work.members << portrait
-
-        work.representative =  preview_pdf
-        work.save!
-
+      build(:oral_history_work, :published, members: [preview_pdf, protected_pdf, protected_mp3, portrait], representative: preview_pdf).tap do |work|
         work.oral_history_content!.update(available_by_request_mode: :automatic)
       end
     end
@@ -95,14 +87,7 @@ describe "Oral History with by-request delivery", type: :system, js: true, queue
 
   context "When you visit an OH with protected by request, approved delivery assets" do
     let!(:work) do
-      create(:oral_history_work, published: true).tap do |work|
-        work.members << preview_pdf
-        work.members << protected_pdf
-        work.members << protected_mp3
-
-        work.representative =  preview_pdf
-        work.save!
-
+      build(:oral_history_work, :published, members: [preview_pdf, protected_pdf, protected_mp3], representative: preview_pdf).tap do |work|
         work.oral_history_content!.update(available_by_request_mode: :manual_review)
       end
     end
@@ -144,7 +129,6 @@ describe "Oral History with by-request delivery", type: :system, js: true, queue
       expect(new_req.intended_use).to eq "Fun & games"
       expect(new_req.delivery_status_pending?).to be(true)
 
-      # expect(page).to have_text("Your request has been logged.")
 
       expect(ActionMailer::MailDeliveryJob).to have_been_enqueued
     end

--- a/spec/system/oral_history_collection_show_spec.rb
+++ b/spec/system/oral_history_collection_show_spec.rb
@@ -12,14 +12,14 @@ describe "Collection show page", solr: true, indexable_callbacks: true do
         #
         # We will assign some that will show up on front page in counts
         #
-        create(:oral_history_work,
-          published: true, title: "public work one",
+        create(:oral_history_work, :published,
+          title: "public work one",
           date_of_work: Work::DateOfWork.new(start: "2019"),
           subject: ["Nobel Prize winners"],
           contained_by: [col])
 
-        create(:oral_history_work,
-          published: true, title: "public work two",
+        create(:oral_history_work, :published,
+          title: "public work two",
           date_of_work: Work::DateOfWork.new(start: "1900"),
           project: ["Nanotechnology"],
           contained_by: [col])

--- a/spec/system/oral_history_with_audio_spec.rb
+++ b/spec/system/oral_history_with_audio_spec.rb
@@ -5,9 +5,7 @@ describe "Oral history with audio display", type: :system, js: true do
   let(:portrait) { create(:asset_with_faked_file, role: "portrait")}
 
   let!(:parent_work) do
-    create(:oral_history_work, :ohms_xml, published: true).tap do |work|
-      work.members << portrait
-    end
+    create(:oral_history_work, :published, :ohms_xml, members: [portrait])
   end
 
   let(:audio_file_path) { Rails.root.join("spec/test_support/audio/5-seconds-of-silence.mp3")}
@@ -392,7 +390,7 @@ describe "Oral history with audio display", type: :system, js: true do
     let(:interviewer_profile) { InterviewerProfile.create(name: "Smith, John", profile: "This has some <i>html</i>")}
 
     let(:parent_work) {
-      create(:oral_history_work, rights: "http://creativecommons.org/publicdomain/mark/1.0/", published: true).tap do |work|
+      create(:oral_history_work, :published, rights: "http://creativecommons.org/publicdomain/mark/1.0/").tap do |work|
         work.oral_history_content!.update(ohms_xml_text: File.read(ohms_xml_path), interviewer_profiles: [interviewer_profile])
       end
     }


### PR DESCRIPTION
Ref #496

- Require a published representative to publish a work
- Prevent the deletion of a work or asset if the published parent work would be left without a representative

What this means, practically, to an admin user:

 - Pick a published work. Try deleting its representative. You can no longer do that.
 - Unpublish the work. Now, you can delete the representative.
 - However, you can’t republish the work until you explicitly assign it a new representative.

The old PR was getting really cluttered and hard to work with, so this is the same information presented more cleanly.

