### PR TITLE
Allow browserstack proxy host

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -90,4 +90,6 @@ Rails.application.configure do
   # hostname, by default oh.sciencehistory.org. You might use /etc/hosts
   # locally to test our legacy redirect functionality.
   config.hosts << ScihistDigicoll::Env.lookup!(:oral_history_legacy_host)
+  # for browserstack local
+  config.hosts << "bs-local.com"
 end


### PR DESCRIPTION
Browserstack iOS now requires you to use bs-local.com as a proxy host when connecting to localhost. Tell our rails app to allow it.
