### PR TITLE
Redirects from legacy downloads URLs should behave properly when given an asset ID that doesn't exist

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -171,7 +171,13 @@ Rails.application.routes.draw do
   # We redirect the old version of /downloads/:asset_id, before we changed to above
   # with status 301 Moved Permanently
   get "downloads/:asset_id", status: 301, to: redirect {|path_params, req|
-    file_category = Asset.find_by_friendlier_id(path_params[:asset_id]).file_category
+    file_category = Asset.find_by_friendlier_id(path_params[:asset_id])&.file_category
+
+    unless file_category
+      # Rails will catch and handle with a 404.
+      raise ActionController::RoutingError.new("no such asset as #{path_params[:asset_id]}")
+    end
+
     "/downloads/orig/#{file_category}/#{path_params[:asset_id]}"
   }
   # and old version of derivative /downloads/:asset_id/:derivative_key, in

--- a/spec/requests/download_redirects_spec.rb
+++ b/spec/requests/download_redirects_spec.rb
@@ -9,6 +9,12 @@ describe "legacy original download links redirect" do
     expect(response).to have_http_status(301)
   end
 
+  it "404's for missing asset ID on original" do
+    expect {
+      get("/downloads/no_such_thing")
+    }.to raise_error(ActionController::RoutingError)
+  end
+
   it "redirects derivative" do
     get("/downloads/#{asset.friendlier_id}/thumb_small")
     expect(response).to redirect_to(download_derivative_path(asset, "thumb_small"))
@@ -20,4 +26,12 @@ describe "legacy original download links redirect" do
     expect(response).to redirect_to(download_derivative_path(asset, "thumb_small", disposition: "inline"))
     expect(response).to have_http_status(301)
   end
+
+  it "still redirects for missing asset ID on derivative" do
+    get("/downloads/no_such_thing/thumb_small")
+    expect(response).to redirect_to(download_derivative_path("no_such_thing", "thumb_small"))
+    expect(response).to have_http_status(301)
+  end
+
+
 end


### PR DESCRIPTION
https://app.honeybadger.io/projects/58989/faults/84935348
