### PR TITLE
Hirefire should not auto-scale 'worker' dynos based on 'special_jobs' queue

### DIFF
--- a/config/initializers/hirefire_resource.rb
+++ b/config/initializers/hirefire_resource.rb
@@ -12,7 +12,12 @@ if ENV['HIREFIRE_TOKEN']
     # https://help.hirefire.io/article/53-job-queue-ruby-on-rails
     # https://github.com/hirefire/hirefire-resource
     config.dyno(:worker) do
-      HireFire::Macro::Resque.queue
+      # We want all queues EXCEPT `special_jobs`, which are not handled by
+      # 'worker' dynos. But there's currently no way to say "all queues except",
+      # so we have to list the queues we know about.
+      #
+      # Pitfall: If we add more queues, we're going to forget to edit here, sorry.
+      HireFire::Macro::Resque.queue("default", "on_demand_derivatives", "mailers")
     end
 
     # for queue time-based web dyno scaling, if we choose to use that.


### PR DESCRIPTION
Worker dynos don't work that queue, it's reserved for `special_worker` dynos.

Unfortunately, hirefire config currently has no way to say "all queues except X". so we have to explicitly list the non-special_jobs queues we know about.

Pitfall: If we add more queues, we're going to forget to edit here, sorry.

This seems to be the only way at present.
