### PR TITLE
Avoid Rsolr deprecation on read_timeout config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -178,7 +178,7 @@ end
 # Added by blacklight. Not sure why rsolr isn't just a BL dependency.
   # We need RSolr 2.x to get faraday-based connection so we can customize
   # middleware, so we customize dependency to require 2.x
-  gem 'rsolr', '~> 2.0'
+  gem 'rsolr', '~> 2.4'
   # gem 'popper_js' #popper shouldn't be needed, it's already a dep of BL 4. PR to BL?
 
   # Used only for autocomplete, which we aren't currently using.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -732,7 +732,7 @@ DEPENDENCIES
   resque-heroku-signals
   resque-pool
   rinku (~> 2.0)
-  rsolr (~> 2.0)
+  rsolr (~> 2.4)
   rspec-rails (~> 5.0)
   rubyzip (~> 2.0)
   sane_patch (< 2.0)

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -7,6 +7,4 @@ test: &test
 production:
   adapter: solr
   url: <%= ScihistDigicoll::Env.lookup!(:solr_url) %>
-  # RSolr 2.3.0 actually translates read_timeout to faraday `timeout`.
-  # Future RSolr may want `timeout`.
-  read_timeout: 4
+  timeout: 4


### PR DESCRIPTION
Noticed in logs: DEPRECATION: Rsolr.new/connect option `read_timeout` is deprecated and will be removed in Rsolr 3. `timeout` is currently a synonym, use that instead.

Fixed, updating Gemfile to require latest Rsolr that uses new config.
