### PR TITLE
Support use of CloudFront CDN on top of video derivatives bucket (for HLS)

### DIFF
--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -357,9 +357,7 @@ module ScihistDigicoll
       @shrine_cache_storage ||=
         # special handling with "web" prefix, I forget why.
         appropriate_shrine_storage( bucket_key: :s3_bucket_uploads,
-                                    s3_storage_options: {
-                                      prefix: "web"
-                                    })
+                                    prefix: "web")
     end
 
     def self.shrine_store_storage


### PR DESCRIPTION
This come after #1685, first merge that. 

Allow a S3_BUCKET_DERIVATIVES_VIDEO_HOST env variable to hold the cloudfront distribution hostname for the distribution we are putting in front of the video derivatives bucket. (see https://github.com/sciencehistory/terraform_scihist_digicoll/pull/20)

Note if this variable isn't set -- the app won't complain, it just won't use a cloudfront distribution, silently.  This maybe makes it easy to make that mistake?  But also makes it a lot more flexible, the app is happy to work with or without a cloudfront distro, easier to deploy in stages with less coupling/dependency (this can be merged now), easier to deal with different environments (say dev) that might not have one, etc. 

The value of the variable is output by terraform, if you need it again, `terraform output`  in specific workspace for staging/production. 