### PR TITLE
Make exhibition field private

### DIFF
--- a/app/components/work_show_info_component.html.erb
+++ b/app/components/work_show_info_component.html.erb
@@ -122,7 +122,7 @@
 
 <table class="work chf-attributes">
   <%= render AttributeTable::RowComponent.new(:department, values: [department], link_to_facet: "department_facet") %>
-  <%= render AttributeTable::RowComponent.new(:exhibition, values: exhibition, link_to_facet: "exhibition_facet", alpha_sort: true) %>
+  <%= render AttributeTable::RowComponent.new(:exhibition, values: exhibition, link_to_facet: "exhibition_facet", alpha_sort: true) if current_staff_user? %>
 
   <% if contained_by.present? %>
     <tr>

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -108,7 +108,7 @@ class CatalogController < ApplicationController
     # These three methods
     # were outputting links (rel="alternate") in the HTML head tag that sent bots
     # to crawl RSS, atom, and json versions
-    # of our search results, which we are not offering yet.
+    # of our search results, which we don't offer,
     # and we are overrriding them so they output nothing instead.
     #
     # Overridden methods:
@@ -301,7 +301,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'language_facet', label: "Language", limit: 5
     config.add_facet_field "rights_facet", helper_method: :rights_label, label: "Rights", limit: 5
     config.add_facet_field 'department_facet', label: "Department", limit: 5
-    config.add_facet_field 'exhibition_facet', label: "Exhibition", limit: 5, show: :current_user
+    config.add_facet_field 'exhibition_facet', label: "Exhibition (Staff-only)", limit: 5, show: :current_user
     config.add_facet_field 'published_bsi',    label: "Visibility (Staff-only)", show: :current_user, helper_method: :visibility_facet_labels
 
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -301,7 +301,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'language_facet', label: "Language", limit: 5
     config.add_facet_field "rights_facet", helper_method: :rights_label, label: "Rights", limit: 5
     config.add_facet_field 'department_facet', label: "Department", limit: 5
-    config.add_facet_field 'exhibition_facet', label: "Exhibition", limit: 5
+    config.add_facet_field 'exhibition_facet', label: "Exhibition", limit: 5, show: :current_user
     config.add_facet_field 'published_bsi',    label: "Visibility (Staff-only)", show: :current_user, helper_method: :visibility_facet_labels
 
 

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -1,4 +1,4 @@
-# Solr indexing for our work class. Still a work in progress.
+# Solr indexing for our work class.
 class WorkIndexer < Kithe::Indexer
   configure do
     # instead of a Solr field per attribute, we group them into fields
@@ -41,15 +41,16 @@ class WorkIndexer < Kithe::Indexer
 
     to_field "text_no_boost_tesim", obj_extract("inscription"), transform(->(v) { "#{v.location}: #{v.text}" })
     to_field "text_no_boost_tesim", obj_extract("additional_credit"), transform(->(v) { "#{v.role}: #{v.name}" })
-    to_field ["text_no_boost_tesim", "exhibition_facet"], obj_extract("exhibition")
+    
     to_field "text_no_boost_tesim", obj_extract("digitization_funder")
     to_field "text_no_boost_tesim", obj_extract("extent")
 
     to_field "text_no_boost_tesim", obj_extract("physical_container"), transform( ->(v) { v.display_as })
 
-    # We put this one in a separate field, cause we only allow logged in users
-    # to search it
+    # We put these in a separate field, cause we only allow logged in users
+    # to search them
     to_field "admin_only_text_tesim", obj_extract("admin_note")
+    to_field ["admin_only_text_tesim", "exhibition_facet"], obj_extract("exhibition")
 
     # for date/year range facet
     to_field "year_facet_isim" do |record, acc|

--- a/spec/system/work_show_spec.rb
+++ b/spec/system/work_show_spec.rb
@@ -113,7 +113,8 @@ describe "Public work show page", type: :system, js: false do
       expect_attribute_row("Rights", RightsTerm.label_for(work.rights), as_links: true)
 
       expect_attribute_row("Department", work.department, as_links: true)
-      expect_attribute_row("Exhibition", work.exhibition, as_links: true)
+
+      expect(page).not_to have_text(work.exhibition)
       expect_attribute_row("Series arrangement", work.series_arrangement)
 
       expect_attribute_row("Physical container", work.physical_container.display_as)


### PR DESCRIPTION
Requires reindex.
Compare results `/catalog?search_field=all_fields&q=Science+at+play` before and after logging in; specifically, take a look at the department facet breakdown.
