### PR TITLE
tag s3 uploads

### DIFF
--- a/app/uploaders/asset_uploader.rb
+++ b/app/uploaders/asset_uploader.rb
@@ -11,27 +11,22 @@ class AssetUploader < Kithe::AssetUploader
   # will only have effect if we are using an AWS store of course.
   plugin :scihist_upload_options, proccessor: -> (io, options, storage_key) do
     output_upload_options = {}
-byebug
     # arguments that might be useful for dynamic processing including, `options[:derivative]`, true
     # if processing derivatives via shrine derivatives plugin; and `storage_key`, might be one
     # of something from config/initializers/shrine.rb.
 
-    content_type = options.dig(:metadata, "mime_type")
-    if content_type.present?
-      # AWS SDK docs: "The tag-set must be encoded as URL Query parameters. (For example, "Key1=Value1")"
-      # Rails #to_query can do it for us.
-      tags = {
-        "Content-Type-Base" => content_type.split("/").first
-        # "Content-Type-Full" => content_type
-      }
+    content_type = options.dig(:metadata, "mime_type") || "unknown"
 
-      # Need the weird tagging_directive REPLACE for confusing reasons.
-      # https://discourse.shrinerb.com/t/gotcha-on-s3-upload-options-and-tags/559
-      output_upload_options.merge!(
-        tagging: tags.to_query,
-        tagging_directive: "REPLACE"
-      )
-    end
+    # AWS SDK docs: "The tag-set must be encoded as URL Query parameters. (For example, "Key1=Value1")"
+    # Rails #to_query can do it for us.
+    tags = {
+      "Content-Type-Base" => content_type.split("/").first
+      # "Content-Type-Full" => content_type
+    }
+
+    # Need the weird tagging_directive REPLACE for confusing reasons.
+    # https://discourse.shrinerb.com/t/gotcha-on-s3-upload-options-and-tags/559
+    output_upload_options[:tagging] = tags.to_query
 
     output_upload_options
   end

--- a/app/uploaders/asset_uploader.rb
+++ b/app/uploaders/asset_uploader.rb
@@ -15,7 +15,7 @@ class AssetUploader < Kithe::AssetUploader
     # if processing derivatives via shrine derivatives plugin; and `storage_key`, might be one
     # of something from config/initializers/shrine.rb.
 
-    content_type = options.dig(:metadata, "mime_type") || "unknown"
+    content_type = options.dig(:metadata, "mime_type").presence || "unknown"
 
     # AWS SDK docs: "The tag-set must be encoded as URL Query parameters. (For example, "Key1=Value1")"
     # Rails #to_query can do it for us.

--- a/app/uploaders/asset_uploader.rb
+++ b/app/uploaders/asset_uploader.rb
@@ -9,17 +9,20 @@ class AssetUploader < Kithe::AssetUploader
 
   # use shrine upload_options plugin to set AWS tagging, only for "store" (not cache),
   # will only have effect if we are using an AWS store of course.
-  plugin :upload_options, store: -> (io, options) do
+  plugin :scihist_upload_options, proccessor: -> (io, options, storage_key) do
     output_upload_options = {}
+byebug
+    # arguments that might be useful for dynamic processing including, `options[:derivative]`, true
+    # if processing derivatives via shrine derivatives plugin; and `storage_key`, might be one
+    # of something from config/initializers/shrine.rb.
 
-    # if you wanted to avoid for derivatives, you might `unless options[:derivative]`
     content_type = options.dig(:metadata, "mime_type")
     if content_type.present?
       # AWS SDK docs: "The tag-set must be encoded as URL Query parameters. (For example, "Key1=Value1")"
       # Rails #to_query can do it for us.
       tags = {
-        "Content-Type-Full" => content_type,
-        #{}"Content-Type-Base" => content_type.split("/").first
+        "Content-Type-Base" => content_type.split("/").first
+        # "Content-Type-Full" => content_type
       }
 
       # Need the weird tagging_directive REPLACE for confusing reasons.

--- a/config/initializers/patch_shrine_s3.rb
+++ b/config/initializers/patch_shrine_s3.rb
@@ -1,0 +1,36 @@
+# Patch to shrine to allow us to do automated S3 tagging via shrine. This is a copy
+# of what has been PR'd and merged into shrine already at:
+#
+#   https://github.com/shrinerb/shrine/pull/569/
+#
+# So this patch can and should be removed when a version of shrine including it
+# is released and we upgrade to it. Presumably shrine 3.5.0
+
+SanePatch.patch('shrine', '3.4.0', details: "this should not be necessary in shrine 3.5.0 if shrine PR #569 is included") do
+  require 'shrine/storage/s3'
+
+  class Shrine
+    module Storage
+      class S3
+        # Copies an existing S3 object to a new location. Uses multipart copy for
+        # large files.
+        def copy(io, id, **copy_options)
+          # don't inherit source object metadata or AWS tags
+          options = {
+            metadata_directive: "REPLACE",
+            tagging_directive: "REPLACE"
+          }
+
+          if io.size && io.size >= @multipart_threshold[:copy]
+            # pass :content_length on multipart copy to avoid an additional HEAD request
+            options.merge!(multipart_copy: true, content_length: io.size)
+          end
+
+          options.merge!(copy_options)
+
+          object(id).copy_from(io.storage.object(io.id), **options)
+        end
+      end
+    end
+  end
+end

--- a/lib/shrine/plugins/scihist_upload_options.rb
+++ b/lib/shrine/plugins/scihist_upload_options.rb
@@ -33,7 +33,6 @@ class Shrine
 
         def _upload(io, **options)
           upload_options = get_upload_options(io, options)
-byebug
           super(io, **options, upload_options: upload_options)
         end
 

--- a/lib/shrine/plugins/scihist_upload_options.rb
+++ b/lib/shrine/plugins/scihist_upload_options.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class Shrine
+  module Plugins
+
+    # This is based on the shrine upload_options plugin, but modified so that:
+    #
+    # * you regsiter upload_options that will apply to ALL storages used by the uploader,
+    #   instead of having to register storage-specific.
+    #
+    # * an upload_options block gets the specific storage as an argument.
+    #
+    # It was copied and modified from shrine at v3.4.0: https://github.com/shrinerb/shrine/blob/v3.4.0/lib/shrine/plugins/upload_options.rb
+    #
+    # You may be interested in docs for the original shrine plugin at https://shrinerb.com/docs/plugins/upload_options
+    #
+    # And some discussion of these additonal features in my post at https://discourse.shrinerb.com/t/upload-options-plugin-for-dynamic-options-but-covering-more-than-one-storage/560
+    #
+    #     plugin :scihist_upload_options, proccessor: -> (io, options, storage_key) {
+    #       if storage_key == :kithe_derivatives
+    #          { acl: "public-read" }
+    #       end
+    #     }
+    #
+    module ScihistUploadOptions
+      def self.configure(uploader, **opts)
+        uploader.opts[:scihist_upload_options] ||= {}
+        uploader.opts[:scihist_upload_options].merge!(opts)
+      end
+
+      module InstanceMethods
+        private
+
+        def _upload(io, **options)
+          upload_options = get_upload_options(io, options)
+byebug
+          super(io, **options, upload_options: upload_options)
+        end
+
+        def get_upload_options(io, options)
+          upload_options = opts[:scihist_upload_options][:proccessor] || {}
+          upload_options = upload_options.call(io, options, storage_key) if upload_options.respond_to?(:call)
+          upload_options = upload_options.merge(options[:scihist_upload_options]) if options[:scihist_upload_options]
+          upload_options
+        end
+      end
+    end
+
+    register_plugin(:scihist_upload_options, ScihistUploadOptions)
+  end
+end

--- a/lib/tasks/data_fixes/set_s3_object_content_type_tags.rake
+++ b/lib/tasks/data_fixes/set_s3_object_content_type_tags.rake
@@ -26,7 +26,7 @@ namespace :scihist do
           storage = shrine_file.storage
 
           if storage.kind_of?(Shrine::Storage::S3)
-            content_type = shrine_file.metadata&.dig("mime_type") || "unknown"
+            content_type = shrine_file.metadata&.dig("mime_type").presence || "unknown"
             content_type_base = content_type.split("/").first
 
             # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Client.html#put_object_tagging-instance_method

--- a/lib/tasks/data_fixes/set_s3_object_content_type_tags.rake
+++ b/lib/tasks/data_fixes/set_s3_object_content_type_tags.rake
@@ -1,0 +1,54 @@
+namespace :scihist do
+  namespace :data_fixes do
+
+    desc """
+      Add Content-Type-Base tag to all S3 originals and derivatives with appropriate value.
+      Going forward, should be done automatically on ingest, but this takes care of existing.
+      WARNING: Will override ANY existing object-level tags. (We don't have any now, so should
+      be fine)
+    """
+    task :set_s3_object_content_type_tags => :environment do
+      scope = Asset
+
+      # useful for testing/debugging, limit to just so many assets
+      if ENV["TEST_LIMIT"]
+        limit = ENV["TEST_LIMIT"].to_i
+      end
+
+      files_processed = 0
+
+      # APPROXIMATE, 9 derivs per asset
+      file_count = Asset.count * 10
+      progress_bar = ProgressBar.create(total: file_count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+
+      scope.find_each do |asset|
+        ([asset.file] + asset.file_derivatives.values).each do |shrine_file|
+          storage = shrine_file.storage
+
+          if storage.kind_of?(Shrine::Storage::S3)
+            content_type = shrine_file.metadata&.dig("mime_type") || "unknown"
+            content_type_base = content_type.split("/").first
+
+            # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Client.html#put_object_tagging-instance_method
+            storage.client.put_object_tagging({
+              bucket: storage.bucket.name,
+              key: storage.object_key(shrine_file.id),
+              tagging: {
+                tag_set: [
+                  {
+                    key: "Content-Type-Base",
+                    value: content_type_base,
+                  }
+                ]
+              }
+            })
+          end
+          files_processed += 1
+          progress_bar.increment if files_processed < file_count
+        end
+        break if limit && files_processed >= limit
+      end
+      puts "Tagged #{files_processed} files"
+    end
+  end
+end


### PR DESCRIPTION
We want to tag all S3 objects with a "Content-Type-Base" tag that has a value that is first part of mime content-type: "image", "audio", "video", "application".  This is to let us get categorized reports on our expenses. Ref #1654

This should be do-able with the shrine [upload_options](https://shrinerb.com/docs/plugins/upload_options) plugin, but was not, for two reasons, which we worked around as described:

* We are using several different shrine "storages" -- a separate for restricted derivatives vs public, originals vs derivatives, etc. We really want to tag all of them, and the upload_options plugin doesn't make it easy to do that, without naming them all specifically -- which could change as we re-architect things. 
   * We could have just tagged originals I guess, but I wanted to do all of them. 
   * So I wrote a custom shrine plugin *based on* the pretty simple shrine `upload_options` plugin, included here. 
   * Some more discussion here: https://discourse.shrinerb.com/t/upload-options-plugin-for-dynamic-options-but-covering-more-than-one-storage/560

* Shrine uses an AWS S3 SDK method to *copy* files from one S3 bucket to another in some cases, and that operation doesn't let you assign tags to destination unless you pass a `tagging_directive: "REPLACE"` option. So our tags were being ignored. 
   *   I PR'd a fix to shrine, and it was accepted at https://github.com/shrinerb/shrine/pull/569/, but we need it now, without waiting for a shrine release
   * So the fix is "monkey-patched" in too. 
   
   
Note also:

* We don't actually test S3 shrine storage at all in our tests/CI, our tests use a different shrine storage so we didn't have to figure out how to set up S3 for testing. The downside of this, though, is that none of this behavior is really tested. :(  (I did manually QA it).  not ideal, but....

* The content type is taken from the associated Asset model's metadata. If it's not there... the logic assigns the value "unknown".  Our DZI tiles for instance end up "unknown".  If in reporting we see a lot of unknown it's probably DZI tiles... but you can probably cross-tab with bucket name in reporting anyhow. 