### PR TITLE
Turning off #suggest and #advanced_search in CatalogController

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -21,6 +21,14 @@ class CatalogController < ApplicationController
   # Not totally sure why we need this, instead of Rails loading all helpers automatically
   helper LocalBlacklightHelpers
 
+  def advanced_search
+    raise ActionController::RoutingError.new('Not Found')
+  end
+
+  def suggest
+    raise ActionController::RoutingError.new('Not Found')
+  end
+
   # a Blacklight override
   def render_bookmarks_control?
     false

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -21,10 +21,20 @@ class CatalogController < ApplicationController
   # Not totally sure why we need this, instead of Rails loading all helpers automatically
   helper LocalBlacklightHelpers
 
+  # This is turned off until/unless we
+  # decide to offer advanced search to the public (unlikely).
   def advanced_search
     raise ActionController::RoutingError.new('Not Found')
   end
 
+  # This functionality is disabled:
+  # config.autocomplete_enabled above is set to false, and
+  # in addition, SOLR's suggester response is turned off anyway.
+  # ( See blacklight/app/models/concerns/blacklight/suggest/response.rb )
+  #
+  # Let's explicitly turn off this method: that way, if you request
+  # /catalog/suggest.json?q=SOME_SEACH_STRING you'll get a 404
+  # instead of bogus empty results.
   def suggest
     raise ActionController::RoutingError.new('Not Found')
   end
@@ -469,7 +479,8 @@ class CatalogController < ApplicationController
 
     # Configuration for autocomplete suggestor
     config.autocomplete_enabled = false
-    config.autocomplete_path = 'suggest'
+    # NOTE: see #suggest below for details.
+    # config.autocomplete_path = 'suggest'
     # if the name of the solr.SuggestComponent provided in your solrcongig.xml is not the
     # default 'mySuggester', uncomment and provide it below
     # config.autocomplete_suggester = 'mySuggester'

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -126,6 +126,18 @@ RSpec.describe CatalogController, solr: true, type: :controller do
     end
   end
 
+  describe "advanced search" do
+    it "is explicitly turned off" do
+      expect { get :advanced_search }.to raise_error(ActionController::RoutingError)
+    end
+  end
+
+  describe "autocomplete suggest" do
+    it "is explicitly turned off" do
+      expect { get :suggest }.to raise_error(ActionController::RoutingError)
+    end
+  end
+
   # We do not implement rss / atom / json search results (or plan to implement them).
   # e.g. /catalog.rss
   # e.g. /focus/alchemy.json


### PR DESCRIPTION
Ref #1583
- Every other route in in `bin/rails routes | grep catalog` now has a reason to be there.
- `autocomplete_enabled` is set to `false`, and the corresponding SOLR suggester is also turned off, so rather than maintain a confusing, vestigial path that always returns an empty array, I did decide to switch off the `#suggest` method.
- Tests confirm that both methods are now turned off. 
- Comments that should save us time and effort later.