### PR TITLE
Consistent access controls for video assets on display page

### DIFF
--- a/app/assets/stylesheets/local/work_show.scss
+++ b/app/assets/stylesheets/local/work_show.scss
@@ -178,25 +178,23 @@
         }
       }
     }
-
-    // A label indicating the thumbnail belongs to a private item.
-    .private-badge-div {
-      position: absolute;
-      right: 0;
-      top: 0;
-      border-top-right-radius: 0;
-      border-top-left-radius: 0;
-      border-bottom-right-radius: 0;
-
-      z-index: 1; // didn't used to be necesssary but some adjustment made it become so
-      .badge-warning {
-        padding-top: 0;
-        padding-bottom: 0;
-        border-radius:0;
-        line-height: 2.3;
-      }
-    }
-
   }
 
+  // A label indicating the thumbnail belongs to a private item.
+  .private-badge-div {
+    position: absolute;
+    right: 0;
+    top: 0;
+    border-top-right-radius: 0;
+    border-top-left-radius: 0;
+    border-bottom-right-radius: 0;
+
+    z-index: 1; // didn't used to be necesssary but some adjustment made it become so
+    .badge-warning {
+      padding-top: 0;
+      padding-bottom: 0;
+      border-radius:0;
+      line-height: 2.3;
+    }
+  }
 }

--- a/app/assets/stylesheets/local/work_show.scss
+++ b/app/assets/stylesheets/local/work_show.scss
@@ -187,6 +187,8 @@
       border-top-right-radius: 0;
       border-top-left-radius: 0;
       border-bottom-right-radius: 0;
+
+      z-index: 1; // didn't used to be necesssary but some adjustment made it become so
       .badge-warning {
         padding-top: 0;
         padding-bottom: 0;

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -16,41 +16,47 @@
   <div class="show-video">
 
     <% if video_asset.present? %>
-      <%= content_tag("video",
-              id: "work-video-player",
-              class: "video-js vjs-fluid vjs-big-play-centered",
-              controls: true,
-              preload: "metadata",
-              poster: poster_src,
-              style: "aspect-ratio: #{video_asset.width }/#{ video_asset.height };",
-              # the data-setup with serialized json triggers video.js
-              data: {
-                setup: {
-                  aspectRatio: "#{video_asset.width}:#{video_asset.height}",
-                  plugins: {
-                    seekButtons: {
-                      forward: 30,
-                      back: 15
-                    }
-                  }
-                }.to_json
-              }
-      ) do %>
-        <% if video_asset.hls_playlist_file.present? %>
-          <%= tag "source", src: video_asset.hls_playlist_file.url, type: "application/x-mpegURL" %>
-        <% else %>
-          <%= tag "source", src: video_src_url, type: video_asset.content_type %>
+      <div class="position-relative">
+        <% if ! video_asset.published? %>
+          <%= private_label %>
         <% end %>
 
+        <%= content_tag("video",
+                id: "work-video-player",
+                class: "video-js vjs-fluid vjs-big-play-centered",
+                controls: true,
+                preload: "metadata",
+                poster: poster_src,
+                style: "aspect-ratio: #{video_asset.width }/#{ video_asset.height };",
+                # the data-setup with serialized json triggers video.js
+                data: {
+                  setup: {
+                    aspectRatio: "#{video_asset.width}:#{video_asset.height}",
+                    plugins: {
+                      seekButtons: {
+                        forward: 30,
+                        back: 15
+                      }
+                    }
+                  }.to_json
+                }
+        ) do %>
+          <% if video_asset.hls_playlist_file.present? %>
+            <%= tag "source", src: video_asset.hls_playlist_file.url, type: "application/x-mpegURL" %>
+          <% else %>
+            <%= tag "source", src: video_src_url, type: video_asset.content_type %>
+          <% end %>
 
-        <p class="vjs-no-js">
-          To view this video please enable JavaScript, and consider upgrading to a
-          web browser that
-          <a href="https://videojs.com/html5-video-support/" target="_blank"
-            >supports HTML5 video</a
-          >
-        </p>
-      <% end %>
+
+          <p class="vjs-no-js">
+            To view this video please enable JavaScript, and consider upgrading to a
+            web browser that
+            <a href="https://videojs.com/html5-video-support/" target="_blank"
+              >supports HTML5 video</a
+            >
+          </p>
+        <% end %>
+      </div>
     <% else %> <%# no video file available %>
       <%= tag "img", src: asset_path("placeholderbox.svg", alt: "") %>
     <% end %>

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -15,40 +15,44 @@
 
   <div class="show-video">
 
-    <%= content_tag("video",
-            id: "work-video-player",
-            class: "video-js vjs-fluid vjs-big-play-centered",
-            controls: true,
-            preload: "metadata",
-            poster: poster_src,
-            style: "aspect-ratio: #{video_asset.width }/#{ video_asset.height };",
-            # the data-setup with serialized json triggers video.js
-            data: {
-              setup: {
-                aspectRatio: "#{video_asset.width}:#{video_asset.height}",
-                plugins: {
-                  seekButtons: {
-                    forward: 30,
-                    back: 15
+    <% if video_asset.present? %>
+      <%= content_tag("video",
+              id: "work-video-player",
+              class: "video-js vjs-fluid vjs-big-play-centered",
+              controls: true,
+              preload: "metadata",
+              poster: poster_src,
+              style: "aspect-ratio: #{video_asset.width }/#{ video_asset.height };",
+              # the data-setup with serialized json triggers video.js
+              data: {
+                setup: {
+                  aspectRatio: "#{video_asset.width}:#{video_asset.height}",
+                  plugins: {
+                    seekButtons: {
+                      forward: 30,
+                      back: 15
+                    }
                   }
-                }
-              }.to_json
-            }
-    ) do %>
-      <% if video_asset.hls_playlist_file.present? %>
-        <%= tag "source", src: video_asset.hls_playlist_file.url, type: "application/x-mpegURL" %>
-      <% else %>
-        <%= tag "source", src: video_src_url, type: video_asset.content_type %>
+                }.to_json
+              }
+      ) do %>
+        <% if video_asset.hls_playlist_file.present? %>
+          <%= tag "source", src: video_asset.hls_playlist_file.url, type: "application/x-mpegURL" %>
+        <% else %>
+          <%= tag "source", src: video_src_url, type: video_asset.content_type %>
+        <% end %>
+
+
+        <p class="vjs-no-js">
+          To view this video please enable JavaScript, and consider upgrading to a
+          web browser that
+          <a href="https://videojs.com/html5-video-support/" target="_blank"
+            >supports HTML5 video</a
+          >
+        </p>
       <% end %>
-
-
-      <p class="vjs-no-js">
-        To view this video please enable JavaScript, and consider upgrading to a
-        web browser that
-        <a href="https://videojs.com/html5-video-support/" target="_blank"
-          >supports HTML5 video</a
-        >
-      </p>
+    <% else %> <%# no video file available %>
+      <%= tag "img", src: asset_path("placeholderbox.svg", alt: "") %>
     <% end %>
 
 

--- a/app/components/work_video_show_component.rb
+++ b/app/components/work_video_show_component.rb
@@ -37,4 +37,13 @@ class WorkVideoShowComponent < ApplicationComponent
       (work.leaf_representative.published? || current_user.present?) &&
       work.leaf_representative) || nil
   end
+
+  def private_label
+    content_tag(:div, class: "private-badge-div") do
+      content_tag(:span, title: "Private", class: "badge badge-warning") do
+        '<i class="fa fa-exclamation-triangle" aria-hidden="true"></i>'.html_safe +
+          " Private"
+      end
+    end
+  end
 end

--- a/app/components/work_video_show_component.rb
+++ b/app/components/work_video_show_component.rb
@@ -29,7 +29,12 @@ class WorkVideoShowComponent < ApplicationComponent
     video_asset.file_url(expires_in: 5.days.to_i)
   end
 
+  # the representative, if it's visible to current user, otherwise nil!
   def video_asset
-  	@video_asset = work.leaf_representative
+    return @video_asset if defined?(@video_asset)
+
+  	@video_asset = (work.leaf_representative &&
+      (work.leaf_representative.published? || current_user.present?) &&
+      work.leaf_representative) || nil
   end
 end

--- a/spec/components/member_image_component_spec.rb
+++ b/spec/components/member_image_component_spec.rb
@@ -45,10 +45,24 @@ describe MemberImageComponent, type: :component do
       it "outputs only placeholder" do
         expect(wrapper_div).to be_present
 
+
+
         expect(wrapper_div).to have_selector(".thumb img.not-available-placeholder")
 
         expect(wrapper_div).not_to have_selector(".action-item-bar .action-item.downloads .btn")
         expect(wrapper_div).not_to have_selector(".action-item-bar .action-item.view .btn")
+      end
+    end
+
+    describe "non-published asset with auth", logged_in_user: true do
+      let(:member) { create(:asset, published: false) }
+
+      it "outputs image with 'private' warning label" do
+        expect(wrapper_div).to be_present
+        expect(wrapper_div).to have_selector(".thumb img")
+        expect(wrapper_div).not_to have_selector(".thumb img.not-available-placeholder")
+
+        expect(wrapper_div).to have_text("Private")
       end
     end
 

--- a/spec/components/work_video_show_component_spec.rb
+++ b/spec/components/work_video_show_component_spec.rb
@@ -58,6 +58,22 @@ describe WorkVideoShowComponent, type: :component do
     end
   end
 
+  describe "when representative is private but visible to staff", logged_in_user: true do
+    let(:work) do
+      create(:video_work, :published).tap do |work|
+        work.representative.update(published: false)
+      end
+    end
+
+    it "includes video and private tag" do
+      render_inline described_class.new(work)
+
+      expect(page).to have_selector("video")
+      expect(page).to have_selector(".show-video", text: /Private/)
+    end
+
+  end
+
   describe "when representative is not visible to non-logged-in user" do
     let(:work) do
       create(:video_work, :published).tap do |work|
@@ -68,8 +84,8 @@ describe WorkVideoShowComponent, type: :component do
     it "includes placeholder only" do
       render_inline described_class.new(work)
 
-      expect(page).not_to have_css("video")
-      expect(page).to have_css("img[src='#{placeholder_img_src}']")
+      expect(page).not_to have_selector("video")
+      expect(page).to have_selector("img[src='#{placeholder_img_src}']")
     end
   end
 end

--- a/spec/components/work_video_show_component_spec.rb
+++ b/spec/components/work_video_show_component_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe WorkVideoShowComponent, type: :component do
   let(:work) { create(:video_work, :published) }
+  let(:placeholder_img_src) { ActionController::Base.helpers.asset_path("placeholderbox.svg") }
 
   it "has video element properly set up" do
     render_inline described_class.new(work)
@@ -54,6 +55,21 @@ describe WorkVideoShowComponent, type: :component do
       expect(first_source_element).to be_present
       expect(first_source_element["type"]).to eq("application/x-mpegURL")
       expect(first_source_element["src"]).to eq(work.representative.hls_playlist_file.url(public: true))
+    end
+  end
+
+  describe "when representative is not visible to non-logged-in user" do
+    let(:work) do
+      create(:video_work, :published).tap do |work|
+        work.representative.update(published: false)
+      end
+    end
+
+    it "includes placeholder only" do
+      render_inline described_class.new(work)
+
+      expect(page).not_to have_css("video")
+      expect(page).to have_css("img[src='#{placeholder_img_src}']")
     end
   end
 end


### PR DESCRIPTION
- make sure video asset is published before letting public see it
- make 'private' badge show again for image display page where it was supposed to but had stopped!
- add private label badge for unpublished video that current user can still see, in similar fashion as on image page

Ref #1793
