### PR TITLE
Use correct type to avoid double-escaping hsl_playlist_file_data

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -23,7 +23,11 @@ class Asset < Kithe::Asset
   # of a db column. We 1) create the `attr_json`, then 2) in the shrine attachment we tell it
   # column_serializer:nil tells shrine not to serialize the JSON, let
   # attr_json take care of that.
-  attr_json :hls_playlist_file_data, :json
+  #
+  # And ActiveModel::Type::Value.new tells attr_json to just pass it through without
+  # transformation (it's sort of the basic no-op or null type), to get serialized to
+  # json by parent column.
+  attr_json :hls_playlist_file_data, ActiveModel::Type::Value.new
   include VideoHlsUploader::Attachment(:hls_playlist_file, store: :video_derivatives, column_serializer: nil)
 
 

--- a/lib/tasks/data_fixes/unescape_hls_playlist_file_data.rake
+++ b/lib/tasks/data_fixes/unescape_hls_playlist_file_data.rake
@@ -1,0 +1,26 @@
+namespace :scihist do
+  namespace :data_fixes do
+
+    desc """
+      Unescape the double-escaped JSON hls_playlist_file_data. Idempotent, safe to run multiple times.
+    """
+    task :unescape_hls_playlist_file_data => :environment do
+      Asset.where("json_attributes->'hls_playlist_file_data' is not null").pluck("id").each do |pk|
+        # clever code to un-escape jsbon in SQL,
+        # https://dev.to/mrmurphy/so-you-put-an-escaped-string-into-a-json-column-2n67
+        #
+        # which we need to use with somewhat confusing PG `jsonb_set`,
+        # since we aren't on PG14 yet that would support hash-index-like setting.
+        Asset.connection.execute(
+          <<-EOS
+            UPDATE kithe_models
+            SET json_attributes = jsonb_set(json_attributes, '{hls_playlist_file_data}',
+                                              (json_attributes->'hls_playlist_file_data' #>> '{}')::jsonb
+                                            )
+            WHERE  id = '#{pk}'
+          EOS
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ref #1757 

With test to ensure it's not double escaped.

Migration of existing data now in rake task: `heroku run rake scihist:data_fixes:unescape_hls_playlist_file_data -r production`
* This is idempotent, it's okay to re-run it on already un-escaped data, it will just leave it alone
* The OLD version of the attribute (with type `:json`)  _can_ still read the unescaped data
    *   So if we deploy this code, then run the rake task before the heroku preboot has actually switched over to our new code --we're good. The fixed data can be read by old still-running version, and will be readable by new version once deployed. 
    * The reverse isn't true, the NEW version of the attribute (with `ActiveModel::Type.new`) can _not_ read old un-migrated data. So if we deploy this code but forget to run the rake task... the new version of app will start raising errors every time it tries to load video content. 

So this is a bit tricky, but, eh, we're not a hospital.  I will leave this in draft until we're ready to actually do the switcheroo, intentionally, so we don't accidentally deploy it and not run the rake task. 

(I could have made the rake task a db migration so it would run automatically on deploy... but there were enough weird things going on here already, I was more comfortable leaving it manual? May not be right call?)