### PR TITLE
update activerecord-postgres_enum to 2.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,7 @@ gem 'sitemap_generator', '~> 6.0' # google sitemap generation
 
 gem 'sane_patch', '< 2.0' # time-limited monkey patches
 
-gem 'activerecord-postgres_enum', '~> 1.3' # can record postgres enums in schema.rb dump
+gem 'activerecord-postgres_enum', '~> 2.0' # can record postgres enums in schema.rb dump
 
 
 # For autoscaling on heroku via hirefire.io service, but hopefully won't cause any problems

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,8 +51,8 @@ GEM
       activesupport (= 6.1.5)
     activerecord-import (1.4.0)
       activerecord (>= 4.2)
-    activerecord-postgres_enum (1.7.0)
-      activerecord (>= 5)
+    activerecord-postgres_enum (2.0.1)
+      activerecord (>= 5.2)
       pg
     activestorage (6.1.5)
       actionpack (= 6.1.5)
@@ -681,7 +681,7 @@ PLATFORMS
 
 DEPENDENCIES
   access-granted (~> 1.0)
-  activerecord-postgres_enum (~> 1.3)
+  activerecord-postgres_enum (~> 2.0)
   attr_json (~> 1.0)
   axe-core-rspec (~> 4.3)
   blacklight (~> 7.24.0)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,13 @@ ActiveRecord::Schema.define(version: 2021_11_12_194219) do
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
-  create_function :kithe_models_friendlier_id_gen, sql_definition: <<-SQL
+  create_enum :available_by_request_mode_type, [
+    "off",
+    "automatic",
+    "manual_review",
+  ], force: :cascade
+
+  create_function :kithe_models_friendlier_id_gen, sql_definition: <<-'SQL'
       CREATE OR REPLACE FUNCTION public.kithe_models_friendlier_id_gen(min_value bigint, max_value bigint)
        RETURNS text
        LANGUAGE plpgsql
@@ -56,12 +62,6 @@ ActiveRecord::Schema.define(version: 2021_11_12_194219) do
         END;
         $function$
   SQL
-
-  create_enum :available_by_request_mode_type, [
-    "off",
-    "automatic",
-    "manual_review",
-  ], force: :cascade
 
   create_table "asset_derivative_storage_type_reports", force: :cascade do |t|
     t.jsonb "data_for_report", default: {}
@@ -210,7 +210,7 @@ ActiveRecord::Schema.define(version: 2021_11_12_194219) do
     t.string "combined_audio_derivatives_job_status"
     t.datetime "combined_audio_derivatives_job_status_changed_at"
     t.text "searchable_transcript_source"
-    t.enum "available_by_request_mode", default: "off", null: false, enum_name: "available_by_request_mode_type"
+    t.enum "available_by_request_mode", default: "off", null: false, enum_type: "available_by_request_mode_type"
     t.jsonb "json_attributes", default: {}
     t.index ["work_id"], name: "index_oral_history_content_on_work_id", unique: true
   end


### PR DESCRIPTION
I noticed running `bundle outdated` that there was an update. It required running `rake db:schema:dump` to update schema.rb file. https://github.com/bibendi/activerecord-postgres_enum/releases/tag/v2.0.0
