### PR TITLE
Fix rake scihist:resque:prune_expired_workers to work on heroku

### DIFF
--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -21,7 +21,7 @@ namespace :scihist do
   namespace :resque do
     desc "prune workers resque knows haven't sent a heartbeat in a while"
     # resque is supposed to do this itself sometimes, but doesn't always.
-    task :prune_expired_workers do
+    task :prune_expired_workers => :environment do
       expired = Resque::Worker.all_workers_with_expired_heartbeats
       if expired.present?
         $stderr.puts "pruning: #{expired}"


### PR DESCRIPTION
We need  :environment dependency to get proper resque connection details

Not sure why. There may be another way to get proper connection details. But this is one simple way to fix it. It wasn't getting proper connection details on heroku before, this fixed it.