### PR TITLE
Create HLS with ActiveEncode/MediaConvert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,15 @@ gem 'scout_apm'
 gem "blacklight", "~> 7.24.0"
 gem "blacklight_range_limit", "~> 8.0" # version no longer sync'd with blacklight, not sure how we tell what version works with what version of BL
 
+# Temporarily pointing at a fork until our PR's are merged!
+gem "active_encode", github: "jrochkind/active_encode", branch: "jrochkind_features"
+# these gems are needed for active_encode MediaConvert adapter
+# https://github.com/samvera-labs/active_encode/blob/main/guides/media_convert_adapter.md
+gem "aws-sdk-cloudwatchevents", "~> 1.0"
+gem "aws-sdk-cloudwatchlogs", "~> 1.0"
+gem "aws-sdk-mediaconvert", "~> 1.0"
+gem "aws-sdk-s3", "~> 1.0"
+
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/jrochkind/active_encode.git
+  revision: dd45a234e87c7dad87385f4c44caa0a09b43c903
+  branch: jrochkind_features
+  specs:
+    active_encode (0.8.2)
+      addressable (~> 2.8)
+      rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -77,12 +86,21 @@ GEM
       execjs (~> 2)
     aws-eventstream (1.2.0)
     aws-partitions (1.579.0)
+    aws-sdk-cloudwatchevents (1.57.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-cloudwatchlogs (1.52.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-core (3.130.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
     aws-sdk-kms (1.56.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-mediaconvert (1.88.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-s3 (1.113.0)
@@ -681,8 +699,13 @@ PLATFORMS
 
 DEPENDENCIES
   access-granted (~> 1.0)
+  active_encode!
   activerecord-postgres_enum (~> 2.0)
   attr_json (~> 1.0)
+  aws-sdk-cloudwatchevents (~> 1.0)
+  aws-sdk-cloudwatchlogs (~> 1.0)
+  aws-sdk-mediaconvert (~> 1.0)
+  aws-sdk-s3 (~> 1.0)
   axe-core-rspec (~> 4.3)
   blacklight (~> 7.24.0)
   blacklight_range_limit (~> 8.0)

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -127,6 +127,15 @@ class Admin::AssetsController < AdminController
     redirect_to edit_admin_work_path(new_child), notice: "Asset promoted to child work #{new_child.title}"
   end
 
+  # requires params[:active_encode_status_id]
+  def refresh_active_encode_status
+    status = ActiveEncodeStatus.find(params[:active_encode_status_id])
+
+    RefreshActiveEncodeStatusJob.perform_later(status)
+
+    redirect_to admin_asset_url(status.asset), notice: "Started refresh for ActiveEncode job #{status.active_encode_id}"
+  end
+
   def work_is_oral_history?
     @asset.parent.genre && @asset.parent.genre.include?('Oral histories')
   end

--- a/app/jobs/create_hls_video_job.rb
+++ b/app/jobs/create_hls_video_job.rb
@@ -1,0 +1,6 @@
+class CreateHlsVideoJob < ApplicationJob
+  def perform(asset)
+    CreateHlsMediaconvertJobService.new(asset).call
+  end
+end
+

--- a/app/jobs/refresh_active_encode_status_job.rb
+++ b/app/jobs/refresh_active_encode_status_job.rb
@@ -1,0 +1,6 @@
+class RefreshActiveEncodeStatusJob < ApplicationJob
+  # @param active_encode_status [ActiveEncodeStatus]
+  def perform(active_encode_status)
+    active_encode_status.refresh_from_aws
+  end
+end

--- a/app/models/active_encode_status.rb
+++ b/app/models/active_encode_status.rb
@@ -11,7 +11,24 @@ class ActiveEncodeStatus < ApplicationRecord
       active_encode_id: active_encode_result.id,
       state: active_encode_result.state,
       encode_error: active_encode_result.errors.join("\n; ").presence,
-      percent_complete: active_encode_result.percent_complete
+      percent_complete: active_encode_result.percent_complete,
+    )
+  end
+
+  # Refreshes status from AWS MediaConvert. Will raise Aws::MediaConvert::Errors::NotFoundException
+  # if it's more than 90 days past job creation! AWS holds em for 90 days.
+  def refresh_from_aws
+    active_encode_result = ActiveEncode::Base.find(self.active_encode_id)
+
+    # active_encode let's us recognize the master playlist just cause
+    # it has no height/width set? OK, fine.
+    master_playlist = active_encode_result.output.find { |o| o.height.nil? }
+
+    update!(
+      state: active_encode_result.state,
+      encode_error: active_encode_result.errors.join("\n; ").presence,
+      percent_complete: active_encode_result.percent_complete,
+      hls_master_playlist_s3_url: master_playlist&.url
     )
   end
 end

--- a/app/models/active_encode_status.rb
+++ b/app/models/active_encode_status.rb
@@ -1,3 +1,17 @@
+# Note the active_encode_id is also exactly the MediaConvert job ID in AWS,
+# if we're using MediaConvert, as we are.
 class ActiveEncodeStatus < ApplicationRecord
   belongs_to :asset
+
+  enum state: [ "running", "cancelled", "failed", "completed" ].map {|v| [v, v]}.to_h
+
+  def self.create_from!(asset:, active_encode_result:)
+    ActiveEncodeStatus.create!(
+      asset: asset,
+      active_encode_id: active_encode_result.id,
+      state: active_encode_result.state,
+      encode_error: active_encode_result.errors.join("\n; ").presence,
+      percent_complete: active_encode_result.percent_complete
+    )
+  end
 end

--- a/app/models/active_encode_status.rb
+++ b/app/models/active_encode_status.rb
@@ -1,0 +1,3 @@
+class ActiveEncodeStatus < ApplicationRecord
+  belongs_to :asset
+end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -12,6 +12,8 @@ class Asset < Kithe::Asset
 
   has_many :fixity_checks, foreign_key: "asset_id", inverse_of: "asset", dependent: :destroy
 
+  has_many :active_encode_statuses, foreign_key: "asset_id", inverse_of: "asset", dependent: :nullify
+
   set_shrine_uploader(AssetUploader)
 
   THUMB_WIDTHS = AssetUploader::THUMB_WIDTHS

--- a/app/services/create_hls_mediaconvert_job_service.rb
+++ b/app/services/create_hls_mediaconvert_job_service.rb
@@ -1,0 +1,123 @@
+# Encapsulates the logic for launching a MediaConvert job to create
+# HLS for a given video asset, via ActiveEncode, and storing it in the
+# ActiveEncodeStatuses table for future progress checks.
+#
+#     CreateHlsMediaconvertJobService.new(asset).call
+#
+# ActiveEncode call will look something like this:
+#
+#     ActiveEncode::Base.create(
+#       "s3:/",
+#       {
+#         use_original_url: true,
+#         destination: "s3://",
+#         outputs: [
+#           { preset: "scihist-hls-high", modifier: "_high" },
+#           { preset: "scihist-hls-medium", modifier: "_medium" },
+#           { preset: "scihist-hls-low", modifier: "_low" }
+#         ]
+#       }
+#      )
+#
+class CreateHlsMediaconvertJobService
+  HlsPresetInfo = Struct.new(:preset_name, :name_modifier, :pixel_height,
+                             keyword_init: true)
+
+  # MediaConvert preset names we'll use to create the HLS, including
+  # some metadata we may use to decide whether a given preset is
+  # needed.
+  HLS_PRESETS = [
+    HlsPresetInfo.new(preset_name: "scihist-hls-high", name_modifier: "_high", pixel_height: 1080),
+    HlsPresetInfo.new(preset_name: "scihist-hls-medium", name_modifier: "_medium", pixel_height: 720),
+    HlsPresetInfo.new(preset_name: "scihist-hls-low", name_modifier: "_low", pixel_height: 480),
+  ]
+
+  OUTPUT_SHRINE_STORAGE_KEY = :video_derivatives
+
+  attr_accessor :asset
+
+  def initialize(asset)
+    unless asset
+      raise ArgumentError.new("Missing required asset argument")
+    end
+
+    unless asset.content_type.start_with?("video/")
+      raise ArgumentError.new("Asset must have a video file content_type, not `#{asset.file_content_type}`")
+    end
+
+    unless asset.file&.storage&.respond_to?(:bucket)
+      raise ArgumentError.new("Asset must have a file in shrine S3 storage, with a `bucket` method")
+    end
+
+    @asset = asset
+  end
+
+  def call
+    result = ActiveEncode::Base.create(input_s3_url,
+      {
+        destination: output_s3_destination,
+        use_original_url: true,
+        outputs: mediaconvert_outputs_arg
+      }
+    )
+    ActiveEncodeStatus.create_from!(asset: asset, active_encode_result: result)
+  end
+
+  private
+
+  # we need an s3:// url to pass to MediaConvert, which neither Shrine nor the AWS SDK
+  # Will give us directly!
+  #
+  def input_s3_url
+    # It is not entirely clear how to escape for URL safety in an S3 url, not
+    # documented anywhere, not necessarily handled consistently by AWS...
+    #
+    # We'll start out doing it the same way as S3 does for http urls, just taking
+    # the URL from shrine?  Note we DO need to respect shrine storage prefixes,
+    # there might be a prefix in front of just the shrine `id`!
+    #
+    # TODO: test mediaconvert figure out escaping demands?
+    @input_s3_url ||= begin
+      path = URI.parse(asset.file.url(public:true)).path
+
+      "s3://#{asset.file.storage.bucket.name}#{path}"
+    end
+  end
+
+  # Where MediaConvert should put output. If we supply a prefix with a filename,
+  # the main manifest output will be at that wiht a `.m3u8` on the end -- the
+  # various adaptive bitrate options from the prefixes will get the `modifiers` added
+  # on the end, plus `.m3u8`.
+  #
+  # These things are going to go in the video_derivatives bucket, we'll
+  # assign paths based on asset PK UUID, similar to what we do in ordinary
+  # derivatives bucket. Also a random number similar to shrine for uniqueness
+  # and permanent cacheability in case we re-create differently.
+  #
+  # So return value will be something like:
+  #
+  #     s3://scihist-digicoll-production-derivatives-video/ff93bea5-dbca-4895-ae59-73fb64851fc3/bef2010a59ecad3da38c005cfcfb5747/manifest`
+  #
+  # And actual main manifest will be at that with `.m3u8` on the end!
+  def output_s3_destination
+    @output_s3_destination ||= begin
+      bucket_name = Shrine.storages[OUTPUT_SHRINE_STORAGE_KEY].bucket.name
+
+      unique_number = SecureRandom.hex
+
+      path = "/hls/#{asset.id}/#{unique_number}/manifest"
+
+      "s3://#{bucket_name}#{path}"
+    end
+  end
+
+  # TODO don't create presets that are bigger than our actual video!
+  def mediaconvert_outputs_arg
+    HLS_PRESETS.map do |config|
+      {
+        preset: config.preset_name,
+        modifier: config.name_modifier
+      }
+    end
+  end
+end

--- a/app/services/create_hls_mediaconvert_job_service.rb
+++ b/app/services/create_hls_mediaconvert_job_service.rb
@@ -88,7 +88,7 @@ class CreateHlsMediaconvertJobService
   end
 
   # Where MediaConvert should put output. If we supply a prefix with a filename,
-  # the main manifest output will be at that wiht a `.m3u8` on the end -- the
+  # the main playlist output will be at that wiht a `.m3u8` on the end -- the
   # various adaptive bitrate options from the prefixes will get the `modifiers` added
   # on the end, plus `.m3u8`.
   #
@@ -99,16 +99,16 @@ class CreateHlsMediaconvertJobService
   #
   # So return value will be something like:
   #
-  #     s3://scihist-digicoll-production-derivatives-video/ff93bea5-dbca-4895-ae59-73fb64851fc3/bef2010a59ecad3da38c005cfcfb5747/manifest`
+  #     s3://scihist-digicoll-production-derivatives-video/ff93bea5-dbca-4895-ae59-73fb64851fc3/bef2010a59ecad3da38c005cfcfb5747/playlist`
   #
-  # And actual main manifest will be at that with `.m3u8` on the end!
+  # And actual main playlist will be at that with `.m3u8` on the end!
   def output_s3_destination
     @output_s3_destination ||= begin
       bucket_name = Shrine.storages[OUTPUT_SHRINE_STORAGE_KEY].bucket.name
 
       unique_number = SecureRandom.hex
 
-      path = "/hls/#{asset.id}/#{unique_number}/manifest"
+      path = "/hls/#{asset.id}/#{unique_number}/playlist"
 
       "s3://#{bucket_name}#{path}"
     end

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -48,7 +48,34 @@
       </div>
     <% end %>
 
+    <% if @asset.content_type&.start_with?("video/") %>
+    <h3 class="mt-4 mb-4">HLS Encode Jobs</h3>
+    <% @asset.active_encode_statuses.order(updated_at: :desc).each do |status| %>
+      <dl class='row'>
+        <dt class="col-sm-4">started</dt><dd class="col-sm-8"><%= l status.created_at, format: :admin %></dd>
+        <dt class="col-sm-4">last updated</dt><dd class="col-sm-8"><%= l status.updated_at, format: :admin %></dd>
+        <dt class="col-sm-4">state</dt>
+          <dd class="col-sm-8">
+            <%= status.state %>
+            <% if status.running? %>
+              (<%= status.percent_complete  %>%)
+            <% end %>
+          </dd>
+        <dt class="col-sm-4">job id</dt><dd class="col-sm-8"><%= status.active_encode_id %></dd>
+        <% if status.encode_error.present? %>
+          <dt>Error</dt>
+          <dd><code><%= status.encode_error %></code></dd>
+        <% end %>
+        <% if status.hls_master_playlist_s3_url.present? %>
+          <dt class="col-sm-4">playlist</dt>
+          <dd class="col-sm-8"><%= text_field_tag "", status.hls_master_playlist_s3_url, readonly: true, style: "width: 100%" %></dd>
+        <% end %>
+      </dl>
+      <hr>
+    <% end %>
 
+
+    <% end %>
 
   </div>
 

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -71,6 +71,9 @@
           <dd class="col-sm-8"><%= text_field_tag "", status.hls_master_playlist_s3_url, readonly: true, style: "width: 100%" %></dd>
         <% end %>
       </dl>
+      <% if status.running? %>
+        <%= link_to "Refresh status", admin_refresh_active_encode_status_path(status.id), method: "put", class: "btn btn-primary btn-sm" %>
+      <% end %>
       <hr>
     <% end %>
 

--- a/config/initializers/active_encode.rb
+++ b/config/initializers/active_encode.rb
@@ -1,0 +1,16 @@
+# Set up ActiveEncode to use the MediaConvert adapter
+#
+# https://sciencehistory.atlassian.net/l/c/Hz0zMh4z
+
+ActiveEncode::Base.engine_adapter = :media_convert
+
+# Role that actual MediaConvert will use, needs access to
+# relevant S3 buckets, and MediaConvert itself.
+ActiveEncode::Base.engine_adapter.role = ScihistDigicoll::Env.lookup!("aws_mediaconvert_role_arn")
+
+# Don't require a CloudWatch layer to get output results, just infer it from
+# the MediaConvert job itself
+ActiveEncode::Base.engine_adapter.direct_output_lookup = true
+
+# We don't set the output_bucket config, we just use `destination` with complete
+# S3 destination URLs with the ActiveEncode adapter

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -12,6 +12,7 @@ Shrine.storages = {
   cache: ScihistDigicoll::Env.shrine_cache_storage,
   store: ScihistDigicoll::Env.shrine_store_storage,
   video_store: ScihistDigicoll::Env.shrine_store_video_storage,
+  video_derivatives: ScihistDigicoll::Env.shrine_video_derivatives_storage,
   kithe_derivatives: ScihistDigicoll::Env.shrine_derivatives_storage,
   restricted_kithe_derivatives: ScihistDigicoll::Env.shrine_restricted_derivatives_storage,
   on_demand_derivatives: ScihistDigicoll::Env.shrine_on_demand_derivatives_storage,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -273,6 +273,9 @@ Rails.application.routes.draw do
       end
     end
 
+    # a cheesy way to provide this one-off action
+    put "/active_encode_status/:active_encode_status_id", to: "assets#refresh_active_encode_status", as: "refresh_active_encode_status"
+
     post "/asset_files/:asset_id/check_fixity", to: "assets#check_fixity", as: "check_fixity"
     get "/fixity_report", to: "assets#fixity_report", as: "fixity_report"
     get "/storage_report", to: "storage_report#index", as: "storage_report"

--- a/db/migrate/20220426162417_create_active_encode_statuses.rb
+++ b/db/migrate/20220426162417_create_active_encode_statuses.rb
@@ -1,0 +1,17 @@
+class CreateActiveEncodeStatuses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :active_encode_statuses do |t|
+      t.string :active_encode_id
+      t.uuid :asset_id
+      t.string :state
+      t.text :encode_error
+      t.integer :percent_complete
+      t.string :hls_master_playlist_s3_url
+
+      t.timestamps
+    end
+    add_index :active_encode_statuses, :active_encode_id
+    add_index :active_encode_statuses, :asset_id
+    add_index :active_encode_statuses, :state
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_12_194219) do
+ActiveRecord::Schema.define(version: 2022_04_26_162417) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -62,6 +62,20 @@ ActiveRecord::Schema.define(version: 2021_11_12_194219) do
         END;
         $function$
   SQL
+
+  create_table "active_encode_statuses", force: :cascade do |t|
+    t.string "active_encode_id"
+    t.uuid "asset_id"
+    t.string "state"
+    t.text "encode_error"
+    t.integer "percent_complete"
+    t.string "hls_master_playlist_s3_url"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["active_encode_id"], name: "index_active_encode_statuses_on_active_encode_id"
+    t.index ["asset_id"], name: "index_active_encode_statuses_on_asset_id"
+    t.index ["state"], name: "index_active_encode_statuses_on_state"
+  end
 
   create_table "asset_derivative_storage_type_reports", force: :cascade do |t|
     t.jsonb "data_for_report", default: {}

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -388,7 +388,7 @@ module ScihistDigicoll
     end
 
     def self.shrine_video_derivatives_storage
-      @shrine_derivatives_storage ||=
+      @shrine_derivatives_video_storage ||=
         appropriate_shrine_storage( bucket_key: :s3_bucket_derivatives_video,
                                     s3_storage_options: {
                                       public: true,

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -103,6 +103,20 @@ module ScihistDigicoll
       self.class.aws_credentials.secret_access_key if Rails.env.development?
     }
 
+    # MediaConvert requires a special role to be passed to MediaConvert
+    # jobs, that has access to input/output buckets, and MediaConvert itself.
+    #
+    # https://github.com/aws-samples/aws-media-services-simple-vod-workflow/blob/master/1-IAMandS3/README.md#1-create-an-iam-role-to-use-with-aws-elemental-mediaconvert
+    #
+    # prod/staging roles are probably scihist-digicoll-staging-MediaConvertRole etc,
+    # but should be set in ENV.
+    define_key :aws_mediaconvert_role_arn, default: -> {
+      if lookup(:service_level).nil?
+        # role that only gives access to dev bucket
+        "arn:aws:iam::335460257737:role/scihist-digicoll-DEV-MediaConvertRole"
+      end
+    }
+
     define_key :lockbox_master_key, default: -> {
       # In production, we insist that local_env.yml contain
       # a real 64-bit key; if none is defined, we fail at
@@ -193,6 +207,7 @@ module ScihistDigicoll
     define_key :s3_bucket_originals
     define_key :s3_bucket_originals_video
     define_key :s3_bucket_derivatives
+    define_key :s3_bucket_derivatives_video
     define_key :s3_bucket_uploads
     define_key :s3_bucket_on_demand_derivatives
     define_key :s3_bucket_dzi
@@ -305,6 +320,7 @@ module ScihistDigicoll
     #
     def self.appropriate_shrine_storage(bucket_key:, mode: lookup!(:storage_mode), s3_storage_options: {}, prefix: nil)
       unless %I{s3_bucket_uploads s3_bucket_originals s3_bucket_originals_video s3_bucket_derivatives
+                s3_bucket_derivatives_video
                 s3_bucket_on_demand_derivatives s3_bucket_dzi}.include?(bucket_key)
         raise ArgumentError.new("Unrecognized bucket_key: #{bucket_key}")
       end
@@ -361,6 +377,19 @@ module ScihistDigicoll
     def self.shrine_derivatives_storage
       @shrine_derivatives_storage ||=
         appropriate_shrine_storage( bucket_key: :s3_bucket_derivatives,
+                                    s3_storage_options: {
+                                      public: true,
+                                      upload_options: {
+                                        # derivatives are public and at unique random URLs, so
+                                        # can be cached far-future
+                                        cache_control: "max-age=31536000, public"
+                                      }
+                                    })
+    end
+
+    def self.shrine_video_derivatives_storage
+      @shrine_derivatives_storage ||=
+        appropriate_shrine_storage( bucket_key: :s3_bucket_derivatives_video,
                                     s3_storage_options: {
                                       public: true,
                                       upload_options: {

--- a/lib/tasks/active_encode_status.rake
+++ b/lib/tasks/active_encode_status.rake
@@ -1,0 +1,22 @@
+namespace :scihist do
+  namespace :active_encode_status do
+
+
+    desc """
+    Creates jobs to update ActiveEncode status for all non-complete jobs registered
+
+    Also deletes old no longer needed status records.
+
+    You want a scheduled job to run this periodically, maybe once an hour.
+    """
+    task :update => :environment do
+      ActiveEncodeStatus.running.find_each do |job_status|
+        RefreshActiveEncodeStatusJob.perform_later(job_status)
+      end
+
+      # And delete any old ones that are not running, use delete_all, one
+      # quick SQL, no Rails callbacks.
+      ActiveEncodeStatus.not_running.where("updated_at < ?", 7.days.ago).delete_all
+    end
+  end
+end

--- a/spec/models/active_encode_status_spec.rb
+++ b/spec/models/active_encode_status_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ActiveEncodeStatus, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -199,10 +199,16 @@ describe Asset do
       end
     end
 
-    describe "video" do
+    describe "video", queue_adapter: :test do
       let(:asset) { create(:asset_with_faked_file, :video) }
       it "correct" do
         expect(asset.file_category).to eq("video")
+      end
+
+      it "enqueues job to create HLS"  do
+        expect {
+          create(:asset, :inline_promoted_file, file: File.open(Rails.root + "spec/test_support/video/sample_video.mp4"))
+        }.to have_enqueued_job(CreateHlsVideoJob)
       end
     end
 

--- a/spec/services/create_hls_mediaconvert_job_service_spec.rb
+++ b/spec/services/create_hls_mediaconvert_job_service_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+# A bit hard to really test without actually talking to live MediaConvert or s3,
+# but that's our goal, per our current testing practices. There ends up being a lot
+# of mocking, i'm not feeling great about these tests...
+describe CreateHlsMediaconvertJobService do
+  let(:asset) { create(:asset_with_faked_file, :video) }
+  let(:service) { CreateHlsMediaconvertJobService.new(asset) }
+
+  # make the  shrine file pretend to be enough of an S3 storage to satisfy the code,
+  # even though it's not actually S3 in test.
+  # we're going to mock the actual AWS things later.
+  before do
+    without_partial_double_verification do
+      allow(asset.file.storage).to receive(:bucket).and_return(OpenStruct.new(name: "fake-video-original-bucket"))
+      allow(Shrine.storages[CreateHlsMediaconvertJobService::OUTPUT_SHRINE_STORAGE_KEY]).to receive(:bucket).and_return(OpenStruct.new(name: "fake-video-derivatives-bucket"))
+    end
+  end
+
+  it "creates" do
+    # We're going to mock active_encode entirely!
+    expect(ActiveEncode::Base).to receive(:create).with(any_args) do |input, options|
+      expect(input).to start_with("s3://")
+      expect(input).to eq service.send(:input_s3_url)
+
+      expect(options[:destination]).to start_with("s3://")
+      expect(options[:destination]).to eq service.send(:output_s3_destination)
+
+      expect(options[:use_original_url]).to be(true)
+      expect(options[:outputs]).to be_present
+    end.and_return(
+      ActiveEncode::Base.new(service.send(:input_s3_url), {}).tap do |encode|
+        encode.id =  "faked-id"
+        encode.state = :running
+        encode.percent_complete = 0
+        encode.errors = []
+        encode.output = []
+      end
+    )
+
+    status_model = service.call
+    expect(status_model).to be_kind_of(ActiveEncodeStatus)
+    expect(status_model).to be_persisted
+
+    expect(status_model.active_encode_id).to eq("faked-id")
+    expect(status_model.asset).to eq(asset)
+    expect(status_model.state).to eq "running"
+  end
+end


### PR DESCRIPTION
In this PR:

* We can launch AWS MediaConvert jobs via ActiveEncode adapter, to use Asset original video and produce HLS in video derivatives bucket
* This is wired in to happen automatically on asset ingest (via a bg job)
* We have an ActiveEncodeStatus model/table, which can be used to track current status of the AWS MediaConvert job
* There is a way to poll to update status, and a rake task to do it for all statuses in `running` state. 
  * We will have a heroku scheduled job, that runs (every hour? Every ten minutes?) `rake scihist:active_encode_status:update`
* On the asset admin screen, for video, it can show you any ActiveEncodeStatus and their status, and let you press a button to kick off refresh status for a particular one, instead of waiting for the scheduled job. 

However, these HLS copies won't actually be used yet, that's for a subsequent PR. Also, the testing situation is a bit not great, this stuff is pretty hard to test, I put in some limited tests, that use extensive AWS mocking. 

## Things to be included in later PR necessary to actually have HLS be live

* The HLS copies once created need to be actually used -- probably the "refresh status" task will, if the thing is "complete", do something to let someone know there is an HLS playlist that can be used
* lifecycle management -- deleting HLS when an Asset is deleted, or when a new HLS is created!

## Things to be included in later PR's for full administrative control

* orphan checking on video_derivatives of HLS?
* prod->staging sync coveres video_derivatives bucket?
* dev copy_data copies HLS?  Or maybe skip that; I think it won't actually work since our dev buckets aren't public, and we don't have a way of serving HLS from non-public bucket. This is gonna get a bit messy. 


