### PR TITLE
Need to pass args as real keywords in ruby 3

### DIFF
--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -287,7 +287,7 @@ module ScihistDigicoll
       if mode == "dev_file"
         Shrine::Storage::FileSystem.new("public", prefix: "shrine_storage_#{Rails.env}/#{shared_bucket_path_prefix}")
       elsif mode == "dev_s3"
-        FasterS3Url::Shrine::Storage.new({
+        FasterS3Url::Shrine::Storage.new(**{
           bucket:            lookup(:s3_dev_bucket),
           prefix:            "#{lookup(:s3_dev_prefix)}/#{shared_bucket_path_prefix}",
           access_key_id:     lookup(:aws_access_key_id),
@@ -295,7 +295,7 @@ module ScihistDigicoll
           region:            lookup(:aws_region)
         }.merge(s3_storage_options))
       elsif mode == "production"
-        FasterS3Url::Shrine::Storage.new({
+        FasterS3Url::Shrine::Storage.new(**{
           bucket:            lookup!(bucket_key),
           prefix:            prefix,
           access_key_id:     lookup!(:aws_access_key_id),


### PR DESCRIPTION
We were passing a hash to something that wanted keyword arguments. That doesn't work in ruby 3.0 anymore -- we are dynamically constructing the keyword args from a hash, so we need to use the `**` operator to convert them to actual keyword arguments.

Caused an error in production even though tests didn't catch, because tests didn't exersize this Env code that only is used in development and test environments, for differnet shrine setup. Oops, so it goes.

Ref #1539
