### PR TITLE
Opt-in to attr_json feature for jsonb_contains query

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -1,4 +1,5 @@
 class Asset < Kithe::Asset
+  include AttrJson::Record::QueryScopes
 
   include RecordPublishedAt
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -4,6 +4,7 @@
 # Since the member relation destroys children when parent is deleted, deleting a collection
 # automatically deletes the thumb (which automatically deletes the stored file)
 class Collection < Kithe::Collection
+  include AttrJson::Record::QueryScopes
 
   include RecordPublishedAt
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1,4 +1,6 @@
 class Work < Kithe::Work
+  include AttrJson::Record::QueryScopes
+
   # will trigger automatic solr indexing in callbacks
 
   include RecordPublishedAt


### PR DESCRIPTION
attr_json gem provides this as an opt-in feature. Not sure why I left it out of kithe and out of here until now! It's super useful, makes it way easier to do queries on our json_attributes stuff without having to work it all out, including in situations with arrays.

https://github.com/jrochkind/attr_json#querying

For instance, ref #1751, wouldn't it be easier to do `Work.jsonb_contains("additional_credit.name": "Julie Huggony")`? Now we can.