### PR TITLE
store video originals in segregated bucket for video

### DIFF
--- a/app/uploaders/asset_uploader.rb
+++ b/app/uploaders/asset_uploader.rb
@@ -6,6 +6,19 @@ class AssetUploader < Kithe::AssetUploader
   # URL location, to be fetched on promotion.
   plugin :kithe_accept_remote_url
 
+  # store VIDEO originals in separate bucket, identified as separate shrine
+  # storage ID. Instead of usual default :store shrine storage ID
+  #
+  # https://shrinerb.com/docs/plugins/default_storage
+  plugin :default_storage
+  Attacher.default_store  do
+    if record.content_type&.start_with?("video/")
+      :video_store
+    else
+      :store
+    end
+  end
+
   # audio/video file characterization
   add_metadata do |source_io, **context|
     Kithe::FfprobeCharacterization.characterize_from_uploader(source_io, context)

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -93,12 +93,12 @@
       <dd class="col-sm-8"><%= @asset.caption %></dd>
 
 
-      <%if @asset.stored? && Shrine.storages[:store].try('bucket').try('name') %>
+      <%if @asset.stored? %>
         <dt class="col-sm-4">File in s3</dt>
         <dd class="col-sm-8"><%= link_to @asset.file.url(public: true).split('/').last, S3ConsoleUri.new(@asset.file.url(public: true)).console_uri %></dd>
 
         <dt class="col-sm-4">Stored in S3 bucket</dt>
-        <dd class="col-sm-8"><%= Shrine.storages[:store].bucket.name %></dd>
+        <dd class="col-sm-8"><%= @asset.file.storage.try(:bucket).try(:name) || "UNKNOWN" %></dd>
       <% end %>
 
       <dt class="col-sm-4">Content-type</dt>

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -11,6 +11,7 @@ Shrine.plugin :uppy_s3_multipart
 Shrine.storages = {
   cache: ScihistDigicoll::Env.shrine_cache_storage,
   store: ScihistDigicoll::Env.shrine_store_storage,
+  video_store: ScihistDigicoll::Env.shrine_store_video_storage,
   kithe_derivatives: ScihistDigicoll::Env.shrine_derivatives_storage,
   restricted_kithe_derivatives: ScihistDigicoll::Env.shrine_restricted_derivatives_storage,
   on_demand_derivatives: ScihistDigicoll::Env.shrine_on_demand_derivatives_storage,

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -185,6 +185,7 @@ module ScihistDigicoll
     end
 
     define_key :s3_bucket_originals
+    define_key :s3_bucket_originals_video
     define_key :s3_bucket_derivatives
     define_key :s3_bucket_uploads
     define_key :s3_bucket_on_demand_derivatives
@@ -297,7 +298,7 @@ module ScihistDigicoll
     #
     #
     def self.appropriate_shrine_storage(bucket_key:, mode: lookup!(:storage_mode), s3_storage_options: {}, prefix: nil)
-      unless %I{s3_bucket_uploads s3_bucket_originals s3_bucket_derivatives
+      unless %I{s3_bucket_uploads s3_bucket_originals s3_bucket_originals_video s3_bucket_derivatives
                 s3_bucket_on_demand_derivatives s3_bucket_dzi}.include?(bucket_key)
         raise ArgumentError.new("Unrecognized bucket_key: #{bucket_key}")
       end
@@ -342,6 +343,12 @@ module ScihistDigicoll
     def self.shrine_store_storage
       @shrine_store_storage ||=
         appropriate_shrine_storage(bucket_key: :s3_bucket_originals)
+    end
+
+    # we store video originals in separate location
+    def self.shrine_store_video_storage
+      @shrine_video_store_storage ||=
+        appropriate_shrine_storage(bucket_key: :s3_bucket_originals_video)
     end
 
     # Note we set shrine S3 storage to public, to upload with public ACLs


### PR DESCRIPTION
Using shrine default_storage plugin to allow dynamic choice of shrine storage based on record attributes.  https://shrinerb.com/docs/plugins/default_storage

Ref https://github.com/sciencehistory/scihist_digicoll/issues/1575

Please merge only after merging of https://github.com/sciencehistory/terraform_scihist_digicoll/pull/9

# Additional "out of band" setup

## IAM config

staging and  production IAM users/roles need to have access to write to the new buckets. We don't control IAM via terraform at the moment (see https://github.com/sciencehistory/terraform_scihist_digicoll/issues/6), so need to do this manually. 

- [x] staging
  *  The AWS access key used by the app in staging is associated with AWS IAM user `s3_digicoll_staging` https://console.aws.amazon.com/iam/home#/users/s3_digicoll_staging
  * It has a a policy `s3_kithe_staging` "attached directly:, 
  * it needs to be edited to include `"arn:aws:s3:::scihist-digicoll-staging-originals-video"` `"arn:aws:s3:::scihist-digicoll-staging-originals-video/*"` (matching template of existing buckets in policy, not sure if we really need both)
- [x] production
  * The AWS access key used by the app in production is associated with AWS IAM user `s3_digicoll_production` https://console.aws.amazon.com/iam/home#/users/s3_digicoll_production
  * It has a policy `S3_kithe_production` attached directly. 
  * It needs to be edited to include `"arn:aws:s3:::scihist-digicoll-production-originals-video"` `"arn:aws:s3:::scihist-digicoll-production-originals-video/*"` (matching template of existing buckets in policy, not sure if we really need both)

## Heroku config to set



- [x] staging: `heroku config:set S3_BUCKET_ORIGINALS_VIDEO="scihist-digicoll-staging-originals-video"`
- [x] production:  `heroku config:set S3_BUCKET_ORIGINALS_VIDEO="scihist-digicoll-production-originals-video" -r production`

## Wiki docs?

The relevant wiki docs need updating anyway, so let's update them now as well as adding new info about this stuff. 

- [x] S3 Bucket Setup and Architecture: https://chemheritage.atlassian.net/l/c/JDd3QvVK  -- significant edits, updated info here. Moved to HDC space so stakeholders can see. 
- [x] Maybe "Backups and Recovery" at https://chemheritage.atlassian.net/l/c/Dm05z1pf  -- left this as "historical", linked to more up to date content including S3 Bucket Setup page above. 

