### PR TITLE
Try to better auto-detect Rails development settings for app_url_base

### DIFF
--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -139,7 +139,11 @@ module ScihistDigicoll
         # This seems to match what Rails/Capybara/Rspec are using/expect
         "http://127.0.0.1"
       elsif Rails.env.development?
-        "http://localhost:3000"
+        # hacky maybe not public API way to try to get current dev server
+        require "rails/commands/server/server_command"
+        server_options = Rails::Command::ServerCommand.new([], ARGV).server_options
+
+        "#{server_options[:SSLEnable] ? 'https' : 'http'}://#{server_options[:Host] || ENV['HOST'] || 'localhost'}:#{server_options[:Port] || ENV['PORT'] || '3000'}"
       end
     }
 


### PR DESCRIPTION
Our app needs to know the "base url". I realized we were defaulting to assume it was alwasy http://localhost:3000 in development. While you can always locally set APP_URL_BASE to something differnet, can we default to auto detecting if you for instance did `rails server -p 3002`, a totally normal and reasonable thing to do? And annoying if every time you change the port you need to change teh setting of a local APP_URL_BASE too?

I found a way to do it, although it's pretty hacky and uses maybe not entirely public Rails API. But maybe it'll work out?
