### PR TITLE
accomodate blank deadline in dig queue item

### DIFF
--- a/app/views/admin/digitization_queue_items/index.html.erb
+++ b/app/views/admin/digitization_queue_items/index.html.erb
@@ -82,7 +82,7 @@
           <td>
              <%= render DigitizationQueueItemStatusFormComponent.new(admin_digitization_queue_item) %>
           </td>
-          <td><%= l(admin_digitization_queue_item.deadline.to_date, format: :admin) %></td>
+          <td><%= l(admin_digitization_queue_item.deadline.to_date, format: :admin) if admin_digitization_queue_item.deadline %></td>
         </tr>
       <% end %>
     </tbody>


### PR DESCRIPTION
all existing items have blank deadline, even though the form doesn't allow creating new ones like that.
