### PR TITLE
OAI-PMH: Include all child images as edm:object

### DIFF
--- a/app/controllers/oai_pmh_controller.rb
+++ b/app/controllers/oai_pmh_controller.rb
@@ -12,8 +12,9 @@
       sample_id (Work.first.friendlier_id rescue "tq57nr00k")
 
       # Note we limit to published true, and pre-load any accessed associations for performance
+      # use .strict_loading to ensure we can't access any n+1 associations we haven't pre-loaded
       source_model OAI::Provider::ActiveRecordWrapper.new(
-        Work.where(published: true).includes(:leaf_representative, :contained_by),
+        Work.where(published: true).includes(:leaf_representative, :contained_by, members: [:leaf_representative]).strict_loading,
         identifier_field: :friendlier_id
       )
     end


### PR DESCRIPTION
Ref #1779

* Per PA Digital's instructions for contribution to wikimedia commons -- they want all child images, and this is where they get it from
* if no full-size JPG download deriv is available (say for video), we just don't include, and test to make sure that's fine.
* We don't necessarily handle multi-level child works (like a child that itself has child works); becuase we don't do that much, and it's hard to handle in a performant way. We may leave out some images if that happens though. There are other parts of our app that make this perf optimization too at cost of complete inclusion, it's ok.
* added strict_loading to fetch for oai-pmh export, so we'll raise if we accidentally n+1!
* This does mean that a given entity in our oai xml export can have hundreds of edm:object tags. PA Digital tells us they and wikimedia commons can handle this just fine. It will slow down our export somewhat, but I don't think enough to cause a problem, as far as I can tell, and no other problems for us. This seems to be the most straightforward way to get them the data.
