### PR TITLE
[experimental] good_job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,8 @@ gem "resque", "~> 2.0"
 gem "resque-pool"
 gem "resque-heroku-signals" # gah, weirdly needed for graceful shutdown on heroku. https://github.com/resque/resque#heroku
 
+gem "good_job", "~> 2.16"
+
 gem 'honeybadger', '~> 4.0'
 
 # Until we get things working under sprockets 4, lock to sprockets 3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,6 +224,8 @@ GEM
       oauth2 (~> 1.1)
     dumb_delegator (1.0.0)
     erubi (1.10.0)
+    et-orbi (1.2.7)
+      tzinfo
     ethon (0.15.0)
       ffi (>= 1.15.0)
     execjs (2.8.1)
@@ -265,6 +267,9 @@ GEM
       rake
     font-awesome-rails (4.7.0.8)
       railties (>= 3.2, < 8.0)
+    fugit (1.5.3)
+      et-orbi (~> 1, >= 1.2.7)
+      raabro (~> 1.4)
     fx (0.7.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
@@ -272,6 +277,15 @@ GEM
     geocoder (1.8.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    good_job (2.16.1)
+      activejob (>= 5.2.0)
+      activerecord (>= 5.2.0)
+      concurrent-ruby (>= 1.0.2)
+      fugit (>= 1.1)
+      railties (>= 5.2.0)
+      thor (>= 0.14.1)
+      webrick (>= 1.3)
+      zeitwerk (>= 2.0)
     google-api-client (0.53.0)
       google-apis-core (~> 0.1)
       google-apis-generator (~> 0.1)
@@ -491,6 +505,7 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 5.0, < 6.2)
       rdf
+    raabro (1.4.0)
     racc (1.6.0)
     rack (2.2.3.1)
     rack-protection (2.2.0)
@@ -763,6 +778,7 @@ DEPENDENCIES
   factory_bot_rails
   faster_s3_url (< 2)
   font-awesome-rails (~> 4.7)
+  good_job (~> 2.16)
   hirefire-resource
   honeybadger (~> 4.0)
   html_aware_truncation (~> 1.0)

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -77,7 +77,8 @@
               <li><%= link_to "Interviewee Biographies", admin_interviewee_biographies_path %></li>
 
               <li><hr></li>
-              <li><%= link_to "Job Queues", admin_resque_server_path %></li>
+              <li><%= link_to "Job Queues (resque)", admin_resque_server_path %></li>
+              <li><%= link_to "Job Queues (good_job)", admin_good_job_path %></li>
               <li><%= link_to "Fixity Report", admin_fixity_report_path %></li>
               <li><%= link_to "Storage Report", admin_storage_report_path %></li>
               <li><%= link_to "Orphan Report", admin_orphan_report_path %></li>

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,8 @@ require "action_cable/engine"
 require "sprockets/railtie"
 require "rails/test_unit/railtie"
 
+# Enable good_job dashboard
+require 'good_job/engine'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,6 +17,10 @@ Rails.application.configure do
   # sassc-rails
   config.sass.inline_source_maps = true
 
+  # For some consistency, use good_job in development too, although by
+  # default in development it'll be running in an in-process execution mode
+  config.active_job.queue_adapter = :good_job
+
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,7 +77,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
-  config.active_job.queue_adapter     = :resque
+  config.active_job.queue_adapter     = :good_job
 
   # We are not sharing a redis among multiple apps, seems no need to queue_name_prefix,
   # and it makes it confusing when trying to set resque workers to work specific

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -1,0 +1,19 @@
+Rails.application.configure do
+  # Preserve completed records, so we can view them in dashboard
+  #
+  # Nope this does not seem to work...
+  #Rails.application.config.good_job.preserve_job_records = true
+  config.good_job.preserve_job_records = true
+
+  # Do NOT retry errors that make it to good_job.
+  #
+  # This kind of ALWAYS needs to be false to avoid infinite loop on erroring job,
+  # why doesn't it default to false??
+  #
+  # https://github.com/bensheldon/good_job#retries
+  config.good_job.retry_on_unhandled_error = false
+
+  # And when we do manually clear old job completion records, we do NOT
+  # want to clear any currently listed as "discarded" (ie failed)
+  config.good_job.cleanup_discarded_jobs = false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -337,6 +337,8 @@ Rails.application.routes.draw do
       if Shrine.storages[:cache].kind_of?(Shrine::Storage::S3)
         mount Shrine.uppy_s3_multipart(:cache) => "/s3"
       end
+
+      mount GoodJob::Engine => 'good_job'
     end
   end
 

--- a/db/migrate/20220622141336_create_good_jobs.rb
+++ b/db/migrate/20220622141336_create_good_jobs.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+class CreateGoodJobs < ActiveRecord::Migration[6.1]
+  def change
+    enable_extension 'pgcrypto'
+
+    create_table :good_jobs, id: :uuid do |t|
+      t.text :queue_name
+      t.integer :priority
+      t.jsonb :serialized_params
+      t.timestamp :scheduled_at
+      t.timestamp :performed_at
+      t.timestamp :finished_at
+      t.text :error
+
+      t.timestamps
+
+      t.uuid :active_job_id
+      t.text :concurrency_key
+      t.text :cron_key
+      t.uuid :retried_good_job_id
+      t.timestamp :cron_at
+    end
+
+    create_table :good_job_processes, id: :uuid do |t|
+      t.timestamps
+      t.jsonb :state
+    end
+
+    add_index :good_jobs, :scheduled_at, where: "(finished_at IS NULL)", name: "index_good_jobs_on_scheduled_at"
+    add_index :good_jobs, [:queue_name, :scheduled_at], where: "(finished_at IS NULL)", name: :index_good_jobs_on_queue_name_and_scheduled_at
+    add_index :good_jobs, [:active_job_id, :created_at], name: :index_good_jobs_on_active_job_id_and_created_at
+    add_index :good_jobs, :concurrency_key, where: "(finished_at IS NULL)", name: :index_good_jobs_on_concurrency_key_when_unfinished
+    add_index :good_jobs, [:cron_key, :created_at], name: :index_good_jobs_on_cron_key_and_created_at
+    add_index :good_jobs, [:cron_key, :cron_at], name: :index_good_jobs_on_cron_key_and_cron_at, unique: true
+    add_index :good_jobs, [:active_job_id], name: :index_good_jobs_on_active_job_id
+    add_index :good_jobs, [:finished_at], where: "retried_good_job_id IS NULL AND finished_at IS NOT NULL", name: :index_good_jobs_jobs_on_finished_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_26_194233) do
+ActiveRecord::Schema.define(version: 2022_06_22_141336) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -126,6 +127,37 @@ ActiveRecord::Schema.define(version: 2022_05_26_194233) do
     t.index ["asset_id", "checked_uri"], name: "by_asset_and_checked_uri"
     t.index ["asset_id"], name: "index_fixity_checks_on_asset_id"
     t.index ["checked_uri"], name: "index_fixity_checks_on_checked_uri"
+  end
+
+  create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.jsonb "state"
+  end
+
+  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "queue_name"
+    t.integer "priority"
+    t.jsonb "serialized_params"
+    t.datetime "scheduled_at"
+    t.datetime "performed_at"
+    t.datetime "finished_at"
+    t.text "error"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.uuid "active_job_id"
+    t.text "concurrency_key"
+    t.text "cron_key"
+    t.uuid "retried_good_job_id"
+    t.datetime "cron_at"
+    t.index ["active_job_id", "created_at"], name: "index_good_jobs_on_active_job_id_and_created_at"
+    t.index ["active_job_id"], name: "index_good_jobs_on_active_job_id"
+    t.index ["concurrency_key"], name: "index_good_jobs_on_concurrency_key_when_unfinished", where: "(finished_at IS NULL)"
+    t.index ["cron_key", "created_at"], name: "index_good_jobs_on_cron_key_and_created_at"
+    t.index ["cron_key", "cron_at"], name: "index_good_jobs_on_cron_key_and_cron_at", unique: true
+    t.index ["finished_at"], name: "index_good_jobs_jobs_on_finished_at", where: "((retried_good_job_id IS NULL) AND (finished_at IS NOT NULL))"
+    t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
+    t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
   end
 
   create_table "interviewee_biographies", force: :cascade do |t|


### PR DESCRIPTION
Testing good_job ActiveJob queue

- [x] admin dashboard IS enabled!
- [x] development mode IS set up to by default use good_job in async mode, instead of rails async. test mode is still using Rails job harnesses. 
- [ ] Procfile does NOT yet have workers set up for good_job, there are still some things we need to figure out
- [ ] resque has NOT been removed, if we were really switching over, we'd remove it and all references to it

## Using good_job in development

While this isn't (yet) set up to run good_job workers on heroku, you can totally test out good job in dev. 

By default, this branch is using good_job in "async" mode, meaning the workers are actually threads in the Rails process. You can take a look at the queue admin page this way though -- it's pretty snazzy. 

If you want to run in development with actual good_job workers, you can do that too!

1. Launch as `GOOD_JOB_EXECUTION_MODE=external rails server` (good_job by default looks at that env var, and others, it isn't something we set up)
2. In another terminal window, just do `bundle exed good_job` to start a worker with default config. (You can also pass various things on the command line to control worker behavior)
3. If you want to open a console in which you might manually enqueue jobs, `GOOD_JOB_EXECUTION_MODE=external rails console` is probably a good idea. 
