### PR TITLE
rake task to remove all Work#related_url to museum provenance note

### DIFF
--- a/db/migrate/20220809213542_remove_related_url_provenance.rb
+++ b/db/migrate/20220809213542_remove_related_url_provenance.rb
@@ -1,0 +1,5 @@
+class RemoveRelatedUrlProvenance < ActiveRecord::Migration[6.1]
+  def change
+    Rake::Task['scihist:data_fixes:remove_related_url_provenance_note'].invoke
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_09_164350) do
+ActiveRecord::Schema.define(version: 2022_08_09_213542) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/lib/tasks/data_fixes/remove_related_url_provenance.rake
+++ b/lib/tasks/data_fixes/remove_related_url_provenance.rake
@@ -1,0 +1,25 @@
+namespace :scihist do
+  namespace :data_fixes do
+
+    desc """
+      Remove provenance note from Work#{}related_urls
+    """
+    task :remove_related_url_provenance_note => :environment do
+      PROVENANCE_NOTE_URL = "https://www.sciencehistory.org/fine-art#provenance"
+
+      progress_bar = ProgressBar.create(total: Work.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+
+      Kithe::Indexable.index_with(batching: true) do
+        Work.find_each do |work|
+          if work.related_url.include?(PROVENANCE_NOTE_URL)
+            work.related_url.delete(PROVENANCE_NOTE_URL)
+            work.save!
+            progress_bar.log("removed provenance related_url: #{work.friendlier_id}")
+          end
+          progress_bar.increment
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
We decided not to use these here, we may put them on Collection level instead. https://github.com/sciencehistory/scihist_digicoll/issues/1776#issuecomment-1202840485
