### PR TITLE
.gitignore .irb_history file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 
 /public/assets
 .byebug_history
+.irb_history
 
 # MacOS bookkeeping file
 .DS_Store


### PR DESCRIPTION
the version of IRB we are using seems to create this file in root dir. It's individual to the developer, let's .gitignore it so it doens't go in git or show up as an uncommitted file.
