### PR TITLE
Fix serialize_work and restore_work to take video and restricted derivative storage into account.

### DIFF
--- a/app/models/copy_staging/restore_work.rb
+++ b/app/models/copy_staging/restore_work.rb
@@ -32,9 +32,15 @@ module CopyStaging
   # could be disastrous. This object can take thread_pool_size as an init
   # argument, but the wrapping rake task isn't currently written to exersize that.
   class RestoreWork
-    REMOTE_STORE_STORAGE_KEY =       :remote_store_storage
-    REMOTE_VIDEO_STORE_STORAGE_KEY = :remote_video_store_storage
-    REMOTE_DERIVATIVES_STORAGE_KEY = :remote_derivatives_storage
+
+    # Associate dev with staging shrine storage keys:
+    ORIGINALS_STORAGE = {
+      store:             :remote_store_storage, #non-video
+      video_store:       :remote_video_store_storage # video
+    }
+    DERIVATIVES_STORAGE = {
+      kithe_derivatives: :remote_derivatives_storage
+    }
 
     attr_accessor :json_file, :thread_pool, :tracked_futures, :thread_pool_size
 
@@ -42,24 +48,15 @@ module CopyStaging
     #   exported from correspoinding SerializeWork file.
     #
     # @param thread_pool_size how big a thread pool to use for our parallel
-    #   bytestrea copy operations. See docs at top of class. Defaults to 50,
+    #   bytestream copy operations. See docs at top of class. Defaults to 50,
     #   could be faster if we made it unlimited, but could also be more disastrous.
     def initialize(json_file:, thread_pool_size: 50)
       @json_file = json_file
       @thread_pool_size = thread_pool_size
-
       @thread_pool = Concurrent::FixedThreadPool.new(thread_pool_size)
       @tracked_futures = Concurrent::Array.new
-
-      @remote_asset_storage_keys = {
-          'store'         => REMOTE_STORE_STORAGE_KEY,
-          'video_store'   => REMOTE_VIDEO_STORE_STORAGE_KEY
-      }
-
-      # make sure they get registered
-      remote_store_storage
-      remote_video_store_storage
-      remote_derivatives_storage
+      @storage_map = ORIGINALS_STORAGE.merge(DERIVATIVES_STORAGE)
+      register_remote_storages
     end
 
     def restore
@@ -128,67 +125,46 @@ module CopyStaging
       components.join("/")
     end
 
-    def lookup_remote_storage_key(asset_model)
-      model_storage = asset_model.file.data['storage']
-      unless @remote_asset_storage_keys.has_key? model_storage
-         raise RuntimeError, "Unrecognized storage for asset #{asset_model.friendlier_id}: #{model_storage}"
-      end
-      @remote_asset_storage_keys[model_storage]
-    end
-
     def restore_asset_file(asset_model)
+      local_storage_key = asset_model.file.data['storage'].to_sym
+      unless @storage_map.has_key? local_storage_key
+         raise RuntimeError, "Unrecognized remote storage for asset #{asset_model.friendlier_id}: #{local_storage_key}"
+      end
       tracked_futures << Concurrent::Promises.future_on(thread_pool) do
-        puts "  -> Copying original file for #{asset_model.class.name}/#{asset_model.friendlier_id}\n\n"
-        remote_storage_key = lookup_remote_storage_key(asset_model)
-        remote_file = Shrine::UploadedFile.new(asset_model.file.data.merge("storage" => remote_storage_key))
-        Shrine.storages[:store].upload(remote_file, asset_model.file.id)
+        puts "  -> Copying original file for #{asset_model.class.name}/#{asset_model.friendlier_id}\n\n"        
+        copy_file( key: local_storage_key, file: asset_model.file)
       end
     end
 
     def restore_derivative_file(derivative_uploaded_file, asset_id:, derivative_key:)
       tracked_futures << Concurrent::Promises.future_on(thread_pool) do
         puts "  -> Copying derivative file for #{asset_id}/#{derivative_key}\n\n"
-
-        remote_file = Shrine::UploadedFile.new(derivative_uploaded_file.data.merge("storage" => REMOTE_DERIVATIVES_STORAGE_KEY))
-        Shrine.storages[:kithe_derivatives].upload(remote_file, derivative_uploaded_file.id)
+        copy_file(key: derivative_uploaded_file.storage_key, file: derivative_uploaded_file)
       rescue Aws::S3::Errors::NoSuchKey => e
-        puts "   ERROR: Could not find file to copy `#{remote_file.id}` on #{Shrine.storages[REMOTE_DERIVATIVES_STORAGE_KEY].then {|s| [s.bucket&.name, s.prefix].compact.join('/')}}"
+        path = Shrine.storages[remote_storage_key].then {|s| [s.bucket&.name, s.prefix].compact.join('/')}
+        puts "   ERROR: Could not find file to copy `#{remote_file.id}` on #{path}"
       end
+    end
+
+    def copy_file(key:, file:)
+      remote_file_data = file.data.merge("storage" => @storage_map[key])
+      Shrine.storages[key].upload(Shrine::UploadedFile.new(remote_file_data),file.id)
     end
 
     def input_hash
       @input_hash ||= ActiveSupport::JSON.decode(json_file.read)
     end
 
-    def remote_store_storage
-      Shrine.storages[REMOTE_STORE_STORAGE_KEY] ||= Shrine::Storage::S3.new(
-        bucket:            input_hash["shrine_s3_storage_staging"]["store"]["bucket_name"],
-        prefix:            input_hash["shrine_s3_storage_staging"]["store"]["prefix"],
-        access_key_id:     ScihistDigicoll::Env.lookup!(:aws_access_key_id),
-        secret_access_key: ScihistDigicoll::Env.lookup!(:aws_secret_access_key),
-        region:            ScihistDigicoll::Env.lookup!(:aws_region)
-      )
+    def register_remote_storages
+      @storage_map.each_pair do |local_key, remote_key|
+        Shrine.storages[remote_key] ||= Shrine::Storage::S3.new(
+          bucket:            input_hash["shrine_s3_storage_staging"][local_key.to_s]["bucket_name"],
+          prefix:            input_hash["shrine_s3_storage_staging"][local_key.to_s]["prefix"],
+          access_key_id:     ScihistDigicoll::Env.lookup!(:aws_access_key_id),
+          secret_access_key: ScihistDigicoll::Env.lookup!(:aws_secret_access_key),
+          region:            ScihistDigicoll::Env.lookup!(:aws_region)
+        )
+      end
     end
-
-    def remote_video_store_storage
-      Shrine.storages[REMOTE_VIDEO_STORE_STORAGE_KEY] ||= Shrine::Storage::S3.new(
-        bucket:            input_hash["shrine_s3_storage_staging"]["video_store"]["bucket_name"],
-        prefix:            input_hash["shrine_s3_storage_staging"]["video_store"]["prefix"],
-        access_key_id:     ScihistDigicoll::Env.lookup!(:aws_access_key_id),
-        secret_access_key: ScihistDigicoll::Env.lookup!(:aws_secret_access_key),
-        region:            ScihistDigicoll::Env.lookup!(:aws_region)
-      )
-    end
-
-    def remote_derivatives_storage
-      Shrine.storages[REMOTE_DERIVATIVES_STORAGE_KEY] ||= Shrine::Storage::S3.new(
-        bucket:            input_hash["shrine_s3_storage_staging"]["kithe_derivatives"]["bucket_name"],
-        prefix:            input_hash["shrine_s3_storage_staging"]["kithe_derivatives"]["prefix"],
-        access_key_id:     ScihistDigicoll::Env.lookup!(:aws_access_key_id),
-        secret_access_key: ScihistDigicoll::Env.lookup!(:aws_secret_access_key),
-        region:            ScihistDigicoll::Env.lookup!(:aws_region)
-      )
-    end
-
   end
 end

--- a/app/models/copy_staging/restore_work.rb
+++ b/app/models/copy_staging/restore_work.rb
@@ -146,9 +146,11 @@ module CopyStaging
       end
     end
 
+    # "Upload" a remote file to a local Shrine storage, effectively copying it.
     def copy_file(key:, file:)
-      remote_file_data = file.data.merge("storage" => @storage_map[key])
-      Shrine.storages[key].upload(Shrine::UploadedFile.new(remote_file_data),file.id)
+      remote_metadata = file.data.merge("storage" => @storage_map[key])
+      remote_file = Shrine::UploadedFile.new(remote_metadata)
+      Shrine.storages[key].upload(remote_file,file.id)
     end
 
     def input_hash

--- a/app/models/copy_staging/restore_work.rb
+++ b/app/models/copy_staging/restore_work.rb
@@ -32,16 +32,8 @@ module CopyStaging
   # could be disastrous. This object can take thread_pool_size as an init
   # argument, but the wrapping rake task isn't currently written to exersize that.
   class RestoreWork
-
-    # Associate dev with staging shrine storage keys:
-    ORIGINALS_STORAGE = {
-      store:                         :remote_store_storage,      #non-video
-      video_store:                   :remote_video_store_storage # video
-    }
-    DERIVATIVES_STORAGE = {
-      kithe_derivatives:             :remote_derivatives_storage,
-      restricted_kithe_derivatives:  :remote_restricted_derivatives_storage
-    }
+    ORIGINALS_STORAGE   = [:store, :video_store]
+    DERIVATIVES_STORAGE = [:kithe_derivatives, :restricted_kithe_derivatives]
 
     attr_accessor :json_file, :thread_pool, :tracked_futures, :thread_pool_size
 
@@ -56,7 +48,7 @@ module CopyStaging
       @thread_pool_size = thread_pool_size
       @thread_pool = Concurrent::FixedThreadPool.new(thread_pool_size)
       @tracked_futures = Concurrent::Array.new
-      @storage_map = ORIGINALS_STORAGE.merge(DERIVATIVES_STORAGE)
+      @storage_map = Hash[ (ORIGINALS_STORAGE + DERIVATIVES_STORAGE).collect { |v| [v, "remote_#{v.to_s}".to_sym  ] } ]
       register_remote_storages
     end
 

--- a/app/models/copy_staging/restore_work.rb
+++ b/app/models/copy_staging/restore_work.rb
@@ -35,11 +35,12 @@ module CopyStaging
 
     # Associate dev with staging shrine storage keys:
     ORIGINALS_STORAGE = {
-      store:             :remote_store_storage, #non-video
-      video_store:       :remote_video_store_storage # video
+      store:                         :remote_store_storage,      #non-video
+      video_store:                   :remote_video_store_storage # video
     }
     DERIVATIVES_STORAGE = {
-      kithe_derivatives: :remote_derivatives_storage
+      kithe_derivatives:             :remote_derivatives_storage,
+      restricted_kithe_derivatives:  :remote_restricted_derivatives_storage
     }
 
     attr_accessor :json_file, :thread_pool, :tracked_futures, :thread_pool_size

--- a/app/models/copy_staging/serialize_work.rb
+++ b/app/models/copy_staging/serialize_work.rb
@@ -22,12 +22,10 @@ module CopyStaging
       {
         "models" => serialized_models,
         "shrine_s3_storage_staging" => {
-          # originals (non-video)
-          "store" =>             shrine_config(:store),
-          # originals (video)
-          "video_store" =>       shrine_config(:video_store),
-          # derivatives
-          "kithe_derivatives" => shrine_config(:kithe_derivatives)
+          "store" =>                        shrine_config(:store), #originals
+          "video_store" =>                  shrine_config(:video_store), # video originals
+          "kithe_derivatives" =>            shrine_config(:kithe_derivatives), # regular derivs
+          "restricted_kithe_derivatives" => shrine_config(:restricted_kithe_derivatives) # restricted derivs
         }
       }
     end

--- a/app/models/copy_staging/serialize_work.rb
+++ b/app/models/copy_staging/serialize_work.rb
@@ -22,8 +22,11 @@ module CopyStaging
       {
         "models" => serialized_models,
         "shrine_s3_storage_staging" => {
-          "store" => shrine_config(:store),
-          "video_store" => shrine_config(:video_store),
+          # originals (non-video)
+          "store" =>             shrine_config(:store),
+          # originals (video)
+          "video_store" =>       shrine_config(:video_store),
+          # derivatives
           "kithe_derivatives" => shrine_config(:kithe_derivatives)
         }
       }

--- a/app/models/copy_staging/serialize_work.rb
+++ b/app/models/copy_staging/serialize_work.rb
@@ -21,12 +21,7 @@ module CopyStaging
     def as_json
       {
         "models" => serialized_models,
-        "shrine_s3_storage_staging" => {
-          "store" =>                        shrine_config(:store), #originals
-          "video_store" =>                  shrine_config(:video_store), # video originals
-          "kithe_derivatives" =>            shrine_config(:kithe_derivatives), # regular derivs
-          "restricted_kithe_derivatives" => shrine_config(:restricted_kithe_derivatives) # restricted derivs
-        }
+        "shrine_s3_storage_staging" => storages
       }
     end
 
@@ -87,5 +82,14 @@ module CopyStaging
         "prefix" => storage.prefix
       }
     end
+
+    # The list of Shrine storages we can copy from and to
+    # is listed as a constant in
+    # CopyStaging::RestoreWok, so let's use that here.
+    def storages
+      storage_list = CopyStaging::RestoreWork::ORIGINALS_STORAGE + CopyStaging::RestoreWork::DERIVATIVES_STORAGE
+      Hash[ storage_list.collect { |v| [v.to_s, shrine_config(v)  ] } ]
+    end
+
   end
 end

--- a/app/models/copy_staging/serialize_work.rb
+++ b/app/models/copy_staging/serialize_work.rb
@@ -23,6 +23,7 @@ module CopyStaging
         "models" => serialized_models,
         "shrine_s3_storage_staging" => {
           "store" => shrine_config(:store),
+          "video_store" => shrine_config(:video_store),
           "kithe_derivatives" => shrine_config(:kithe_derivatives)
         }
       }

--- a/app/models/copy_staging/serialize_work.rb
+++ b/app/models/copy_staging/serialize_work.rb
@@ -11,6 +11,11 @@ module CopyStaging
   #     SerializeWork.new(work).as_json #=> Hash
   #     SerializeWork.new(work).to_json #=> serialized string
   #
+  # To make sure the models do match, we're storing them in RestoreWork and they
+  # are referenced in #storages below. This means if you need to change the list of buckets
+  # available to copy_data, you want to modify ORIGINALS_STORAGE and DERIVATIVES_STORAGE
+  # in RestoreWork.
+
   class SerializeWork
     attr_accessor :work
 
@@ -85,10 +90,10 @@ module CopyStaging
 
     # The list of Shrine storages we can copy from and to
     # is listed as a constant in
-    # CopyStaging::RestoreWok, so let's use that here.
+    # CopyStaging::RestoreWork, so let's use that here.
     def storages
       storage_list = CopyStaging::RestoreWork::ORIGINALS_STORAGE + CopyStaging::RestoreWork::DERIVATIVES_STORAGE
-      Hash[ storage_list.collect { |v| [v.to_s, shrine_config(v)  ] } ]
+      Hash[ storage_list.collect { |shrine_storage_key| [shrine_storage_key.to_s, shrine_config(shrine_storage_key) ] } ]
     end
 
   end

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -16,6 +16,11 @@ namespace :scihist do
       end
     end
 
+    # If the work does not exist in dev:
+    # bundle exec rake scihist:heroku:copy_data[WORK_FRIENDLIER_ID]
+    #
+    # If the work DOES exist in dev and you want to REPLACE it with the work on staging:
+    # bundle exec rake scihist:heroku:copy_data[WORK_FRIENDLIER_ID,true]
     desc "Copy remote work from staging to local dev, with all data"
     task :copy_data, [:work_friendlier_id, :force_erase] => :environment do |t, args|
       heroku_app = ENV['HEROKU_APP'] || "scihist-digicoll-staging"


### PR DESCRIPTION
Ref #1600 .
Spent some time cleaning up restore_work. 
Restricted derivatives weren't working; fixed them as well.

Try e.g.
```
# restricted derivatives
bundle exec rake scihist:heroku:copy_data[bwv8gvz,true]
# video test
bundle exec rake scihist:heroku:copy_data[bhfkgwq, true]
```
To test this code, both dev and staging need to be running it.