### PR TITLE
Additional Credit Field additions 

### DIFF
--- a/app/models/work/additional_credit.rb
+++ b/app/models/work/additional_credit.rb
@@ -5,6 +5,7 @@ class Work
     ROLES = ['photographed_by', 'translated_by', 'transcribed_by']
     NAMES = [
       'Douglas Lockard',
+      'Gudrun Dauner',
       'Gregory Tobias',
       'Jocelyn R. McDaniel',
       'Mark Backrath',

--- a/app/models/work/additional_credit.rb
+++ b/app/models/work/additional_credit.rb
@@ -2,7 +2,7 @@ class Work
   class AdditionalCredit
     include AttrJson::Model
 
-    ROLES = ['photographed_by', 'translated_by']
+    ROLES = ['photographed_by', 'translated_by', 'transcribed_by']
     NAMES = [
       'Douglas Lockard',
       'Gregory Tobias',

--- a/lib/tasks/data_fixes/add_transcribed_by_mcdaniel.rake
+++ b/lib/tasks/data_fixes/add_transcribed_by_mcdaniel.rake
@@ -1,0 +1,33 @@
+namespace :scihist do
+  namespace :data_fixes do
+    desc """
+      Add 'Transcribed by Jocelyn R. McDaniel' to Bredig documents that currently
+      have the metadata 'Translated by Jocelyn R. McDaniel'
+      https://github.com/sciencehistory/scihist_digicoll/issues/1525
+    """
+
+    task :add_transcribed_by_mcdaniel => :environment do
+      bredig_collection_id = ENV['SOURCE_COL_ID'] || 'qfih5hl'
+      scope = Collection.find_by_friendlier_id(bredig_collection_id).contains
+
+      changed = 0
+
+      progress_bar = ProgressBar.create(total: scope.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+
+      Kithe::Indexable.index_with(batching: true) do
+        scope.find_each do |work|
+          if ( work.additional_credit.find { |ac| ac.name == "Jocelyn R. McDaniel" && ac.role == "translated_by"} &&
+               !work.additional_credit.find { |ac| ac.name == "Jocelyn R. McDaniel" && ac.role == "transcribed_by"}
+          )
+            work.additional_credit << Work::AdditionalCredit.new(name: "Jocelyn R. McDaniel", role: "transcribed_by")
+            work.save!
+            changed += 1
+          end
+          progress_bar.increment
+        end
+      end
+
+      puts "updated #{changed} works"
+    end
+  end
+end


### PR DESCRIPTION
ref #1525

- Add "Transcribed by" as a drop-down option
- Add "Gudrun Dauner" to the name drop-down options
- rake task: Add "Transcribed by Jocelyn R. McDaniel" to Bredig documents that currently have the metadata "Translated by Jocelyn R. McDaniel"

After deployment need to run `heroku run rake scihist:data_fixes:add_transcribed_by_mcdaniel -r production`. 

(Should we come up with a new pattern, possibly using migrations, so these data fixes automatically get run on deploy? Maybe. But I'm not doing it yet). 
