### PR TITLE
Adjust oai-pmh DC serialization for DPLA/PA Digital specs

### DIFF
--- a/app/controllers/oai_pmh_controller.rb
+++ b/app/controllers/oai_pmh_controller.rb
@@ -11,9 +11,9 @@
       # Try to get one from the db, if we can't this is one we have in production
       sample_id (Work.first.friendlier_id rescue "tq57nr00k")
 
-      # Note we limit to published true, and pre-load leaf_representative for performance
+      # Note we limit to published true, and pre-load any accessed associations for performance
       source_model OAI::Provider::ActiveRecordWrapper.new(
-        Work.where(published: true).includes(:leaf_representative),
+        Work.where(published: true).includes(:leaf_representative, :contained_by),
         identifier_field: :friendlier_id
       )
     end

--- a/app/serializers/work_oai_dc_serialization.rb
+++ b/app/serializers/work_oai_dc_serialization.rb
@@ -13,6 +13,8 @@
 #
 # The serializer will use these associations, so they should be eager-loaded:
 # * leaf_representative
+# * contained_by (collection)
+#
 class WorkOaiDcSerialization
   # all of em from https://drive.google.com/file/d/1fJEWhnYy5Ch7_ef_-V48-FAViA72OieG/view
   # why not, be complete in case we need em.
@@ -103,6 +105,19 @@ class WorkOaiDcSerialization
           xml["dc"].description DescriptionDisplayFormatter.new(work.description).format_plain
         end
 
+        (work.contained_by || []).each do |collection|
+          xml["dcterms"].isPartOf collection.title
+        end
+
+        (work.extent || []).each do |extent_str|
+          xml["dcterms"].extent extent_str
+        end
+
+        (work.place || []).each do |place|
+          xml["dcterms"].spatial place.value
+        end
+
+
         # Mime types in DC:format
         # work.content_types.each do |ctype|
         #   xml["dc"].format ctype
@@ -118,8 +133,8 @@ class WorkOaiDcSerialization
           xml["dc"].publisher publisher
         end
 
-        if work.rights.present?
-          xml["dcterms"].rightsholder work.rights
+        if work.rights_holder.present?
+          xml["dcterms"].rightsholder work.rights_holder
         end
 
         # Could do: dc:source archival location. A pain cause it requires collection, and

--- a/spec/serializers/work_oai_dc_serialization_spec.rb
+++ b/spec/serializers/work_oai_dc_serialization_spec.rb
@@ -2,14 +2,19 @@ require 'rails_helper'
 
 describe WorkOaiDcSerialization do
   let(:member_asset) { create(:asset, :inline_promoted_file)}
+  let(:collection) { create(:collection, title: "My Local Collection") }
   let(:work) { create(:work, :with_complete_metadata,
     description: "This starts out with <b>tags</b>\n\nAnother paragraph",
+    extent: ["8.75 in. H x 5.6 in. W"],
+    place: [{ category: "place_of_creation", value: "Université de Bordeaux (1441-1970"}],
     creator: [
       { category: :author, value: "Smith, Joe" },
       { category: :editor, value: "Editor, Joe" }
     ],
+    rights_holder: "Science History Institute",
     representative: member_asset,
-    members: [member_asset]
+    members: [member_asset],
+    contained_by: [collection]
   )}
 
   # hacky probably a better way to do this. :(
@@ -58,6 +63,11 @@ describe WorkOaiDcSerialization do
     expect(container.at_xpath("./dpla:originalRecord").text).to eq public_work_url
     expect(container.at_xpath("./edm:object").text).to eq full_jpg_url
     expect(container.at_xpath("./edm:preview").text).to eq work_thumb_url
+
+    expect(container.at_xpath("./dcterms:isPartOf")&.text).to eq collection.title
+    expect(container.at_xpath("./dcterms:extent")&.text).to eq work.extent.first
+    expect(container.at_xpath("./dcterms:spatial")&.text).to eq work.place.first.value
+    expect(container.at_xpath("./dcterms:rightsholder")&.text).to eq work.rights_holder
 
     # TODO xml["dc"].format for mime/types of all included files
     # TODO test more than one thing?


### PR DESCRIPTION
Ref #1672

Note we need to make sure to pre-load the contained_by association on fetch, as we are now including collection name in output


