### PR TITLE
When calculating how many assets to fixity-check in the cycle, round UP after division

### DIFF
--- a/app/lib/scihist_digicoll/assets_needing_fixity_checks.rb
+++ b/app/lib/scihist_digicoll/assets_needing_fixity_checks.rb
@@ -71,7 +71,8 @@ module ScihistDigicoll
     end
 
     def expected_num_to_check
-      @expected_num_to_check ||= (cycle_length == 0 ? Asset.count : Asset.count / cycle_length)
+      # make sure we round UP
+      @expected_num_to_check ||= (cycle_length == 0 ? Asset.count : (Asset.count.to_f / cycle_length).ceil)
     end
 
     private


### PR DESCRIPTION
Was rounding down before using ruby's semantics for interger division.  Round up to make it so we actually make sure all assets that are supposed to be checked are checked. Can't hurt.
