### PR TITLE
When recent items enlarge on overlap, they should be ABOVE the other things they overlap.

### DIFF
--- a/app/assets/stylesheets/local/homepage.scss
+++ b/app/assets/stylesheets/local/homepage.scss
@@ -173,6 +173,7 @@
         transition: transform .2s;
         &:hover, &:focus {
           transform: scale(1.2);
+          z-indeX: 1;
 
           .recent-title {
             opacity: 1;


### PR DESCRIPTION
This problem before this PR: 

![Screen Shot 2021-11-23 at 12 19 28 PM](https://user-images.githubusercontent.com/149304/143073155-7e5089a2-2c65-495d-8bf6-1b07f6005c2a.png)

Fixed with this one-liner. CSS stacking rules are confusing, something about the way we do potentially lazy-loading ThumbComponent layout triggered this problem, which wouldn't be there in simpler markup.  But this easy fix fixed it. 