### PR TITLE
Allow test Solr to be started externally and left running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,16 @@ jobs:
               tmp/solr_test
             key: ${{ runner.os }}-solr-${{ hashFiles('.solr_wrapper.yml') }}
 
+        - name: Start test Solr
+          env:
+            RAILS_ENV: test
+          run: |
+            bundle exec rake solr:start
+
         - name: Run tests
           run: |
             bundle exec rspec
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,15 @@ Or by putting in a local_env[_development].yml file:
 
 ### Running tests
 
-`./bin/rspec`.
+Start the test solr (if you don't, test setup should do it for you if needed, but this is cleaner):
+
+  RAILS_ENV=test ./bin/rake solr:start
+
+Then:
+
+  ./bin/rspec
+
+(You can shut down or restart test solr with eg `RAILS_ENV=test ./bin/rake solr:stop` or `:restart`, as well as check on it's status with `:status`)
 
 ## Development Notes
 


### PR DESCRIPTION
Spec setup uses a simple net 'ping' sort of code to see if something is connectable on host/port solr is expected. If so, it assumes test solr is running.

If not, it still tries to start it automatically if needed, and then shuts it down after tests.

But since solr is slow to start up and shut down, you probably just want to leave it running.

Additionally,this means that profiling and timing of our specs won't include the slow solr startup in it's measurements, which is good.

Github CI has been changed to explicitly start up solr too.

We might eventually remove altogether the solr auto-startup code, it's a bit fragile.  But not here yet.

Ref #1482
