### PR TITLE
Sort by full date

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -431,12 +431,12 @@ class CatalogController < ApplicationController
 
     config.add_sort_field("newest_date") do |field|
       field.label = "newest date"
-      field.sort = "latest_year desc"
+      field.sort = "latest_date desc"
     end
 
     config.add_sort_field("oldest_date") do |field|
       field.label = "oldest date"
-      field.sort = "earliest_year asc"
+      field.sort = "earliest_date asc"
     end
 
     config.add_sort_field("recently_added") do |field|

--- a/app/indexers/date_index_helper.rb
+++ b/app/indexers/date_index_helper.rb
@@ -1,16 +1,79 @@
-# Takes DateOfWork metadata from a Work, expands it into
-# an array of integer years to be used to fill an int facet
-# in solr for date range limit or sortable fields.
+# A Work can have one or more DateOfWork objects representing a date, or date range,
+# or partial date. Including things like "the 1930s" or "May 1940 to June 1941"
 #
-# Copied from https://github.com/sciencehistory/chf-sufia/blob/master/app/indexers/chf/generic_work_indexer/date_values.rb
+# This class interprets/expands those DateOfWork objects into more specific things
+# that we need for Solr indexing.
+#
+# #expanded_years is an array of years, any year that might be represented
+# by any dates included, that we use for some solr fields to facet upon
+#
+# #min_date and #max_date are actual Ruby date objects, the latest or
+# earliest dates that might be represented by the DateOfWork set,
+# that we use for Solr fields to sort on.
+#
 class DateIndexHelper
   attr_reader :work
   def initialize(work)
     @work = work
   end
 
+  # An array of int, all the years that might be included by any dates/ranges in work
+  # We use for a year facet value
   def expanded_years
     @expanded_years ||= work.date_of_work.collect { |date_of_work| years_for_date_of_work(date_of_work) }.flatten
+  end
+
+
+  # @return [Date] the earliest date in the work -- for dates effectively
+  #   representing ranges,the earliest possible date in the range is it.
+  #
+  #   Returns nil if none can be found because of no dates or malformed dates.
+  def min_date
+    work.date_of_work.collect do |date_of_work|
+      start, start_qualifier, finish, finish_qualifier = date_of_work.start, date_of_work.start_qualifier, date_of_work.finish, date_of_work.finish_qualifier
+
+      case start_qualifier
+      when "Undated"
+        nil
+      when "decade"
+        complete_min_date(start.strip.slice(0..2)) # send first three year digits
+      when "century"
+        complete_min_date(start.strip.slice(0..1)) # send first two year digits
+      else
+        # For all other types of start date (circa, before, after, as well as blank)
+        # we're just going to index it as the date we've got, if we've got one.
+        complete_min_date(start)
+      end
+    end.compact.min
+  end
+
+  # @return [Date] The latest date in the work -- for dates effectively
+  #    representing ranges, the latest possible date in the range is it.
+  #
+  #    Returns nil if none can be found because of no dates or malformed dates.
+  def max_date
+    work.date_of_work.collect do |date_of_work|
+      start, start_qualifier, finish, finish_qualifier = date_of_work.start, date_of_work.start_qualifier, date_of_work.finish, date_of_work.finish_qualifier
+
+      if finish.present?
+        operative_date, operative_qualifier = finish, finish_qualifier
+      else
+        operative_date, operative_qualifier = start, start_qualifier
+      end
+
+      case operative_qualifier
+      when "Undated"
+        nil
+      when "decade"
+        complete_max_date(operative_date.strip.slice(0..2)) # send first three year digits
+      when "century"
+        complete_max_date(operative_date.strip.slice(0..1)) # send first two year digits
+      else
+        # For all other types of start date (circa, before, after, as well as blank)
+        # we're just going to index it as the date we've got, if we've got one.
+        complete_max_date(operative_date)
+      end
+    end.compact.max
   end
 
   def min_year
@@ -21,6 +84,11 @@ class DateIndexHelper
     @maximum_year ||= expanded_years.max
   end
 
+
+  private
+
+  # helper method for expanded_years, take a single DateOfWork and expand it into
+  # all the years that might be included by dates referenced.
   def years_for_date_of_work(repo_d)
     start, start_qualifier, finish, finish_qualifier = repo_d.start, repo_d.start_qualifier, repo_d.finish, repo_d.finish_qualifier
 
@@ -69,6 +137,77 @@ class DateIndexHelper
       # like a year.
       return (start_year..finish_year).to_a
     end
+  end
+
+  # Helper method for min_date, completes partial dates into a ruby Date
+  #
+  # Can pass in a yyyy-mm-dd date, OR a partial one:
+  #
+  # * \d\d (century, eg `20`)
+  # * \d\d\d (decade, eg `193`)
+  # * \d\d\d\d (just year, `1973`)
+  # * \d\d\d\d-\d\d (just year and month, `2020-09`)
+  # * \d\d\d\d-\d\d-\d\d (full date, 2020-04-21)
+  #
+  # @ returns [Date] representing the MINIMUM possible date for input that may
+  #   represent a date. Like for `193` (decade), that means 1930-01-01
+  #   Returns nil if bad unparseable unexpected input.
+  #
+  def complete_min_date(date_str)
+    unless date_str && date_str =~ /(\d\d\d?\d?)(?:-(\d\d))?(?:-(\d\d))?/
+      return nil # malformed date
+    end
+
+    year  = $1
+    month = $2
+    day   = $3
+
+    if year.length == 2 # century
+      Date.iso8601("#{date_str}00-01-01")
+    elsif year.length == 3 #decade
+      Date.iso8601("#{date_str}0-01-01")
+    else
+      # full year, maybe with month, maybe with date
+      month ||= "01"
+      day ||= "01"
+      Date.iso8601("#{year}-#{month}-#{day}")
+    end
+  rescue Date::Error
+    nil
+  end
+
+  # Helper method for max_date, completes partial dates into a ruby Date.
+  #
+  # like complete_min_date, but returns the date representing the MAXIMUM
+  # possible date for input that may represent a date.
+  #
+  # @returns [Date] represneting MAXIMIM possible date for input,
+  #   like for `193` (decade), that means `1939-12-31`. Returns
+  #   nil if bad, unparseable, or unexpected input.
+  def complete_max_date(date_str)
+    unless date_str && date_str =~ /(\d\d\d?\d?)(?:-(\d\d))?(?:-(\d\d))?/
+      return nil # malformed date
+    end
+
+    year  = $1
+    month = $2
+    day   = $3
+
+    if year.length == 2 # century
+      Date.iso8601("#{date_str}99-12-31")
+    elsif year.length == 3 #decade
+      Date.iso8601("#{date_str}9-12-31")
+    elsif day.nil?
+      month ||= "12" # maybe we don't have month either
+
+      # have to auto-complete to last day in month, which
+      # we can have date class figure out for us this way:
+      Date.iso8601("#{year}-#{month}-01").next_month.prev_day
+    else
+      Date.iso8601("#{year}-#{month}-#{day}")
+    end
+  rescue Date::Error
+    nil
   end
 end
 

--- a/app/indexers/date_index_helper.rb
+++ b/app/indexers/date_index_helper.rb
@@ -76,15 +76,6 @@ class DateIndexHelper
     end.compact.max
   end
 
-  def min_year
-    @minimum_year ||= expanded_years.min
-  end
-
-  def max_year
-    @maximum_year ||= expanded_years.max
-  end
-
-
   private
 
   # helper method for expanded_years, take a single DateOfWork and expand it into

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -57,9 +57,6 @@ class WorkIndexer < Kithe::Indexer
     end
 
     # For sorting by oldest first
-    to_field "earliest_year" do |record, acc|
-      acc << DateIndexHelper.new(record).min_year
-    end
     to_field "earliest_date" do |record, acc|
       # for Solr, we need in "xml schema" format, with 00:00:00 time, and UTC timezone
       # Rails date extensions are confusing, but this works to get it.
@@ -67,9 +64,6 @@ class WorkIndexer < Kithe::Indexer
     end
 
     # for sorting by newest first
-    to_field "latest_year" do |record, acc|
-      acc << DateIndexHelper.new(record).max_year
-    end
     to_field "latest_date" do |record, acc|
       # for Solr, we need in "xml schema" format, with 00:00:00 time, and UTC timezone
       # Rails date extensions are confusing, but this works to get it.

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -60,11 +60,22 @@ class WorkIndexer < Kithe::Indexer
     to_field "earliest_year" do |record, acc|
       acc << DateIndexHelper.new(record).min_year
     end
+    to_field "earliest_date" do |record, acc|
+      # for Solr, we need in "xml schema" format, with 00:00:00 time, and UTC timezone
+      # Rails date extensions are confusing, but this works to get it.
+      acc << DateIndexHelper.new(record).min_date&.in_time_zone("UTC")&.xmlschema
+    end
 
     # for sorting by newest first
     to_field "latest_year" do |record, acc|
       acc << DateIndexHelper.new(record).max_year
     end
+    to_field "latest_date" do |record, acc|
+      # for Solr, we need in "xml schema" format, with 00:00:00 time, and UTC timezone
+      # Rails date extensions are confusing, but this works to get it.
+      acc << DateIndexHelper.new(record).max_date&.in_time_zone("UTC")&.xmlschema
+    end
+
 
     # We need to know what collection(s) this work is in, to support search-within-a-collection.
     #

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -60,6 +60,7 @@
   <types>
     <!-- added by Science History Institute, int with sort missing last -->
     <fieldType name="int_sortmissinglast" class="solr.IntPointField" docValues="true" sortMissingLast="true"/>
+    <fieldType name="date_sortmissinglast" class="solr.DatePointField" docValues="true" sortMissingLast="true"/>
 
     <!-- added by Science History Institute, string field with docValues, good for faceting, or
          in the case of a single-valued field, sorting -->
@@ -244,6 +245,9 @@
     <!-- added by CHF, our year sort fields -->
     <field name="latest_year" type="int_sortmissinglast" stored="true" indexed="true" multiValued="false"/>
     <field name="earliest_year" type="int_sortmissinglast" stored="true" indexed="true" multiValued="false"/>
+    <field name="latest_date" type="date_sortmissinglast" stored="true" indexed="true" multiValued="false"/>
+    <field name="earliest_date" type="date_sortmissinglast" stored="true" indexed="true" multiValued="false"/>
+
 
     <!-- create a field for fulltext (eg oral history transcripts), let's try with omitNorms false.
          stored=true is necessary for highlighting.

--- a/spec/indexers/date_index_helper_spec.rb
+++ b/spec/indexers/date_index_helper_spec.rb
@@ -3,82 +3,248 @@ require 'rails_helper'
 RSpec.describe DateIndexHelper do
   let(:work) { FactoryBot.build(:work, date_of_work: date_of_work ) }
   let(:generator) { DateIndexHelper.new(work) }
-  # individual cases have to define `date_values` with `let`
-  let(:index_values) { generator.expanded_years }
 
-  describe "no dates" do
-    let(:date_of_work) { [Work::DateOfWork.new] }
-    it "has no index dates" do
-      expect(index_values).to eq([])
+
+  describe "#expanded_years" do
+    # individual cases have to define `date_values` with `let`
+    let(:index_values) { generator.expanded_years }
+
+    describe "no dates" do
+      let(:date_of_work) { [Work::DateOfWork.new] }
+      it "has no index dates" do
+        expect(index_values).to eq([])
+      end
     end
-  end
 
-  describe "Undated" do
-    let(:date_of_work) { [ Work::DateOfWork.new(start_qualifier: "Undated") ] }
-    it "has no index dates" do
-      expect(index_values).to eq([])
+    describe "Undated" do
+      let(:date_of_work) { [ Work::DateOfWork.new(start_qualifier: "Undated") ] }
+      it "has no index dates" do
+        expect(index_values).to eq([])
+      end
     end
-  end
 
-  describe "decade" do
-    let(:decade) { 1910 }
-    let(:date_of_work) { [ Work::DateOfWork.new(start: decade.to_s, start_qualifier: "decade") ] }
-    it "has whole decade" do
-      expect(index_values).to eq( (decade..(decade+9)).to_a )
+    describe "decade" do
+      let(:decade) { 1910 }
+      let(:date_of_work) { [ Work::DateOfWork.new(start: decade.to_s, start_qualifier: "decade") ] }
+      it "has whole decade" do
+        expect(index_values).to eq( (decade..(decade+9)).to_a )
+      end
     end
-  end
 
-  describe "century" do
-    let(:century) { 1800 }
-    let(:date_of_work) { [ Work::DateOfWork.new(start: century.to_s, start_qualifier: "century") ] }
-    it "has whole century" do
-      expect(index_values).to eq( (century..(century+99)).to_a )
+    describe "century" do
+      let(:century) { 1800 }
+      let(:date_of_work) { [ Work::DateOfWork.new(start: century.to_s, start_qualifier: "century") ] }
+      it "has whole century" do
+        expect(index_values).to eq( (century..(century+99)).to_a )
+      end
     end
-  end
 
-  describe "bare start date" do
-    let(:date_of_work) { [ Work::DateOfWork.new(start: "1955-05-12") ] }
-    it "has single year" do
-      expect(index_values).to eq( [1955] )
+    describe "bare start date" do
+      let(:date_of_work) { [ Work::DateOfWork.new(start: "1955-05-12") ] }
+      it "has single year" do
+        expect(index_values).to eq( [1955] )
+      end
     end
-  end
 
-  describe "start and end date" do
-    let(:start_year) { 1954}
-    let(:end_year) { 2001 }
-    let(:date_of_work) { [ Work::DateOfWork.new(start: start_year.to_s, start_qualifier: "circa", finish: end_year.to_s, finish_qualifier: "circa") ] }
-    it "has the range" do
-      expect(index_values).to eq( (start_year..end_year).to_a )
-    end
-  end
-
-  describe "multiple dates" do
-    let(:date_of_work) { [ Work::DateOfWork.new(start: "1905"), Work::DateOfWork.new(start: "1910", finish: "1912") ] }
-    it "has all dates" do
-      expect(index_values).to match_array( (1910..1912).to_a + [1905] )
-    end
-  end
-
-  describe "weird cases" do
-    describe "finish before start" do
+    describe "start and end date" do
       let(:start_year) { 1954}
-      let(:date_of_work) { [ Work::DateOfWork.new(start: start_year.to_s, finish: (start_year-10).to_s) ] }
-      it "has only start_year" do
-        expect(index_values).to eq( [start_year] )
+      let(:end_year) { 2001 }
+      let(:date_of_work) { [ Work::DateOfWork.new(start: start_year.to_s, start_qualifier: "circa", finish: end_year.to_s, finish_qualifier: "circa") ] }
+      it "has the range" do
+        expect(index_values).to eq( (start_year..end_year).to_a )
       end
     end
-    describe "finish but no start" do
-      let(:date_of_work) { [ Work::DateOfWork.new(finish: "1910") ] }
-      it "has no date" do
-        expect(index_values).to eq( [] )
+
+    describe "multiple dates" do
+      let(:date_of_work) { [ Work::DateOfWork.new(start: "1905"), Work::DateOfWork.new(start: "1910", finish: "1912") ] }
+      it "has all dates" do
+        expect(index_values).to match_array( (1910..1912).to_a + [1905] )
       end
     end
-    describe "non-date data" do
-      let(:date_of_work) { [ Work::DateOfWork.new(start: "this ain't right") ] }
-      it "has no date" do
-        expect(index_values).to eq( [] )
+
+    describe "weird cases" do
+      describe "finish before start" do
+        let(:start_year) { 1954}
+        let(:date_of_work) { [ Work::DateOfWork.new(start: start_year.to_s, finish: (start_year-10).to_s) ] }
+        it "has only start_year" do
+          expect(index_values).to eq( [start_year] )
+        end
+      end
+      describe "finish but no start" do
+        let(:date_of_work) { [ Work::DateOfWork.new(finish: "1910") ] }
+        it "has no date" do
+          expect(index_values).to eq( [] )
+        end
+      end
+      describe "non-date data" do
+        let(:date_of_work) { [ Work::DateOfWork.new(start: "this ain't right") ] }
+        it "has no date" do
+          expect(index_values).to eq( [] )
+        end
       end
     end
   end
 
+  describe "min and max" do
+    let(:min_date) { generator.min_date }
+    let(:max_date) { generator.max_date }
+
+    describe "no dates" do
+      let(:date_of_work) { [Work::DateOfWork.new] }
+
+      it "has no min_date" do
+        expect(min_date).to eq(nil)
+      end
+
+      it "has no max_date" do
+        expect(max_date).to eq(nil)
+      end
+    end
+
+    describe "Undated" do
+      let(:date_of_work) { [ Work::DateOfWork.new(start_qualifier: "Undated") ] }
+
+      it "has no min_date" do
+        expect(min_date).to eq(nil)
+      end
+
+      it "has no max_date" do
+        expect(max_date).to eq(nil)
+      end
+    end
+
+    describe "decade" do
+      let(:decade) { 1910 }
+      let(:date_of_work) { [ Work::DateOfWork.new(start: decade.to_s, start_qualifier: "decade") ] }
+
+      it "has min date at beginning of decade" do
+        expect(min_date).to eq(Date.iso8601("1910-01-01"))
+      end
+
+      it "has max date at end of decade" do
+        expect(max_date).to eq(Date.iso8601("1919-12-31"))
+      end
+    end
+
+    describe "century" do
+      let(:century) { 1800 }
+      let(:date_of_work) { [ Work::DateOfWork.new(start: century.to_s, start_qualifier: "century") ] }
+
+      it "has min date at beginning of century" do
+        expect(min_date).to eq(Date.iso8601("1800-01-01"))
+      end
+
+      it "has max date at end of century" do
+        expect(max_date).to eq(Date.iso8601("1899-12-31"))
+      end
+    end
+
+    describe "bare start date" do
+      let(:date_of_work) { [ Work::DateOfWork.new(start: "1955-05-12") ] }
+
+      it "has min_date equal to date" do
+        expect(min_date).to eq( Date.iso8601("1955-05-12") )
+      end
+
+      it "has max_date equal to date" do
+        expect(max_date).to eq( Date.iso8601("1955-05-12") )
+      end
+    end
+
+    describe "one date with only year/month" do
+      let(:date_of_work) { [ Work::DateOfWork.new(start: "1955-04") ] }
+
+      it "has min_date first day of month" do
+        expect(min_date).to eq( Date.iso8601("1955-04-01"))
+      end
+
+      it "has max_date last day of month specific to month" do
+        expect(max_date).to eq( Date.iso8601("1955-04-30") )
+      end
+    end
+
+    describe "start and end year" do
+      let(:start_year) { 1954}
+      let(:end_year) { 2001 }
+      let(:date_of_work) { [ Work::DateOfWork.new(start: start_year.to_s, start_qualifier: "circa", finish: end_year.to_s, finish_qualifier: "circa") ] }
+
+      it "has min_date equal to beginning of start year" do
+        expect(min_date).to eq(Date.iso8601("#{start_year}-01-01"))
+      end
+
+      it "has max_date equal to end of end year" do
+        expect(max_date).to eq(Date.iso8601("#{end_year}-12-31"))
+      end
+    end
+
+    describe "start and end just months" do
+      let(:date_of_work) { [ Work::DateOfWork.new(start: "1980-10", start_qualifier: "circa", finish: "1985-09", finish_qualifier: "circa") ] }
+
+      it "has min date equal to beginning of start month" do
+        expect(min_date).to eq( Date.iso8601("1980-10-01"))
+      end
+
+      it "has max date equal to end of end month" do
+        expect(max_date).to eq( Date.iso8601("1985-09-30"))
+      end
+    end
+
+    describe "just month on a leap month" do
+      let(:date_of_work) { [ Work::DateOfWork.new(start: "2016-02") ] }
+
+      it "max_date has proper leap day" do
+        expect(max_date).to eq Date.iso8601("2016-02-29")
+      end
+    end
+
+    describe "multiple years" do
+      let(:date_of_work) { [ Work::DateOfWork.new(start: "1905"), Work::DateOfWork.new(start: "1910", finish: "1912") ] }
+
+      it "has min date equal to beginning of earliest year" do
+        expect(min_date).to eq( Date.iso8601("1905-01-01") )
+      end
+
+      it "has max date equal to end of latest year" do
+        expect(max_date).to eq(Date.iso8601("1912-12-31"))
+      end
+    end
+
+    describe "multiple dates" do
+      let(:date_of_work) { [ Work::DateOfWork.new(start: "1905-04-12"), Work::DateOfWork.new(start: "1910-03-20", finish: "1912-06-10") ] }
+
+      it "has min date equal to earliest date" do
+        expect(min_date).to eq( Date.iso8601("1905-04-12") )
+      end
+
+      it "has max date equal to latest date" do
+        expect(max_date).to eq(Date.iso8601("1912-06-10"))
+      end
+    end
+
+    describe "weird cases" do
+      describe "non-date data" do
+        let(:date_of_work) { [ Work::DateOfWork.new(start: "this ain't right") ] }
+
+        it "has no min date" do
+          expect(min_date).to be_nil
+        end
+
+        it "has no max date" do
+          expect(max_date).to be_nil
+        end
+      end
+
+      describe "impossible date" do
+        let(:date_of_work) { [ Work::DateOfWork.new(start: "1985-06-45") ] }
+
+        it "has no min date" do
+          expect(min_date).to be_nil
+        end
+
+        it "has no max date" do
+          expect(max_date).to be_nil
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Before we were just sorting by year. 

1. Logic to pull out min and max dates represneted by compelex DateOfWork objects
2. Solr fields to hold full dates, that will sort nulls last
3. Indexer code writes to new solr date fields instead of old integer year fields

This is in draft at present, because we need to make sure to reindex right after deploying (date sorts won't function properly in the interim). So please mark "approved" now, but don't merge. 

Since we have solr schema changes, in your local checkout you will need to run:

    ./bin/rake solr:clean
    RAILS_ENV=test ./bin/rake solr:clean

That _should_ work, but not totally sure we have that working to refresh your local solr for schema changes. Let's find out. 
