### PR TITLE
update ransack to 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,7 @@ gem "content_disposition", "~> 1.0"
 
 gem 'faster_s3_url', "< 2" # for generating s3 urls faster!
 
-gem "ransack", "~> 2.1"
+gem "ransack", "~> 3.0"
 gem "kaminari", "~> 1.2"
 gem 'bootstrap4-kaminari-views'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -482,7 +482,7 @@ GEM
       rake (>= 12.2)
       thor (~> 1.0)
     rake (13.0.6)
-    ransack (2.6.0)
+    ransack (3.1.0)
       activerecord (>= 6.0.4)
       activesupport (>= 6.0.4)
       i18n
@@ -724,7 +724,7 @@ DEPENDENCIES
   qa (~> 5.2)
   rails (~> 6.1.1)
   rails-controller-testing
-  ransack (~> 2.1)
+  ransack (~> 3.0)
   reline (>= 0.2.1)
   resque (~> 2.0)
   resque-heroku-signals


### PR DESCRIPTION
Noticed running `bundle outdated` that there was a new major version. The backwards compat seems to be removal of a previously deprecated method we weren't using. https://github.com/activerecord-hackery/ransack/blob/main/CHANGELOG.md#300---2022-03-30
