### PR TITLE
Clean up combined audio creator a bit

### DIFF
--- a/app/services/combined_audio_derivative_creator.rb
+++ b/app/services/combined_audio_derivative_creator.rb
@@ -54,7 +54,7 @@ class CombinedAudioDerivativeCreator
 
 
   def cmd
-    @cmd ||= TTY::Command.new(output: Rails.logger)
+    @cmd ||= TTY::Command.new(output: TtyLoggerWrapper.new(logger))
   end
 
   def output_file(format)
@@ -175,6 +175,20 @@ class CombinedAudioDerivativeCreator
         work.members.order(:position, :id).select do |member|
           (member.is_a? Asset) && member.published? && member.stored? && member.content_type && member.content_type.start_with?("audio/")
         end
+      end
+    end
+
+    # TTY:::Command wants a logger that uses method `<<`. We want
+    # that to go to specific chosen level of logging in our Rails logger.
+    #
+    # Also TTY log messages have newlines that are better off removed.
+    class TtyLoggerWrapper
+      def initialize(wrapped_logger, level: :info)
+        @wrapped_logger = wrapped_logger
+        @level = level
+      end
+      def <<(str)
+        @wrapped_logger.send(@level, str.chomp)
       end
     end
 

--- a/app/services/combined_audio_derivative_creator.rb
+++ b/app/services/combined_audio_derivative_creator.rb
@@ -73,10 +73,7 @@ class CombinedAudioDerivativeCreator
     @components ||= begin
       result = []
       audio_member_files.each do |original_file|
-        new_temp_file = Tempfile.new(['temp_', original_file.metadata['filename'].downcase], :encoding => 'binary')
-        original_file.open(rewindable:false) do |input_audio_io|
-          new_temp_file.write input_audio_io.read until input_audio_io.eof?
-        end
+        new_temp_file = original_file.download(rewindable: false)
         result << new_temp_file
       end
       result

--- a/app/services/combined_audio_derivative_creator.rb
+++ b/app/services/combined_audio_derivative_creator.rb
@@ -24,10 +24,11 @@ class CombinedAudioDerivativeCreator
 
   Response = Struct.new(:webm_file, :mp3_file, :fingerprint, :start_times, :errors, keyword_init: true)
 
-  attr_reader :work
+  attr_reader :work, :logger
 
-  def initialize(work)
+  def initialize(work, logger: Rails.logger)
     @work = work
+    @logger = logger
   end
 
   def generate
@@ -71,11 +72,13 @@ class CombinedAudioDerivativeCreator
 
   def components
     @components ||= begin
+      logger.debug("#{self.class}: downloading original assets")
       result = []
       audio_member_files.each do |original_file|
         new_temp_file = original_file.download(rewindable: false)
         result << new_temp_file
       end
+      logger.debug("#{self.class}: downloading original assets complete")
       result
     end
   end


### PR DESCRIPTION
- use standard Shrine#download instead of trying to reinvent it

Noticed that downloads of originals was taking a long time. I don't think this actually speeds it up much, but we were kind of reinventing how to "stream from S3 to a tempfile via shrine", when we could have been using the func built into shrine that has had more developer eyes on it. 

- a few more debug log lines, make it easier to see duration of each part of process

Let's try to log a bit more too. 
