### PR TITLE
Collection#external_id attribute, move collection OPAC urls to bibID metadata

### DIFF
--- a/app/components/collection_metadata_component.rb
+++ b/app/components/collection_metadata_component.rb
@@ -18,8 +18,21 @@ class CollectionMetadataComponent < ApplicationComponent
     @all_count ||= collection.contains.count
   end
 
+  # from related_url (legacy), or from our external_id with bib IDs in it.
   def opac_urls
-    related_url_filter.opac_urls
+    @opac_urls ||= begin
+      # bib_ids are supposed to be `b` followed by 7 numbers, but sometimes
+      # extra digits get in, cause Siera staff UI wants to add em, but
+      # they won't work for links to OPAC, phew.
+      bib_ids = (collection.external_id || []).find_all do |external_id|
+        external_id.category == "bib"
+      end.map(&:value).map { |id| id.slice(0,8) }
+
+      (bib_ids.collect(&:downcase) + related_url_filter.opac_ids.collect(&:downcase)).uniq.map do |bib_id|
+        ScihistDigicoll::Util.opac_url(bib_id)
+      end
+    end
+    @opac_urls
   end
 
   def related_urls

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -77,11 +77,12 @@ class Admin::CollectionsController < AdminController
       permitted_attributes = [:title, :description, :department]
       permitted_attributes << :published if can?(:publish, @collection || Collection)
 
-      params.
+      Kithe::Parameters.new(params).
         require(:collection).
         permit(*permitted_attributes,
                 :representative_attributes => {},
                 :funding_credit_attributes => {},
+                :external_id_attributes => true,
                 :related_url_attributes => []
         ).tap do |hash|
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -20,6 +20,8 @@ class Collection < Kithe::Collection
 
   accepts_nested_attributes_for :representative
 
+  attr_json :external_id, Work::ExternalId.to_type, array: true, default: -> { [] }
+
   attr_json :description, :text
   attr_json :related_url, :string, array: true
 

--- a/app/views/admin/collections/_form.html.erb
+++ b/app/views/admin/collections/_form.html.erb
@@ -32,6 +32,11 @@
 
     <%= f.input :department, collection: Work::ControlledLists::DEPARTMENT  %>
 
+    <%= f.repeatable_attr_input(:external_id, build: :at_least_one) do |sub_form| %>
+      <%= category_and_value(sub_form, category_list: Work::ExternalId::CATEGORY_VALUES) %>
+    <% end %>
+
+
     <%= f.input :description, as: :text, input_html: { rows: 14 } %>
 
     <% if can? :publish, collection %>

--- a/config/locales/collection.en.yml
+++ b/config/locales/collection.en.yml
@@ -5,6 +5,7 @@ en:
     attributes:
       collection:
         related_url: "Related URL"
+        external_id: "External ID"
 
   simple_form:
     hints:

--- a/db/migrate/20220809164350_collection_external_id.rb
+++ b/db/migrate/20220809164350_collection_external_id.rb
@@ -1,0 +1,5 @@
+class CollectionExternalId < ActiveRecord::Migration[6.1]
+  def change
+    Rake::Task['scihist:data_fixes:migrate_collection_bib_ids'].invoke
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_21_210438) do
+ActiveRecord::Schema.define(version: 2022_08_09_164350) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/lib/tasks/data_fixes/migrate_collection_bib_id.rake
+++ b/lib/tasks/data_fixes/migrate_collection_bib_id.rake
@@ -1,0 +1,23 @@
+namespace :scihist do
+  namespace :data_fixes do
+    desc "move Collection opac URL in related_url to external_id bib"
+    task :migrate_collection_bib_ids => [:environment] do
+      progress_bar = ProgressBar.create(total: Collection.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+      Kithe::Indexable.index_with(batching: true) do
+        Collection.find_each do |collection|
+          related_urls = collection.related_url.dup
+          related_urls.each do |url|
+            if url =~ RelatedUrlFilter::OPAC_PREFIX_RE
+              collection.external_id += [{ category: "bib", value: url.sub(RelatedUrlFilter::OPAC_PREFIX_RE, '')}]
+              collection.related_url.delete(url)
+              collection.save!
+
+              progress_bar.log("updated #{collection.friendlier_id}")
+            end
+            progress_bar.increment
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/system/collection/edit_collection_spec.rb
+++ b/spec/system/collection/edit_collection_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe "Edit Collection form", :logged_in_user, type: :system, queue_ada
     fill_in "collection[description]", with: "Edited collection desc"
     fill_in "collection[related_url_attributes][]", with: "http://example.org/edited"
 
+    select "Sierra Bib No", from: "collection[external_id_attributes][0][category]"
+    fill_in "collection[external_id_attributes][0][value]", with: "b1234567"
+
     # # the hidden file input used by uppy, we can target directly...
     add_file_via_uppy_dashboard input_name: "files[]", file_path: (Rails.root + "spec/test_support/images/20x20.png").to_s
     expect(page).to have_text("Will be saved") # wait for direct upload to complete
@@ -36,5 +39,6 @@ RSpec.describe "Edit Collection form", :logged_in_user, type: :system, queue_ada
     expect(collection.representative.file).to be_present
     expect(collection.representative.file).not_to eq(original_file)
     expect(original_file.exists?).to be(false) # has been deleted
+    expect(collection.external_id).to eq([Work::ExternalId.new("value"=>"b1234567", "category"=>"bib")])
   end
 end

--- a/spec/system/collection_show_spec.rb
+++ b/spec/system/collection_show_spec.rb
@@ -5,6 +5,7 @@ describe "Collection show page", solr: true, indexable_callbacks: true do
     let(:collection) do
       create(:collection,
         description: "some description",
+        external_id: [{category: "bib", value: "b9999999"}],
         related_url: ["http://othmerlib.sciencehistory.org/record=b1234567", "https://example.org/foo/bar"]
       ).tap do |col|
         # doing these as separate creates after collection exists necessary for them to have collection
@@ -28,7 +29,8 @@ describe "Collection show page", solr: true, indexable_callbacks: true do
 
       expect(page).to have_content(collection.description)
 
-      expect(page).to have_link(href: "http://othmerlib.sciencehistory.org/record=b1234567", text: "View in library catalog")
+      expect(page).to have_link(href: "https://othmerlib.sciencehistory.org/record=b1234567", text: "View in library catalog")
+      expect(page).to have_link(href: "https://othmerlib.sciencehistory.org/record=b9999999", text: "View in library catalog")
       expect(page).to have_link(href: "https://example.org/foo/bar", text: "example.org/…")
 
       expect(page).to have_content("public work one")


### PR DESCRIPTION
- add Collection#external_id field
- show bibID as link to OPAC on collection page
- rake task to migrate Collection bib_ids

Rake task will actually remove all OPAC urls from Collection#related_url, recording them in Collection#external_id as bibIDs instead. 

Feels risky cause destroying data, but I tested in staging, data seems to have properly migrated. 

Part of #1804