### PR TITLE
When trying to start up solr, if the collection name already exists just keep going

### DIFF
--- a/lib/scihist_digicoll/solr_wrapper_util.rb
+++ b/lib/scihist_digicoll/solr_wrapper_util.rb
@@ -15,7 +15,16 @@ module ScihistDigicoll
       WebMock.disable! if defined?(WebMock) && defined?(RSpec) && defined?(SCIHIST_WEBMOCK_USED)
 
       instance.start
-      instance.create(instance.config.collection_options)
+
+      begin
+        instance.create(instance.config.collection_options)
+      rescue StandardError => e
+        # Only if we couldn't create it cause it already existed, let it slide.
+        unless e.message =~ /Core '#{instance.config.collection_options[:name]}' already exists!/
+          raise e
+        end
+      end
+
 
     ensure
       WebMock.enable! if defined?(WebMock) && defined?(RSpec) && defined?(SCIHIST_WEBMOCK_USED)


### PR DESCRIPTION
This came up because when we switched how we're doing CI Solr setup, we ended up having GH Actions cache a copy of solr that already had the collection. I think. Not totally sure why this wasn't always a problem.

Anyway, now if the collection already exists, instead of bombing when we try to create it, we just continue on happy.

Not totally sure if this will end up causing additional problems. This stuff starts getting messy, it's true. This also isn't a very tidy way to catch an exception, `solr_wrapper` doesn't give us specific exception class to match we have to look at message, and hope it doesn't change. 
