### PR TITLE
Fine-tune collection description responsive wrapping

### DIFF
--- a/app/assets/stylesheets/local/collection_show.scss
+++ b/app/assets/stylesheets/local/collection_show.scss
@@ -24,7 +24,7 @@
 
   .collection-main-links {
     display: flex;
-    flex: wrap;
+    flex-wrap: wrap;
     gap: $paragraph-spacer ($paragraph_spacer * 4);
     margin-bottom: 2rem;
 
@@ -35,8 +35,18 @@
 
   .collection-related-links {
     display: flex;
-    flex: wrap;
-    gap: $paragraph-spacer ($paragraph_spacer * 4);
+    flex-wrap: wrap;
+    gap: ($paragraph_spacer * 2);
+    margin: 2rem 0;
+
+
+
+    @include media-breakpoint-up(md) {
+      .related-link-component {
+        width: 20rem;
+        flex-grow: 1;
+      }
+    }
   }
 
   .chf-attributes > tbody >tr:first-child td, .chf-attributes > tbody > tr:first-child th {

--- a/app/assets/stylesheets/local/collection_show.scss
+++ b/app/assets/stylesheets/local/collection_show.scss
@@ -4,20 +4,14 @@
   margin-right: auto;
 
   .collection-top {
-    display: flex;
-
     a.title-link {
       color: inherit; // underline is enough, the bright blue is too much
     }
 
-    .collection-desc {
-      flex-grow: 1;
-      flex-shrink: 1;
-      //padding-bottom: $line-height-computed;
-    }
     .collection-thumb {
-      min-width: 266px;
-      flex-shrink: 0;
+      float: right;
+
+      width: 266px;
       margin-left: 3rem;
       margin-bottom: $spacer;
 

--- a/app/assets/stylesheets/local/related_link.scss
+++ b/app/assets/stylesheets/local/related_link.scss
@@ -1,0 +1,5 @@
+.related-link-component {
+  // can sometimes have URLs in it
+  overflow-wrap: break-word;
+  word-wrap: break-work;
+}

--- a/app/assets/stylesheets/local/work_show.scss
+++ b/app/assets/stylesheets/local/work_show.scss
@@ -71,9 +71,7 @@
   }
 
   .related-link-component {
-    // can sometimes have URLs in it
-    overflow-wrap: break-word;
-    word-wrap: break-work;
+    @extend .mb-4;
   }
 
   .related-work {

--- a/app/components/related_link_component.html.erb
+++ b/app/components/related_link_component.html.erb
@@ -1,4 +1,4 @@
-<div class="mb-4 related-link-component">
+<div class="related-link-component">
   <div class="show-genre"><%= link_category_display %></div>
   <div class="h4">
     <%= link_to (related_link.label.presence || related_link.url), related_link.url, target: link_target  %>

--- a/app/views/collection_show/index.html.erb
+++ b/app/views/collection_show/index.html.erb
@@ -5,6 +5,12 @@
 
   <div class="collection-top">
     <div class="collection-desc clearfix">
+      <% unless has_search_parameters? %>
+        <div class="collection-thumb">
+          <%= render ThumbComponent.new(collection.leaf_representative, thumb_size: :collection_page, placeholder_img_url: asset_path("default_collection.svg")) %>
+        </div>
+      <% end %>
+
       <div class="show-title">
         <header>
           <div class="show-genre"><%= link_to "Collections", collections_path %></div>
@@ -17,16 +23,11 @@
         </header>
       </div>
 
+
       <% unless has_search_parameters? %>
         <%= render CollectionMetadataComponent.new(collection: collection) %>
       <% end %>
     </div>
-
-    <% unless has_search_parameters? %>
-      <div class="collection-thumb">
-        <%= render ThumbComponent.new(collection.leaf_representative, thumb_size: :collection_page, placeholder_img_url: asset_path("default_collection.svg")) %>
-      </div>
-    <% end %>
   </div>
 
 


### PR DESCRIPTION
Make related links on collection page wrap as intended when there are many of them -- and take up full width of page. Ref #1858

Pursuant to doing that, I also changed the collection thumbnail to be FLOATED, so at certain screen sizes text will wrap around it. 

At first I thought this was kind of necessary for the desired full-width related links, and maybe also beneficial for responsive behavior in general... but after actually doing it, I realize that wasnt' really true, as far as the HTML is concenred there was another way... but now it's done, and the other way will require more substantial refacotrings of how we divide our code up between components... so I'm going to propose just this for now, with the float change?  Even though the float is kind of weird in some ways. It's mostly the same except at very specific intermediate screen sizes. 

(In general, this CSS, which I am responsible for, has become very hard to manage, spagetthi CSS with difficult intertwined self-dependencies.)

## Before

![before1](https://user-images.githubusercontent.com/149304/189984971-f689f4cf-a334-4f57-a90f-3bf87720da16.png)
![before2](https://user-images.githubusercontent.com/149304/189984973-da0b339f-b07c-4713-a37f-2794dbe87736.png)

## After
![after1](https://user-images.githubusercontent.com/149304/189984995-223722d8-a81c-4143-bbc5-ab5a0bd0051a.png)




![after2](https://user-images.githubusercontent.com/149304/189985006-ef70d541-76c9-4317-bc04-a849d7ed63ee.png)
