### PR TITLE
Rake task to remove all OPAC urls from Work#related_url

### DIFF
--- a/db/migrate/20220810145124_remove_related_url_opac.rb
+++ b/db/migrate/20220810145124_remove_related_url_opac.rb
@@ -1,0 +1,5 @@
+class RemoveRelatedUrlOpac < ActiveRecord::Migration[6.1]
+  def change
+    Rake::Task['scihist:data_fixes:remove_related_url_opac'].invoke
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_09_213542) do
+ActiveRecord::Schema.define(version: 2022_08_10_145124) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/lib/tasks/data_fixes/remove_related_url_opac.rake
+++ b/lib/tasks/data_fixes/remove_related_url_opac.rake
@@ -1,0 +1,24 @@
+namespace :scihist do
+  namespace :data_fixes do
+    desc "Remove opac URLs from Work#related_url"
+    task :remove_related_url_opac => [:environment] do
+      progress_bar = ProgressBar.create(total: Work.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+
+      Kithe::Indexable.index_with(batching: true) do
+        Work.find_each do |work|
+          related_urls = work.related_url.dup
+
+          related_urls.each do |url|
+            if url =~ RelatedUrlFilter::OPAC_PREFIX_RE
+              work.related_url.delete(url)
+              work.save!
+
+              progress_bar.log("updated #{work.friendlier_id}")
+            end
+            progress_bar.increment
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/data_fixes/remove_related_url_opac.rake
+++ b/lib/tasks/data_fixes/remove_related_url_opac.rake
@@ -5,6 +5,7 @@ namespace :scihist do
       progress_bar = ProgressBar.create(total: Work.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
 
       Kithe::Indexable.index_with(batching: true) do
+        removed = 0
         Work.find_each do |work|
           related_urls = work.related_url.dup
 
@@ -13,11 +14,14 @@ namespace :scihist do
               work.related_url.delete(url)
               work.save!
 
-              progress_bar.log("updated #{work.friendlier_id}")
+              removed += 1
+              # too many of these to log them all
+              #progress_bar.log("updated #{work.friendlier_id}")
             end
-            progress_bar.increment
           end
+          progress_bar.increment
         end
+        progress_bar.log "Removed #{removed} OPAC urls"
       end
     end
   end


### PR DESCRIPTION
We have previously confirmed in production that all of these are mirrored in Work#external_id bibIDs. (Well, all but one we are fine deleting anyway).

There are actually 4700 of these redundant OPAC urls! Cleared with @apinkney0696 that it makes sense to delete. 

Ref #1776 and #1804