### PR TITLE
Generate longer expirationf for s3 urls used as ffmpeg input'

### DIFF
--- a/app/services/combined_audio_derivative_creator.rb
+++ b/app/services/combined_audio_derivative_creator.rb
@@ -85,7 +85,7 @@ class CombinedAudioDerivativeCreator
 
       audio_member_files.collect do |original_file|
         if original_file.url.present? && original_file.url.start_with?(/https?:/)
-          original_file.url
+          original_file.url(expires_in: 48.hours.to_i)
         else
           new_temp_file = original_file.download(rewindable: false)
           input_tempfiles << new_temp_file


### PR DESCRIPTION
Possibly relevant to #1639. A default signed S3 URL is good for 15 minutes. We feed these URLs to ffmpeg to create a combined derivative. What if it takes longer than 15 minutes to create, and S3 starts refusing? You'd think we'd get an error message. But maybe not.

Just in case this is part of the problem, it doesn't hurt to make these S3 URLs we use as ffmpeg input last a lot longer. How about 48 hours.
