### PR TITLE
Fix schema.rb to be in sync, without r_and_r_id column

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -108,7 +108,6 @@ ActiveRecord::Schema.define(version: 2022_05_26_194233) do
     t.datetime "status_changed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "r_and_r_item_id"
     t.date "deadline"
     t.boolean "is_digital_collections"
     t.boolean "is_rights_and_reproduction"


### PR DESCRIPTION
This column was removed from our db a while ago, somehow it's still in schema.rb.

Got this fix by running `rails db:schema:dump` in dev, and seeing it removed this reference. After noticing it as a diff in adding another migration, separated out into separate PR.
