### PR TITLE
Add explicit `matrix` dependency for ruby 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -129,6 +129,14 @@ gem "rinku", '~> 2.0' # auto-linking
 gem 'html_aware_truncation', '~> 1.0'
 
 gem "prawn", "~> 2.2" # creating PDFs
+# The prawn gem uses `matrix`; as of ruby 3.1 it needs to be declared explicitly.
+# There isn't a prawn release that does that yet, although it's been
+# fixed in prawn master. We can work around that by adding an explicit top-level dependency.
+#
+# https://github.com/prawnpdf/prawn/issues/1235
+# https://github.com/prawnpdf/prawn/commit/3658d5125c3b20eb11484c3b039ca6b89dc7d1b7
+gem 'matrix', '~> 0.4'
+
 gem "pdf-reader", "~> 2.2" # simple metadata extraction from pdfs
 gem 'rubyzip', '~> 2.0'
 gem 'browser', '~> 5.0' # browser user-agent detection, maybe only for IE-unsupported warning.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -759,6 +759,7 @@ DEPENDENCIES
   lockbox
   lograge (< 2)
   mail (>= 2.8.0.rc1, < 3)
+  matrix (~> 0.4)
   oai (~> 1.0, >= 1.0.1)
   pdf-reader (~> 2.2)
   pg (>= 0.18, < 2.0)


### PR DESCRIPTION
The prawn gem uses matrix; as of ruby 3.1 it needs to be declared explicitly. There isn't a prawn release that does that yet, although it's been fixed in prawn master. We can work around that by adding an explicit top-level dependency.

This didn't cause a problem in development (unless/until you tried to use a prawn function that used matrix, which we might not ever), but did in production, as it does eager loading of all code and tries to require `matrix` on boot, causing heroku deploy to fail.
