### PR TITLE
URL used for video SRC should expire later

### DIFF
--- a/app/components/work_video_component.html.erb
+++ b/app/components/work_video_component.html.erb
@@ -35,7 +35,7 @@
               }.to_json
             }
     ) do %>
-      <%= tag "source", src: video_asset.file_url, type: video_asset.content_type %>
+      <%= tag "source", src: video_src_url, type: video_asset.content_type %>
 
       <p class="vjs-no-js">
         To view this video please enable JavaScript, and consider upgrading to a

--- a/app/components/work_video_component.rb
+++ b/app/components/work_video_component.rb
@@ -1,13 +1,13 @@
 # Individual work detail/show/view page for VIDEO
 #
-# Initially designed for a SINGLE video, which is the work #representative. 
+# Initially designed for a SINGLE video, which is the work #representative.
 #
 # If the work has any other members, they may not show up on display page... starting
-# with the simple use case. 
+# with the simple use case.
 #
 # This is very similar in some wyas to standard WorkImageShowComponent, but we make
 # it a separate class instead of trying to use lots of conditionals in one class, betting
-# that will be simpler overall, and allow them to diverge as more features are added. 
+# that will be simpler overall, and allow them to diverge as more features are added.
 class WorkVideoComponent < ApplicationComponent
   delegate :construct_page_title, :current_user, to: :helpers
 
@@ -19,6 +19,10 @@ class WorkVideoComponent < ApplicationComponent
     unless work.leaf_representative&.content_type&.start_with?("video/")
     	raise ArgumentError.new("work.leaf_representative must be a video to use #{self.class.name}")
     end
+  end
+
+  def video_src_url
+    video_asset.file_url(expires_in: 5.days.to_i)
   end
 
   def video_asset


### PR DESCRIPTION
We are using S3 signed URL for video originals bucket (which is not publicly visible). S3 signed urls by default expire in 15 minutes. That's not enough, if you left your window open for more than 15 minutes, you couldn't play the video embedded in it anymore!

5 days seems fine? The maximum is 7 days. I dunno, this should be more than enough, but I don't think it needs to be any shorter.
