### PR TITLE
Add strict_loading to work 'show'/detail pages, to guard against future accidental n+1 lazy loads

### DIFF
--- a/app/components/work_file_list_show_component.rb
+++ b/app/components/work_file_list_show_component.rb
@@ -91,7 +91,7 @@ class WorkFileListShowComponent < ApplicationComponent
   # We need to slice and dice the members in a couple ways, so just load them all in,
   # but we should never show this to the public
   def all_members
-    @all_members = work.members.includes(:leaf_representative).order(:position).to_a
+    @all_members = work.members.includes(:leaf_representative).order(:position).strict_loading.to_a
   end
 
 

--- a/app/components/work_oh_audio_show_component.rb
+++ b/app/components/work_oh_audio_show_component.rb
@@ -21,6 +21,7 @@ class WorkOhAudioShowComponent < ApplicationComponent
     @all_members ||= begin
       members = work.members.includes(:leaf_representative)
       members = members.where(published: true) if current_user.nil?
+      members = members.strict_loading # prevent accidental n+1 lazy-loading.
       members.order(:position).to_a
     end
   end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -118,9 +118,13 @@ class Work < Kithe::Work
   def ordered_viewable_members(current_user:)
     members = self.members.includes(:leaf_representative)
     members = members.where(published: true) if current_user.nil?
-    members = members.order(:position).to_a
+    members = members.order(:position)
 
-    members
+    # the point of this is to avoid n+1's, so let's set strict_loading, which
+    # it turns out you can do on an association/relation
+    members = members.strict_loading
+
+    members.to_a
   end
 
   # Ensures the optional sidecar OralHistoryContent is present if it wans't already


### PR DESCRIPTION
While we don't seem to have any now, these strict_loading directives will make Rails raise if we try to trigger database queries off these objects or relations after they were initially loaded. We intend to load everything we need up front to avoid n+1 query problem; strict_loading will hold us to it.

Ref #1310
