### PR TITLE
Fix typo in translator name "Julie Huggony" => "Julie Hugonny"

### DIFF
--- a/app/models/work/additional_credit.rb
+++ b/app/models/work/additional_credit.rb
@@ -8,7 +8,7 @@ class Work
       'Gudrun Dauner',
       'Gregory Tobias',
       'Jocelyn R. McDaniel',
-      'Julie Huggony',
+      'Julie Hugonny',
       'Mark Backrath',
       'Penn School of Medicine',
       'Will Brown'

--- a/db/migrate/20220621210438_fix_translator_typo.rb
+++ b/db/migrate/20220621210438_fix_translator_typo.rb
@@ -1,0 +1,11 @@
+class FixTranslatorTypo < ActiveRecord::Migration[6.1]
+  # additional credit name from "Julie Huggony" to 'Julie Hugonny'
+  def change
+    Work.jsonb_contains("additional_credit.name": "Julie Huggony").each do |work|
+      work.additional_credit.find_all { |ac| ac.name == "Julie Huggony"}.each do |ac|
+        ac.name = 'Julie Hugonny'
+      end
+      work.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_26_194233) do
+ActiveRecord::Schema.define(version: 2022_06_21_210438) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
Ref #1751

Includes a migration that will automatically fix existing data, automatically on deploy (since migrations run on deploy)
