### PR TITLE
keep very high images from taking up unbounded space on search results.

### DIFF
--- a/app/assets/stylesheets/local/search_results.scss
+++ b/app/assets/stylesheets/local/search_results.scss
@@ -165,6 +165,10 @@
       flex-shrink: 0;
       text-align: right;
 
+      // Keep really high ones from taking up too much space
+      max-height: $standard-thumb-width * 2.2;
+      overflow: hidden;
+
       .scihist-results-list-item-num-members {
         @extend %special-label;
         // hack we shoudl change special-label to a sass mixin


### PR DESCRIPTION
By clipping with CSS to around 2.2 times as high as wide. Ref #1461
