### PR TITLE
Use `published_at` for the "Newest Added" and "Oldest Added" search results sorts.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -423,7 +423,7 @@ class CatalogController < ApplicationController
 
     config.add_sort_field("recently_added") do |field|
       field.label = "recently added"
-      field.sort = "date_published_dtsi desc, date_modified_dtsi desc"
+      field.sort = "date_published_dtsi desc, date_created_dtsi desc"
       # will be used by our custom code as default sort when no query has been entered
       field.blank_query_default = true
     end
@@ -431,7 +431,7 @@ class CatalogController < ApplicationController
     # limit to just available for logged-in admins, with `if ` param
     config.add_sort_field("oldest_added") do |field|
       field.label = "oldest added"
-      field.sort = "date_published_dtsi asc, date_modified_dtsi asc"
+      field.sort = "date_published_dtsi asc, date_created_dtsi asc"
       field.if = ->(controller, field) { controller.current_user }
     end
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -428,13 +428,6 @@ class CatalogController < ApplicationController
       field.blank_query_default = true
     end
 
-    # limit to just available for logged-in admins, with `if ` param
-    config.add_sort_field("oldest_added") do |field|
-      field.label = "oldest added"
-      field.sort = "date_published_dtsi asc, date_created_dtsi asc"
-      field.if = ->(controller, field) { controller.current_user }
-    end
-
     config.add_sort_field("date_modified_desc") do |field|
       field.label = "date modified \u25BC"
       field.sort = "date_modified_dtsi desc"
@@ -568,7 +561,6 @@ class CatalogController < ApplicationController
     "earliest_year asc" => "oldest_date",
     "score desc, system_create_dtsi desc" => "relevance",
     "system_create_dtsi desc" => "recently_added",
-    "system_create_dtsi asc" => "oldest_added",
     "system_modified_dtsi desc" => "date_modified_desc",
     "system_modified_dtsi asc" => "date_modified_asc"
   }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -423,16 +423,15 @@ class CatalogController < ApplicationController
 
     config.add_sort_field("recently_added") do |field|
       field.label = "recently added"
-      field.sort = "date_published_dtsi desc, date_created_dtsi desc"
+      field.sort = "date_published_dtsi desc, date_modified_dtsi desc"
       # will be used by our custom code as default sort when no query has been entered
       field.blank_query_default = true
     end
 
     # limit to just available for logged-in admins, with `if ` param
-
     config.add_sort_field("oldest_added") do |field|
       field.label = "oldest added"
-      field.sort = "date_published_dtsi asc, date_created_dtsi asc"
+      field.sort = "date_published_dtsi asc, date_modified_dtsi asc"
       field.if = ->(controller, field) { controller.current_user }
     end
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -448,6 +448,18 @@ class CatalogController < ApplicationController
       field.if = ->(controller, field) { controller.current_user }
     end
 
+    config.add_sort_field("date_created_asc") do |field|
+      field.label = "date created \u25BC"
+      field.sort = "date_created_dtsi asc"
+      field.if = ->(controller, field) { controller.current_user }
+    end
+
+    config.add_sort_field("date_created_desc") do |field|
+      field.label = "date created \u25B2"
+      field.sort = "date_created_dtsi desc"
+      field.if = ->(controller, field) { controller.current_user }
+    end
+
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -423,7 +423,7 @@ class CatalogController < ApplicationController
 
     config.add_sort_field("recently_added") do |field|
       field.label = "recently added"
-      field.sort = "date_created_dtsi desc"
+      field.sort = "date_published_dtsi desc, date_created_dtsi desc"
       # will be used by our custom code as default sort when no query has been entered
       field.blank_query_default = true
     end
@@ -432,7 +432,7 @@ class CatalogController < ApplicationController
 
     config.add_sort_field("oldest_added") do |field|
       field.label = "oldest added"
-      field.sort = "date_created_dtsi asc"
+      field.sort = "date_published_dtsi asc, date_created_dtsi asc"
       field.if = ->(controller, field) { controller.current_user }
     end
 

--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -25,6 +25,13 @@ class CollectionIndexer < Kithe::Indexer
       end
     end
 
+    to_field "date_published_dtsi" do |rec, acc|
+      if rec.published_at
+        acc << rec.published_at.utc.iso8601
+      end
+    end
+
+
     # for now we index 'published', not sure if we'll move to ONLY indexing
     # things that are published.
     to_field "published_bsi", obj_extract("published?")

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -84,9 +84,6 @@ class WorkIndexer < Kithe::Indexer
 
     # Note standard created_at, updated_at, and published are duplicated
     # in CollectionIndexer. Maybe we want to DRY it somehow.
-
-    # May want to switch to or add a 'date published' instead, right
-    # now we only have date added to DB, which is what we had in sufia.
     to_field "date_created_dtsi" do |rec, acc|
       if rec.created_at
         acc << rec.created_at.utc.iso8601
@@ -98,6 +95,14 @@ class WorkIndexer < Kithe::Indexer
         acc << rec.updated_at.utc.iso8601
       end
     end
+
+
+    to_field "date_published_dtsi" do |rec, acc|
+      if rec.published_at
+        acc << rec.published_at.utc.iso8601
+      end
+    end
+
 
     # for now we index 'published', not sure if we'll move to ONLY indexing
     # things that are published.

--- a/app/views/admin/works/_metadata.html.erb
+++ b/app/views/admin/works/_metadata.html.erb
@@ -37,6 +37,9 @@
     <dt>Created</dt>
     <dd><%= l @work.created_at, format: :admin %></dd>
 
+    <dt>Published</dt>
+    <dd><%= l(@work.published_at, format: :admin) if  @work.published_at.present? %></dd>
+
     <dt>Last Modified</dt>
     <dd><%= l @work.updated_at, format: :admin %></dd>
 

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -74,6 +74,13 @@ describe WorkIndexer do
       expect(output_hash["oh_birth_country_facet"]).to eq(work.oral_history_content.interviewee_biographies.collect(&:birth).flatten.collect(&:country_name))
     end
 
+    it "indexes created, modified, and published dates" do
+      output_hash = WorkIndexer.new.map_record(no_members_work)
+      expect(Time.parse(output_hash["date_created_dtsi"  ].first)).to be_within(1.seconds).of Time.now
+      expect(Time.parse(output_hash["date_modified_dtsi" ].first)).to be_within(1.seconds).of Time.now
+      expect(Time.parse(output_hash["date_published_dtsi"].first)).to be_within(1.seconds).of Time.now
+    end
+
     describe "features facet" do
       it "has transcript value" do
         output_hash = WorkIndexer.new.map_record(work)

--- a/spec/system/catalog_search_spec.rb
+++ b/spec/system/catalog_search_spec.rb
@@ -233,51 +233,51 @@ describe CatalogController, solr: true, indexable_callbacks: true do
         create(:public_work).tap do |w|
           w.title = "published_at old"
           w.published_at = days_ago[5]
-          w.updated_at   = days_ago[5]
+          w.created_at   = days_ago[5]
           w.save(validate:false)
         end,
         create(:public_work).tap do |w|
           w.title = "published_at medium"
           w.published_at = days_ago[4]
-          w.updated_at   = days_ago[4]
+          w.created_at   = days_ago[4]
           w.save(validate:false)
         end,
         create(:public_work).tap do |w|
-          w.title = "published_at new, updated_at older"
+          w.title = "published_at new, created_at older"
           w.published_at = days_ago[3]
-          w.updated_at   = days_ago[3]
+          w.created_at   = days_ago[3]
           w.save(validate:false)
         end,
         create(:public_work).tap do |w|
-          w.title = "published_at new, updated_at newer"
+          w.title = "published_at new, created_at newer"
           w.published_at = days_ago[3]
-          w.updated_at   = days_ago[2]
+          w.created_at   = days_ago[2]
           w.save(validate:false)
         end,
         create(:public_work).tap do |w|
-          w.title = "published_at nil, updated_at older"
+          w.title = "published_at nil, created_at older"
           w.published_at = nil
-          w.updated_at   = days_ago[2]
+          w.created_at   = days_ago[2]
           w.save(validate:false)
         end,
         create(:public_work).tap do |w|
-          w.title = "published_at nil, updated_at newer"
+          w.title = "published_at nil, created_at newer"
           w.published_at = nil
-          w.updated_at   = days_ago[1]
+          w.created_at   = days_ago[1]
           w.save(validate:false)
         end
       ]
     end
-    it "default search shows them sorted correctly: first by published_at, then by updated_at" do
+    it "default search shows them sorted correctly: first by published_at, then by created_at" do
       visit search_catalog_path(search_field: "all_fields")
       titles_in_order =  page.find_all('.scihist-results-list-item-content h2 a').map {|link| link.text}
       expect(titles_in_order).to eq [
-        "published_at new, updated_at newer",
-        "published_at new, updated_at older",
+        "published_at new, created_at newer",
+        "published_at new, created_at older",
         "published_at medium",
         "published_at old",
-        "published_at nil, updated_at newer",
-        "published_at nil, updated_at older"
+        "published_at nil, created_at newer",
+        "published_at nil, created_at older"
       ]
     end
   end

--- a/spec/system/catalog_search_spec.rb
+++ b/spec/system/catalog_search_spec.rb
@@ -225,4 +225,60 @@ describe CatalogController, solr: true, indexable_callbacks: true do
       end
     end
   end
+
+  describe "works with various combinations of published_at and modified_at" do
+    let(:days_ago) { (1..6).to_a.map { |i| i.days.ago } }
+    let!(:works) do
+      [
+        create(:public_work).tap do |w|
+          w.title = "published_at old"
+          w.published_at = days_ago[5]
+          w.updated_at   = days_ago[5]
+          w.save(validate:false)
+        end,
+        create(:public_work).tap do |w|
+          w.title = "published_at medium"
+          w.published_at = days_ago[4]
+          w.updated_at   = days_ago[4]
+          w.save(validate:false)
+        end,
+        create(:public_work).tap do |w|
+          w.title = "published_at new, updated_at older"
+          w.published_at = days_ago[3]
+          w.updated_at   = days_ago[3]
+          w.save(validate:false)
+        end,
+        create(:public_work).tap do |w|
+          w.title = "published_at new, updated_at newer"
+          w.published_at = days_ago[3]
+          w.updated_at   = days_ago[2]
+          w.save(validate:false)
+        end,
+        create(:public_work).tap do |w|
+          w.title = "published_at nil, updated_at older"
+          w.published_at = nil
+          w.updated_at   = days_ago[2]
+          w.save(validate:false)
+        end,
+        create(:public_work).tap do |w|
+          w.title = "published_at nil, updated_at newer"
+          w.published_at = nil
+          w.updated_at   = days_ago[1]
+          w.save(validate:false)
+        end
+      ]
+    end
+    it "default search shows them sorted correctly: first by published_at, then by updated_at" do
+      visit search_catalog_path(search_field: "all_fields")
+      titles_in_order =  page.find_all('.scihist-results-list-item-content h2 a').map {|link| link.text}
+      expect(titles_in_order).to eq [
+        "published_at new, updated_at newer",
+        "published_at new, updated_at older",
+        "published_at medium",
+        "published_at old",
+        "published_at nil, updated_at newer",
+        "published_at nil, updated_at older"
+      ]
+    end
+  end
 end


### PR DESCRIPTION
 - Add new solr sort using `published_at` (the tiebreaker for the sort, if there's no value, is `created_at`);
 - Use that sort in search results, with the existing labels "newest added"  (which were formerly actually sorting by `created_at`);
 - removed admin-only "oldest added", no longer needed. 
 -  Display `published_at` on admin work metadata show page along with its friends `created_at` and `modified_at`;
 - Add two new sorts (visible to admins only) to explicitly sort works by `created_at`, `asc` and `desc`;
 - We are indexing published_at for collections too, but at the moment that date isn't being set when you publish a collection.

We are also not changing the display of the list of works in `/admin`, which can be sorted by `created` or `last modified`, neither of which is our concern here.

Ref #1410 .

This will require a reindex.