### PR TITLE
Protect /facet action from bad params too

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -5,8 +5,8 @@ require 'kithe/blacklight_tools/bulk_loading_search_service'
 class CatalogController < ApplicationController
   before_action :redirect_hash_facet_params, only: :index
   before_action :redirect_legacy_query_urls, only: :index
-  before_action :catch_bad_blacklight_params, only: :index
-  before_action :swap_range_limit_params_if_needed, only: :index
+  before_action :catch_bad_blacklight_params, only: [:index, :facet]
+  before_action :swap_range_limit_params_if_needed, only: [:index, :facet]
   before_action :catch_bad_request_headers, only: :index
 
   before_action :screen_params_for_range_limit, only: :range_limit

--- a/spec/requests/bad_blacklight_requests_spec.rb
+++ b/spec/requests/bad_blacklight_requests_spec.rb
@@ -36,6 +36,15 @@ describe CatalogController do
       get "/catalog?range%5Byear_facet_isim%5D%5Bbegin%5D=1989%27,(;))%23-%20--&range%5Byear_facet_isim%5D%5Bend%5D=1989%27,(;))%23-%20--"
       expect(response.code).to eq("400")
     end
+
+    describe "on a collection search" do
+      let(:collection) { create(:collection) }
+
+      it "responds with 400" do
+        get "/collections/#{collection.friendlier_id}/facet?id=subject_facet&range[year_facet_isim][end]=1894%27[0]"
+        expect(response.code).to eq("400")
+      end
+    end
   end
 
   # Missing facet ID, e.g.


### PR DESCRIPTION
The /facet action is used for fetching the list of facets for the "more facets" paginating display. In main catalog controller, and in collection_show controllers that sub-class it.
We were protecting the /catalog action itself from various kind of bad parameters -- making sure they got caught and got a pretty error message, instead of being un-rescued 500s.

We need to do the same thing for the /facet action, which takes the same limit params to constrain the search.

Re: tests, we could and perhaps "should" be repeating ALL of our bad param tests for each context it can be in -- catalog controller vs collection_show; /catalog action vs /facet action. Four repeats of each test. We hypothetically could be doing that using rspec shared tests feature, although it makes it harder the way we are doing the tests, which are a bit disorganized.  We aren't doing those repeats of all tests. We just added one more test for the actual problem encountered in #1510. I did do it TDD though.

Ref #1510
