### PR TITLE
fixing bug in orphan checker - stop delete_prefix(nil)

### DIFF
--- a/app/services/orphan_s3_dzi.rb
+++ b/app/services/orphan_s3_dzi.rb
@@ -174,6 +174,8 @@ class OrphanS3Dzi
   def bucket_prefix
     @bucket_prefix ||= if shrine_storage.prefix
       shrine_storage.prefix.chomp('/') + '/'
+    else
+      ""
     end
   end
 


### PR DESCRIPTION
Ref #1823 
Will self-merge since this is a bug fix, doesn't modify any data, and only runs in a scheduled task.