### PR TITLE
Dig Queue form changes

### DIFF
--- a/app/controllers/admin/digitization_queue_items_controller.rb
+++ b/app/controllers/admin/digitization_queue_items_controller.rb
@@ -118,8 +118,9 @@ class Admin::DigitizationQueueItemsController < AdminController
     def admin_digitization_queue_item_params
       params.require(:admin_digitization_queue_item).permit(
         :title, :status, :accession_number, :museum_object_id, :bib_number, :location,
-        :box, :folder, :dimensions, :materials, :copyright_status,
-        :scope, :instructions, :additional_notes, :collecting_area
+        :box, :folder, :dimensions, :copyright_status,
+        :scope, :additional_notes, :collecting_area, :deadline,
+        :is_digital_collections, :is_rights_and_reproduction
       )
     end
 

--- a/app/controllers/admin/digitization_queue_items_controller.rb
+++ b/app/controllers/admin/digitization_queue_items_controller.rb
@@ -125,7 +125,7 @@ class Admin::DigitizationQueueItemsController < AdminController
     end
 
     def filtered_index_items
-      scope = Admin::DigitizationQueueItem.where(collecting_area: collecting_area).order(status_changed_at: :asc)
+      scope = Admin::DigitizationQueueItem.where(collecting_area: collecting_area).order(deadline: :asc)
 
       if (q = params.dig(:query, :q)).present?
         scope = scope.where("title like ? OR bib_number = ? or accession_number = ? OR museum_object_id = ?", "%#{q}%", q, q, q)

--- a/app/models/admin/digitization_queue_item.rb
+++ b/app/models/admin/digitization_queue_item.rb
@@ -107,8 +107,5 @@ class Admin::DigitizationQueueItem < ApplicationRecord
     if self.dimensions.present?
       work.extent =  self.dimensions
     end
-    if self.materials.present?
-      work.medium = self.materials
-    end
   end
 end

--- a/app/views/admin/digitization_queue_items/_form.html.erb
+++ b/app/views/admin/digitization_queue_items/_form.html.erb
@@ -20,14 +20,27 @@
 
     <%= f.input :title, hint: "or Object Name/Description" %>
 
+    <div class="row row-cols-lg-auto">
+      <div class="col-3">
+        <%= f.input :is_digital_collections, as: :boolean, label: "Digital Collections" %>
+      </div>
+      <div class="col-3">
+        <%= f.input :is_rights_and_reproduction, as: :boolean, label: "Rights and Reproductions" %>
+      </div>
+    </div>
+
     <div class="row">
-      <div class="col-6">
+      <div class="col">
         <%= f.input :status,
           label: "Digitization Queue Status",
           collection: Admin::DigitizationQueueItem::STATUSES.collect {|s| [s.humanize, s]},
           include_blank: false %>
       </div>
+      <div class="col">
+         <%= f.input :deadline, as: :date, required: true %>
+      </div>
     </div>
+
 
     <div class="row">
       <div class="col">

--- a/app/views/admin/digitization_queue_items/_form.html.erb
+++ b/app/views/admin/digitization_queue_items/_form.html.erb
@@ -65,7 +65,7 @@
         <%= f.input :dimensions %>
       </div>
       <div class="col">
-        <%= f.input :materials %>
+
       </div>
     </div>
 
@@ -74,7 +74,7 @@
         <%= f.input :scope, hint: "Pages, Components, etc." %>
       </div>
       <div class="col">
-        <%= f.input :instructions, hint: "Staging notes, handling instructions, etc." %>
+      <%= f.input :additional_notes, label: "Additional notes", hint: "Staging notes, handling instructions, anything else" %>
       </div>
     </div>
 
@@ -83,7 +83,6 @@
         <%= f.input :copyright_status, as: :text %>
       </div>
       <div class="col">
-        <%= f.input :additional_notes, label: "Additional notes <small>(shows up on list view)</small>".html_safe %>
       </div>
     </div>
   </div>

--- a/app/views/admin/digitization_queue_items/index.html.erb
+++ b/app/views/admin/digitization_queue_items/index.html.erb
@@ -53,7 +53,7 @@
         <th style="width: 6rem;">acc. #</th>
         <th style="width: 8rem;">object id</th>
         <th style="width: 11rem;">status</th>
-        <th style="width: 8rem;">status changed</th>
+        <th style="width: 8rem;">deadline</th>
       </tr>
     </thead>
 
@@ -82,7 +82,7 @@
           <td>
              <%= render DigitizationQueueItemStatusFormComponent.new(admin_digitization_queue_item) %>
           </td>
-          <td><%= l(admin_digitization_queue_item.status_changed_at.to_date, format: :admin) %></td>
+          <td><%= l(admin_digitization_queue_item.deadline.to_date, format: :admin) %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/admin/digitization_queue_items/show.html.erb
+++ b/app/views/admin/digitization_queue_items/show.html.erb
@@ -27,6 +27,23 @@
       <dt>Collecting area</dt>
       <dd><%= link_to @admin_digitization_queue_item.collecting_area.humanize, admin_digitization_queue_items_url(@admin_digitization_queue_item.collecting_area) %></dd>
 
+      <dt>Purpose</dt>
+      <dd>
+        Digital Collections:
+        <% if @admin_digitization_queue_item.is_digital_collections %>
+          <span class="text-success">YES</span>
+        <% else %>
+          <span class="text-danger">NO</span>
+        <% end %>
+        <br>
+        Rights and Reproduction:
+        <% if @admin_digitization_queue_item.is_rights_and_reproduction %>
+          <span class="text-success">YES</span>
+        <% else %>
+          <span class="text-danger">NO</span>
+        <% end %>
+      </dd>
+
       <dt>Created at</dt>
       <dd>
         <%= l @admin_digitization_queue_item.created_at, format: :admin %>
@@ -38,6 +55,7 @@
         <%= @admin_digitization_queue_item.status.humanize %> (<%= l @admin_digitization_queue_item.status_changed_at, format: :admin %>)
       </dd>
 
+      <%= queue_item_show_field(@admin_digitization_queue_item, :deadline) %>
 
       <%= queue_item_show_field(@admin_digitization_queue_item, :bib_number) %>
       <%= queue_item_show_field(@admin_digitization_queue_item, :location) %>

--- a/app/views/admin/digitization_queue_items/show.html.erb
+++ b/app/views/admin/digitization_queue_items/show.html.erb
@@ -47,11 +47,9 @@
       <%= queue_item_show_field(@admin_digitization_queue_item, :folder) %>
 
       <%= queue_item_show_field(@admin_digitization_queue_item, :dimensions) %>
-      <%= queue_item_show_field(@admin_digitization_queue_item, :materials) %>
 
 
       <%= queue_item_show_field(@admin_digitization_queue_item, :scope, paragraphs: true) %>
-      <%= queue_item_show_field(@admin_digitization_queue_item, :instructions, paragraphs: true) %>
       <%= queue_item_show_field(@admin_digitization_queue_item, :additional_notes, paragraphs: true) %>
       <%= queue_item_show_field(@admin_digitization_queue_item, :copyright_status, paragraphs: true) %>
 

--- a/db/migrate/20220526184053_add_columns_to_dig_queue_item.rb
+++ b/db/migrate/20220526184053_add_columns_to_dig_queue_item.rb
@@ -1,0 +1,7 @@
+class AddColumnsToDigQueueItem < ActiveRecord::Migration[6.1]
+  def change
+    add_column :digitization_queue_items, :deadline, :date
+    add_column :digitization_queue_items, :is_digital_collections, :boolean
+    add_column :digitization_queue_items, :is_rights_and_reproduction, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_10_192754) do
+ActiveRecord::Schema.define(version: 2022_05_26_184053) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -112,6 +112,9 @@ ActiveRecord::Schema.define(version: 2022_05_10_192754) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "r_and_r_item_id"
+    t.date "deadline"
+    t.boolean "is_digital_collections"
+    t.boolean "is_rights_and_reproduction"
   end
 
   create_table "fixity_checks", force: :cascade do |t|
@@ -214,7 +217,6 @@ ActiveRecord::Schema.define(version: 2022_05_10_192754) do
 
   create_table "oral_history_content", force: :cascade do |t|
     t.uuid "work_id", null: false
-    t.jsonb "combined_audio_m4a_data"
     t.string "combined_audio_fingerprint"
     t.jsonb "combined_audio_component_metadata"
     t.text "ohms_xml_text"
@@ -225,6 +227,7 @@ ActiveRecord::Schema.define(version: 2022_05_10_192754) do
     t.text "searchable_transcript_source"
     t.enum "available_by_request_mode", default: "off", null: false, enum_type: "available_by_request_mode_type"
     t.jsonb "json_attributes", default: {}
+    t.jsonb "combined_audio_m4a_data"
     t.index ["work_id"], name: "index_oral_history_content_on_work_id", unique: true
   end
 

--- a/spec/system/digitization_queue_spec.rb
+++ b/spec/system/digitization_queue_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe "Digitization Queue", :logged_in_user, type: :system, js: true do
     click_on "New Queue Item"
 
     fill_in "Title", with: "Test Item"
+
+    select "2020", from: "admin_digitization_queue_item_deadline_1i"
+    select "February", from: "admin_digitization_queue_item_deadline_2i"
+    select "3", from: "admin_digitization_queue_item_deadline_3i"
+
     fill_in "Accession number", with: "test-acc"
     fill_in "Object ID (Past Perfect)", with: "test-obj-id"
     fill_in "Bib number", with: "b1234567"
@@ -22,8 +27,8 @@ RSpec.describe "Digitization Queue", :logged_in_user, type: :system, js: true do
     click_on "Create Digitization queue item"
     # return to listing page, now click on item we just made
 
-
-
+    dq  = Admin::DigitizationQueueItem.order(created_at: :desc).last
+    expect(dq.deadline).to eq Date.new(2020, 2, 3)
 
     ######
     ######
@@ -32,8 +37,6 @@ RSpec.describe "Digitization Queue", :logged_in_user, type: :system, js: true do
     #
     #
     # START STATUS CHANGE AJAX TEST:
-
-    dq  = Admin::DigitizationQueueItem.order(created_at: :desc).last
 
     # Change the status of the DQ item via the dropdown:
     expect(dq.status).to eq("awaiting_dig_on_cart")

--- a/spec/system/digitization_queue_spec.rb
+++ b/spec/system/digitization_queue_spec.rb
@@ -15,9 +15,8 @@ RSpec.describe "Digitization Queue", :logged_in_user, type: :system, js: true do
     fill_in "Box", with: "test-box"
     fill_in "Folder", with: "test-folder"
     fill_in "Dimensions", with: "test-dimensions"
-    fill_in "Materials", with: "test-materials"
     fill_in "Scope", with: "Do this"
-    fill_in "Instructions", with: "And this"
+    fill_in "Additional notes", with: "And this"
     fill_in "Location", with: "Some location"
 
     click_on "Create Digitization queue item"
@@ -97,6 +96,5 @@ RSpec.describe "Digitization Queue", :logged_in_user, type: :system, js: true do
     expect(work.physical_container.box).to eq("test-box")
     expect(work.physical_container.folder).to eq("test-folder")
     expect(work.extent).to eq(["test-dimensions"])
-    expect(work.medium).to eq(["test-materials"])
   end
 end


### PR DESCRIPTION
* Add fields: deadline, is digital collections, is r&r

* remove fields: instructions, materials

* Index page should display and sort by deadline, not status last changed

Ref #1683 

Removal of unused database fields will come in separate PR for two-phase roll out to avoid errors. 