### PR TITLE
try a slightly differnet design tweak for collection links

### DIFF
--- a/app/assets/stylesheets/local/collection_show.scss
+++ b/app/assets/stylesheets/local/collection_show.scss
@@ -27,8 +27,16 @@
     }
   }
 
-  .collection_description {
-    max-width: $max-readable-width;
+
+  .collection-main-links {
+    display: flex;
+    flex: wrap;
+    gap: $paragraph-spacer ($paragraph_spacer * 4);
+    margin-bottom: 2rem;
+
+    .collection-main-link {
+      @include font-size($h4-font-size);
+    }
   }
 
   .collection-related-links {

--- a/app/components/collection_metadata_component.html.erb
+++ b/app/components/collection_metadata_component.html.erb
@@ -12,19 +12,23 @@
   </div>
 
   <% if show_links && (opac_urls.present? || finding_aid_urls.present?) %>
-    <table class="collection-attributes table-borderless chf-attributes">
+    <div class="collection-main-links">
       <% finding_aid_urls.each do |url| %>
-        <tr>
-          <td colspan="2"><span class="h4"><%= link_to "View collection guide", url %></span></td>
-        </tr>
+        <span class="collection-main-link">
+          <%= link_to url do %>
+            <i class="fa fa-link" aria-hidden="true"></i> Collection guide
+          <% end  %>
+        </span>
       <% end %>
 
       <% opac_urls.each do |url| %>
-        <tr>
-          <td  colspan="2"><span class="h4"><%= link_to "View in library catalog", url %></span></td>
-        </tr>
+        <span class="collection-main-link">
+          <%= link_to url do %>
+            <i class="fa fa-link" aria-hidden="true"></i> Collection in library catalog
+          <% end  %>
+        </span>
       <% end %>
-    </table>
+    </div>
   <% end %>
 
   <% if show_links && related_links.present? %>

--- a/spec/system/collection_show_spec.rb
+++ b/spec/system/collection_show_spec.rb
@@ -32,8 +32,8 @@ describe "Collection show page", solr: true, indexable_callbacks: true do
 
       expect(page).to have_content(collection.description)
 
-      expect(page).to have_link(href: "https://othmerlib.sciencehistory.org/record=b9999999", text: "View in library catalog")
-      expect(page).to have_link(href: "http://archives.sciencehistory.org/some/collection", text: "View collection guide")
+      expect(page).to have_link(href: "https://othmerlib.sciencehistory.org/record=b9999999", text: "Collection in library catalog")
+      expect(page).to have_link(href: "http://archives.sciencehistory.org/some/collection", text: "Collection guide")
       expect(page).to have_link(href: "https://sciencehistory.org/foo/bar", text: "Article about this")
 
       expect(page).to have_content("public work one")


### PR DESCRIPTION
Finding aid/OPAC links are side-by-side, and with a link icon and different text.
