### PR TITLE
Don't remove the properties of birth_attributes or death_attributes if they're blank

### DIFF
--- a/app/controllers/admin/interviewee_biographies_controller.rb
+++ b/app/controllers/admin/interviewee_biographies_controller.rb
@@ -79,9 +79,7 @@ class Admin::IntervieweeBiographiesController < AdminController
         tmp["#{name}_attributes"]&.reject! { |k, v| v.values.all?(&:empty?) }
       end
 
-      tmp["birth_attributes"].reject! {|k,v| v.blank? } if tmp["birth_attributes"]
       tmp.delete("birth_attributes") if tmp["birth_attributes"].blank?
-      tmp["death_attributes"].reject! {|k,v| v.blank? } if tmp["death_attributes"]
       tmp.delete("death_attributes") if tmp["death_attributes"].blank?
 
       %w{birth death school job honor}.each do |name|

--- a/spec/controllers/admin/interviewee_biographies_spec.rb
+++ b/spec/controllers/admin/interviewee_biographies_spec.rb
@@ -102,8 +102,33 @@ RSpec.describe Admin::IntervieweeBiographiesController, :logged_in_user, type: :
         }
       end
 
+      it "can delete birth dates" do
+        patch :update, params: {
+          "id" => interviewee_biography.id,
+          "interviewee_biography" =>
+            { "birth_attributes"=>{"date"=>"", "city"=>"", "state"=>"", "province"=>"", "country"=>""} }
+        }    
+        birth = interviewee_biography.reload.birth
+        expect(birth.date).to eq("")
+        expect(birth.city).to eq("")
+        expect(birth.state).to eq("")
+        expect(birth.province).to eq("")
+        expect(birth.country).to eq("")
+      end
+
+      it "can delete death dates" do
+        patch :update, params: {
+          "id" => interviewee_biography.id,
+          "interviewee_biography" =>
+            { "death_attributes"=>{"date"=>"", "city"=>"", "state"=>"", "province"=>"", "country"=>""} }
+        }
+        death = interviewee_biography.reload.death
+        expect(death.date).to eq("")
+        expect(death.city).to eq("")
+        expect(death.state).to eq("")
+        expect(death.province).to eq("")
+        expect(death.country).to eq("")
+      end
     end
-
-
   end
 end


### PR DESCRIPTION
Fixes #1673; includes simple tests.

- The params method in the IntervieweeBiographiesController was _removing_ blank birth/death attributes from the params hash.
- Because of this, the blank attributes never made it to the  #update method, and it was thus impossible to *remove* e.g. someone's death date.
- I'm keeping the fix simple and not changing the UI because *removing* this biographical info is an action we do very seldom. It took us quite a while to even figure out this was broken in the first place.