### PR TITLE
Admin work search includes UUID id

### DIFF
--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -80,6 +80,9 @@
       <dt class="col-sm-4">Last Modified</dt>
       <dd class="col-sm-8"><%= l @asset.updated_at, format: :admin %></dd>
 
+      <dt class="col-sm-4">Internal ID</dt>
+      <dd class="col-sm-8 text-monospace small"><%= @asset.id %></dd>
+
       <dt class="col-sm-4">Orig. Filename</dt>
       <dd class="col-sm-8"><%= @asset&.file&.metadata.try { |h| h["filename"]} %></dd>
 

--- a/app/views/admin/works/_metadata.html.erb
+++ b/app/views/admin/works/_metadata.html.erb
@@ -43,6 +43,9 @@
     <dt>Last Modified</dt>
     <dd><%= l @work.updated_at, format: :admin %></dd>
 
+    <dt>Internal ID</dt>
+    <dd class="text-monospace small"><%= @work.id %></dd>
+
     <dt>Title</dt>
     <dd><%= work.title %></dd>
 

--- a/app/views/admin/works/index.html.erb
+++ b/app/views/admin/works/index.html.erb
@@ -10,9 +10,9 @@
   <div class="row">
     <div class="input-group col-sm-10 mb-3">
       <div class="input-group-prepend">
-        <%= f.label :title_or_friendlier_id_cont, "In Title or ID", class: "input-group-text" %>
+        <%= label_tag "q[q]", "In Title or ID", class: "input-group-text" %>
       </div>
-      <%= f.search_field :title_or_friendlier_id_cont, class: "form-control" %>
+      <%= search_field_tag "q[q]", params[:q][:q], class: "form-control" %>
       <div class="input-group-append">
         <%= f.button "Search", class: "btn btn-primary" %>
       </div>


### PR DESCRIPTION
- display internal UUID pk on staff page
  * also on Asset admin page, why not. 

- Query searches id field too
    * By moving it out of ransack so we can just supply our own logic for handling the UUID. We cast it so it just turns into NULL if it's not a valid UUID format, and then OR it together with the other text fields -- the text fields use ILIKE case-insenstive like, but the UUID field just uses equality.
    * Ransack is convenient when you are on it's path, but when fighting it to do somethin weird... we end up using it less and less, resulting in a weird hybrid. Oh well!

Ref #1464
