### PR TITLE
Make featured topic page match collection page

### DIFF
--- a/app/views/featured_topic/index.html.erb
+++ b/app/views/featured_topic/index.html.erb
@@ -19,28 +19,31 @@
       <%= image_tag @featured_topic.thumb_asset_path, class: "featured-topic-image", width: "266px" %>
     </div>
   </div>
-  <div class="collection-search-form">
-    <h2 class="search-title">
-      Search within featured <%= @featured_topic.title %> items
-    </h2>
-    <%= form_tag "", method: :get do |f| %>
-      <div class="input-group">
-        <%= search_field_tag :q, '', class: "q form-control",
-        id: "collectionQ",
-        autocomplete: "off",
-        placeholder: t("collection.search_form.search_field.placeholder"),
-        :"aria-label" => t('collection.search_form.search_field.label')
-        %>
-        <label class="sr-only" for="collectionQ"><%= t('collection.search_form.search_field.label') %></label>
-        <div class="input-group-append">
-          <button type="submit" class="btn btn-emphasis" title="Search">
-            <i class="fa fa-search" aria-hidden="true"></i>
-            <%= t('blacklight.search.form.submit') %>
-          </button>
+
+  <div class="collection-control-area">
+    <div class="collection-search-form">
+      <h2 class="search-title">
+        Search within featured <%= @featured_topic.title %> items
+      </h2>
+      <%= form_tag "", method: :get do |f| %>
+        <div class="input-group">
+          <%= search_field_tag :q, '', class: "q form-control",
+          id: "collectionQ",
+          autocomplete: "off",
+          placeholder: t("collection.search_form.search_field.placeholder"),
+          :"aria-label" => t('collection.search_form.search_field.label')
+          %>
+          <label class="sr-only" for="collectionQ"><%= t('collection.search_form.search_field.label') %></label>
+          <div class="input-group-append">
+            <button type="submit" class="btn btn-emphasis" title="Search">
+              <i class="fa fa-search" aria-hidden="true"></i>
+              <%= t('blacklight.search.form.submit') %>
+            </button>
+          </div>
         </div>
-      </div>
-      <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>
-    <% end %>
+        <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>
+      <% end %>
+    </div>
   </div>
   <%= render 'catalog/constraints' %>
   <div class="row">

--- a/app/views/featured_topic/index.html.erb
+++ b/app/views/featured_topic/index.html.erb
@@ -8,43 +8,52 @@
           <h1><%= @featured_topic.title %></h1>
         </header>
       </div>
-      <div class="show-metadata">
-          <p class="show-item-count"><%= number_with_delimiter(total_count) + ' item'.pluralize(total_count) %></p>
-          <div class="collection-description long-text-line-height">
-            <%= DescriptionDisplayFormatter.new(@featured_topic.description).format %>
-          </div>
-      </div>
-    </div>
-    <div class="collection-thumb">
-      <%= image_tag @featured_topic.thumb_asset_path, class: "featured-topic-image", width: "266px" %>
-    </div>
-  </div>
 
-  <div class="collection-control-area">
-    <div class="collection-search-form">
-      <h2 class="search-title">
-        Search within featured <%= @featured_topic.title %> items
-      </h2>
-      <%= form_tag "", method: :get do |f| %>
-        <div class="input-group">
-          <%= search_field_tag :q, '', class: "q form-control",
-          id: "collectionQ",
-          autocomplete: "off",
-          placeholder: t("collection.search_form.search_field.placeholder"),
-          :"aria-label" => t('collection.search_form.search_field.label')
-          %>
-          <label class="sr-only" for="collectionQ"><%= t('collection.search_form.search_field.label') %></label>
-          <div class="input-group-append">
-            <button type="submit" class="btn btn-emphasis" title="Search">
-              <i class="fa fa-search" aria-hidden="true"></i>
-              <%= t('blacklight.search.form.submit') %>
-            </button>
-          </div>
+      <% unless has_search_parameters? %>
+        <div class="show-metadata">
+            <p class="show-item-count"><%= number_with_delimiter(total_count) + ' item'.pluralize(total_count) %></p>
+            <div class="collection-description long-text-line-height">
+              <%= DescriptionDisplayFormatter.new(@featured_topic.description).format %>
+            </div>
         </div>
-        <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>
       <% end %>
     </div>
+
+    <% unless has_search_parameters? %>
+      <div class="collection-thumb">
+        <%= image_tag @featured_topic.thumb_asset_path, class: "featured-topic-image", width: "266px" %>
+      </div>
+    <% end %>
   </div>
+
+  <% unless has_search_parameters? %>
+    <div class="collection-control-area">
+      <div class="collection-search-form">
+        <h2 class="search-title">
+          Search within featured <%= @featured_topic.title %> items
+        </h2>
+        <%= form_tag "", method: :get do |f| %>
+          <div class="input-group">
+            <%= search_field_tag :q, '', class: "q form-control",
+            id: "collectionQ",
+            autocomplete: "off",
+            placeholder: t("collection.search_form.search_field.placeholder"),
+            :"aria-label" => t('collection.search_form.search_field.label')
+            %>
+            <label class="sr-only" for="collectionQ"><%= t('collection.search_form.search_field.label') %></label>
+            <div class="input-group-append">
+              <button type="submit" class="btn btn-emphasis" title="Search">
+                <i class="fa fa-search" aria-hidden="true"></i>
+                <%= t('blacklight.search.form.submit') %>
+              </button>
+            </div>
+          </div>
+          <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
   <%= render 'catalog/constraints' %>
   <div class="row">
     <% if @response.documents.present? %>

--- a/app/views/featured_topic/index.html.erb
+++ b/app/views/featured_topic/index.html.erb
@@ -10,7 +10,7 @@
       </div>
       <div class="show-metadata">
           <p class="show-item-count"><%= number_with_delimiter(total_count) + ' item'.pluralize(total_count) %></p>
-          <div class="collection-description">
+          <div class="collection-description long-text-line-height">
             <%= DescriptionDisplayFormatter.new(@featured_topic.description).format %>
           </div>
       </div>

--- a/spec/system/featured_topic_spec.rb
+++ b/spec/system/featured_topic_spec.rb
@@ -40,6 +40,7 @@ describe "Featured Topic show page", type: :system, js: false, solr:true, indexa
     visit featured_topic_path(:instruments_and_innovation.to_s.dasherize)
     expect(page).to have_title "Instruments & Innovation"
     expect(page).to have_selector("h1", text: 'Instruments & Innovation')
+    expect(page).to have_text("2 items")
     expect(page).to have_selector("p", text: 'Fireballs')
     expect(page).to have_content("artillery")
     expect(page).to have_content("lithographs")
@@ -49,7 +50,6 @@ describe "Featured Topic show page", type: :system, js: false, solr:true, indexa
   it "searches, and keeps total count accurate" do
     visit featured_topic_path(:instruments_and_innovation.to_s.dasherize, q: "artillery")
 
-    expect(page).to have_text("2 items")
     expect(page).to have_text("1 entry found")
 
     expect(page).to have_content("artillery")


### PR DESCRIPTION
Ref #1810, but the "crowded" aspect was really caused by losing CSS styling meant to apply. We use the same CSS for collection and featured topic, and at some point the HTML/CSS targetting diverged, and featured topic "search" box ended up unstyled, not intentionally.  

In addition to fixing that, fixed a couple other places where featured topics page had diverged from collection page, to make them again parallel. 

- style featured topic search like collection search
- long-text-line-height for featured topic description
- Featured topic -- don't show description apparatus with search results
