### PR TITLE
Rake task to actually migrate related_url to related_link

### DIFF
--- a/app/models/related_link.rb
+++ b/app/models/related_link.rb
@@ -6,6 +6,7 @@ class RelatedLink
   include AttrJson::Model
 
   CATEGORY_VALUES = %w{finding_aid distillations_article distillations_podcast
+                      distillations_video
                       institute_biography institute_blog_post institute_libguide
                       related_work other_external other_internal}
 

--- a/lib/tasks/data_fixes/convert_related_url.rake
+++ b/lib/tasks/data_fixes/convert_related_url.rake
@@ -1,0 +1,54 @@
+namespace :scihist do
+  namespace :data_fixes do
+
+    # note `label` will sometimes be blank in new related_links, meaning URLs will show
+    desc "convert related_url to related_link"
+    task :convert_related_url => :environment do
+      scope = Work.where("json_attributes -> 'related_url' IS NOT NULL AND json_attributes -> 'related_url' != '[]'")
+
+      progress_bar = ProgressBar.create(total: scope.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+
+      scope.find_each do |work|
+        related_urls = work.related_url.dup
+
+        related_urls.each do |url|
+          case url
+          when %r{\A\s*https?://digital\.sciencehistory\.org/works}
+            progress_bar.log("#{work.friendlier_id} related_work #{url}")
+            work.related_link << RelatedLink.new(category: "related_work", url: url)
+          when %r{\A\s*https?://archives\.sciencehistory\.org/}
+            progress_bar.log("#{work.friendlier_id} finding_aid #{url}")
+            work.related_link << RelatedLink.new(category: "finding_aid", url: url)
+          when /\Ahttps?:\/\/guides\.othmerlibrary\.(chemheritage|sciencehistory)\.org\//
+            progress_bar.log("#{work.friendlier_id} institute_libguide #{url}")
+            new_url = url.sub("chemheritage.org", "sciencehistory.org")
+            work.related_link << RelatedLink.new(category: "institute_libguide", url: new_url)
+          when %r{\A\s*https?://www\.sciencehistory\.org/historical-profile/}
+            progress_bar.log("#{work.friendlier_id} institute_biography #{url}")
+            work.related_link << RelatedLink.new(category: "institute_biography", url: url)
+          when %r{\A\s*https?://www\.sciencehistory\.org/distillations/video/}
+            progress_bar.log("#{work.friendlier_id} distillations_video #{url}")
+            work.related_link << RelatedLink.new(category: "distillations_video", url: url)
+          when %r{\A\s*https?://www\.sciencehistory\.org/distillations/podcast/}
+            progress_bar.log("#{work.friendlier_id} distillations_podcast #{url}")
+            work.related_link << RelatedLink.new(category: "distillations_podcast", url: url)
+          when %r{\A\s*https?://www\.sciencehistory\.org/distillations/}
+            progress_bar.log("#{work.friendlier_id} distillations_article #{url}")
+            work.related_link << RelatedLink.new(category: "distillations_article", url: url)
+          when %r{\A\s*https?://.*\.sciencehistory\.org/}
+            progress_bar.log("#{work.friendlier_id} other_internal #{url}")
+            work.related_link << RelatedLink.new(category: "other_internal", url: url)
+          else
+            progress_bar.log("#{work.friendlier_id} other_external #{url}")
+            work.related_link << RelatedLink.new(category: "other_external", url: url)
+          end
+
+          work.related_url.delete(url)
+        end
+
+        work.save!
+        progress_bar.increment
+      end
+    end
+  end
+end

--- a/lib/tasks/data_fixes/convert_related_url.rake
+++ b/lib/tasks/data_fixes/convert_related_url.rake
@@ -8,39 +8,57 @@ namespace :scihist do
 
       progress_bar = ProgressBar.create(total: scope.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
 
+      # for some known existing ones, supply label
+      label_hash = {
+        "http://guides.othmerlibrary.chemheritage.org/DyesandDyeing" => "History of Dyes and Dyeing",
+        "http://www.encyclopedia.com/doc/1G2-2841300057.html" => "Crompton & Knowles Corp.",
+        "https://www.sciencehistory.org/distillations/video/distilled-3-water-fit-for-a-king"=> "Distilled #3: Water Fit for a King",
+        "https://www.sciencehistory.org/distillations/celluloid-the-eternal-substitute" => "Celluloid: The Eternal Substitute",
+        "https://www.sciencehistory.org/distillations/video/distilled-8-penicillin-jug" => "Distilled #8: Penicillin Jug",
+        "https://www.sciencehistory.org/distillations/braving-the-elements-why-mendeleev-left-russian-soil-for-american-oil" => "Braving the Elements: Why Mendeleev Left Russian Soil for American Oil",
+        "https://www.sciencehistory.org/historical-profile/joseph-louis-gay-lussac" => "Joseph Louis Gay-Lussac",
+        "http://archives.dickinson.edu/people/c-scott-althouse-1880-1970" => "C. Scott Althouse (1880-1970)",
+        "https://catalog.hathitrust.org/Record/006496880" => "Über katalyse.",
+        "https://www.sciencehistory.org/distillations/video/distilled-5-porcelain-painting" => "Distilled #5: Porcelain Painting",
+        "http://www.sciencehistory.org/distillations/video/distilled-7-bicycle-horn-or-breast-pump" => "Distilled #7: Bicycle Horn or Breast Pump?",
+        "https://www.sciencehistory.org/distillations/video/distilled-2-an-early-gold-plated-not-quite-iud" => "Distilled #2: An Early (Gold-Plated!) Not-Quite-IUD"
+      }
+
       scope.find_each do |work|
         related_urls = work.related_url.dup
 
         related_urls.each do |url|
+          label = label_hash[url]
+
           case url
           when %r{\A\s*https?://digital\.sciencehistory\.org/works}
             progress_bar.log("#{work.friendlier_id} related_work #{url}")
-            work.related_link << RelatedLink.new(category: "related_work", url: url)
+            work.related_link << RelatedLink.new(category: "related_work", url: url, label: label)
           when %r{\A\s*https?://archives\.sciencehistory\.org/}
             progress_bar.log("#{work.friendlier_id} finding_aid #{url}")
-            work.related_link << RelatedLink.new(category: "finding_aid", url: url)
+            work.related_link << RelatedLink.new(category: "finding_aid", url: url, label: label)
           when /\Ahttps?:\/\/guides\.othmerlibrary\.(chemheritage|sciencehistory)\.org\//
             progress_bar.log("#{work.friendlier_id} institute_libguide #{url}")
             new_url = url.sub("chemheritage.org", "sciencehistory.org")
-            work.related_link << RelatedLink.new(category: "institute_libguide", url: new_url)
+            work.related_link << RelatedLink.new(category: "institute_libguide", url: new_url, label: label)
           when %r{\A\s*https?://www\.sciencehistory\.org/historical-profile/}
             progress_bar.log("#{work.friendlier_id} institute_biography #{url}")
-            work.related_link << RelatedLink.new(category: "institute_biography", url: url)
+            work.related_link << RelatedLink.new(category: "institute_biography", url: url, label: label)
           when %r{\A\s*https?://www\.sciencehistory\.org/distillations/video/}
             progress_bar.log("#{work.friendlier_id} distillations_video #{url}")
-            work.related_link << RelatedLink.new(category: "distillations_video", url: url)
+            work.related_link << RelatedLink.new(category: "distillations_video", url: url, label: label)
           when %r{\A\s*https?://www\.sciencehistory\.org/distillations/podcast/}
             progress_bar.log("#{work.friendlier_id} distillations_podcast #{url}")
-            work.related_link << RelatedLink.new(category: "distillations_podcast", url: url)
+            work.related_link << RelatedLink.new(category: "distillations_podcast", url: url, label: label)
           when %r{\A\s*https?://www\.sciencehistory\.org/distillations/}
             progress_bar.log("#{work.friendlier_id} distillations_article #{url}")
-            work.related_link << RelatedLink.new(category: "distillations_article", url: url)
+            work.related_link << RelatedLink.new(category: "distillations_article", url: url, label: label)
           when %r{\A\s*https?://.*\.sciencehistory\.org/}
             progress_bar.log("#{work.friendlier_id} other_internal #{url}")
-            work.related_link << RelatedLink.new(category: "other_internal", url: url)
+            work.related_link << RelatedLink.new(category: "other_internal", url: url, label: label)
           else
             progress_bar.log("#{work.friendlier_id} other_external #{url}")
-            work.related_link << RelatedLink.new(category: "other_external", url: url)
+            work.related_link << RelatedLink.new(category: "other_external", url: url, label: label)
           end
 
           work.related_url.delete(url)

--- a/lib/tasks/data_fixes/convert_related_url.rake
+++ b/lib/tasks/data_fixes/convert_related_url.rake
@@ -24,48 +24,50 @@ namespace :scihist do
         "https://www.sciencehistory.org/distillations/video/distilled-2-an-early-gold-plated-not-quite-iud" => "Distilled #2: An Early (Gold-Plated!) Not-Quite-IUD"
       }
 
-      scope.find_each do |work|
-        related_urls = work.related_url.dup
+      Kithe::Indexable.index_with(batching: true) do
+        scope.find_each do |work|
+          related_urls = work.related_url.dup
 
-        related_urls.each do |url|
-          label = label_hash[url]
+          related_urls.each do |url|
+            label = label_hash[url]
 
-          case url
-          when %r{\A\s*https?://digital\.sciencehistory\.org/works}
-            progress_bar.log("#{work.friendlier_id} related_work #{url}")
-            work.related_link << RelatedLink.new(category: "related_work", url: url, label: label)
-          when %r{\A\s*https?://archives\.sciencehistory\.org/}
-            progress_bar.log("#{work.friendlier_id} finding_aid #{url}")
-            work.related_link << RelatedLink.new(category: "finding_aid", url: url, label: label)
-          when /\Ahttps?:\/\/guides\.othmerlibrary\.(chemheritage|sciencehistory)\.org\//
-            progress_bar.log("#{work.friendlier_id} institute_libguide #{url}")
-            new_url = url.sub("chemheritage.org", "sciencehistory.org")
-            work.related_link << RelatedLink.new(category: "institute_libguide", url: new_url, label: label)
-          when %r{\A\s*https?://www\.sciencehistory\.org/historical-profile/}
-            progress_bar.log("#{work.friendlier_id} institute_biography #{url}")
-            work.related_link << RelatedLink.new(category: "institute_biography", url: url, label: label)
-          when %r{\A\s*https?://www\.sciencehistory\.org/distillations/video/}
-            progress_bar.log("#{work.friendlier_id} distillations_video #{url}")
-            work.related_link << RelatedLink.new(category: "distillations_video", url: url, label: label)
-          when %r{\A\s*https?://www\.sciencehistory\.org/distillations/podcast/}
-            progress_bar.log("#{work.friendlier_id} distillations_podcast #{url}")
-            work.related_link << RelatedLink.new(category: "distillations_podcast", url: url, label: label)
-          when %r{\A\s*https?://www\.sciencehistory\.org/distillations/}
-            progress_bar.log("#{work.friendlier_id} distillations_article #{url}")
-            work.related_link << RelatedLink.new(category: "distillations_article", url: url, label: label)
-          when %r{\A\s*https?://.*\.sciencehistory\.org/}
-            progress_bar.log("#{work.friendlier_id} other_internal #{url}")
-            work.related_link << RelatedLink.new(category: "other_internal", url: url, label: label)
-          else
-            progress_bar.log("#{work.friendlier_id} other_external #{url}")
-            work.related_link << RelatedLink.new(category: "other_external", url: url, label: label)
+            case url
+            when %r{\A\s*https?://digital\.sciencehistory\.org/works}
+              progress_bar.log("#{work.friendlier_id} related_work #{url}")
+              work.related_link << RelatedLink.new(category: "related_work", url: url, label: label)
+            when %r{\A\s*https?://archives\.sciencehistory\.org/}
+              progress_bar.log("#{work.friendlier_id} finding_aid #{url}")
+              work.related_link << RelatedLink.new(category: "finding_aid", url: url, label: label)
+            when /\Ahttps?:\/\/guides\.othmerlibrary\.(chemheritage|sciencehistory)\.org\//
+              progress_bar.log("#{work.friendlier_id} institute_libguide #{url}")
+              new_url = url.sub("chemheritage.org", "sciencehistory.org")
+              work.related_link << RelatedLink.new(category: "institute_libguide", url: new_url, label: label)
+            when %r{\A\s*https?://www\.sciencehistory\.org/historical-profile/}
+              progress_bar.log("#{work.friendlier_id} institute_biography #{url}")
+              work.related_link << RelatedLink.new(category: "institute_biography", url: url, label: label)
+            when %r{\A\s*https?://www\.sciencehistory\.org/distillations/video/}
+              progress_bar.log("#{work.friendlier_id} distillations_video #{url}")
+              work.related_link << RelatedLink.new(category: "distillations_video", url: url, label: label)
+            when %r{\A\s*https?://www\.sciencehistory\.org/distillations/podcast/}
+              progress_bar.log("#{work.friendlier_id} distillations_podcast #{url}")
+              work.related_link << RelatedLink.new(category: "distillations_podcast", url: url, label: label)
+            when %r{\A\s*https?://www\.sciencehistory\.org/distillations/}
+              progress_bar.log("#{work.friendlier_id} distillations_article #{url}")
+              work.related_link << RelatedLink.new(category: "distillations_article", url: url, label: label)
+            when %r{\A\s*https?://.*\.sciencehistory\.org/}
+              progress_bar.log("#{work.friendlier_id} other_internal #{url}")
+              work.related_link << RelatedLink.new(category: "other_internal", url: url, label: label)
+            else
+              progress_bar.log("#{work.friendlier_id} other_external #{url}")
+              work.related_link << RelatedLink.new(category: "other_external", url: url, label: label)
+            end
+
+            work.related_url.delete(url)
           end
 
-          work.related_url.delete(url)
+          work.save!
+          progress_bar.increment
         end
-
-        work.save!
-        progress_bar.increment
       end
     end
   end

--- a/lib/tasks/data_fixes/convert_related_url.rake
+++ b/lib/tasks/data_fixes/convert_related_url.rake
@@ -21,7 +21,8 @@ namespace :scihist do
         "https://catalog.hathitrust.org/Record/006496880" => "Über katalyse.",
         "https://www.sciencehistory.org/distillations/video/distilled-5-porcelain-painting" => "Distilled #5: Porcelain Painting",
         "http://www.sciencehistory.org/distillations/video/distilled-7-bicycle-horn-or-breast-pump" => "Distilled #7: Bicycle Horn or Breast Pump?",
-        "https://www.sciencehistory.org/distillations/video/distilled-2-an-early-gold-plated-not-quite-iud" => "Distilled #2: An Early (Gold-Plated!) Not-Quite-IUD"
+        "https://www.sciencehistory.org/distillations/video/distilled-2-an-early-gold-plated-not-quite-iud" => "Distilled #2: An Early (Gold-Plated!) Not-Quite-IUD",
+        "http://www.acs.org/content/acs/en/education/whatischemistry/landmarks/beckman.html" => "Development of the Beckman pH Meter"
       }
 
       Kithe::Indexable.index_with(batching: true) do


### PR DESCRIPTION
Also adds a new related_link category for distillations_video. 

    rake scihist:data_fixes:convert_related_url

Categories existing related_urls according to their urls, to make them related_links with proper categories. Adds labels for the identified existing related_urls that need em.

Should be idempotent, so we could for instance run in production multiple times if needed, and people are still editing. 
