### PR TITLE
Fix to add_m4a_derivative_to_audio_assets task; create derivs via job in  special_jobs queue

### DIFF
--- a/app/jobs/create_m4a_derivative_job.rb
+++ b/app/jobs/create_m4a_derivative_job.rb
@@ -1,0 +1,17 @@
+class CreateM4aDerivativeJob < ApplicationJob
+  def perform(audio_asset)
+    if audio_asset.stored?
+      begin
+        logger.info("#{self.class}: Creating m4a for #{audio_asset.friendlier_id}.")
+        audio_asset.create_derivatives(lazy: true)
+        unless :m4a.in? audio_asset.file_derivatives.keys
+         logger.info("ERROR: unable to create m4a for #{audio_asset.friendlier_id}")
+        end
+      rescue Shrine::FileNotFound => e
+        logger.info("ERROR: Original missing for #{audio_asset.friendlier_id}")
+      end
+    else
+      logger.info("ERROR: File not found in s3 storage: #{audio_asset.friendlier_id}")
+    end
+  end
+end

--- a/lib/tasks/data_fixes/add_m4a_derivative_to_audio_assets.rake
+++ b/lib/tasks/data_fixes/add_m4a_derivative_to_audio_assets.rake
@@ -1,24 +1,22 @@
 namespace :scihist do
   namespace :data_fixes do
     desc """
-      Creates an m4a derivative -- lazily -- for all flac audio assets.
+      Enqueues a job for the creation of an m4a derivative -- lazily -- for all flac audio assets.
       bundle exec rake scihist:data_fixes:add_m4a_derivative_to_audio_assets
     """
 
     task :add_m4a_derivative_to_audio_assets => :environment do
-      scope = Asset.where("file_data -> 'metadata' ->> 'mime_type' like 'audio/%'")
-
+      scope = Asset.where("(file_data -> 'metadata' ->> 'mime_type' like 'audio/flac') or (file_data -> 'metadata' ->> 'mime_type' like 'audio/x-flac')")
       progress_bar = ProgressBar.create(total: scope.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
-
-      scope.find_each do |audio_asset|
-        unless audio_asset.stored? && audio_asset.content_type.end_with?('flac')
-          begin
-            progress_bar.title = audio_asset.friendlier_id
-            audio_asset.create_derivatives(lazy: true)
-          rescue Shrine::FileNotFound => e
-            progress_bar.log("original missing for #{audio_asset.friendlier_id}")
-          end
+      queue = :special_jobs
+      scope.find_each do |audio_asset|     
+        if :m4a.in? audio_asset.file_derivatives.keys
+          progress_bar.log("SKIPPING: Already found m4a for #{audio_asset.friendlier_id}")
+          progress_bar.increment
+          next
         end
+        progress_bar.log("Enqueuing #{audio_asset.friendlier_id}")
+        CreateM4aDerivativeJob.set(queue: queue).perform_later(audio_asset)
         progress_bar.increment
       end
     end


### PR DESCRIPTION
Fixes a trivial error that misled me yesterday into believing this job could run in less than a day.
Also now runs the derivative creation in a series of `special_jobs` jobs.