### PR TITLE
Fix ActiveEncodeStatus#refresh_from_aws when Asset has been deleted

### DIFF
--- a/app/models/active_encode_status.rb
+++ b/app/models/active_encode_status.rb
@@ -1,7 +1,7 @@
 # Note the active_encode_id is also exactly the MediaConvert job ID in AWS,
 # if we're using MediaConvert, as we are.
 class ActiveEncodeStatus < ApplicationRecord
-  belongs_to :asset
+  belongs_to :asset, optional: true
 
   enum state: [ "running", "cancelled", "failed", "completed" ].map {|v| [v, v]}.to_h
 

--- a/spec/models/active_encode_status_spec.rb
+++ b/spec/models/active_encode_status_spec.rb
@@ -72,6 +72,8 @@ RSpec.describe ActiveEncodeStatus, type: :model do
     describe "for asset no longer present on completion" do
       before do
         Asset.where(id: active_encode_status.asset_id).delete_all
+        # so it doesn't refer to an in-memory but deleted asset, for better test!
+        active_encode_status.reload
       end
 
       it "deletes leftover files" do
@@ -83,6 +85,10 @@ RSpec.describe ActiveEncodeStatus, type: :model do
         expect(Rails.logger).to receive(:error).with(/^Deleting leftover HLS files for apparently missing asset ID: #{active_encode_status.asset_id}/)
 
         active_encode_status.refresh_from_aws
+
+        expect(active_encode_status.asset_id).to be_present
+        expect(active_encode_status.asset).to be nil
+        expect(active_encode_status.completed?).to be true
       end
     end
 


### PR DESCRIPTION
Ref #1796 which is an error where this situation resulted in an uncaught exception. We actually already meant to handle this and even had a spec for it -- but turns out the spec was unrealistic. Adding the "reload" to the spec made it realistic, and initially reproduced the exception. Marking the association optional then made the spec pass again.

So I think this should work to take care of #1796. Once merged we must re-enable cron job as per instructions there.
