### PR TITLE
update github actions to checkout@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
 
         - name: Set up Ruby
           uses: ruby/setup-ruby@v1


### PR DESCRIPTION
It doesn't make a difference at the moment except for being a more recent version of node, but let's stay current
