### PR TITLE
Fix problems with HLS derivatives un-createable in test

### DIFF
--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -207,7 +207,12 @@ describe Asset do
 
       it "enqueues job to create HLS"  do
         expect {
-          create(:asset, :inline_promoted_file, file: File.open(Rails.root + "spec/test_support/video/sample_video.mp4"))
+          build(:asset, file: File.open(Rails.root + "spec/test_support/video/sample_video.mp4")).tap do |asset|
+            # We want to promote inline, but still have derivatives in ActiveJob, so we
+            # can test that HLS job was enqueued.
+            asset.file_attacher.set_promotion_directives(promote: :inline)
+            asset.save!
+          end
         }.to have_enqueued_job(CreateHlsVideoJob)
       end
     end

--- a/spec/services/orphan_s3_originals_spec.rb
+++ b/spec/services/orphan_s3_originals_spec.rb
@@ -35,9 +35,10 @@ describe OrphanS3Originals do
       create(:asset, :inline_promoted_file,
         file: File.open((Rails.root + "spec/test_support/images/20x20.png"))
       )
-    } 
+    }
     let(:asset_v)  {
-      create(:asset, :inline_promoted_file,
+      # Video derivatives creation has problems in test due to HLS....
+      create(:asset, :inline_promoted_file, :no_derivatives_creation,
         file: File.open((Rails.root + "spec/test_support/video/sample_video.mp4"))
       )
     }


### PR DESCRIPTION
If we try to run our HLS derivative creations job with a video original that is not in a Shrine S3 storage -- it raises. In test, our storages are not S3. (The raise here may or may not be a good idea, it does lead to some headaches and confusing situations. Perhaps we should configure our HLS creation to be by default not happen in test, and/or make it silently log failure instead of raise if it can't. But this PR doesn't do that).

Some past PR's resulted in a situation where this problem became visible, in a way that wasn't caught by PR builds -- becuase it resulted from interaction of several seperate PRs.  Test code may have been triggering HLS creation that failed before too... but the failures could be hidden/invisible, recent PR's to make things more consistent and predictable may have made them show up and fail tests.

So we use some kind of cryptic code to prevent HLS creation in those tests where it was failing. This *whole thing* has ended up rahter too byzantine/confusing for me, but for now it's what we've got.

This should get tests green again.
