### PR TITLE
New sort for recent items on the home page takes into account published_at, if available.

### DIFF
--- a/app/presenters/recent_items.rb
+++ b/app/presenters/recent_items.rb
@@ -28,9 +28,9 @@ class RecentItems
   end
 
   def fetch_bag
-    Work.where('published = true').
+    Work.where(published: true).
       includes(:leaf_representative).
-      order(published_at: :desc, updated_at: :desc).
+      order(Arel.sql "published_at desc nulls last, updated_at desc").
       limit(@how_many_works_in_bag)
   end
 

--- a/spec/presenters/recent_items_spec.rb
+++ b/spec/presenters/recent_items_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+describe RecentItems, type: :model do
+  describe "correctly picks most recently updated" do
+    let(:bag) { RecentItems.new(how_many_works_to_show: 2, how_many_works_in_bag: 10).fetch_bag }
+    describe "Works with nil published date" do
+      let!(:works) { 
+        (1..10).to_a.map do |i|
+          midnight = Time.now.to_date.to_time
+          create(:public_work, title: i).tap do |w|
+            w.published_at = [midnight] * 5 + [nil] * 5
+            w.updated_at   = i.days.ago
+            w.save(validate:false)
+          end
+        end
+      }
+      it "are correctly sorted" do
+        expect(bag.map(&:title)).to eq (1..10).map(&:to_s)
+      end
+    end
+  end
+end

--- a/spec/presenters/recent_items_spec.rb
+++ b/spec/presenters/recent_items_spec.rb
@@ -1,40 +1,61 @@
 require 'rails_helper'
 describe RecentItems, type: :model do
-  describe "correctly picks most recently updated" do
-    let(:bag) { RecentItems.new(how_many_works_to_show: 2, how_many_works_in_bag: 10).fetch_bag }
-    let(:published_at) {
-      midnight = Time.now.to_date.to_time
-      [nil] * 5 + [midnight] * 5
-    }
-    let!(:works) { 
-      (1..10).to_a.map do |i|
-        create(:public_work, title: i).tap do |w|
-          w.published_at = published_at[i]
-          w.updated_at   = i.days.ago
-          w.save(validate:false)
-        end
+  let(:bag) do
+    RecentItems.new(
+      how_many_works_to_show: 2,
+      how_many_works_in_bag: 10).fetch_bag
+  end
+  # Evaluating (for instance) 2.days.ago
+  # repeatedly yields different results.
+  let(:days_ago) { (1..6).to_a.map { |i| i.days.ago } }
+  let!(:works) do
+    [
+      create(:public_work).tap do |w|
+        w.title = "published_at old"
+        w.published_at = days_ago[5]
+        w.updated_at   = days_ago[5]
+        w.save(validate:false)
+      end,
+      create(:public_work).tap do |w|
+        w.title = "published_at medium"
+        w.published_at = days_ago[4]
+        w.updated_at   = days_ago[4]
+        w.save(validate:false)
+      end,
+      create(:public_work).tap do |w|
+        w.title = "published_at new, updated_at older"
+        w.published_at = days_ago[3]
+        w.updated_at   = days_ago[3]
+        w.save(validate:false)
+      end,
+      create(:public_work).tap do |w|
+        w.title = "published_at new, updated_at newer"
+        w.published_at = days_ago[3]
+        w.updated_at   = days_ago[2]
+        w.save(validate:false)
+      end,
+      create(:public_work).tap do |w|
+        w.title = "published_at nil, updated_at older"
+        w.published_at = nil
+        w.updated_at   = days_ago[2]
+        w.save(validate:false)
+      end,
+      create(:public_work).tap do |w|
+        w.title = "published_at nil, updated_at newer"
+        w.published_at = nil
+        w.updated_at   = days_ago[1]
+        w.save(validate:false)
       end
-    }
-
-    describe "Works with nil published date" do
-      it "sorts nil values after dates" do
-        midnight = Time.now.to_date.to_time
-        expect(bag.map(&:published_at)).to eq [midnight] * 5 + [nil] * 5
-      end
-    end
-
-    describe "identical published_at dates" do
-      let(:published_at_midnight) {
-        midnight = Time.now.to_date.to_time
-        published_at_midnight = bag.select{|w| w.published_at == midnight}  
-      }
-      it "are sorted by reverse cron updated_at" do
-        should_be_reverse_cron = published_at_midnight.
-          map(&:updated_at)
-        reverse_cron = should_be_reverse_cron.dup.
-          sort.reverse
-        expect(should_be_reverse_cron).to eq reverse_cron
-      end
-    end
+    ]
+  end
+  it "sorts nil values after dates; breaks ties between published_at using updated_at" do
+    expect(bag.map(&:title)).to eq [
+      "published_at new, updated_at newer",
+      "published_at new, updated_at older",
+      "published_at medium",
+      "published_at old",
+      "published_at nil, updated_at newer",
+      "published_at nil, updated_at older"
+    ]
   end
 end

--- a/spec/presenters/recent_items_spec.rb
+++ b/spec/presenters/recent_items_spec.rb
@@ -2,19 +2,38 @@ require 'rails_helper'
 describe RecentItems, type: :model do
   describe "correctly picks most recently updated" do
     let(:bag) { RecentItems.new(how_many_works_to_show: 2, how_many_works_in_bag: 10).fetch_bag }
-    describe "Works with nil published date" do
-      let!(:works) { 
-        (1..10).to_a.map do |i|
-          midnight = Time.now.to_date.to_time
-          create(:public_work, title: i).tap do |w|
-            w.published_at = [midnight] * 5 + [nil] * 5
-            w.updated_at   = i.days.ago
-            w.save(validate:false)
-          end
+    let(:published_at) {
+      midnight = Time.now.to_date.to_time
+      [nil] * 5 + [midnight] * 5
+    }
+    let!(:works) { 
+      (1..10).to_a.map do |i|
+        create(:public_work, title: i).tap do |w|
+          w.published_at = published_at[i]
+          w.updated_at   = i.days.ago
+          w.save(validate:false)
         end
+      end
+    }
+
+    describe "Works with nil published date" do
+      it "sorts nil values after dates" do
+        midnight = Time.now.to_date.to_time
+        expect(bag.map(&:published_at)).to eq [midnight] * 5 + [nil] * 5
+      end
+    end
+
+    describe "identical published_at dates" do
+      let(:published_at_midnight) {
+        midnight = Time.now.to_date.to_time
+        published_at_midnight = bag.select{|w| w.published_at == midnight}  
       }
-      it "are correctly sorted" do
-        expect(bag.map(&:title)).to eq (1..10).map(&:to_s)
+      it "are sorted by reverse cron updated_at" do
+        should_be_reverse_cron = published_at_midnight.
+          map(&:updated_at)
+        reverse_cron = should_be_reverse_cron.dup.
+          sort.reverse
+        expect(should_be_reverse_cron).to eq reverse_cron
       end
     end
   end


### PR DESCRIPTION
Included a basic smoke tests for recent_items, which involved a small refactor.