### PR TITLE
Limit batch size in fetches for solr reindex

### DIFF
--- a/lib/tasks/scihist.rake
+++ b/lib/tasks/scihist.rake
@@ -112,7 +112,8 @@ namespace :scihist do
           Work.strict_loading.for_batch_indexing,
           Collection.strict_loading.includes(:contains_contained_by)
         ].each do |scope|
-          scope.find_each do |model|
+          # limiting batch size to 100 seems to have good effect on limiting RAM use
+          scope.find_each(batch_size: 100) do |model|
             progress_bar.title = "#{model.class.name}:#{model.friendlier_id}" if progress_bar
             model.update_index
             progress_bar.increment if progress_bar


### PR DESCRIPTION
Hoping this will reduce RAM usage on heroku of bulk reindexes. See https://github.com/sciencehistory/scihist_digicoll/issues/1797#issuecomment-1197221150

It looks like it might? And shoudln't hurt.
