### PR TITLE
Simple test for more-like-this

### DIFF
--- a/app/services/more_like_this_getter.rb
+++ b/app/services/more_like_this_getter.rb
@@ -1,26 +1,60 @@
-# Makes an extra call to the SOLR server's more-like-this request handler
+# MoreLikeThisGetter.new(work).works
+#
+# returns an array of zero to ten
+# published works that SOLR thinks
+# are "like" the given work.
+#
+# This calls the SOLR server's more-like-this request handler
 # at http://SOME_URL/solr/SOME_CORE/mlt
 # to request a list of works that are deemed similar.
-# See the work_indexer.rb for indexing details.
 #
+# See also:
+# work_indexer.rb for indexing details,
+# solr/config/solrconfig.xml for the request handler.
 #
-# This code is invoked on the work show page,
-# which gets all its other information
-# from the database and is generally very fast.
-# An important goal for this helper class is that it
-# not slow down (or worse, break) the work show page
-# if SOLR is slow or unreachable.
+# We really do not want to slow down (or worse, break) the work show page
+# if SOLR is slow or unreachable, as it often is.
+# If anything goes wrong, you'll just get an empty array.
 #
 # MoreLikeThisGetter.new(work).works
 #
 class MoreLikeThisGetter
   attr_reader :work
+
+  # These timeouts are short. We want to be conservative,
+  # as we don't want to trust our SOLR provider too much
+  # and this appears on a part of the website that's usually fast.
   TIMEOUT=1
   OPEN_TIMEOUT=1
 
   # @param work [Work] Work
   def initialize(work) 
     @work = work
+  end
+
+  # Returns an array of up to 10 published works that SOLR deems similar.
+  def works
+    works_in_arbitrary_order = Work.where(
+      friendlier_id: friendlier_ids,
+      published: true)&.
+      index_by(&:friendlier_id) || {}
+    friendlier_ids.map {|id| works_in_arbitrary_order[id] }.compact
+  end
+
+  # Some justification for the choices SOLR made.
+  # Does not result in an additional call to SOLR.
+  def json
+    more_like_this_doc_set&.map do |doc|
+      doc.select do |key, value|
+        key == 'text1_tesim' || key.include?('more_like_this')
+      end
+    end
+  end
+
+  private
+
+  def friendlier_ids
+    @friendlier_ids ||= more_like_this_doc_set&.map { |d| d['id'] }
   end
 
   # Note: it appears that the mlt.count variable is ignored.
@@ -32,31 +66,22 @@ class MoreLikeThisGetter
     }
   end
 
-  # Returns a RSolr::Response::PaginatedDocSet
+  def solr_url
+    ScihistDigicoll::Env.lookup!(:solr_url)
+  end
+
+  def solr_connection
+    RSolr.connect( :url => solr_url, :timeout => TIMEOUT,:open_timeout => OPEN_TIMEOUT)
+  end
+
+  # Returns a RSolr::Response::PaginatedDocSet,
+  # or an empty array if RSolr times out or can't be reached.
   def more_like_this_doc_set
     @more_like_this_doc_set ||= begin
-      solr = RSolr.connect(:url => ScihistDigicoll::Env.lookup!(:solr_url), :timeout => TIMEOUT, :open_timeout => OPEN_TIMEOUT)
-      solr.get('mlt', :params => mlt_params)&.
+      solr_connection.get('mlt', :params => mlt_params)&.
         dig("response", "docs") || []
     rescue
       []
-    end
-  end
-
-  # Returns an array of up to 10 published works that SOLR deems similar.
-  def works
-    ids = more_like_this_doc_set&.map { |d| d['id'] }
-    works_in_arbitrary_order = Work.where(friendlier_id: ids, published: true).index_by(&:friendlier_id)
-    ids.map {|id| works_in_arbitrary_order[id] }.compact
-  end
-
-  # Some justification for the choices SOLR made.
-  # Does not result in an additional call to SOLR.
-  def json
-    more_like_this_doc_set&.map do |doc|
-      doc.select do |key, value|
-        key == 'text1_tesim' || key.include?('more_like_this')
-      end
     end
   end
 end

--- a/spec/services/more_like_this_getter_spec.rb
+++ b/spec/services/more_like_this_getter_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+# Testing the SOLR part of this is slow -- and a pain --
+# so we are short-circuiting that part of the code.
+describe MoreLikeThisGetter do
+  let(:work_to_match)   { create(:public_work)  }
+  let(:getter) {MoreLikeThisGetter.new(work_to_match) }
+  let(:three_public_work_ids) { [1,2,3].map {create(:public_work).friendlier_id } }
+  let(:matching_work_ids) { three_public_work_ids + [create(:private_work).friendlier_id]} 
+
+  it "returns only published works; displays them in order" do
+    allow(getter).to receive(:friendlier_ids).and_return(matching_work_ids)
+    expect(getter.works.map {|w| w.friendlier_id}).to eq (matching_work_ids[0..2])
+  end
+end


### PR DESCRIPTION
The test assumes that SOLR is returning a work IDs.
This feature isn't essential, so that's probably fine. (Also, SOLR tests are slow.)