### PR TITLE
change Orig and Deriv download urls

### DIFF
--- a/app/components/file_list_item_component.rb
+++ b/app/components/file_list_item_component.rb
@@ -58,7 +58,7 @@ class FileListItemComponent < ApplicationComponent
       # image thumb is in a link, but right next to filename with same link.
       # Suppress image thumb from assistive technology to avoid un-useful double
       # link. https://www.sarasoueidan.com/blog/keyboard-friendlier-article-listings/
-      link_to(download_path(member.leaf_representative, disposition: :inline),
+      link_to(download_path(member.leaf_representative.file_category, member.leaf_representative, disposition: :inline),
               view_link_attributes.merge("aria-hidden" => "true", "tabindex" => -1)) do
         yield
       end
@@ -93,7 +93,7 @@ class FileListItemComponent < ApplicationComponent
     if member.kind_of?(Work)
       link_to "Info", work_path(member), class: "btn btn-primary"
     elsif download_original_only
-      link_to "Download", download_path(member), class: "btn btn-primary", data: {
+      link_to "Download", download_path(member.file_category, member), class: "btn btn-primary", data: {
         "analytics-category" => "Work",
         "analytics-action" => "download_original",
         "analytics-label"  => member.parent.friendlier_id

--- a/app/components/member_image_component.rb
+++ b/app/components/member_image_component.rb
@@ -179,7 +179,7 @@ class MemberImageComponent < ApplicationComponent
     if member.parent && representative_asset&.content_type&.start_with?("image/")
       viewer_path(member.parent.friendlier_id, member.friendlier_id)
     else # PDF, etc, just try to show it in the browser
-      download_path(representative_asset, disposition: :inline)
+      download_path(representative_asset.file_category, representative_asset, disposition: :inline)
     end
   end
 

--- a/app/components/oral_history/downloads_list_component.html.erb
+++ b/app/components/oral_history/downloads_list_component.html.erb
@@ -57,7 +57,7 @@
     <div  class="track-listing" data-role="track-listing"
           data-title="<%= track.title %>"
           data-member-id="<%= track.id %>"
-          data-original-url="<%= download_path(track.id) %>"
+          data-original-url="<%= download_path(track.file_category, track.id) %>"
       >
 
       <% if start_time_for(track) %>

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -132,14 +132,17 @@ class Asset < Kithe::Asset
   # major category of our file type, used in routing to put the file category in URL
   # @returns String image, audio, video, pdf, etc.
   def file_category
-    primary, secondary = (content_type || "").split("/")
-    return "unk" unless primary.present? && secondary.present?
-
-    if primary == "application"
-      # intended for use case "pdf", but could be anything, whatever.
-      secondary.split.first.parameterize.downcase
+    if content_type == "application/pdf"
+      "pdf"
     else
-      primary
+      # audio, video, image, hypothetically could be "application" for something
+      # we're not expecting, no big deal. "unk" for unknown if we don't have
+      # a content-type
+
+      primary, secondary = (content_type || "").split("/")
+      return "unk" unless primary.present? && secondary.present?
+
+      primary.downcase
     end
   end
 

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -129,6 +129,20 @@ class Asset < Kithe::Asset
   # to schedule a future deletion from ingest bucket.
   around_promotion :schedule_ingest_bucket_deletion, if: ->(asset) { asset.file.storage_key == :remote_url }
 
+  # major category of our file type, used in routing to put the file category in URL
+  # @returns String image, audio, video, pdf, etc.
+  def file_category
+    primary, secondary = (content_type || "").split("/")
+    return "unk" unless primary.present? && secondary.present?
+
+    if primary == "application"
+      # intended for use case "pdf", but could be anything, whatever.
+      secondary.split.first.parameterize.downcase
+    else
+      primary
+    end
+  end
+
   # Used as an around_promotion callback. If we're promoting a shrine cache file using remote_url storage, and
   # the file is from our ingest_bucket, then add a record to table to schedule it's deletion in the future
   # by an

--- a/app/presenters/download_options/audio_download_options.rb
+++ b/app/presenters/download_options/audio_download_options.rb
@@ -17,7 +17,7 @@ module DownloadOptions
 
       if asset.stored?
         options << DownloadOption.with_formatted_subhead("Original file",
-          url: download_path(asset),
+          url: download_path(asset.file_category, asset),
           analyticsAction: "download_original",
           content_type: asset.content_type,
           size: asset.size

--- a/app/presenters/download_options/image_download_options.rb
+++ b/app/presenters/download_options/image_download_options.rb
@@ -64,7 +64,7 @@ module DownloadOptions
 
       if asset.stored?
         options << DownloadOption.with_formatted_subhead("Original file",
-          url: download_path(asset),
+          url: download_path(asset.file_category, asset),
           analyticsAction: "download_original",
           content_type: asset.content_type,
           width: asset.width,

--- a/app/serializers/work_oai_dc_serialization.rb
+++ b/app/serializers/work_oai_dc_serialization.rb
@@ -220,7 +220,7 @@ class WorkOaiDcSerialization
   def appropriate_thumb_url
     unless defined?(@appropriate_thumb_url)
       @appropriate_thumb_url = if work.leaf_representative
-        "#{ScihistDigicoll::Env.lookup!(:app_url_base)}/downloads/#{work.leaf_representative.friendlier_id}/thumb_large_2X?disposition=inline"
+        "#{ScihistDigicoll::Env.lookup!(:app_url_base)}/downloads/deriv/#{work.leaf_representative.friendlier_id}/thumb_large_2X?disposition=inline"
       else
         nil
       end
@@ -232,7 +232,7 @@ class WorkOaiDcSerialization
   def full_jpg_url
     unless defined?(@full_jpg_url)
       @full_jpg_url = if work.leaf_representative
-        "#{ScihistDigicoll::Env.lookup!(:app_url_base)}/downloads/#{work.leaf_representative.friendlier_id}/download_full?disposition=inline"
+        "#{ScihistDigicoll::Env.lookup!(:app_url_base)}/downloads/deriv/#{work.leaf_representative.friendlier_id}/download_full?disposition=inline"
       else
         nil
       end

--- a/app/views/application/robots.txt.erb
+++ b/app/views/application/robots.txt.erb
@@ -35,6 +35,11 @@ Disallow: /collections/*f[
 Disallow: /focus/*f%5B
 Disallow: /focus/*f[
 
+<%# Disallow all 'original' downloads EXCEPT PDFs. The others are too much
+    bandwidth for no apparent purpose %>
+Allow: /downloads/orig/pdf/
+Disallow: /downloads/orig/
+
 
 <% else %>
 # Non-production, no robots please, although we let twitter in to test twitter integration

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,8 +163,12 @@ Rails.application.routes.draw do
   # download_url(asset.file_category, asset)
   get "downloads/orig/:file_category/:asset_id", to: "downloads#original", as: :download
 
-  # TODO redirect old one please
-
+  # We redirect the old version of /downloads/:asset_id, before we changed to above
+  # with status 301 Moved Permanently
+  get "downloads/:asset_id", status: 301, to: redirect {|path_params, req|
+    file_category = Asset.find_by_friendlier_id(path_params[:asset_id]).file_category
+    "/downloads/orig/#{file_category}/#{path_params[:asset_id]}"
+  }
 
   # download_derivative_path(asset, "thumb_small")
   # download_derivative_url(asset, "thumb_small")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,12 +156,19 @@ Rails.application.routes.draw do
   get "focus/:slug/facet" => "featured_topic#facet"
 
 
-  # download_path(asset)
-  # download_url(asset)
-  get "downloads/:asset_id", to: "downloads#original", as: :download
+  # the file_category is in here solely so we can distinguish in robots.txt,
+  # we want the file type in the URL. It's not actually used by controller.
+  #
+  # download_path(asset.file_category, asset)
+  # download_url(asset.file_category, asset)
+  get "downloads/orig/:file_category/:asset_id", to: "downloads#original", as: :download
+
+  # TODO redirect old one please
+
+
   # download_derivative_path(asset, "thumb_small")
   # download_derivative_url(asset, "thumb_small")
-  get "downloads/:asset_id/:derivative_key", to: "downloads#derivative", as: :download_derivative
+  get "downloads/deriv/:asset_id/:derivative_key", to: "downloads#derivative", as: :download_derivative
 
   ##
   # Blacklight-generated routes, that were then modified a bit by us to take

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,16 +163,20 @@ Rails.application.routes.draw do
   # download_url(asset.file_category, asset)
   get "downloads/orig/:file_category/:asset_id", to: "downloads#original", as: :download
 
+  # download_derivative_path(asset, "thumb_small")
+  # download_derivative_url(asset, "thumb_small")
+  get "downloads/deriv/:asset_id/:derivative_key", to: "downloads#derivative", as: :download_derivative
+
+
   # We redirect the old version of /downloads/:asset_id, before we changed to above
   # with status 301 Moved Permanently
   get "downloads/:asset_id", status: 301, to: redirect {|path_params, req|
     file_category = Asset.find_by_friendlier_id(path_params[:asset_id]).file_category
     "/downloads/orig/#{file_category}/#{path_params[:asset_id]}"
   }
-
-  # download_derivative_path(asset, "thumb_small")
-  # download_derivative_url(asset, "thumb_small")
-  get "downloads/deriv/:asset_id/:derivative_key", to: "downloads#derivative", as: :download_derivative
+  # and old version of derivative /downloads/:asset_id/:derivative_key, in
+  # case some are in google images etc.
+  get "downloads/:asset_id/:derivative_key", to: redirect(path: '/downloads/deriv/%{asset_id}/%{derivative_key}'), status: 301
 
   ##
   # Blacklight-generated routes, that were then modified a bit by us to take

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -67,7 +67,7 @@ SitemapGenerator::Sitemap.create(
       asset.content_type == "application/pdf"
     end
     pdf_members.each do |pdf_asset|
-      add download_path(pdf_asset, disposition: :inline)
+      add download_path(pdf_asset.file_category, pdf_asset, disposition: :inline)
     end
   end
 end

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -20,10 +20,12 @@ describe DownloadsController do
 
 
   describe "#original" do
+    let(:file_category) { "image" }
+
     describe "non-existing ID" do
       it "raises not found" do
         expect {
-          get :original, params: { asset_id: "no_such_id" }
+          get :original, params: { asset_id: "no_such_id", file_category: file_category }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -31,7 +33,7 @@ describe DownloadsController do
     describe "no access asset" do
       let(:asset) { create(:asset, published: false) }
       it "redirects to login page" do
-        get :original, params: { asset_id: asset }
+        get :original, params: { asset_id: asset, file_category: file_category }
         expect(response).to redirect_to(new_user_session_path)
       end
     end
@@ -41,7 +43,7 @@ describe DownloadsController do
 
       it "does not give access" do
         expect {
-          get :original, params: { asset_id: asset }
+          get :original, params: { asset_id: asset, file_category: file_category }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -57,7 +59,7 @@ describe DownloadsController do
       }
 
       it "returns redirect" do
-        get :original, params: { asset_id: asset }
+        get :original, params: { asset_id: asset, file_category: file_category }
 
         expect(response.status).to eq 302 # temporary redirect
 
@@ -72,7 +74,7 @@ describe DownloadsController do
       end
 
       it "uses disposition inline when specified" do
-        get :original, params: { asset_id: asset, disposition: "inline" }
+        get :original, params: { asset_id: asset, disposition: "inline", file_category: file_category }
 
         expect(response.status).to eq 302 # temporary redirect
 
@@ -98,7 +100,7 @@ describe DownloadsController do
     describe "no access asset" do
       let(:asset) { create(:asset, published: false) }
       it "redirects to login page" do
-        get :original, params: { asset_id: asset, derivatives_key: "thumb_mini" }
+        get :derivative, params: { asset_id: asset, derivative_key: "thumb_mini" }
         expect(response).to redirect_to(new_user_session_path)
       end
     end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -177,4 +177,40 @@ describe Asset do
     end
   end
 
+  describe "#file_category" do
+    describe "image" do
+      let(:asset) { create(:asset_with_faked_file) }
+      it "correct" do
+        expect(asset.file_category).to eq("image")
+      end
+    end
+
+    describe "pdf" do
+      let(:asset) { create(:asset_with_faked_file, :pdf) }
+      it "correct" do
+        expect(asset.file_category).to eq("pdf")
+      end
+    end
+
+    describe "mp3" do
+      let(:asset) { create(:asset_with_faked_file, :mp3) }
+      it "correct" do
+        expect(asset.file_category).to eq("audio")
+      end
+    end
+
+    describe "video" do
+      let(:asset) { create(:asset_with_faked_file, :video) }
+      it "correct" do
+        expect(asset.file_category).to eq("video")
+      end
+    end
+
+    describe "unknown content-type" do
+      let(:asset) { create(:asset) }
+      it "can still route with 'unk'" do
+        expect(asset.file_category).to eq("unk")
+      end
+    end
+  end
 end

--- a/spec/requests/download_redirects_spec.rb
+++ b/spec/requests/download_redirects_spec.rb
@@ -3,8 +3,21 @@ require 'rails_helper'
 describe "legacy original download links redirect" do
   let(:asset) {  create(:asset_with_faked_file, :pdf) }
 
-  it "redirects" do
+  it "redirects original" do
     get("/downloads/#{asset.friendlier_id}")
     expect(response).to redirect_to(download_path(asset.file_category, asset))
+    expect(response).to have_http_status(301)
+  end
+
+  it "redirects derivative" do
+    get("/downloads/#{asset.friendlier_id}/thumb_small")
+    expect(response).to redirect_to(download_derivative_path(asset, "thumb_small"))
+    expect(response).to have_http_status(301)
+  end
+
+  it "redirects derivative keeping any query params" do
+    get("/downloads/#{asset.friendlier_id}/thumb_small?disposition=inline")
+    expect(response).to redirect_to(download_derivative_path(asset, "thumb_small", disposition: "inline"))
+    expect(response).to have_http_status(301)
   end
 end

--- a/spec/requests/download_redirects_spec.rb
+++ b/spec/requests/download_redirects_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe "legacy original download links redirect" do
+  let(:asset) {  create(:asset_with_faked_file, :pdf) }
+
+  it "redirects" do
+    get("/downloads/#{asset.friendlier_id}")
+    expect(response).to redirect_to(download_path(asset.file_category, asset))
+  end
+end

--- a/spec/system/site_map_spec.rb
+++ b/spec/system/site_map_spec.rb
@@ -89,7 +89,7 @@ describe "sitemap generator", js: false do
     let!(:work) { create(:work, :published, representative: asset, members: [asset]) }
 
     let(:expected_work_url) { work_url(work) }
-    let(:expected_pdf_url) { download_url(asset, disposition: :inline)}
+    let(:expected_pdf_url) { download_url(asset.file_category, asset, disposition: :inline)}
 
     it "lists PDF URL in sitemap" do
       Rake::Task["sitemap:create"].invoke


### PR DESCRIPTION
So more is transparent in the URLs, for distinguishing in robots.txt.

Since download_path/url helper changes, this required changes in a lot of files that used it. 

Will also include redirects for old URLs -- so we can maintain our SEO on any old URLs that will remain allowed by robots.txt. 
