### PR TITLE
video social media thumbnail

### DIFF
--- a/app/presenters/work_social_share_attributes.rb
+++ b/app/presenters/work_social_share_attributes.rb
@@ -89,8 +89,15 @@ class WorkSocialShareAttributes
 
   private
 
+  # social media sites want a fairly big thumb if possible. Faccebook recommends 1200x630.
+  # https://developers.facebook.com/docs/sharing/webmasters/images/
+  #
+  # But if we only have smaller available (say for videos), we'll use that.
   def share_representative_derivative
-    @share_representative_deriative ||= work&.leaf_representative&.file_derivatives&.dig(:download_medium)
+    @share_representative_deriative ||= work&.leaf_representative&.file_derivatives&.dig(:download_medium) ||
+      work&.leaf_representative&.file_derivatives&.dig(:download_small) ||
+      work&.leaf_representative&.file_derivatives&.dig(:thumb_large_2x) ||
+      work&.leaf_representative&.file_derivatives&.dig(:thumb_large)
   end
 
 end

--- a/spec/factories/asset_factory.rb
+++ b/spec/factories/asset_factory.rb
@@ -97,8 +97,8 @@ FactoryBot.define do
             create(:stored_uploaded_file,
               file: File.open((Rails.root + "spec/test_support/images/30x30.png").to_s),
               content_type: "image/jpg",
-              width: "760",
-              height: "420",
+              width: 760,
+              height: 420,
               md5: faked_md5,
               sha512: faked_sha512)
           }

--- a/spec/presenters/work_social_share_attributes_spec.rb
+++ b/spec/presenters/work_social_share_attributes_spec.rb
@@ -49,6 +49,22 @@ describe WorkSocialShareAttributes, type: :component do
       expect(attributes.share_media_width).to eq download_medium_derivative.metadata["width"]
     end
 
+    describe "video file" do
+      let(:work) { create(:video_work) }
+      let(:best_derivative) { work.representative.file_derivatives[:thumb_large_2x] }
+
+      it "can still find a representative even if it needs to go to smaller" do
+        expect(attributes.share_media_url).to be_present
+
+        parsed_uri = Addressable::URI.parse attributes.share_media_url
+        expect(parsed_uri).not_to be_relative
+        expect(parsed_uri.path).to eq Addressable::URI.parse(best_derivative.url(public: true)).path
+
+        expect(attributes.share_media_height).to eq best_derivative.metadata["height"]
+        expect(attributes.share_media_width).to eq best_derivative.metadata["width"]
+      end
+    end
+
     describe "with no representative" do
       let(:work) { build(:work) }
 


### PR DESCRIPTION
Ref #1627. Verified working on pinterest and facebook. 

Still having some trouble on live twitter with our one public staging example video... but I think that's just because twitter has it cached. It looks right on https://cards-dev.twitter.com/validator

