### PR TITLE
Override Blacklight changed CSS to put .constraints-container back to display:block

### DIFF
--- a/app/assets/stylesheets/local/results_constraints.scss
+++ b/app/assets/stylesheets/local/results_constraints.scss
@@ -11,6 +11,12 @@
   margin-top: -1 * (1.375 * $navbar-margin-bottom) / 2; // dunno, but matches chf_sufia
   line-height: 2.5;
 
+  // Blacklight 7.20.0 changed this to display:flex, which messes up
+  // some our custom styles written for display:block, and has other
+  // as-of-yet unsolved problems too. https://github.com/projectblacklight/blacklight/issues/2552
+  // Make it display:block for our custom styling again.
+  display: block;
+
   padding-top: 0;
   padding-bottom: 0;
 


### PR DESCRIPTION
We had written some custom CSS for display:block that doesn't work when BL 7.20.0 changes to display:flex. The display:flex also causes some other display we find undesirable. https://github.com/projectblacklight/blacklight/issues/2552

We'll just stick with display:block at least for now, although diverging from Blacklight CSS further increases possible maintenance risk.

Ref #1478