### PR TITLE
remove anchor on cancel URL

### DIFF
--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -556,11 +556,11 @@ class Admin::WorksController < AdminController
 
     def cancel_url
       if @work && @work.parent
-        return admin_work_path(@work.parent, anchor: "admin-nav")
+        return admin_work_path(@work.parent)
       end
 
       if @work && @work.persisted?
-        return admin_work_path(@work, anchor: "admin-nav")
+        return admin_work_path(@work)
       end
 
       admin_works_path


### PR DESCRIPTION
The anchor was preventing the cancel url from working sometimes -- after a validation error, the cancel url would be the same as the URL you were already looking at in browser, and when it included a #fragment, the browser would not actually reload the page on clicking it, as intended. oops.

Also this was the wrong fragment anchor for our new tab system anyway. AND the tab it was trying to highlight is default tab for this page anyway, not really necessary.

Just remove it!