### PR TITLE
Don't do automatic ActiveJob retries in test environment

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -7,5 +7,7 @@ class ApplicationJob < ActiveJob::Base
   # Resque, which we ae are using at the moment, by default doesn't support
   # future-scheduled jobs, so we retry just once, immediately. Could have
   # a more sophisticated retry pattern with a back-end that supports future-scheduling.
-  retry_on StandardError, attempts: 2, wait: 0
+  if ScihistDigicoll::Env.lookup(:activejob_auto_retry)
+    retry_on StandardError, attempts: 2, wait: 0
+  end
 end

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -294,6 +294,13 @@ module ScihistDigicoll
     # Supplied only on production servers, should have form 'UA-XXXXX-Y'
     define_key :google_analytics_property_id
 
+    # Don't configure ActiveJob to automatically retry on failure in test, that would be a mess.
+    define_key :activejob_auto_retry,
+      system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM,
+      default: -> {
+        ! Rails.env.test?
+      }
+
     # Return appropriate Shrine::Storage instance for our mode (dev_file, dev_s3, or production),
     # and the bucket key.
     #


### PR DESCRIPTION
Behind one of our Env config variables, default to false in test
