### PR TITLE
Consolidate Digitization Queue collecting areas per #1683

### DIFF
--- a/app/models/admin/digitization_queue_item.rb
+++ b/app/models/admin/digitization_queue_item.rb
@@ -20,8 +20,11 @@ class Admin::DigitizationQueueItem < ApplicationRecord
 
   # collecting areas could have been normalized as a separate table, but
   # not really needed, we'll just leave it as a controlled string.
-  COLLECTING_AREAS = %w{archives photographs rare_books modern_library museum_objects museum_fine_art}
-  validates :collecting_area, inclusion: { in: COLLECTING_AREAS }
+  COLLECTING_AREAS = %w{archives rare_books modern_library museum}
+
+  # These can be removed after change to collecting areas is fully deployed!
+  LEGACY_COLLECTING_AREAS = %w{photographs museum_objects museum_fine_art}
+  validates :collecting_area, inclusion: { in: COLLECTING_AREAS + LEGACY_COLLECTING_AREAS }
 
   STATUSES = %w{
     awaiting_dig_on_cart imaging_in_process post_production_completed

--- a/db/migrate/20220526161121_consolidate_dig_queue_collecting_areas.rb
+++ b/db/migrate/20220526161121_consolidate_dig_queue_collecting_areas.rb
@@ -1,0 +1,8 @@
+class ConsolidateDigQueueCollectingAreas < ActiveRecord::Migration[6.1]
+  # change from legacy collecting areas to new ones they are meant to be merged into.
+  def change
+    Admin::DigitizationQueueItem.where(collecting_area: "photographs").update_all(collecting_area: "archives")
+    Admin::DigitizationQueueItem.where(collecting_area: "museum_objects").update_all(collecting_area: "museum")
+    Admin::DigitizationQueueItem.where(collecting_area: "museum_fine_art").update_all(collecting_area: "museum")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_10_192754) do
+ActiveRecord::Schema.define(version: 2022_05_26_161121) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -214,7 +214,6 @@ ActiveRecord::Schema.define(version: 2022_05_10_192754) do
 
   create_table "oral_history_content", force: :cascade do |t|
     t.uuid "work_id", null: false
-    t.jsonb "combined_audio_m4a_data"
     t.string "combined_audio_fingerprint"
     t.jsonb "combined_audio_component_metadata"
     t.text "ohms_xml_text"
@@ -225,6 +224,7 @@ ActiveRecord::Schema.define(version: 2022_05_10_192754) do
     t.text "searchable_transcript_source"
     t.enum "available_by_request_mode", default: "off", null: false, enum_type: "available_by_request_mode_type"
     t.jsonb "json_attributes", default: {}
+    t.jsonb "combined_audio_m4a_data"
     t.index ["work_id"], name: "index_oral_history_content_on_work_id", unique: true
   end
 


### PR DESCRIPTION
Written in a way to not cause problems with heroku pre-boot -- old values are still allowed.

Will have to do a cleanup later to remove them.

* Combine Photographs and Archives Queues into "Archives"
* Combine Museum Fine Arts and Museum Objects Queues into "Museum"
