### PR TITLE
No need for exemptions from webmock control for Solr

### DIFF
--- a/lib/scihist_digicoll/spec_util.rb
+++ b/lib/scihist_digicoll/spec_util.rb
@@ -12,11 +12,13 @@ module ScihistDigicoll
     #      ScihistDigicoll::SpecUtil.disable_net_connect!
     #    end
     def self.disable_net_connect!
+      # localhost connections are allowed for Capybara (standard instructions) -- and also for our solr connections.
+      # solr_wrapper sometimes wants to use 127.0.0.1 instead of localhost, so we need to explicitly mention
+      # that too.
+
       # chromedriver.storage.googleapis.com for `webdrivers` gem automatic downloading of chromedriver.
       # https://github.com/titusfortner/webdrivers/issues/4
-      #
-      # solr_wrapper wants to use 127.0.0.1 instead of localhost.
-      #
+
       # net_http_connect_on_start needed for reasons I don't totally understand
       # for "too many open files" error in capybara test that should be passing.
       # * https://stackoverflow.com/questions/59632283/chromedriver-capybara-too-many-open-files-socket2-for-127-0-0-1-port-951

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -179,14 +179,14 @@ RSpec.configure do |config|
             $test_solr_started = false
           }
 
-          ScihistDigicoll::SpecUtil.allow_net_connect!
+
           ScihistDigicoll::SolrWrapperUtil.start_with_collection(SolrWrapper.instance)
 
           $test_solr_started = true
           $test_solr_known_running = true
         end
       ensure
-        ScihistDigicoll::SpecUtil.disable_net_connect!
+
       end
     end
   end


### PR DESCRIPTION
We use WebMock to "mock" HTTP requests in tests, but also to *prevent* the app from making external HTTP requests in tests -- we don't want tests depending on external remote HTTP sites, generally, and WebMock can hook into ruby to raise if something tries.

Our webmock disallow net connect command already allowed connections to localhost though -- this is standard setup to get Capybara tests to work, and just generally.

So we don't need to turn off the webmock disallow for our solr-using tests. Which is what the code had been doing previously, I guess I thought it was needed so the app could get to solr for solr-using tests. But it's not, our disallow already had an exemption for localhost, and we want to leave the rest of the disallow in place.

Our tests all still pass fine when we remove the special "allow net connect, then run the test, then disallow it again" around tests tagged :solr. So remove the unncesssary fiddling.
