### PR TITLE
Increase format facet initial-display limit

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -295,7 +295,7 @@ class CatalogController < ApplicationController
     config.add_facet_field "subject_facet", label: "Subject", limit: 5
     config.add_facet_field "creator_facet", label: "Creator", limit: 5
     config.add_facet_field "genre_facet", label: "Genre", limit: 5
-    config.add_facet_field "format_facet", label: "Format", limit: 5
+    config.add_facet_field "format_facet", label: "Format", limit: 10
     config.add_facet_field "medium_facet", label: "Medium", limit: 5
     config.add_facet_field 'place_facet', label: "Place", limit: 5
     config.add_facet_field 'language_facet', label: "Language", limit: 5


### PR DESCRIPTION
To be long enough to include our 6th term added "Moving Image". But just make it 10 in case we somehow add more -- we want to show all of these on the initial search results, not require 'more' link.
