### PR TITLE
Add Scout credit to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,3 +352,7 @@ This feature was in our v1 sufia-based app, we copied it over.
 <img src="https://www.browserstack.com/images/layout/browserstack-logo-600x315.png" width="280"/>
 
 [BrowserStack](http://www.browserstack.com) supports us with [free access for open source](https://www.browserstack.com/open-source).
+
+<hr>
+
+[Scout APM](https://ter.li/h8k29r) supports us with free access for open source.


### PR DESCRIPTION
We would prefer they give us a them-hosted linkable image for an image, so for now this is just text.

Ref #1707 
@CHF-IT-Staff note that we aren't including the image here; not sure if they require it or not, since their terms aren't written anywhere. it would be easier to include an image if they give us one they are hosting that we can hot-link in, that's what BrowserStack did. 