### PR TITLE
change CombinedAudioDerivativeCreator to call ffmpeg with url args

### DIFF
--- a/app/services/combined_audio_derivative_creator.rb
+++ b/app/services/combined_audio_derivative_creator.rb
@@ -105,7 +105,7 @@ class CombinedAudioDerivativeCreator
     end.to_h
 
     sum = 0
-    end_points = duration_map.values.map {|i| sum += i}
+    end_points = duration_map.values.map {|i| sum += i}.map { |i| i.round(3) }
 
     duration_map.keys.zip([0] + end_points)
   end

--- a/app/services/combined_audio_derivative_creator.rb
+++ b/app/services/combined_audio_derivative_creator.rb
@@ -19,7 +19,7 @@ require 'tempfile'
 #   [["ddbd1a8d-c2eb-47b3-85a4-11b4ffb41719", 0],
 #    ["df773502-56d7-4756-a58c-b1f479910e97", 1.593469]]
 #  >
-
+#
 class CombinedAudioDerivativeCreator
 
   Response = Struct.new(:webm_file, :mp3_file, :fingerprint, :start_times, :errors, keyword_init: true)
@@ -99,6 +99,9 @@ class CombinedAudioDerivativeCreator
 
   # A list of arrays; the first item in each is the UUID of each audio member,
   # while the second is the *starting point* of that audio w/r/t the combined audio.
+  #
+  # The durations are obtained from stored characterization metadata, we count on that
+  # being present and correct!
   def calculate_start_times
     duration_map = published_audio_members.collect do |audio_asset|
       [audio_asset.id, audio_asset.file&.metadata&.dig("duration_seconds")]

--- a/app/services/combined_audio_derivative_creator.rb
+++ b/app/services/combined_audio_derivative_creator.rb
@@ -32,8 +32,8 @@ class CombinedAudioDerivativeCreator
   end
 
   def generate
-    if components.length == 0
-      return Response.new(errors: "Could not assemble all the components.")
+    if input_sources.length == 0
+      return Response.new(errors: "Could not assemble all the input sources.")
     end
     output_files = {}
     # Create the two output files:
@@ -47,9 +47,12 @@ class CombinedAudioDerivativeCreator
     resp.mp3_file    = output_files['mp3']
     resp.fingerprint = fingerprint
     resp.start_times = calculate_start_times
-    # Before leaving, get rid of the downloaded originals:
-    components.map!(&:unlink)
     resp
+  ensure
+    # Before leaving, get rid of the downloaded originals:
+    input_tempfiles.map!(&:unlink)
+    input_tempfiles.clear
+    input_sources.clear
   end
 
 
@@ -70,47 +73,61 @@ class CombinedAudioDerivativeCreator
     cmd.run(*options).out.strip.to_f
   end
 
-  def components
-    @components ||= begin
+  def input_tempfiles
+    @input_tempfiles = []
+  end
+
+  # an array of args to ffmpeg for the input files, will be URLs if possible, otherwise
+  # local file paths from temporarily downloaded local files.
+  def input_sources
+    @input_args ||= begin
       logger.debug("#{self.class}: downloading original assets")
-      result = []
-      audio_member_files.each do |original_file|
-        new_temp_file = original_file.download(rewindable: false)
-        result << new_temp_file
+
+      audio_member_files.collect do |original_file|
+        if original_file.url.present? && original_file.url.start_with?(/https?:/)
+          original_file.url
+        else
+          new_temp_file = original_file.download(rewindable: false)
+          input_tempfiles << new_temp_file
+          new_temp_file.path
+        end
+      end.tap do
+        logger.debug("#{self.class}: downloading original assets complete")
       end
-      logger.debug("#{self.class}: downloading original assets complete")
-      result
     end
   end
 
   # A list of arrays; the first item in each is the UUID of each audio member,
   # while the second is the *starting point* of that audio w/r/t the combined audio.
-  def calculate_start_times()
-    durations = components.map do |f|
-      duration_of_audio_file_in_seconds(f.path)
-    end
+  def calculate_start_times
+    duration_map = published_audio_members.collect do |audio_asset|
+      [audio_asset.id, audio_asset.file&.metadata&.dig("duration_seconds")]
+    end.to_h
+
     sum = 0
-    audio_member_ids = published_audio_members.map(&:id)
-    end_points = durations.map {|i| sum += i}
-    audio_member_ids.zip([0] + end_points)
+    end_points = duration_map.values.map {|i| sum += i}
+
+    duration_map.keys.zip([0] + end_points)
   end
 
   # Generate ffmpeg command to concatenate a set of audio files using
   # ffmpeg stream mapping.
   # This is tricky but documented at
-  # https://trac.ffmpeg.org/wiki/Map .
+  # https://trac.ffmpeg.org/wiki/Map and https://trac.ffmpeg.org/wiki/Concatenate#protocol
+  #
   # For now, the audio settings are hardwired.
   # This does not run the command; it just returns
   # an array that can be passed to cmd.run .
+  #
   def args_for_ffmpeg(output_file_path)
     # ffmpeg -y: overwrite the already-existing temp file
     ffmpeg_command = ['ffmpeg', '-y']
 
-    # Then a list of input files specified with -i
-    input_files = components.map {|x| [ "-i", x.path] }.flatten
+    # Then a list of input URLs or file paths specified with -i
+    input_files = input_sources.map {|x| [ "-i", x] }.flatten
 
     # List the number of audio streams: one per file
-    stream_list = 0.upto(components.count - 1).to_a.map{ |n| "[#{n}:a]"}.join
+    stream_list = 0.upto(input_sources.count - 1).to_a.map{ |n| "[#{n}:a]"}.join
 
     # Specify what to do with the audio streams:
     #
@@ -122,7 +139,7 @@ class CombinedAudioDerivativeCreator
     #   concat -> Stream #0:0 (libmp3lame)
     #
     # v=0 means there is no video.
-    filtergraph = "concat=n=#{components.count}:v=0:a=1[a]"
+    filtergraph = "concat=n=#{input_sources.count}:v=0:a=1[a]"
 
     # Finally, some output options:
     # -map [a] : map just the audio to the output

--- a/spec/services/work_combined_audio_creator_spec.rb
+++ b/spec/services/work_combined_audio_creator_spec.rb
@@ -27,7 +27,7 @@ describe "Combined Audio" do
     # The lengths should be correct:
     expect(combined_audio_info.start_times).to match([
       [audio_asset_1.id, 0],
-      [audio_asset_2.id, 1.593469]
+      [audio_asset_2.id, 1.593]
     ])
 
     # The files should be tempfiles:
@@ -71,7 +71,7 @@ describe "Combined Audio" do
 
     expect( combined_audio_info.start_times).to match([
       [audio_asset_2.id, 0],
-      [audio_asset_1.id, 3.160816]
+      [audio_asset_1.id, 3.161]
     ])
 
     # Get some verbose details about the files output:


### PR DESCRIPTION
No need to download them locally as tempfiles if we can access them remotely as URLs, say an s3 signed url. ffmpeg can use the URLs! Should be somewhat more efficient timewise. Maybe more RAM-efficient too? Not sure.

We also change the logic to use new duration metadata, instead of previous code that re-extracted duration.

Note all existing tests pass, this is just a refactor hooray. EXCEPT the number of significant digits on duration changes, now we're only to ms level of granularity, before it was nanoseconds. which is fine.
