### PR TITLE
Send email alert on dig queue create

### DIFF
--- a/app/controllers/admin/digitization_queue_items_controller.rb
+++ b/app/controllers/admin/digitization_queue_items_controller.rb
@@ -33,6 +33,11 @@ class Admin::DigitizationQueueItemsController < AdminController
 
     respond_to do |format|
       if @admin_digitization_queue_item.save
+        # send an alert if email address is set
+        if ScihistDigicoll::Env.lookup(:digitization_queue_alerts_email_address)
+          DigitizationQueueMailer.with(digitization_queue_item: @admin_digitization_queue_item).new_item_email.deliver_later
+        end
+
         format.html { redirect_to admin_digitization_queue_items_url(@admin_digitization_queue_item.collecting_area), notice: 'Digitization queue item was successfully created.' }
         format.json { render :show, status: :created, location: admin_digitization_queue_items_url(@admin_digitization_queue_item.collecting_area) }
       else

--- a/app/mailers/digitization_queue_mailer.rb
+++ b/app/mailers/digitization_queue_mailer.rb
@@ -1,0 +1,15 @@
+class DigitizationQueueMailer < ApplicationMailer
+  # @example DigitizationQueueMailer.with(digitization_queue_item: dig_queue_item).new_item_email.deliver_later
+  def new_item_email
+    @digitization_queue_item = params[:digitization_queue_item]
+
+    subject = "New Digitization Queue Item in #{@digitization_queue_item.collecting_area.humanize}: #{@digitization_queue_item.title}"
+    unless ScihistDigicoll::Env.production?
+      subject = "[#{ScihistDigicoll::Env.lookup(:service_level)}] #{subject}"
+    end
+
+    mail(to: ScihistDigicoll::Env.lookup!(:digitization_queue_alerts_email_address),
+      subject: subject
+    )
+  end
+end

--- a/app/views/digitization_queue_mailer/new_item_email.html.erb
+++ b/app/views/digitization_queue_mailer/new_item_email.html.erb
@@ -1,0 +1,18 @@
+<h1>A new Digitization Queue Item has been created</h1>
+
+<dl>
+  <dt>Title</dt>
+  <dd>
+    <%= link_to @digitization_queue_item.title, admin_digitization_queue_item_url(@digitization_queue_item) %>
+  </dd>
+
+  <dt>Collecting Area</dt>
+  <dd><%= @digitization_queue_item.collecting_area.humanize %></dd>
+
+  <dt>Created</dt>
+  <dd><%= l(@digitization_queue_item.created_at, format: :admin) %></dd>
+
+  <dt>Application Environment</dt>
+  <dd><%= ScihistDigicoll::Env.lookup(:service_level) || "Unknown" %></dd>
+</dl>
+

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -468,6 +468,8 @@ module ScihistDigicoll
     # To addresses (these are email lists maintained by IT.)
     define_key :digital_tech_email_address, default: "digital-tech@sciencehistory.org"
     define_key :digital_email_address, default: "digital@sciencehistory.org"
+    # requested simple email alerting for Digitization Queue creation, unset to disable feature
+    define_key :digitization_queue_alerts_email_address, default: "digital@sciencehistory.org"
 
     # These are the credentials used for accessing Amazon's simple email server:
     define_key :smtp_username

--- a/spec/mailers/digitization_queue_mailer_spec.rb
+++ b/spec/mailers/digitization_queue_mailer_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe DigitizationQueueMailer, :type => :mailer do
+  describe "#new_item_email" do
+    let(:digization_queue_item) { create(:digitization_queue_item) }
+
+    it "executes without errors" do
+      mail = DigitizationQueueMailer.with(digitization_queue_item: digization_queue_item).new_item_email
+      expect(mail.to).to be_present
+      expect(mail.from).to be_present
+      expect(mail.subject).to be_present
+      expect(mail.body).to be_present
+    end
+  end
+end


### PR DESCRIPTION
Ref #1500

A not-that-smart email alerting system, just sends to the same fixed email address for everything.  R-and-r is a different controller, so should not apply to r-and-r, as spec'd. 
