### PR TITLE
SingleAssetCheckerJob should gracefully ignore ActiveJob::DeserializationError

### DIFF
--- a/app/jobs/single_asset_checker_job.rb
+++ b/app/jobs/single_asset_checker_job.rb
@@ -4,4 +4,15 @@ class SingleAssetCheckerJob < ApplicationJob
     checker.check
     checker.prune_checks
   end
+
+  # We think this almost always means Asset was deleted sometime after this
+  # job was queued but before this job executed, so the Asset no longer exists
+  #
+  # This will probably prevent the job from retring on error even once, as it
+  # usually does -- that should be fine.
+  discard_on ActiveJob::DeserializationError do |job, error|
+    # This is probably already logged by Rails with these same details,
+    # but just to be sure we have it logged, let's do it too.
+    Rails.logger.error("#{job.class.name} (#{job.id}): Cancelling job due to ActiveJob::DeserializationError: #{error.message}")
+  end
 end


### PR DESCRIPTION
Ref #1636

Yeah there's no test. It's pretty inconvenient to test, and this should be standard ActiveJob functionality. I just googled and found it. If it doens't work... we'll just get an error like we always were. :) I did some manual tests, it did seem to work.

I believe the discard_on will override our general retry_on, so on this error the job won't even be retried once, it'll just be discarded. I think that's fine. Note it will be logged. The log should include the Asset PK UUID, as that's part of the error message.

See https://app.honeybadger.io/projects/58989/faults/80992180/01FZGPCVHRN3AC6PHZX0M90C7W
