### PR TITLE
rake task to migrate previously mis-migrated legacy related_works links

### DIFF
--- a/lib/tasks/data_fixes/migrate_old_related_work_links.rake
+++ b/lib/tasks/data_fixes/migrate_old_related_work_links.rake
@@ -1,0 +1,31 @@
+namespace :scihist do
+  namespace :data_fixes do
+    desc """
+      Migrate legacy related work links with /concern/generic_works/
+
+      They were migrated over to new related_links in somewhat corrupt fashion as other_internal
+    """
+
+    task :migrate_old_related_works_links => :environment do
+      scope = Work.jsonb_contains("related_link.category" => "other_internal")
+
+      progress_bar = ProgressBar.create(total: scope.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+
+      Kithe::Indexable.index_with(batching: true) do
+        scope.find_each do |work|
+          related_links = work.related_link.dup
+          work.related_link.each do |rl|
+            if rl.url =~ %r{\Ahttps://digital.sciencehistory.org/concern/generic_works/([^/]+)$}
+              rl.category = "related_work"
+              rl.url = "https://digital.sciencehistory.org/works/#{$1}"
+
+              work.save!
+            end
+          end
+
+          progress_bar.increment
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
What has become eg category:other_internal url: https://digital.sciencehistory.org/concern/generic_works/wd375w406 in database, should be category:related_work, url:https://digital.sciencehistory.org/works/wd375w406

Ref fixup of #1847

Tested in staging, seems to work okay. 

After merge and deploy:

    heroku run rake scihist:data_fixes:migrate_old_related_works_links
