### PR TITLE
Remove code that references mp3 combined audio derivatives

### DIFF
--- a/app/components/oral_history/admin/combined_audio_derivatives_component.html.erb
+++ b/app/components/oral_history/admin/combined_audio_derivatives_component.html.erb
@@ -15,14 +15,6 @@
                 <%= link_to combined_m4a_audio,  combined_m4a_audio %>
               </small>
             </li>
-          <% elsif combined_mp3_audio.present? # REMOVE_AFTER_MP3_TO_M4A_MIGRATION %>
-            <li class="alert-danger">
-              Do not use this mp3 link as the OHMS Media URL, as it will be deleted soon.<br/>
-              Instead, click "Generate combined audio derivatives" below to create a new m4a link. Once that's created, use that mp4 link instead.<br/>
-              <small>
-                <%= link_to combined_mp3_audio,  combined_mp3_audio %>
-              </small>
-            </li>
           <% end %>
         </ul>
     <% elsif ! work_available_members? %>

--- a/app/components/oral_history/admin/combined_audio_derivatives_component.rb
+++ b/app/components/oral_history/admin/combined_audio_derivatives_component.rb
@@ -30,13 +30,6 @@ module OralHistory
         oh_content.combined_audio_m4a&.url(public:true)
       end
 
-      def combined_mp3_audio # REMOVE_AFTER_MP3_TO_M4A_MIGRATION
-        return nil unless work.is_oral_history?
-        return nil unless work_available_members?
-        oh_content = work.oral_history_content!
-        oh_content.combined_audio_mp3&.url(public:true)
-      end
-
       def combined_audio_fingerprint
         return nil unless work.is_oral_history?
         work.oral_history_content!.combined_audio_fingerprint

--- a/app/components/oral_history/downloads_list_component.html.erb
+++ b/app/components/oral_history/downloads_list_component.html.erb
@@ -42,24 +42,6 @@
   </div>
 <% end %>
 
-<% if combined_mp3_audio_url.present? && combined_derivatives_up_to_date? && combined_derivatives_up_to_date? #REMOVE_AFTER_MP3_TO_M4A_MIGRATION %>
-  <div class="combined-audio-download-links">
-    <div class="combined-audio-download-icon-container">
-      <a href="<%= combined_mp3_audio_download_url %>"
-        data-analytics-category="Work"
-        data-analytics-action="download_combined_audio_derivatives"
-        data-analytics-label="<%= work.friendlier_id %>"
-        >
-        <i class="fa fa-download" aria-hidden="true"></i>
-        Web-quality MP3
-      </a>
-    </div>
-    <div class="combined-audio-download-link-size">
-      <small><%= combined_display_mp3_audio_size %></small>
-    </div>
-  </div>
-<% end %>
-
 
 <h2 class="attribute-sub-head sound-file-header">
   <% if audio_members.count > 1 %>

--- a/app/components/oral_history/downloads_list_component.rb
+++ b/app/components/oral_history/downloads_list_component.rb
@@ -8,10 +8,6 @@ module OralHistory
       :m4a_audio_download_filename, :display_m4a_audio_size,
       to: :combined_audio_derivatives, prefix: "combined"
 
-    # REMOVE_AFTER_MP3_TO_M4A_MIGRATION
-    delegate :mp3_audio_url, :mp3_audio_download_url, :mp3_audio_download_filename,
-      :display_mp3_audio_size, to: :combined_audio_derivatives, prefix: "combined"
-
     attr_reader :decorator, :work, :combined_audio_derivatives
 
     # TODO decorator is a WIP on the path to a refactor

--- a/app/components/work_oh_audio_show_component.html.erb
+++ b/app/components/work_oh_audio_show_component.html.erb
@@ -24,18 +24,6 @@
               </div>
             <% end %>
           </div>
-        <% elsif combined_mp3_audio_url.present? && combined_derivatives_up_to_date? #REMOVE_AFTER_MP3_TO_M4A_MIGRATION %>
-          <div class="d-flex" style="align-items: center">
-            <audio controls controlslist="nodownload" data-role="ohms-audio-elem">
-              <source src="<%= combined_mp3_audio_url%>"  type="audio/mpeg"/>
-              <source src="<%= combined_webm_audio_url%>"  type="audio/webm"/>
-            </audio>
-            <% if has_ohms_index? || has_ohms_transcript? %>
-              <div class="pl-3">
-                <button class="btn btn-emphasis btn-sm text-nowrap" data-trigger="ohms-jump-to-text">Jump to text</button>
-              </div>
-            <% end %>
-          </div>
         <% else %>
           <div class="alert alert-warning" role="alert" data-role="no-audio-alert">
              This oral history is not properly prepared for the audio player. (Staff: please create a combined derivative.)

--- a/app/components/work_oh_audio_show_component.rb
+++ b/app/components/work_oh_audio_show_component.rb
@@ -4,9 +4,6 @@
 class WorkOhAudioShowComponent < ApplicationComponent
   delegate :construct_page_title, :current_user, to: :helpers
 
-  #REMOVE_AFTER_MP3_TO_M4A_MIGRATION
-  delegate :mp3_audio_url, :webm_audio_url, to: :combined_audio_derivatives, prefix: "combined"
-
   delegate  :m4a_audio_url, :derivatives_up_to_date?, to: :combined_audio_derivatives, prefix: "combined"
 
   attr_reader :work, :combined_audio_derivatives

--- a/app/models/oral_history_content.rb
+++ b/app/models/oral_history_content.rb
@@ -45,11 +45,6 @@ class OralHistoryContent < ApplicationRecord
   has_and_belongs_to_many :interviewer_profiles
   has_and_belongs_to_many :interviewee_biographies
 
-  # REMOVE_AFTER_MP3_TO_M4A_MIGRATION
-  include CombinedAudioUploader::Attachment.new(:combined_audio_mp3, store: :combined_audio_derivatives)
-  # REMOVE_AFTER_MP3_TO_M4A_MIGRATION
-  include CombinedAudioUploader::Attachment.new(:combined_audio_webm, store: :combined_audio_derivatives)
-
   include CombinedAudioUploader::Attachment.new(:combined_audio_m4a, store: :combined_audio_derivatives)
 
   enum combined_audio_derivatives_job_status: {

--- a/app/presenters/combined_audio_derivatives.rb
+++ b/app/presenters/combined_audio_derivatives.rb
@@ -11,16 +11,6 @@ class CombinedAudioDerivatives
     @work = work
   end
 
-  # REMOVE_AFTER_MP3_TO_M4A_MIGRATION
-  def mp3_audio_url
-    work&.oral_history_content&.combined_audio_mp3&.url(public:true)
-  end
-
-  # REMOVE_AFTER_MP3_TO_M4A_MIGRATION
-  def webm_audio_url
-    work&.oral_history_content&.combined_audio_webm&.url(public:true)
-  end
-
   def m4a_audio_url
     work&.oral_history_content&.combined_audio_m4a&.url(public:true)
   end
@@ -33,37 +23,12 @@ class CombinedAudioDerivatives
     CombinedAudioDerivativeCreator.new(work).fingerprint == audio_fingerprint
   end
 
-
-  # REMOVE_AFTER_MP3_TO_M4A_MIGRATION
-  def mp3_audio_download_filename
-    parts = [
-      DownloadFilenameHelper.first_three_words(work.title),
-      work.friendlier_id
-    ].collect(&:presence).compact
-    Pathname.new(parts.join("_")).sub_ext('.mp3').to_s
-  end
-
-
   def m4a_audio_download_filename
     parts = [
       DownloadFilenameHelper.first_three_words(work.title),
       work.friendlier_id
     ].collect(&:presence).compact
     Pathname.new(parts.join("_")).sub_ext('.m4a').to_s
-  end
-
-
-  # REMOVE_AFTER_MP3_TO_M4A_MIGRATION
-  def mp3_audio_download_url
-    work&.oral_history_content&.combined_audio_mp3&.url(
-      public: false,
-      expires_in: DOWNLOAD_URL_EXPIRES_IN,
-      response_content_type: 'audio/mpeg',
-      response_content_disposition: ContentDisposition.format(
-        disposition: 'attachment',
-        filename: mp3_audio_download_filename
-      )
-    )
   end
 
   def m4a_audio_download_url
@@ -76,12 +41,6 @@ class CombinedAudioDerivatives
         filename: m4a_audio_download_filename
       )
     )
-  end
-
-
-  # REMOVE_AFTER_MP3_TO_M4A_MIGRATION
-  def display_mp3_audio_size
-    ScihistDigicoll::Util.simple_bytes_to_human_string(work&.oral_history_content&.combined_audio_mp3&.size)
   end
 
   def display_m4a_audio_size

--- a/db/migrate/20220510192754_remove_combined_audio_mp3_data_from_oral_history_content.rb
+++ b/db/migrate/20220510192754_remove_combined_audio_mp3_data_from_oral_history_content.rb
@@ -1,0 +1,6 @@
+class RemoveCombinedAudioMp3DataFromOralHistoryContent < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :oral_history_content, :combined_audio_mp3_data,  :jsonb
+    remove_column :oral_history_content, :combined_audio_webm_data, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_26_162417) do
+ActiveRecord::Schema.define(version: 2022_05_10_192754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -214,8 +214,6 @@ ActiveRecord::Schema.define(version: 2022_04_26_162417) do
 
   create_table "oral_history_content", force: :cascade do |t|
     t.uuid "work_id", null: false
-    t.jsonb "combined_audio_mp3_data"
-    t.jsonb "combined_audio_webm_data"
     t.jsonb "combined_audio_m4a_data"
     t.string "combined_audio_fingerprint"
     t.jsonb "combined_audio_component_metadata"


### PR DESCRIPTION
- All oral histories with public audio members have already had their combined audio derivatives generated as m4a;
- The underlying mp3 and webm files, and references to them, are already removed from s3 and the production database.
So it's now time to remove code mentioning these derivatives.
- And a migration to remove the columns. @jrochkind argues that it's better to include the migration removing the DB columns in the same PR that removes the code: "[...] more worried about forgetting to remove columns we were no longer using. In general, I think I always remove the columns in the same PR I remove all the code that uses them!"

Ref #1654
Ref #1662)