### PR TITLE
solr indexers switch from using related_url to new strucutured related_link

### DIFF
--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -11,7 +11,8 @@ class CollectionIndexer < Kithe::Indexer
 
     to_field "text4_tesim", obj_extract("description"), transform(->(val) { ActionView::Base.full_sanitizer.sanitize(val) })
 
-    to_field "text_no_boost_tesim", obj_extract("related_url")
+    to_field "text_no_boost_tesim", obj_extract("related_link", "label")
+    to_field "text_no_boost_tesim", obj_extract("related_link", "url")
 
     to_field "date_created_dtsi" do |rec, acc|
       if rec.created_at

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -28,9 +28,11 @@ class WorkIndexer < Kithe::Indexer
 
     to_field ["text_no_boost_tesim", "language_facet"], obj_extract("language")
     to_field "text_no_boost_tesim", obj_extract("external_id", "value")
-    to_field "text_no_boost_tesim", obj_extract("related_url")
+
+    to_field "text_no_boost_tesim", obj_extract("related_link", "label")
+    to_field "text_no_boost_tesim", obj_extract("related_link", "url")
+
     to_field ["text_no_boost_tesim", "place_facet"], obj_extract("place", "value")
-    to_field "text_no_boost_tesim", obj_extract("related_url")
     to_field ["text_no_boost_tesim", "department_facet"], obj_extract("department")
     to_field ["text_no_boost_tesim", "medium_facet"], obj_extract("medium")
     to_field ["text_no_boost_tesim", "format_facet"], obj_extract("format"), transform(->(v) { v.titleize })


### PR DESCRIPTION
We were indexing URLs before. Index the new label too, I guess?
