### PR TITLE
Extract re-usable AudioPlayerComponent

### DIFF
--- a/app/assets/stylesheets/local/video_js.scss
+++ b/app/assets/stylesheets/local/video_js.scss
@@ -5,8 +5,11 @@
 // Adapted from this SO comment and other stuff in this SO question:
 // https://github.com/videojs/video.js/issues/2777#issuecomment-161912138
 //
-// With some customizations
-
+// With some customizations.
+//
+// This markup is intended for the <audio> tag set up as in our local
+// AudioPlayerComponent.
+//
 .video-js.scihist-video-js-audio-no-poster {
     // make sure video.js popup menus are above navbar items
     z-index: 1;

--- a/app/components/audio_player_component.html.erb
+++ b/app/components/audio_player_component.html.erb
@@ -1,0 +1,41 @@
+<%= content_tag("audio",
+    class: "video-js scihist-video-js-audio-no-poster",
+    controls: true,
+    # we offer our own download buttons for per-segment.
+    controlslist: "nodownload",
+    data: {
+      role: "ohms-audio-elem",
+      # the data-setup with serialized json triggers video.js to be the player
+      setup: {
+        playbackRates: [0.5, 0.75, 1, 1.25, 1.5, 2],
+        bigPlayButton: false,
+        audioOnlyMode: true,
+        controlBar: {
+          pictureInPictureToggle: false,
+          fullscreenToggle: false,
+          volumePanel: {
+            inline: false
+          },
+          # we want to customize the ORDER of control elements,
+          # while also removing some.  Making it similar
+          # to default html5 audio players in popular browsers
+          children: [
+            "playToggle",
+            "currentTimeDisplay",
+            "progressControl",
+            "durationDisplay",
+            "volumePanel",
+            "playbackRateMenuButton"
+          ]
+        },
+        plugins: {
+          seekButtons: {
+            forward: 30,
+            back: 15
+          }
+        }
+      }
+    }
+) do %>
+  <%= content %>
+<% end %>

--- a/app/components/audio_player_component.rb
+++ b/app/components/audio_player_component.rb
@@ -1,0 +1,17 @@
+# Outputs an <audio> tag that has markup to have video.js actually take it over,
+# but in audio-only mode, with custom styling and features we have chosen as
+# what we want for our audio player.
+#
+# Goes with styling from .scihist-video-js-audio-no-poster class in video_js.scss
+#
+# Content wrapped in the component will be wrapped in the <audio> tag, and should
+# normally include one or more <source> tags!
+#
+# @example
+#
+#     <%= render AudioPlayerComponent.new do %>
+#       <source src="some_path" type="audio/mp4">
+#     <% end %>
+class AudioPlayerComponent < ApplicationComponent
+
+end

--- a/app/components/work_oh_audio_show_component.html.erb
+++ b/app/components/work_oh_audio_show_component.html.erb
@@ -15,46 +15,8 @@
         </h1>
         <% if combined_m4a_audio_url.present? && combined_derivatives_up_to_date? %>
           <div class="d-flex" style="align-items: center">
-            <%= content_tag("audio",
-                  class: "video-js scihist-video-js-audio-no-poster",
-                  controls: true,
-                  # we offer our own download buttons for per-segment.
-                  controlslist: "nodownload",
-                  data: {
-                    role: "ohms-audio-elem",
-                    # the data-setup with serialized json triggers video.js to be the player
-                    setup: {
-                      playbackRates: [0.5, 0.75, 1, 1.25, 1.5, 2],
-                      bigPlayButton: false,
-                      audioOnlyMode: true,
-                      controlBar: {
-                        pictureInPictureToggle: false,
-                        fullscreenToggle: false,
-                        volumePanel: {
-                          inline: false
-                        },
-                        # we want to customize the ORDER of control elements,
-                        # while also removing some.  Making it similar
-                        # to default html5 audio players in popular browsers
-                        children: [
-                          "playToggle",
-                          "currentTimeDisplay",
-                          "progressControl",
-                          "durationDisplay",
-                          "volumePanel",
-                          "playbackRateMenuButton"
-                        ]
-                      },
-                      plugins: {
-                        seekButtons: {
-                          forward: 30,
-                          back: 15
-                        }
-                      }
-                    }
-                  }
-            ) do %>
-                  <source src="<%= combined_m4a_audio_url %>" type="audio/mp4">
+            <%= render AudioPlayerComponent.new do %>
+                <source src="<%= combined_m4a_audio_url %>" type="audio/mp4">
             <% end %>
 
             <% if has_ohms_index? || has_ohms_transcript? %>


### PR DESCRIPTION
For video.js-controlled audio-player, customized how we want. Follow-up to #1789, meant to do this in there but forgot.
