### PR TITLE
bundle exec rake scihist:heroku:copy_data more tolerant of missing buckets in staging.

### DIFF
--- a/app/models/copy_staging/restore_work.rb
+++ b/app/models/copy_staging/restore_work.rb
@@ -168,6 +168,10 @@ module CopyStaging
     # ]
     def register_remote_storages
       @storage_map.each_pair do |local_key, remote_key|
+        unless input_hash["shrine_s3_storage_staging"].has_key? local_key.to_s
+          puts "    WARNING: Could not find a remote #{local_key} Shrine storage. If the work has files in this bucket, we will not be able to download them."
+          next
+        end
         Shrine.storages[remote_key] ||= Shrine::Storage::S3.new(
           bucket:            input_hash["shrine_s3_storage_staging"][local_key.to_s]["bucket_name"],
           prefix:            input_hash["shrine_s3_storage_staging"][local_key.to_s]["prefix"],


### PR DESCRIPTION
Ref #1619

If all  of these are true:

- You want to copy a work from staging to dev.
- Your shrine storages in dev do not match up with the ones defined in staging (because e.g. the code deployed in staging is older than what's in `master`).
- However, all the work's assets and derivs are in Shrine storages that do exist in both staging and dev.

Then:
- Show a warning
- Don't abort the copy from staging to dev operation if there are buckets in dev that staging does not know about.
- Copy the work down anyway.

In theory this should never happen. In practice it's happened enough times already.