### PR TITLE
Audio player via video.js

### DIFF
--- a/app/assets/stylesheets/local/video_js.scss
+++ b/app/assets/stylesheets/local/video_js.scss
@@ -43,4 +43,10 @@
     .vjs-time-control {
       display: block;
     }
+
+    // We like how it looks with some rounded corners
+    border-radius: 3em;
+    .vjs-control-bar {
+      border-radius: 3em;
+    }
 }

--- a/app/assets/stylesheets/local/video_js.scss
+++ b/app/assets/stylesheets/local/video_js.scss
@@ -1,0 +1,30 @@
+// The video.js player can play audio-only, even from an audio tag --
+// but by default with a big static poster image etc. This is a custom
+// style for a more standard audio controls only control bar.
+//
+// Adapted from this SO comment and other stuff in this SO question:
+// https://github.com/videojs/video.js/issues/2777#issuecomment-161912138
+
+.video-js.scihist-video-js-audio-no-poster {
+    /* Reset the height of the player to the height of the control bar, set
+    to 3em exactly by video.js default theme */
+    height: 3em;
+
+    // at scihist, we want width to expand to available space,
+    // like browser native audio players do
+    width: 100%;
+
+    /* Big player button can be disabled in config, but in case we missed it there,
+       hide it for real here. There's no room for it, just a control bar! */
+    .vjs-big-play-button {
+      display: none;
+    }
+
+    /* Make the controlbar visible always/initially even before playing */
+    .vjs-control-bar {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+    }
+}

--- a/app/assets/stylesheets/local/video_js.scss
+++ b/app/assets/stylesheets/local/video_js.scss
@@ -27,4 +27,11 @@
         display: -ms-flexbox;
         display: flex;
     }
+
+    // Show time elapsed/total time -- video.js default theme hides by default via
+    // CSS, but it's in most standard html5 audio palyers -- and for OH important
+    // for references, knowing where you are in transcript, etc.
+    .vjs-time-control.vjs-current-time {
+      display: block;
+    }
 }

--- a/app/assets/stylesheets/local/video_js.scss
+++ b/app/assets/stylesheets/local/video_js.scss
@@ -8,6 +8,9 @@
 // With some customizations
 
 .video-js.scihist-video-js-audio-no-poster {
+    // make sure video.js popup menus are above navbar items
+    z-index: 1;
+
     // The default font size was 11px, makes numeric text hard to read
     // and buttons small targets for touch. this is a lot more readable and
     // visible for a control-bar only display and works in our layout.

--- a/app/assets/stylesheets/local/video_js.scss
+++ b/app/assets/stylesheets/local/video_js.scss
@@ -4,8 +4,16 @@
 //
 // Adapted from this SO comment and other stuff in this SO question:
 // https://github.com/videojs/video.js/issues/2777#issuecomment-161912138
+//
+// With some customizations
 
 .video-js.scihist-video-js-audio-no-poster {
+    // The default font size was 11px, makes numeric text hard to read
+    // and buttons small targets for touch. this is a lot more readable and
+    // visible for a control-bar only display and works in our layout.
+    // video.js CSS was nice enough to adapt all around when we do this.
+    font-size: 14px;
+
     /* Reset the height of the player to the height of the control bar, set
     to 3em exactly by video.js default theme */
     height: 3em;

--- a/app/assets/stylesheets/local/video_js.scss
+++ b/app/assets/stylesheets/local/video_js.scss
@@ -38,8 +38,9 @@
 
     // Show time elapsed/total time -- video.js default theme hides by default via
     // CSS, but it's in most standard html5 audio palyers -- and for OH important
-    // for references, knowing where you are in transcript, etc.
-    .vjs-time-control.vjs-current-time {
+    // for references, knowing where you are in transcript, etc. We customize
+    // things further in the setup for the player itself.
+    .vjs-time-control {
       display: block;
     }
 }

--- a/app/assets/stylesheets/local/video_js.scss
+++ b/app/assets/stylesheets/local/video_js.scss
@@ -61,6 +61,18 @@
       border: 1px solid #2B333F;
     }
 
+    // And for those menus above, we don't have a video/poster image above,
+    // make popups go down instead of  up, avoid a problem in our fixed navbar.
+    .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+      bottom: unset;
+      top: calc(1.5em + 1px);
+    }
+    .vjs-volume-vertical {
+      bottom: unset;
+      top: calc(3em + 1px);
+    }
+
+
     // When mouse hover over progress bar, there's a current time tooltip and a
     // where-you're-hovering tooltip, but it seems to a bug/misdesign which
     // one is on top, let's fix to put the mouse-position on on top:

--- a/app/assets/stylesheets/local/video_js.scss
+++ b/app/assets/stylesheets/local/video_js.scss
@@ -50,6 +50,14 @@
       border-radius: 3em;
     }
 
+    // Popup menus are transparent in video.js, but in an audio-only context
+    // where they are over page content not a video/poster, this is not helpful.
+    // Make them opaque.
+    .vjs-volume-vertical, .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+      background-color: #2B333F;
+      border: 1px solid #2B333F;
+    }
+
     // When mouse hover over progress bar, there's a current time tooltip and a
     // where-you're-hovering tooltip, but it seems to a bug/misdesign which
     // one is on top, let's fix to put the mouse-position on on top:

--- a/app/assets/stylesheets/local/video_js.scss
+++ b/app/assets/stylesheets/local/video_js.scss
@@ -49,4 +49,32 @@
     .vjs-control-bar {
       border-radius: 3em;
     }
+
+    // on small screens, we'll just hide many of the elements. Somewhat
+    // based on https://github.com/videojs/video.js/blob/f16d73b52840452f217722fc6ee7f9f51ba57cb2/src/css/components/_adaptive.scss
+    // but for our actual screen size (we have a button next to video.js audio), and
+    // using a media query (why doesn't video.js? Weird)
+    @media only screen and (max-width: 640px) {
+      .vjs-time-divider,
+      .vjs-duration,
+      .vjs-remaining-time,
+      .vjs-playback-rate,
+      .vjs-volume-control,
+      .vjs-seek-button {
+        display: none;
+      }
+      .vjs-current-time {
+        padding-left: 0;
+      }
+    }
+    @media only screen and (max-width: 380px) {
+      .vjs-current-time {
+        display: none;
+      }
+    }
+    @media only screen and (max-width: 300px) {
+      .vjs-progress-control {
+        display: none;
+      }
+    }
 }

--- a/app/assets/stylesheets/local/video_js.scss
+++ b/app/assets/stylesheets/local/video_js.scss
@@ -50,6 +50,13 @@
       border-radius: 3em;
     }
 
+    // When mouse hover over progress bar, there's a current time tooltip and a
+    // where-you're-hovering tooltip, but it seems to a bug/misdesign which
+    // one is on top, let's fix to put the mouse-position on on top:
+    .vjs-progress-control .vjs-mouse-display {
+      z-index: 2;
+    }
+
     // on small screens, we'll just hide many of the elements. Somewhat
     // based on https://github.com/videojs/video.js/blob/f16d73b52840452f217722fc6ee7f9f51ba57cb2/src/css/components/_adaptive.scss
     // but for our actual screen size (we have a button next to video.js audio), and

--- a/app/components/work_oh_audio_show_component.html.erb
+++ b/app/components/work_oh_audio_show_component.html.erb
@@ -15,9 +15,33 @@
         </h1>
         <% if combined_m4a_audio_url.present? && combined_derivatives_up_to_date? %>
           <div class="d-flex" style="align-items: center">
-            <audio controls controlslist="nodownload" data-role="ohms-audio-elem">
-              <source src="<%= combined_m4a_audio_url %>" type="audio/mp4">
-            </audio>
+            <%= content_tag("audio",
+                  class: "video-js scihist-video-js-audio-no-poster",
+                  controls: true,
+                  # we offer our own download buttons for per-segment.
+                  controlslist: "nodownload",
+                  data: {
+                    role: "ohms-audio-elem",
+                    # the data-setup with serialized json triggers video.js to be the player
+                    setup: {
+                      bigPlayButton: false,
+                      audioOnlyMode: true,
+                      controlBar: {
+                        pictureInPictureToggle: false,
+                        fullscreenToggle: false,
+                      },
+                      plugins: {
+                        seekButtons: {
+                          forward: 30,
+                          back: 15
+                        }
+                      }
+                    }
+                  }
+            ) do %>
+                  <source src="<%= combined_m4a_audio_url %>" type="audio/mp4">
+            <% end %>
+
             <% if has_ohms_index? || has_ohms_transcript? %>
               <div class="pl-3">
                 <button class="btn btn-emphasis btn-sm text-nowrap" data-trigger="ohms-jump-to-text">Jump to text</button>

--- a/app/components/work_oh_audio_show_component.html.erb
+++ b/app/components/work_oh_audio_show_component.html.erb
@@ -30,6 +30,17 @@
                       controlBar: {
                         pictureInPictureToggle: false,
                         fullscreenToggle: false,
+                        # we want to customize the ORDER of control elements,
+                        # while also removing some.  Making it similar
+                        # to default html5 audio players in popular browsers
+                        children: [
+                          "playToggle",
+                          "currentTimeDisplay",
+                          "progressControl",
+                          "durationDisplay",
+                          "volumePanel",
+                          "playbackRateMenuButton"
+                        ]
                       },
                       plugins: {
                         seekButtons: {

--- a/app/components/work_oh_audio_show_component.html.erb
+++ b/app/components/work_oh_audio_show_component.html.erb
@@ -30,6 +30,9 @@
                       controlBar: {
                         pictureInPictureToggle: false,
                         fullscreenToggle: false,
+                        volumePanel: {
+                          inline: false
+                        },
                         # we want to customize the ORDER of control elements,
                         # while also removing some.  Making it similar
                         # to default html5 audio players in popular browsers

--- a/app/components/work_oh_audio_show_component.html.erb
+++ b/app/components/work_oh_audio_show_component.html.erb
@@ -24,6 +24,7 @@
                     role: "ohms-audio-elem",
                     # the data-setup with serialized json triggers video.js to be the player
                     setup: {
+                      playbackRates: [0.5, 0.75, 1, 1.25, 1.5, 2],
                       bigPlayButton: false,
                       audioOnlyMode: true,
                       controlBar: {


### PR DESCRIPTION
Ref #1007

Adds jump ahead/back and playback speed functions, as well as standardized player across browsers, via video.js player, custom styled to work better as an audio-only player. 
