### PR TITLE
cleanup orphan report

### DIFF
--- a/app/controllers/admin/orphan_report_controller.rb
+++ b/app/controllers/admin/orphan_report_controller.rb
@@ -2,7 +2,6 @@
 class Admin::OrphanReportController < AdminController
   def index
     @report = Admin::OrphanReport.order(created_at: :desc).first
-    @report_available =  @report&.data_for_report.dig('end_time').present?
-    @data = @report.data_for_report unless @report.nil?
+    @report_available =  @report&.end_time.present?
   end
 end

--- a/app/controllers/admin/orphan_report_controller.rb
+++ b/app/controllers/admin/orphan_report_controller.rb
@@ -4,4 +4,15 @@ class Admin::OrphanReportController < AdminController
     @report = Admin::OrphanReport.order(created_at: :desc).first
     @report_available =  @report&.end_time.present?
   end
+
+  private
+
+  # Strip out any prefix part from shrine storage to get just the id
+  helper_method def display_s3_url(url, storage:)
+    path = URI.parse(url).path.delete_prefix("/")
+    if storage.prefix.present?
+      path = path.delete_prefix(storage.prefix).delete_prefix("/")
+    end
+    path
+  end
 end

--- a/app/models/admin/orphan_report.rb
+++ b/app/models/admin/orphan_report.rb
@@ -1,3 +1,46 @@
 # A report of the most recent check for orphaned files.
+#
+# All the data is currently in a jsonb column `data_for_report`
 class Admin::OrphanReport < ApplicationRecord
+
+  def start_time
+    data_for_report['start_time']&.to_datetime
+  end
+
+  def end_time
+    data_for_report['end_time']&.to_datetime
+  end
+
+  def orphaned_originals_count
+    data_for_report['orphaned_originals_count'].to_i
+  end
+
+  def orphaned_originals_sample
+    data_for_report['orphaned_originals_sample'] || []
+  end
+
+  def orphaned_public_derivatives_count
+    data_for_report['orphaned_public_derivatives_count'].to_i
+  end
+
+  def orphaned_public_derivatives_sample
+    data_for_report['orphaned_public_derivatives_sample'] || []
+  end
+
+  def orphaned_restricted_derivatives_count
+    data_for_report['orphaned_restricted_derivatives_count'].to_i
+  end
+
+  def orphaned_restricted_derivatives_sample
+    data_for_report['orphaned_restricted_derivatives_sample'] || []
+  end
+
+  def orphaned_dzi_count
+    data_for_report['orphaned_dzi_count'].to_i
+  end
+
+  def orphaned_dzi_sample
+    data_for_report['orphaned_dzi_sample'] || []
+  end
+
 end

--- a/app/services/orphan_auditor.rb
+++ b/app/services/orphan_auditor.rb
@@ -1,3 +1,5 @@
+# To conduct an audit, run OrphanAuditor.new.perform!
+# This will audit all derivatives, store it in DB, and remove any but the currently stored report in DB.
 class OrphanAuditor
   attr_reader :originals, :public_derivatives, :restricted_derivatives, :dzi
 
@@ -12,19 +14,19 @@ class OrphanAuditor
   end
 
   def orphans?
-    @tasks.values.any?{ |a| a.orphans_found > 0 }
+    @tasks.values.any?{ |a| a && a.orphans_found > 0 }
   end
 
   def store_audit_results
     results = {
-      orphaned_originals_count:  @tasks[:originals].orphans_found,
-      orphaned_originals_sample: @tasks[:originals].sample,
-      orphaned_public_derivatives_count:  @tasks[:public_derivatives].orphans_found,
-      orphaned_public_derivatives_sample: @tasks[:public_derivatives].sample,
-      orphaned_restricted_derivatives_count:  @tasks[:restricted_derivatives].orphans_found,
-      orphaned_restricted_derivatives_sample: @tasks[:restricted_derivatives].sample,
-      orphaned_dzi_count:  @tasks[:dzi].orphans_found,
-      orphaned_dzi_sample: @tasks[:dzi].sample,
+      orphaned_originals_count:  @tasks[:originals]&.orphans_found,
+      orphaned_originals_sample: @tasks[:originals]&.sample,
+      orphaned_public_derivatives_count:  @tasks[:public_derivatives]&.orphans_found,
+      orphaned_public_derivatives_sample: @tasks[:public_derivatives]&.sample,
+      orphaned_restricted_derivatives_count:  @tasks[:restricted_derivatives]&.orphans_found,
+      orphaned_restricted_derivatives_sample: @tasks[:restricted_derivatives]&.sample,
+      orphaned_dzi_count:  @tasks[:dzi]&.orphans_found,
+      orphaned_dzi_sample: @tasks[:dzi]&.sample,
     }
     results.each { |k, v| log_into_report( { k => v } ) }
   end

--- a/app/services/orphan_s3_derivatives.rb
+++ b/app/services/orphan_s3_derivatives.rb
@@ -181,6 +181,11 @@ class OrphanS3Derivatives
   # from the shrine storage already. We just want a complete good direct to S3 URL
   # as an identifier, it may not be accessible, it wont' use a CDN, etc.
   def s3_url_for_path(s3_path)
-    shrine_storage.bucket.object(s3_path).public_url
+    if shrine_storage.respond_to?(:bucket)
+      shrine_storage.bucket.object(s3_path).public_url
+    else
+      # we aren't S3 at all, not sure what we'll get...
+      shrine_storage.url(s3_path)
+    end
   end
 end

--- a/app/services/orphan_s3_derivatives.rb
+++ b/app/services/orphan_s3_derivatives.rb
@@ -74,7 +74,7 @@ class OrphanS3Derivatives
         if @orphans_found == max_reports
           s3_iterator.log "Reported max #{max_reports} orphans. Not listing subsequent.\n"
         elsif orphans_found < max_reports
-          @sample << s3_path
+          @sample << s3_url_for_path(s3_path)
           if combined_audio_derivative?(first_part)
             report_orphaned_combined_audio_derivative(second_part, shrine_path, s3_path)
           else
@@ -175,5 +175,12 @@ class OrphanS3Derivatives
     return true unless first_part.present? && derivative_key.present?
     return orphaned_combined_audio_derivative?(derivative_key, shrine_path) if combined_audio_derivative?(first_part)
     ! Kithe::Asset.where(id: first_part).where("file_data -> 'derivatives' -> ? ->> 'id' = ?", derivative_key, shrine_path).exists?
+  end
+
+  # note that the s3_path is complete path on bucket, it might include a prefix
+  # from the shrine storage already. We just want a complete good direct to S3 URL
+  # as an identifier, it may not be accessible, it wont' use a CDN, etc.
+  def s3_url_for_path(s3_path)
+    shrine_storage.bucket.object(s3_path).public_url
   end
 end

--- a/app/services/orphan_s3_dzi.rb
+++ b/app/services/orphan_s3_dzi.rb
@@ -77,7 +77,7 @@ class OrphanS3Dzi
         s3_iterator.log "Reported max #{max_reports} orphans, not listing subsquent...\n"
       elsif @orphans_found < max_reports
 
-        @sample << s3_path
+        @sample << s3_url_for_path(s3_path)
         asset = Asset.where(id: asset_id).first
 
         s3_iterator.log "orphaned DZI"
@@ -151,5 +151,12 @@ class OrphanS3Dzi
     end
 
     ! Asset.where(id: asset_id).where("file_data -> 'metadata' ->> 'md5' = ?", md5).exists?
+  end
+
+  # note that the s3_path is complete path on bucket, it might include a prefix
+  # from the shrine storage already. We just want a complete good direct to S3 URL
+  # as an identifier, it may not be accessible, it wont' use a CDN, etc.
+  def s3_url_for_path(s3_path)
+    shrine_storage.bucket.object(s3_path).public_url
   end
 end

--- a/app/services/orphan_s3_dzi.rb
+++ b/app/services/orphan_s3_dzi.rb
@@ -157,6 +157,11 @@ class OrphanS3Dzi
   # from the shrine storage already. We just want a complete good direct to S3 URL
   # as an identifier, it may not be accessible, it wont' use a CDN, etc.
   def s3_url_for_path(s3_path)
-    shrine_storage.bucket.object(s3_path).public_url
+    if shrine_storage.respond_to?(:bucket)
+      shrine_storage.bucket.object(s3_path).public_url
+    else
+      # we aren't S3 at all, not sure what we'll get...
+      shrine_storage.url(s3_path)
+    end
   end
 end

--- a/app/services/orphan_s3_originals.rb
+++ b/app/services/orphan_s3_originals.rb
@@ -52,7 +52,7 @@ class OrphanS3Originals
         if @orphans_found == max_reports
           s3_iterator.log "Reported max #{max_reports} orphans, not listing subsquent...\n"
         elsif @orphans_found < max_reports
-          @sample << s3_key
+          @sample << s3_url_for_path(s3_key)
           asset = Asset.where(id: asset_id).first
 
           s3_iterator.log "orphaned file!"
@@ -125,6 +125,10 @@ class OrphanS3Originals
     return [asset_id, shrine_id_value]
   end
 
-
-
+  # note that the s3_path is complete path on bucket, it might include a prefix
+  # from the shrine storage already. We just want a complete good direct to S3 URL
+  # as an identifier, it may not be accessible, it wont' use a CDN, etc.
+  def s3_url_for_path(s3_path)
+    shrine_storage.bucket.object(s3_path).public_url
+  end
 end

--- a/app/services/orphan_s3_originals.rb
+++ b/app/services/orphan_s3_originals.rb
@@ -129,6 +129,11 @@ class OrphanS3Originals
   # from the shrine storage already. We just want a complete good direct to S3 URL
   # as an identifier, it may not be accessible, it wont' use a CDN, etc.
   def s3_url_for_path(s3_path)
-    shrine_storage.bucket.object(s3_path).public_url
+    if shrine_storage.respond_to?(:bucket)
+      shrine_storage.bucket.object(s3_path).public_url
+    else
+      # we aren't S3 at all, not sure what we'll get...
+      shrine_storage.url(s3_path)
+    end
   end
 end

--- a/app/services/orphan_s3_restricted_derivatives.rb
+++ b/app/services/orphan_s3_restricted_derivatives.rb
@@ -7,7 +7,7 @@ class OrphanS3RestrictedDerivatives
   # @param show_progress_bar [Boolean], default true, should we show a progress
   #   bar with estimated progress.
   def initialize(show_progress_bar: true)
-    
+
     @sample = []
     @shrine_storage = ScihistDigicoll::Env.shrine_store_storage
     @s3_iterator = S3PathIterator.new(
@@ -54,7 +54,7 @@ class OrphanS3RestrictedDerivatives
         if @orphans_found == max_reports
           s3_iterator.log "Reported max #{max_reports} orphans. Not listing subsequent.\n"
         elsif orphans_found < max_reports
-          @sample << s3_path
+          @sample << s3_url_for_path(s3_path)
           report_orphaned_derivative(asset_id, derivative_key, shrine_path, s3_path)
           s3_iterator.log ""
         end
@@ -112,5 +112,12 @@ class OrphanS3RestrictedDerivatives
     return true unless asset_pk.present? && derivative_key.present?
     asset_exists = Kithe::Asset.where(id: asset_pk).where("file_data -> 'derivatives' -> ? ->> 'id' = ?", derivative_key, shrine_path).exists?
     ! asset_exists
+  end
+
+  # note that the s3_path is complete path on bucket, it might include a prefix
+  # from the shrine storage already. We just want a complete good direct to S3 URL
+  # as an identifier, it may not be accessible, it wont' use a CDN, etc.
+  def s3_url_for_path(s3_path)
+    shrine_storage.bucket.object(s3_path).public_url
   end
 end

--- a/app/services/orphan_s3_restricted_derivatives.rb
+++ b/app/services/orphan_s3_restricted_derivatives.rb
@@ -9,10 +9,9 @@ class OrphanS3RestrictedDerivatives
   def initialize(show_progress_bar: true)
 
     @sample = []
-    @shrine_storage = ScihistDigicoll::Env.shrine_store_storage
+    @shrine_storage = ScihistDigicoll::Env.shrine_restricted_derivatives_storage
     @s3_iterator = S3PathIterator.new(
       shrine_storage: shrine_storage,
-      extra_prefix: 'restricted_derivatives',
       show_progress_bar: show_progress_bar,
       progress_bar_total: derivative_count
     )

--- a/app/services/orphan_s3_restricted_derivatives.rb
+++ b/app/services/orphan_s3_restricted_derivatives.rb
@@ -117,6 +117,11 @@ class OrphanS3RestrictedDerivatives
   # from the shrine storage already. We just want a complete good direct to S3 URL
   # as an identifier, it may not be accessible, it wont' use a CDN, etc.
   def s3_url_for_path(s3_path)
-    shrine_storage.bucket.object(s3_path).public_url
+    if shrine_storage.respond_to?(:bucket)
+      shrine_storage.bucket.object(s3_path).public_url
+    else
+      # we aren't S3 at all, not sure what we'll get...
+      shrine_storage.url(s3_path)
+    end
   end
 end

--- a/app/views/admin/orphan_report/index.html.erb
+++ b/app/views/admin/orphan_report/index.html.erb
@@ -36,7 +36,7 @@
       <ul>
         <% @report.orphaned_originals_sample.each do |url|%>
           <li>
-            <%= link_to url.split("/").last, S3ConsoleUri.new(url).console_uri %>
+            <%= link_to display_s3_url(url, storage: Shrine.storages[:store]), S3ConsoleUri.new(url).console_uri %>
           </li>
         <% end %>
         <% if @report.orphaned_originals_count > @report.orphaned_originals_sample.length %>
@@ -66,7 +66,7 @@
       <ul>
         <% @report.orphaned_public_derivatives_sample.each do |url|%>
           <li>
-            <%= link_to url.split("/").last, S3ConsoleUri.new(url).console_uri %>
+            <%= link_to display_s3_url(url, storage: Shrine.storages[:kithe_derivatives]), S3ConsoleUri.new(url).console_uri %>
           </li>
         <% end %>
         <% if @report.orphaned_public_derivatives_count > @report.orphaned_public_derivatives_sample.length %>
@@ -97,7 +97,7 @@
       <ul>
         <% @report.orphaned_restricted_derivatives_sample.each_with_index do |url, i|%>
           <li>
-            <%= link_to url.split("/").last, S3ConsoleUri.new(url).console_uri %>
+            <%= link_to display_s3_url(url, storage: Shrine.storages[:restricted_kithe_derivatives]), S3ConsoleUri.new(url).console_uri %>
           </li>
         <% end %>
         <% if @report.orphaned_restricted_derivatives_count > @report.orphaned_restricted_derivatives_sample.length %>
@@ -128,7 +128,7 @@
       <ul>
         <% @report.orphaned_dzi_sample.each_with_index do |url, i|%>
           <li>
-            <%= link_to url.split("/").last, S3ConsoleUri.new(url).console_uri %>
+            <%= link_to display_s3_url(url, storage: Shrine.storages[:dzi_storage]), S3ConsoleUri.new(url).console_uri %>
           </li>
         <% end %>
         <% if @report.orphaned_dzi_count > @report.orphaned_dzi_sample.length %>

--- a/app/views/admin/orphan_report/index.html.erb
+++ b/app/views/admin/orphan_report/index.html.erb
@@ -3,7 +3,7 @@
 <p>
   Checks whether our stored files actually are have links to them somewhere in our database.
   To save space, this report only lists the total <em>number</em> of "orphaned" files, along with a few sample links.
-  The report also tells you when the files were last checked. Reports are run nightly, but we only keep the latest one.
+  The report also tells you when the files were last checked. Reports are run weekly, but we only keep the latest one.
 </p>
 
 

--- a/app/views/admin/orphan_report/index.html.erb
+++ b/app/views/admin/orphan_report/index.html.erb
@@ -34,12 +34,14 @@
         <i class="fa fa fa-thumbs-down" aria-hidden="true"></i>There are <%= @report.orphaned_originals_count %> orphaned original files.
       </span>
       <ul>
-      <% @report.orphaned_originals_sample.each_with_index do |url, i|%>
-      <li>
-        <%= link_to url.split("/").last, S3ConsoleUri.new(url).console_uri %>
-        <%= '[...]' if (@report.orphaned_originals_count > @report.orphaned_originals_sample.length) && i == @report.orphaned_originals_sample.length - 1 %>
-      </li>
-      <% end %>
+        <% @report.orphaned_originals_sample.each do |url|%>
+          <li>
+            <%= link_to url.split("/").last, S3ConsoleUri.new(url).console_uri %>
+          </li>
+        <% end %>
+        <% if @report.orphaned_originals_count > @report.orphaned_originals_sample.length %>
+          <li>[...]</li>
+        <% end %>
       </ul>
       To delete orphaned originals:
       <code>
@@ -62,11 +64,13 @@
         <i class="fa fa fa-thumbs-down" aria-hidden="true"></i>  There are <%= @report.orphaned_public_derivatives_count %> orphaned public derivatives.
       </span>
       <ul>
-        <% @report.orphaned_public_derivatives_sample.each_with_index do |url, i|%>
+        <% @report.orphaned_public_derivatives_sample.each do |url|%>
           <li>
             <%= link_to url.split("/").last, S3ConsoleUri.new(url).console_uri %>
-            <%= '[...]' if (@report.orphaned_public_derivatives_count > @report.orphaned_public_derivatives_sample.length) && i == @report.orphaned_public_derivatives_sample.length - 1 %>
           </li>
+        <% end %>
+        <% if @report.orphaned_public_derivatives_count > @report.orphaned_public_derivatives_sample.length %>
+          <li>[...]</li>
         <% end %>
       </ul>
       To delete orphaned public derivatives:
@@ -93,9 +97,11 @@
       <ul>
         <% @report.orphaned_restricted_derivatives_sample.each_with_index do |url, i|%>
           <li>
-          <%= link_to url.split("/").last, S3ConsoleUri.new(url).console_uri %>
-          <%= '[...]' if (@report.orphaned_restricted_derivatives_count > @report.orphaned_restricted_derivatives_sample.length) && i == @report.orphaned_restricted_derivatives_sample.length - 1 %>
+            <%= link_to url.split("/").last, S3ConsoleUri.new(url).console_uri %>
           </li>
+        <% end %>
+        <% if @report.orphaned_restricted_derivatives_count > @report.orphaned_restricted_derivatives_sample.length %>
+          <li>[...]</li>
         <% end %>
       </ul>
       To delete restricted derivatives:
@@ -123,8 +129,10 @@
         <% @report.orphaned_dzi_sample.each_with_index do |url, i|%>
           <li>
             <%= link_to url.split("/").last, S3ConsoleUri.new(url).console_uri %>
-            <%= '[...]' if (@report.orphaned_dzi_count > @report.orphaned_dzi_sample.length) && i == @report.orphaned_dzi_sample.length - 1 %>
           </li>
+        <% end %>
+        <% if @report.orphaned_dzi_count > @report.orphaned_dzi_sample.length %>
+          <li>[...]</li>
         <% end %>
       </ul>
       To delete orphaned deep zoom tiles:

--- a/app/views/admin/orphan_report/index.html.erb
+++ b/app/views/admin/orphan_report/index.html.erb
@@ -34,9 +34,9 @@
         <i class="fa fa fa-thumbs-down" aria-hidden="true"></i>There are <%= @report.orphaned_originals_count %> orphaned original files.
       </span>
       <ul>
-      <% @report.orphaned_originals_sample.each_with_index do |path, i|%>
+      <% @report.orphaned_originals_sample.each_with_index do |url, i|%>
       <li>
-        <%= link_to(path.split("/").last, Shrine.storages[:store].url(path)) %>
+        <%= url.split("/").last %>
         <%= '[...]' if (@report.orphaned_originals_count > @report.orphaned_originals_sample.length) && i == @report.orphaned_originals_sample.length - 1 %>
       </li>
       <% end %>
@@ -62,9 +62,9 @@
         <i class="fa fa fa-thumbs-down" aria-hidden="true"></i>  There are <%= @report.orphaned_public_derivatives_count %> orphaned public derivatives.
       </span>
       <ul>
-        <% @report.orphaned_public_derivatives_sample.each_with_index do |path, i|%>
+        <% @report.orphaned_public_derivatives_sample.each_with_index do |url, i|%>
           <li>
-            <%= link_to(path.split("/").last, Shrine.storages[:kithe_derivatives].url(path)) %>
+            <%= url.split("/").last %>
             <%= '[...]' if (@report.orphaned_public_derivatives_count > @report.orphaned_public_derivatives_sample.length) && i == @report.orphaned_public_derivatives_sample.length - 1 %>
           </li>
         <% end %>
@@ -91,9 +91,9 @@
         <i class="fa fa fa-thumbs-down" aria-hidden="true"></i> There are <%= @report.orphaned_restricted_derivatives_count %> orphaned restricted derivatives.
       </span>
       <ul>
-        <% @report.orphaned_restricted_derivatives_sample.each_with_index do |path, i|%>
+        <% @report.orphaned_restricted_derivatives_sample.each_with_index do |url, i|%>
           <li>
-          <%= link_to(path.split("/").last, Shrine.storages[:restricted_kithe_derivatives].url(path)) %>
+          <%= url.split("/").last %>
           <%= '[...]' if (@report.orphaned_restricted_derivatives_count > @report.orphaned_restricted_derivatives_sample.length) && i == @report.orphaned_restricted_derivatives_sample.length - 1 %>
           </li>
         <% end %>
@@ -120,9 +120,9 @@
         <i class="fa fa fa-thumbs-down" aria-hidden="true"></i> There are <%= @report.orphaned_dzi_count %> orphaned deep zoom tiles:
       </span>
       <ul>
-        <% @report.orphaned_dzi_sample.each_with_index do |path, i|%>
+        <% @report.orphaned_dzi_sample.each_with_index do |url, i|%>
           <li>
-            <%= link_to(path.split("/").last, Shrine.storages[:dzi_storage].url(path)) %>
+            <%= url.split("/").last %>
             <%= '[...]' if (@report.orphaned_dzi_count > @report.orphaned_dzi_sample.length) && i == @report.orphaned_dzi_sample.length - 1 %>
           </li>
         <% end %>

--- a/app/views/admin/orphan_report/index.html.erb
+++ b/app/views/admin/orphan_report/index.html.erb
@@ -18,33 +18,33 @@
   <p><%= @report.id %></p>
   <hr/>
   <h4>Started at</h4>
-  <p><%= l(@data['start_time']&.to_datetime, format: :short) if @data['start_time']%></p>
+  <p><%= l(@report.start_time, format: :short) if @report.start_time %></p>
   <hr/>
   <h4>Completed successfully at</h4>
   <p class="text-muted small">If this date is present, the audit checked all assets.</p>
-  <p><%= l(@data['end_time'].to_datetime, format: :short) if @data['end_time']%></p>
+  <p><%= l(@report.end_time, format: :short) if @report.end_time %></p>
   <hr/>
 
 
   <h4>Originals</h4>
   <p class="text-muted small">Original files without a corresponding asset in the database.</p>
   <p>
-    <% if @data['orphaned_originals_count'] > 0 %>
+    <% if @report.orphaned_originals_count > 0 %>
       <span class="text-danger">
-        <i class="fa fa fa-thumbs-down" aria-hidden="true"></i>There are <%= @data['orphaned_originals_count'] %> orphaned original files.
+        <i class="fa fa fa-thumbs-down" aria-hidden="true"></i>There are <%= @report.orphaned_originals_count %> orphaned original files.
       </span>
       <ul>
-      <% @data['orphaned_originals_sample'].each_with_index do |path, i|%>
+      <% @report.orphaned_originals_sample.each_with_index do |path, i|%>
       <li>
         <%= link_to(path.split("/").last, Shrine.storages[:store].url(path)) %>
-        <%= '[...]' if (@data['orphaned_originals_count'] > @data['orphaned_originals_sample'].length) && i == @data['orphaned_originals_sample'].length - 1 %>
+        <%= '[...]' if (@report.orphaned_originals_count > @report.orphaned_originals_sample.length) && i == @report.orphaned_originals_sample.length - 1 %>
       </li>
       <% end %>
       </ul>
       To delete orphaned originals:
       <code>
         rails runner 'OrphanS3Originals.new(show_progress_bar: false).delete_orphans'
-      </code>     
+      </code>
     <% else %>
       <span class="text-success">
         <i class="fa fa fa-thumbs-up" aria-hidden="true"></i>
@@ -57,21 +57,21 @@
   <h4>Public derivatives</h4>
   <p class="text-muted small">Public derivatives without a corresponding asset in the database.</p>
   <p>
-    <% if @data['orphaned_public_derivatives_count'] > 0 %>
+    <% if @report.orphaned_public_derivatives_count > 0 %>
       <span class="text-danger">
-        <i class="fa fa fa-thumbs-down" aria-hidden="true"></i>  There are <%= @data['orphaned_public_derivatives_count'] %> orphaned public derivatives.
+        <i class="fa fa fa-thumbs-down" aria-hidden="true"></i>  There are <%= @report.orphaned_public_derivatives_count %> orphaned public derivatives.
       </span>
       <ul>
-        <% @data['orphaned_public_derivatives_sample'].each_with_index do |path, i|%>
+        <% @report.orphaned_public_derivatives_sample.each_with_index do |path, i|%>
           <li>
             <%= link_to(path.split("/").last, Shrine.storages[:kithe_derivatives].url(path)) %>
-            <%= '[...]' if (@data['orphaned_public_derivatives_count'] > @data['orphaned_public_derivatives_sample'].length) && i == @data['orphaned_public_derivatives_sample'].length - 1 %>
+            <%= '[...]' if (@report.orphaned_public_derivatives_count > @report.orphaned_public_derivatives_sample.length) && i == @report.orphaned_public_derivatives_sample.length - 1 %>
           </li>
         <% end %>
       </ul>
       To delete orphaned public derivatives:
       <code>
-        rails runner 'OrphanS3Derivatives.new(show_progress_bar: false).delete_orphans' 
+        rails runner 'OrphanS3Derivatives.new(show_progress_bar: false).delete_orphans'
       </code>
 
     <% else %>
@@ -86,21 +86,21 @@
   <h4>Restricted derivatives</h4>
   <p class="text-muted small">Restricted derivatives without a corresponding asset in the database.</p>
   <p>
-    <% if @data['orphaned_restricted_derivatives_count'] > 0  %>
+    <% if @report.orphaned_restricted_derivatives_count > 0  %>
       <span class="text-danger">
-        <i class="fa fa fa-thumbs-down" aria-hidden="true"></i> There are <%= @data['orphaned_restricted_derivatives_count'] %> orphaned restricted derivatives.
+        <i class="fa fa fa-thumbs-down" aria-hidden="true"></i> There are <%= @report.orphaned_restricted_derivatives_count %> orphaned restricted derivatives.
       </span>
       <ul>
-        <% @data['orphaned_restricted_derivatives_sample'].each_with_index do |path, i|%>
+        <% @report.orphaned_restricted_derivatives_sample.each_with_index do |path, i|%>
           <li>
           <%= link_to(path.split("/").last, Shrine.storages[:restricted_kithe_derivatives].url(path)) %>
-          <%= '[...]' if (@data['orphaned_restricted_derivatives_count'] > @data['orphaned_restricted_derivatives_sample'].length) && i == @data['orphaned_restricted_derivatives_sample'].length - 1 %>
+          <%= '[...]' if (@report.orphaned_restricted_derivatives_count > @report.orphaned_restricted_derivatives_sample.length) && i == @report.orphaned_restricted_derivatives_sample.length - 1 %>
           </li>
         <% end %>
       </ul>
       To delete restricted derivatives:
       <code>
-        rails runner 'OrphanS3RestrictedDerivatives.new(show_progress_bar: false).delete_orphans' 
+        rails runner 'OrphanS3RestrictedDerivatives.new(show_progress_bar: false).delete_orphans'
       </code>
 
     <% else %>
@@ -115,15 +115,15 @@
   <h4>DZI tiles</h4>
   <p class="text-muted small">Deep zoom tiles without a corresponding asset in the database.</p>
   <p>
-    <% if @data['orphaned_dzi_count'] > 0 %>
-      <span class="text-danger"> 
-        <i class="fa fa fa-thumbs-down" aria-hidden="true"></i> There are <%= @data['orphaned_dzi_count'] %> orphaned deep zoom tiles:
+    <% if @report.orphaned_dzi_count > 0 %>
+      <span class="text-danger">
+        <i class="fa fa fa-thumbs-down" aria-hidden="true"></i> There are <%= @report.orphaned_dzi_count %> orphaned deep zoom tiles:
       </span>
       <ul>
-        <% @data['orphaned_dzi_sample'].each_with_index do |path, i|%>
+        <% @report.orphaned_dzi_sample.each_with_index do |path, i|%>
           <li>
             <%= link_to(path.split("/").last, Shrine.storages[:dzi_storage].url(path)) %>
-            <%= '[...]' if (@data['orphaned_dzi_count'] > @data['orphaned_dzi_sample'].length) && i == @data['orphaned_dzi_sample'].length - 1 %>
+            <%= '[...]' if (@report.orphaned_dzi_count > @report.orphaned_dzi_sample.length) && i == @report.orphaned_dzi_sample.length - 1 %>
           </li>
         <% end %>
       </ul>

--- a/app/views/admin/orphan_report/index.html.erb
+++ b/app/views/admin/orphan_report/index.html.erb
@@ -36,7 +36,7 @@
       <ul>
       <% @report.orphaned_originals_sample.each_with_index do |url, i|%>
       <li>
-        <%= url.split("/").last %>
+        <%= link_to url.split("/").last, S3ConsoleUri.new(url).console_uri %>
         <%= '[...]' if (@report.orphaned_originals_count > @report.orphaned_originals_sample.length) && i == @report.orphaned_originals_sample.length - 1 %>
       </li>
       <% end %>
@@ -64,7 +64,7 @@
       <ul>
         <% @report.orphaned_public_derivatives_sample.each_with_index do |url, i|%>
           <li>
-            <%= url.split("/").last %>
+            <%= link_to url.split("/").last, S3ConsoleUri.new(url).console_uri %>
             <%= '[...]' if (@report.orphaned_public_derivatives_count > @report.orphaned_public_derivatives_sample.length) && i == @report.orphaned_public_derivatives_sample.length - 1 %>
           </li>
         <% end %>
@@ -93,7 +93,7 @@
       <ul>
         <% @report.orphaned_restricted_derivatives_sample.each_with_index do |url, i|%>
           <li>
-          <%= url.split("/").last %>
+          <%= link_to url.split("/").last, S3ConsoleUri.new(url).console_uri %>
           <%= '[...]' if (@report.orphaned_restricted_derivatives_count > @report.orphaned_restricted_derivatives_sample.length) && i == @report.orphaned_restricted_derivatives_sample.length - 1 %>
           </li>
         <% end %>
@@ -122,7 +122,7 @@
       <ul>
         <% @report.orphaned_dzi_sample.each_with_index do |url, i|%>
           <li>
-            <%= url.split("/").last %>
+            <%= link_to url.split("/").last, S3ConsoleUri.new(url).console_uri %>
             <%= '[...]' if (@report.orphaned_dzi_count > @report.orphaned_dzi_sample.length) && i == @report.orphaned_dzi_sample.length - 1 %>
           </li>
         <% end %>


### PR DESCRIPTION
Variety of refactoring cleanup, along with features from #1534

- encapsulate JSONB model access to model, simplifying view a bit
- OrphanReport stores s3 URLs (with bucket) of orphaned files, not just path
- make orphan report urls go to AWS console dashboard
- Trust configured shrine storage, don't try to duplicate un-DRY config
- simplify logic for displaying omission mark for more orphaned list
- display more of orphaned file path
- change 'nightly' to 'weekly' in report, accurately describes current situation
