### PR TITLE
Reduce fetch batch size and turn of query cache for bulk fixity check

### DIFF
--- a/app/lib/scihist_digicoll/assets_needing_fixity_checks.rb
+++ b/app/lib/scihist_digicoll/assets_needing_fixity_checks.rb
@@ -19,7 +19,7 @@ module ScihistDigicoll
   # Note: if you pass in 0 as the cycle length, you just get all the assets.
   #
   class AssetsNeedingFixityChecks
-    BATCH_FETCH_SIZE = 1000
+    BATCH_FETCH_SIZE = 200
     DEFAULT_PERIOD_IN_DAYS  = 90 # in days
     attr_reader :cycle_length
 

--- a/lib/tasks/check_fixity.rake
+++ b/lib/tasks/check_fixity.rake
@@ -37,18 +37,21 @@ namespace :scihist do
       Rails.logger.info(info)
     end
 
-    # Use transaction for every 10 FixityChecks to add, should speed things up.
-    check_lister.assets_to_check.each_slice(10) do | transaction_batch |
-      Asset.transaction do
-        transaction_batch.each do |asset|
-          if asset.stored?
-            checker = FixityChecker.new(asset)
-            new_check = checker.check  unless ENV['SKIP_CHECK'] == 'true'
-            checker.prune_checks       unless ENV['SKIP_PRUNE'] == 'true'
-            FixityCheckFailureService.new(new_check).send if new_check&.failed?
-            count_of_items_checked = count_of_items_checked + 1 unless ENV['SKIP_CHECK'] == 'true'
+    # let's see if uncached improves our memory consumption?
+    ActiveRecord::Base.uncached do
+      # Use transaction for every 10 FixityChecks to add, should speed things up.
+      check_lister.assets_to_check.each_slice(10) do | transaction_batch |
+        Asset.transaction do
+          transaction_batch.each do |asset|
+            if asset.stored?
+              checker = FixityChecker.new(asset)
+              new_check = checker.check  unless ENV['SKIP_CHECK'] == 'true'
+              checker.prune_checks       unless ENV['SKIP_PRUNE'] == 'true'
+              FixityCheckFailureService.new(new_check).send if new_check&.failed?
+              count_of_items_checked = count_of_items_checked + 1 unless ENV['SKIP_CHECK'] == 'true'
+            end
+            progress_bar.increment unless progress_bar.nil?
           end
-          progress_bar.increment unless progress_bar.nil?
         end
       end
     end


### PR DESCRIPTION
Seeing if perhaps this helps us avoid out of memory errors running in heroku standard-1x on our nightly fixity check

Reduce fetch batch size, and try disabling ActiveRecord query cache to see if it helps us avoid memory bloat. 

Ref #1679 