### PR TITLE
Center video play button.

### DIFF
--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -17,7 +17,7 @@
 
     <%= content_tag("video",
             id: "work-video-player",
-            class: "video-js vjs-fluid",
+            class: "video-js vjs-fluid vjs-big-play-centered",
             controls: true,
             preload: "metadata",
             poster: poster_src,


### PR DESCRIPTION
Ref #1617

Looks like this is a common enough desire that video.js already comes with a class you can just add to the video element to do it. Found it googling in a question/answer, tried it, it worked.
