### PR TITLE
add current user to honeybadger context

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,7 +31,8 @@ class ApplicationController < ActionController::Base
     timecode = Time.now.gmtime.to_i
     Honeybadger.context({
       :papertrail_url => "https://papertrailapp.com/events?focus=#{timecode}&selected=#{timecode}",
-      :request_id => request.uuid
+      :request_id => request.uuid,
+      :current_user_email => current_user&.email
     })
   end
 


### PR DESCRIPTION
Useful so we can check with the person doing the ingest when an error happens in ingest. Although actually won't work if the error happened in a bg job as it often does, I now realize. Becuase there's no logged in user there. Oh well, can't hurt might help in some situations.

Ref #1452