### PR TITLE
Remove "project" data from json_attributes column in db

### DIFF
--- a/lib/tasks/data_fixes/remove_project_data.rake
+++ b/lib/tasks/data_fixes/remove_project_data.rake
@@ -1,0 +1,19 @@
+namespace :scihist do
+  namespace :data_fixes do
+    # We'll be removing the "project" attribute altogether, first
+    # remove the data.
+    task :remove_project_data => :environment do
+      Work.find_each do |work|
+        # actually a bit hard to completely remove this key from the DB,
+        # instead of just having it be an empty array cast per current data
+        # types! This seems to work. And will have the benefit of continuing
+        # to work AFTER the project attr is really removed too.
+        #
+        # There would have been a way to do this in a single raw SQL if
+        # we really wanted to.
+        work.json_attributes.delete("project")
+        work.save!
+      end
+    end
+  end
+end


### PR DESCRIPTION
We are no longer tracking data here, using "Collection" feature instead. Ref #1492

Note that #1503  MUST be merged AND deployed before running this -- can't remove the data until we stop trying to use it there!
