### PR TITLE
(orphan S3 file checker) Use shrine_path to look up object to delete

### DIFF
--- a/app/services/orphan_s3_originals.rb
+++ b/app/services/orphan_s3_originals.rb
@@ -61,7 +61,7 @@ class OrphanS3Originals
           if @orphans_found == max_reports
             iter.log "Reported max #{max_reports} orphans, not listing subsquent...\n"
           elsif @orphans_found < max_reports
-            @sample << s3_url_for_path(s3_key, iter.shrine_storage)
+            @sample << url_or_path(s3_key, iter.shrine_storage)
             asset = Asset.where(id: asset_id).first
             iter.log "orphaned file!"
             iter.log "  bucket: #{ bucket_name }"
@@ -167,13 +167,20 @@ class OrphanS3Originals
     end
   end
 
-  # video_asset_count and nonvideo_asset_count could really just be one call to the database.
   def counts
      @counts ||= Kithe::Asset.connection.select_all("select file_data ->> 'storage' as storage, count(*)  from kithe_models where kithe_model_type = 2 group by storage").rows.to_h
   end
 
   def output_to_stderr(text)
     $stderr.puts text
+  end
+
+  def url_or_path(s3_key, storage)
+    if storage.is_a? Shrine::Storage::FileSystem
+      s3_key
+    else
+      s3_url_for_path(s3_key, storage)
+    end
   end
 
 end

--- a/app/services/orphan_s3_originals.rb
+++ b/app/services/orphan_s3_originals.rb
@@ -94,7 +94,7 @@ class OrphanS3Originals
       iter.each_s3_path do |s3_key|
         asset_id, shrine_path = parse_s3_path(s3_key, prefix)
         if orphaned?(asset_id, shrine_path)
-          # iter.shrine_storage.delete(shrine_path)
+          iter.shrine_storage.delete(shrine_path)
           iter.log "deleted: #{ bucket_name }: #{shrine_path}"
           @delete_count += 1
         end

--- a/spec/services/orphan_s3_originals_spec.rb
+++ b/spec/services/orphan_s3_originals_spec.rb
@@ -1,82 +1,76 @@
 require 'rails_helper'
 
 describe OrphanS3Originals do
-  let(:asset_n)  {
-    create(:asset, :inline_promoted_file,
-      file: File.open((Rails.root + "spec/test_support/images/20x20.png"))
-    )
-  }
-  let(:asset_v)  {
-    create(:asset, :inline_promoted_file,
-      file: File.open((Rails.root + "spec/test_support/video/sample_video.mp4"))
-    )
-  }
-  let(:file_paths_v) {['va', 'vb', 'vc']}
-  let(:file_paths_n) {['na', 'nb', 'nc']}
-
-  let(:v_prefix) { ScihistDigicoll::Env.shrine_store_video_storage.prefix }
-  let(:n_prefix) { ScihistDigicoll::Env.shrine_store_storage.      prefix }
-
   let(:fake_clients) do
     {
       video:    AwsHelpers::MockS3Client.new(paths: file_paths_v).client,
       nonvideo: AwsHelpers::MockS3Client.new(paths: file_paths_n).client
     }
   end
-
-
-
   let(:orphan_checker) do
     OrphanS3Originals.new(show_progress_bar: false)
   end
+  let(:public_dir) { Rails.root + 'public' }
+  
+  # Storage prefixes:
+  let(:n_prefix) { ScihistDigicoll::Env.shrine_store_storage.      prefix }
+  let(:v_prefix) { ScihistDigicoll::Env.shrine_store_video_storage.prefix }
 
   before do
     allow_any_instance_of(S3PathIterator).to receive(:log).and_return(nil)
     allow(orphan_checker).to receive(:output_to_stderr).and_return(nil)
-    allow_any_instance_of(S3PathIterator).to receive(:s3_bucket_name).and_return('not using s3')
-    allow(orphan_checker.nonvideo_s3_iterator).
-      to receive(:s3_client).and_return(fake_clients[:nonvideo])
+
     allow(orphan_checker.video_s3_iterator).
       to receive(:s3_client).and_return(fake_clients[:video])
+    allow(orphan_checker.nonvideo_s3_iterator).
+      to receive(:s3_client).and_return(fake_clients[:nonvideo])
+
+    allow_any_instance_of(S3PathIterator).to receive(:s3_bucket_name).and_return('not using s3')
+    
   end
 
-  describe "orphan checker smoke test" do
-    it "smoke test" do
-      orphan_checker.report_orphans
-      expect(orphan_checker.files_checked).to eq 6
-      expect(orphan_checker.orphans_found).to eq 6
-      expect(orphan_checker.sample).
-        to eq file_paths_v.
-          map {|s| "/#{v_prefix}/#{s}" } +
-        file_paths_n.
-          map {|s| "/#{n_prefix}/#{s}" }
-    end
+  describe "two legit assets, one video and one image, plus two orphans" do
+    # Two legitimate, non-orphan assets:
+    let(:asset_n)  {
+      create(:asset, :inline_promoted_file,
+        file: File.open((Rails.root + "spec/test_support/images/20x20.png"))
+      )
+    } 
+    let(:asset_v)  {
+      create(:asset, :inline_promoted_file,
+        file: File.open((Rails.root + "spec/test_support/video/sample_video.mp4"))
+      )
+    }
 
-    it "deletes the orphans" do
-      orphan_checker.delete_orphans
-      expect(orphan_checker.delete_count).to eq 6
-    end    
-  end
+    let(:orphans) { [
+      "#{File.dirname(v_prefix + asset_v.file.id)}/orphan.mp4",
+      "#{File.dirname(n_prefix + asset_n.file.id)}/orphan.png"
+    ] }
 
-  describe "two assets, one video and one image, plus two orphans" do
-    let(:file_paths_v) do
-      ["#{v_prefix}/#{asset_v.file_data['id']}", "video_orphan.mp4"]
-    end
-    let(:file_paths_n) do
-       ["#{n_prefix}/#{asset_n.file_data['id']}", "image_orphan.jpg"]
-    end
+    # Our fake clients will return the following s3 paths:
+    let(:file_paths_v) { ["#{v_prefix}/#{asset_v.file_data['id']}", orphans[0]] }
+    let(:file_paths_n) { ["#{n_prefix}/#{asset_n.file_data['id']}", orphans[1]] }
+    
+    before do
+      dummy = Rails.root + "spec/test_support/images/20x20.png"
+      FileUtils.cp(dummy, public_dir + orphans[0])
+      FileUtils.cp(dummy, public_dir + orphans[1])
+    end  
+    
     it "finds the orphans" do
       orphan_checker.report_orphans
       expect(orphan_checker.files_checked).to eq 4
       expect(orphan_checker.orphans_found).to eq 2
-      expect(orphan_checker.sample).to eq [
-        "/#{v_prefix}/video_orphan.mp4",
-        "/#{n_prefix}/image_orphan.jpg"
-      ]
+      expect(orphan_checker.sample).to eq orphans
     end
+
     it "deletes the orphans" do
+      expect(File.file?(public_dir + orphans[0])).to be true
+      expect(File.file?(public_dir + orphans[1])).to be true
       orphan_checker.delete_orphans
       expect(orphan_checker.delete_count).to eq 2
+      expect(File.file?(public_dir + orphans[0])).to be false
+      expect(File.file?(public_dir + orphans[1])).to be false
     end
   end
 end


### PR DESCRIPTION
Ref #1546

- Use `shrine_path` to look up the shrine object to delete; this is not identical to `s3_key`;
- Better documentation;
- Sample report doesn't use `s3_url_for_path` to generate s3 urls for files that aren't really stored on s3;
- A test that actually creates fake files on the filesystem and ensures the `delete_orphans` method actually removes them;

Ran the detect and delete routines in staging to confirm orphans are still detected and deleted as before.