### PR TITLE
Remove 'project' attribute from Work

### DIFF
--- a/app/components/work_show_info_component.html.erb
+++ b/app/components/work_show_info_component.html.erb
@@ -148,7 +148,6 @@
     </tr>
   <% end %>
 
-  <%= render AttributeTable::RowComponent.new(:project, values: project, link_to_facet: "project_facet", alpha_sort: true) %>
   <%= render AttributeTable::RowComponent.new(:series_arrangement, values: series_arrangement) %>
 
   <% if @work.physical_container.present? %>

--- a/app/components/work_show_info_component.rb
+++ b/app/components/work_show_info_component.rb
@@ -12,7 +12,7 @@ class WorkShowInfoComponent < ApplicationComponent
     :contained_by, :date_of_work, :department,
     :description, :digitization_funder, :extent, :exhibition,
     :format, :genre, :inscription, :language, :medium,
-    :parent, :physical_container, :project, :provenance, :published?,
+    :parent, :physical_container, :provenance, :published?,
     :rights, :rights_holder, :series_arrangement,
     :source, :subject, :title, to: :work
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -283,7 +283,6 @@ class CatalogController < ApplicationController
     config.add_facet_field "rights_facet", helper_method: :rights_label, label: "Rights", limit: 5
     config.add_facet_field 'department_facet', label: "Department", limit: 5
     config.add_facet_field 'exhibition_facet', label: "Exhibition", limit: 5
-    config.add_facet_field 'project_facet',    label: "Project",    limit: 5
     config.add_facet_field 'published_bsi',    label: "Visibility (Staff-only)", show: :current_user, helper_method: :visibility_facet_labels
 
 

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -45,7 +45,6 @@ class WorkIndexer < Kithe::Indexer
     to_field "text_no_boost_tesim", obj_extract("inscription"), transform(->(v) { "#{v.location}: #{v.text}" })
     to_field "text_no_boost_tesim", obj_extract("additional_credit"), transform(->(v) { "#{v.role}: #{v.name}" })
     to_field ["text_no_boost_tesim", "exhibition_facet"], obj_extract("exhibition")
-    to_field ["text_no_boost_tesim", "project_facet"], obj_extract("project")
     to_field "text_no_boost_tesim", obj_extract("digitization_funder")
     to_field "text_no_boost_tesim", obj_extract("extent")
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -33,7 +33,6 @@ class Work < Kithe::Work
   validates :format, array_inclusion: { in: ControlledLists::FORMAT }
   validates :genre, array_inclusion: { in: ControlledLists::GENRE  }
   validates :exhibition, array_inclusion: { in: ControlledLists::EXHIBITION  }
-  validates :project, array_inclusion: { in: ControlledLists::PROJECT  }
   validates :related_url, array_inclusion: {
     proc: ->(v) { ScihistDigicoll::Util.valid_url?(v) } ,
     message: "is not a valid url: %{rejected_values}"
@@ -66,7 +65,6 @@ class Work < Kithe::Work
 
   attr_json :department, :string
   attr_json :exhibition, :string, array: true, default: -> { [] }
-  attr_json :project, :string, array: true, default: -> { [] }
   attr_json :series_arrangement, :string, array: true, default: -> { [] }
   attr_json :physical_container, Work::PhysicalContainer.to_type
 

--- a/app/models/work/controlled_lists.rb
+++ b/app/models/work/controlled_lists.rb
@@ -125,21 +125,5 @@ class Work
       "Things Fall Apart",
       "Transmutations"
     ]
-
-    PROJECT = [
-      'Atmospheric Science',
-      'Chemical History of Electronics',
-      "Imagining Philadelphia's Energy Futures",
-      'Life Sciences Foundation',
-      'Mass Spectrometry',
-      'Nanotechnology',
-      'Oral History of the Toxic Substances Control Act',
-      'Origins of Science and Technology Studies',
-      'Pew Biomedical Scholars',
-      'REACH Ambler',
-      'Scientific and Technical Information Systems',
-      'Science and Disability',
-    ]
-
   end
 end

--- a/app/views/admin/works/_metadata.html.erb
+++ b/app/views/admin/works/_metadata.html.erb
@@ -186,15 +186,6 @@
       </ul>
     </dd>
 
-    <dt>Project</dt>
-    <dd>
-      <ul class="list-unstyled">
-        <% work.project.each do |item| %>
-          <li><%= item %></li>
-        <% end %>
-      </ul>
-    </dd>
-
     <dt>Series Arrangement</dt>
     <dd>
       <ul class="list-unstyled">

--- a/app/views/admin/works/_work_fields.html.erb
+++ b/app/views/admin/works/_work_fields.html.erb
@@ -71,16 +71,6 @@
             class: "form-control input-primitive" %>
     <% end %>
 
-    <%= f.repeatable_attr_input(:project, build: :at_least_one) do |input_name, value| %>
-      <%= f.input_field :project,
-            name: input_name,
-            id: nil,
-            selected: value,
-            collection: Work::ControlledLists::PROJECT,
-            include_blank: true,
-            class: "form-control input-primitive" %>
-    <% end %>
-
     <%= f.repeatable_attr_input :series_arrangement, build: :at_least_one %>
 
     <%# single, not array, so we need some slightly weird setup. Including we need at least one to exist:  %>

--- a/spec/factories/work_factory.rb
+++ b/spec/factories/work_factory.rb
@@ -96,9 +96,6 @@ FactoryBot.define do
       exhibition {
         ["Making Modernity", "Lobby 2017"]
       }
-      project {
-        ["REACH Ambler", "Science and Disability"]
-      }
       description {
         "Description 1"
       }

--- a/spec/system/work/new_work_spec.rb
+++ b/spec/system/work/new_work_spec.rb
@@ -92,8 +92,8 @@ RSpec.describe "New Work form", :logged_in_user, type: :system, js: true do
       find("div.work_#{p} select option[value='#{val}']").select_option
     end
 
-    #Custom single-value selects (2)
-    %w(exhibition project).each do |p|
+    #Custom single-value selects (1)
+    %w(exhibition).each do |p|
       scrollToTop
 
       attr_name = Work.human_attribute_name(p)
@@ -182,7 +182,7 @@ RSpec.describe "New Work form", :logged_in_user, type: :system, js: true do
       file_creator genre inscription language medium
       physical_container place rights
       rights_holder subject title
-      exhibition project
+      exhibition
     ).each do |prop|
       expect(newly_added_work.send(prop)).to eq work.send(prop)
     end

--- a/spec/system/work_show_spec.rb
+++ b/spec/system/work_show_spec.rb
@@ -114,7 +114,6 @@ describe "Public work show page", type: :system, js: false do
 
       expect_attribute_row("Department", work.department, as_links: true)
       expect_attribute_row("Exhibition", work.exhibition, as_links: true)
-      expect_attribute_row("Project", work.project, as_links: true)
       expect_attribute_row("Series arrangement", work.series_arrangement)
 
       expect_attribute_row("Physical container", work.physical_container.display_as)


### PR DESCRIPTION
We now track this relationship via Collections instead. Ref #1492
