### PR TITLE
even top and bottom whitespace in deai footer

### DIFF
--- a/app/assets/stylesheets/local/deai_footer.scss
+++ b/app/assets/stylesheets/local/deai_footer.scss
@@ -1,5 +1,6 @@
 .deai-footer {
-  padding-top: ($paragraph-font-size * $paragraph-line-height-long / 2) !important; // matches paragraph margin bottom please
+  padding-top: map-get($spacers, 3) !important;
+  padding-bottom: map-get($spacers, 3) !important;
   padding-left: 1rem;
   padding-right: 1rem;
 
@@ -21,7 +22,6 @@
     text-align: justify;
     margin-left: auto;
     margin-right: auto;
-
-
+    margin-bottom: 0 !important;
   }
 }


### PR DESCRIPTION
It was annoying me that the top and bottom padding in the footer had ended up somehow uneven. Fixed, with maybe a hair more breathing room too.

Yeah, I think all of this use of overrides and especially \!important means our css is a bit out of control, but so it goes.
