### PR TITLE
Atom format search results are back

### DIFF
--- a/app/components/atom_entry_component.atom.builder
+++ b/app/components/atom_entry_component.atom.builder
@@ -1,0 +1,19 @@
+xml.entry("xmlns:media" => "http://search.yahoo.com/mrss/") do
+  xml.title model.title
+
+  xml.updated (model.updated_at&.iso8601 || Time.current.iso8601)
+
+  xml.id work_url(model)
+  xml.link "rel" => "alternate", "type" => "text/html", "href" => work_url(model)
+
+  xml.link rel: "alternate", type: "application/xml", title: "OAI-DC metadata in XML", href: work_url(model, format: "xml")
+  xml.link rel: "alternate", type: "application/json", title: "local non-standard metadata in JSON", href: work_url(model, format: "json")
+
+  if thumbnail_url
+    xml.media :thumbnail, thumbnail_url
+  end
+
+  xml.summary "type" => "html" do
+    xml.text! DescriptionDisplayFormatter.new(model.description).format
+  end
+end

--- a/app/components/atom_entry_component.atom.builder
+++ b/app/components/atom_entry_component.atom.builder
@@ -4,10 +4,11 @@ xml.entry("xmlns:media" => "http://search.yahoo.com/mrss/") do
   xml.updated (model.updated_at&.iso8601 || Time.current.iso8601)
 
   xml.id work_url(model)
-  xml.link "rel" => "alternate", "type" => "text/html", "href" => work_url(model)
+  xml.link "rel" => "alternate", "type" => "text/html", "href" => model_html_url
 
-  xml.link rel: "alternate", type: "application/xml", title: "OAI-DC metadata in XML", href: work_url(model, format: "xml")
-  xml.link rel: "alternate", type: "application/json", title: "local non-standard metadata in JSON", href: work_url(model, format: "json")
+  model_alternate_links.each do |link_hash|
+    xml.link rel: "alternate", **link_hash
+  end
 
   if thumbnail_url
     xml.media :thumbnail, thumbnail_url

--- a/app/components/atom_entry_component.rb
+++ b/app/components/atom_entry_component.rb
@@ -1,0 +1,15 @@
+class AtomEntryComponent < ApplicationComponent
+  attr_reader :model
+
+  def initialize(model)
+    raise ArgumentError.new("#{self.class} requires non-nil model argument") unless model
+    @model = model
+  end
+
+  private
+
+  def thumbnail_url
+    WorkOaiDcSerialization.shareable_thumbnail_url(model)
+  end
+
+end

--- a/app/components/atom_entry_component.rb
+++ b/app/components/atom_entry_component.rb
@@ -3,6 +3,7 @@ class AtomEntryComponent < ApplicationComponent
 
   def initialize(model)
     raise ArgumentError.new("#{self.class} requires non-nil model argument") unless model
+    raise ArgumentError.new("#{self.class} only supports Work and Collection, not `#{model.class.name}`") unless model.kind_of?(Work) || model.kind_of?(Collection)
     @model = model
   end
 
@@ -12,4 +13,31 @@ class AtomEntryComponent < ApplicationComponent
     WorkOaiDcSerialization.shareable_thumbnail_url(model)
   end
 
+  def model_html_url
+    if model.kind_of?(Work)
+      work_url(model)
+    else
+      collection_url(model)
+    end
+  end
+
+  def model_alternate_links
+    if model.kind_of?(Work)
+      [
+        {
+          type: "application/xml",
+          title: "OAI-DC metadata in XML",
+          href: work_url(model, format: "xml")
+        },
+        {
+          type: "application/json",
+          title: "local non-standard metadata in JSON",
+          href: work_url(model, format: "json")
+        }
+      ]
+    else
+      # we don't currently have .xml and .json metadata links for Collections
+      []
+    end
+  end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -119,8 +119,6 @@ class CatalogController < ApplicationController
     # See issue https://github.com/sciencehistory/scihist_digicoll/pull/497 for more details.
     def rss_feed_link_tag(options = {})
     end
-    def atom_feed_link_tag(options = {})
-    end
     def json_api_link_tag(options = {})
     end
   end
@@ -497,6 +495,7 @@ class CatalogController < ApplicationController
     # if the name of the solr.SuggestComponent provided in your solrcongig.xml is not the
     # default 'mySuggester', uncomment and provide it below
     # config.autocomplete_suggester = 'mySuggester'
+    #
   end
 
   # Some bad actors sometimes send query params that Blacklight doesn't expect and
@@ -594,7 +593,7 @@ class CatalogController < ApplicationController
   #   /focus/alchemy.json
   # See https://github.com/sciencehistory/scihist_digicoll/issues/1578
   def catch_bad_format_param
-    if ['json', 'atom', 'rss'].include? params[:format]
+    if ['json', 'rss'].include? params[:format]
       render plain: "Invalid parameter: we do not provide search results in #{params[:format]} format.", status: 406
     end
   end

--- a/app/serializers/work_oai_dc_serialization.rb
+++ b/app/serializers/work_oai_dc_serialization.rb
@@ -19,6 +19,9 @@ class WorkOaiDcSerialization
   # A URL that can be shared with external partners for a thumbnail. This class
   # method may be used by other parts of the app too.
   #
+  # @param model [Work,Collection] works for Collections too, since their thumbnails
+  #   are also at a #representative asset
+  #
   # @return [String, nil] a URL to a suitable thumbnail/preview image, or nil if none is available.
   #
   # We are using our app url that will REDIRECT to S3:
@@ -39,9 +42,9 @@ class WorkOaiDcSerialization
   # bigger is better than not big enough, especially for DPLA, that seems to use this
   # as a pretty big image in some contexts? Not sure.
   #
-  def self.shareable_thumbnail_url(work)
-    if work.leaf_representative && work.leaf_representative.published?
-      "#{ScihistDigicoll::Env.lookup!(:app_url_base)}/downloads/deriv/#{work.leaf_representative.friendlier_id}/thumb_large_2X?disposition=inline"
+  def self.shareable_thumbnail_url(model)
+    if model.leaf_representative && model.leaf_representative.published?
+      "#{ScihistDigicoll::Env.lookup!(:app_url_base)}/downloads/deriv/#{model.leaf_representative.friendlier_id}/thumb_large_2X?disposition=inline"
     else
       nil
     end

--- a/app/serializers/work_oai_dc_serialization.rb
+++ b/app/serializers/work_oai_dc_serialization.rb
@@ -40,7 +40,7 @@ class WorkOaiDcSerialization
   # as a pretty big image in some contexts? Not sure.
   #
   def self.shareable_thumbnail_url(work)
-    if work.leaf_representative
+    if work.leaf_representative && work.leaf_representative.published?
       "#{ScihistDigicoll::Env.lookup!(:app_url_base)}/downloads/deriv/#{work.leaf_representative.friendlier_id}/thumb_large_2X?disposition=inline"
     else
       nil

--- a/app/views/catalog/index.atom.builder
+++ b/app/views/catalog/index.atom.builder
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+#
+# copy-paste-modify OVERRIDE of blacklight template at:
+#    https://github.com/projectblacklight/blacklight/blob/v7.29.0/app/views/catalog/index.atom.builder
+#
+# We are mostly only modifying the individual document results (<entry> tags) -- while hypothethetically
+# there might be a Blacklight want to have done this via configuration without overriding the whole
+# index.atom.builder template, had trouble figuring it out, it seemed pretty hinky and potentially fragile,
+# seemed better just to take control of the whole response, with some copy/paste.
+#
+# We now call out to an AtomEntry component for the entry element. We send it a Kithe::Model ActiveRecord
+# object, which is available due to our use of the Kithe::BlacklightTools::BulkLoadingSearchService extension.
+
+require 'base64'
+
+xml.instruct!(:xml, encoding: "UTF-8")
+
+xml.feed("xmlns" => "http://www.w3.org/2005/Atom",
+         "xmlns:opensearch" => "http://a9.com/-/spec/opensearch/1.1/") do
+  xml.title   t('blacklight.search.page_title.title', constraints: render_search_to_page_title(params), application_name: application_name)
+  # an author is required, so we'll just use the app name
+  xml.author { xml.name application_name }
+
+  xml.link    "rel" => "self", "href" => url_for(search_state.to_h.merge(only_path: false))
+  xml.link    "rel" => "alternate", "href" => url_for(search_state.to_h.merge(only_path: false, format: nil)), "type" => "text/html"
+  xml.id      url_for(search_state.to_h.merge(only_path: false, format: nil))
+
+  # Navigational and context links
+
+  xml.link( "rel" => "next",
+            "href" => url_for(search_state.to_h.merge(only_path: false, page: @response.next_page.to_s))
+           ) if @response.next_page
+
+  xml.link( "rel" => "previous",
+            "href" => url_for(search_state.to_h.merge(only_path: false, page: @response.prev_page.to_s))
+           ) if @response.prev_page
+
+  xml.link( "rel" => "first",
+            "href" => url_for(search_state.to_h.merge(only_path: false, page: "1")))
+
+  xml.link( "rel" => "last",
+            "href" => url_for(search_state.to_h.merge(only_path: false, page: @response.total_pages.to_s)))
+
+  # "search" doesn't seem to actually be legal, but is very common, and
+  # used as an example in opensearch docs
+  xml.link( "rel" => "search",
+            "type" => "application/opensearchdescription+xml",
+            "href" => url_for(controller: 'catalog',action: 'opensearch', format: 'xml', only_path: false))
+
+  # opensearch response elements
+  xml.opensearch :totalResults, @response.total.to_s
+  xml.opensearch :startIndex, @response.start.to_s
+  xml.opensearch :itemsPerPage, @response.limit_value
+  xml.opensearch :Query, role: "request", searchTerms: params[:q], startPage: @response.current_page
+
+  # updated is required, for now we'll just set it to now, sorry
+  xml.updated Time.current.iso8601
+
+  @response.documents.each do |document|
+    # A Document is a SolrDocument, it should have a `model` attribute with our
+    # actual Kithe::Model AR objects, due to our use of Kithe::BlacklightTools::BulkLoadingSearchService
+    if document.model
+      xml << render(AtomEntryComponent.new(document.model))
+    else
+      Rails.logger.error("index.atom.builder: No model found for #{document.id}; out of date solr index?")
+    end
+  end
+end

--- a/spec/components/atom_entry_component_spec.rb
+++ b/spec/components/atom_entry_component_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe AtomEntryComponent, type: :component do
+  describe "for work" do
+    let(:work) { create(:public_work, :with_complete_metadata) }
+    let(:rendered) { render_inline(AtomEntryComponent.new(work)) }
+
+    it "produces atom entry" do
+      expect(rendered.at_css("title")&.text).to eq work.title
+      expect(rendered.at_css("updated")&.text).to eq work.updated_at.iso8601
+
+      expect(rendered.at_css("link[rel=alternate][type='text/html']")["href"]).to eq work_url(work)
+      expect(rendered.at_css("link[rel=alternate][type='application/json']")['href']).to eq work_url(work, format: "json")
+      expect(rendered.at_css("link[rel=alternate][type='application/xml']")['href']).to eq work_url(work, format: "xml")
+
+      # I don't know why the namespace is being funny here, not letting us use ordinary
+      # nokogiri actual nameespace checking for "media:thumbnanil"
+      expect(rendered.at_css("thumbnail").text).to eq WorkOaiDcSerialization.shareable_thumbnail_url(work)
+
+      expect(rendered.at_css("summary[type=html]").text.strip).to eq DescriptionDisplayFormatter.new(work.description).format
+    end
+  end
+end

--- a/spec/components/atom_entry_component_spec.rb
+++ b/spec/components/atom_entry_component_spec.rb
@@ -20,4 +20,26 @@ describe AtomEntryComponent, type: :component do
       expect(rendered.at_css("summary[type=html]").text.strip).to eq DescriptionDisplayFormatter.new(work.description).format
     end
   end
+
+  describe "for collection" do
+    let(:collection) { create(:collection, :with_representative, published: true) }
+    let(:rendered) { render_inline(AtomEntryComponent.new(collection)) }
+
+    it "produces atom entry" do
+      expect(rendered.at_css("title")&.text).to eq collection.title
+      expect(rendered.at_css("updated")&.text).to eq collection.updated_at.iso8601
+
+      expect(rendered.at_css("link[rel=alternate][type='text/html']")["href"]).to eq collection_url(collection)
+
+      # we don't support collection metadata APIs at present
+      expect(rendered.at_css("link[rel=alternate][type='application/json']")).to be_nil
+      expect(rendered.at_css("link[rel=alternate][type='application/xml']")).to be_nil
+
+      # I don't know why the namespace is being funny here, not letting us use ordinary
+      # nokogiri actual nameespace checking for "media:thumbnanil"
+      expect(rendered.at_css("thumbnail").text).to eq WorkOaiDcSerialization.shareable_thumbnail_url(collection)
+
+      expect(rendered.at_css("summary[type=html]").text.strip).to eq DescriptionDisplayFormatter.new(collection.description).format
+    end
+  end
 end

--- a/spec/factories/collection_factory.rb
+++ b/spec/factories/collection_factory.rb
@@ -13,5 +13,9 @@ FactoryBot.define do
     }
     department { "Archives" }
     published { true }
+
+    trait :with_representative do
+      representative { build(:asset, :inline_promoted_file, published: true) }
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,6 +71,8 @@ RSpec.configure do |config|
   config.include ViewComponent::TestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
   config.include Devise::Test::ControllerHelpers, type: :component
+  # and let us use route helpers in components
+  config.include Rails.application.routes.url_helpers, type: :component
   config.before(:each, type: :component) do
     # for devise support according to ViewComponent docs.
     @request = controller.request
@@ -95,6 +97,10 @@ RSpec.configure do |config|
   # feature vs system? I'm confused.
   config.before(:each, type: /\A(feature|system)\Z/) do
     default_url_options[:host] = ScihistDigicoll::Env.app_url_base_parsed.host
+  end
+  # in view components, urls generated use `test.host`, I don't know why
+  config.before(:each, type: :component) do
+    default_url_options[:host] = "test.host"
   end
 
   # tag your context or text with :logged_in_user, and we'll use devise to

--- a/spec/requests/catalog_search_atom_spec.rb
+++ b/spec/requests/catalog_search_atom_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe CatalogController, solr: true, indexable_callbacks: true, type: :request do
+  let(:parsed_response) do
+    Nokogiri::XML::Document.parse(response.body) do |config|
+      config.strict
+    end
+  end
+
+  let(:namespaces) do
+    {
+      atom: "http://www.w3.org/2005/Atom",
+      opensearch: "http://a9.com/-/spec/opensearch/1.1/",
+      media: "http://search.yahoo.com/mrss/"
+    }
+  end
+
+
+  let!(:work1) do
+    create(:public_work, :with_complete_metadata, title: "priceless work")
+  end
+
+  let!(:work2) do
+    create(:public_work, :with_complete_metadata, title: "ordinary work")
+  end
+
+  let!(:collection) do
+    create(:collection, published: true, title: 'a nice collection')
+  end
+
+  before do
+    get search_catalog_path(format: :atom)
+  end
+
+  it "produces valid Atom XML" do
+    xsd = Nokogiri::XML::Schema(File.open(Rails.root + "spec/test_support/xml_schema/atom.xsd"))
+    expect(xsd.valid?(parsed_response))
+
+    expect(parsed_response.xpath("./atom:feed/atom:entry", namespaces).count).to eq 3
+
+    expect(parsed_response.at_xpath("./atom:feed/atom:link[@rel='alternate'][@type='text/html']", namespaces)["href"]).to eq(
+      search_catalog_url
+    )
+    expect(parsed_response.at_xpath("./atom:feed/opensearch:totalResults", namespaces).text).to eq "3"
+  end
+end

--- a/spec/serializers/work_oai_dc_serialization_spec.rb
+++ b/spec/serializers/work_oai_dc_serialization_spec.rb
@@ -106,4 +106,31 @@ describe WorkOaiDcSerialization do
       expect(container.at_xpath("./edm:object")).to be_nil
     end
   end
+
+  describe ".shareable_thumbnail_url class method" do
+    let(:model) { create(:public_work) }
+    let(:url) { WorkOaiDcSerialization.shareable_thumbnail_url(model) }
+
+    it "delivers an absolute URL" do
+      expect(url).to be_present
+      expect(URI.parse(url).absolute?).to be true
+    end
+
+    it "delivers a local URL for thumb_large_2x" do
+      expected_url = Rails.application.routes.url_helpers.download_derivative_url(
+        model.leaf_representative, :thumb_large_2X,
+        disposition: :inline,
+        host: ScihistDigicoll::Env.app_url_base_parsed.host
+      )
+
+      expect(url).to eq expected_url
+    end
+
+    describe "with no representative" do
+      let(:model) { create(:public_work, members: []) }
+      it "delivers nil result" do
+        expect(url).to be_nil
+      end
+    end
+  end
 end

--- a/spec/serializers/work_oai_dc_serialization_spec.rb
+++ b/spec/serializers/work_oai_dc_serialization_spec.rb
@@ -140,5 +140,15 @@ describe WorkOaiDcSerialization do
         expect(url).to be_nil
       end
     end
+
+    # collections have their thumbnails as #representative too, so
+    describe "with collection" do
+      let(:model) { create(:public_work, representative: create(:asset, published: true)) }
+
+      it "delivers an absolute URL" do
+        expect(url).to be_present
+        expect(URI.parse(url).absolute?).to be true
+      end
+    end
   end
 end

--- a/spec/serializers/work_oai_dc_serialization_spec.rb
+++ b/spec/serializers/work_oai_dc_serialization_spec.rb
@@ -132,5 +132,13 @@ describe WorkOaiDcSerialization do
         expect(url).to be_nil
       end
     end
+
+    describe "with non-public reprensentative" do
+      let(:private_asset) { create(:asset, published: false) }
+      let(:model) { create(:public_work, members: [private_asset], representative: private_asset) }
+      it "delivers nil result" do
+        expect(url).to be_nil
+      end
+    end
   end
 end

--- a/spec/test_support/xml_schema/atom.xsd
+++ b/spec/test_support/xml_schema/atom.xsd
@@ -1,0 +1,451 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- From https://github.com/docjason/XmlValidate/blob/64e6921a721facf957230e7aeb79746a4d2ef6cd/schemas/atom.xsd -->
+
+
+<!--
+		-*- rnc -*- RELAX NG Compact Syntax Grammar for the Atom Format
+		Specification Version 11
+-->
+<!--
+		$Revision: 34 $
+		$Date: 2009-08-07 18:20:47 -0400 (Fri, 07 Aug 2009) $
+		$Author: albertcbrown $
+		$HeadURL: file:///var/lib/subversion/cmis/trunk/SchemaProject/schema/ATOM.xsd $
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        elementFormDefault="qualified" targetNamespace="http://www.w3.org/2005/Atom"
+        xmlns:atom="http://www.w3.org/2005/Atom" xmlns:xhtml="http://www.w3.org/1999/xhtml"
+        xmlns:xml="http://www.w3.org/XML/1998/namespace"
+        xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+        jaxb:extensionBindingPrefixes="xjc" jaxb:version="2.1" version="0.62d">
+
+        <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+                schemaLocation="xml.xsd" />
+
+        <!-- Common attributes -->
+        <xs:attributeGroup name="atomCommonAttributes">
+                <xs:attribute ref="xml:base" />
+                <xs:attribute ref="xml:lang" />
+                <xs:attributeGroup ref="atom:undefinedAttribute" />
+        </xs:attributeGroup>
+        <!-- Text Constructs -->
+        <xs:attributeGroup name="atomPlainTextConstruct">
+                <xs:attributeGroup ref="atom:atomCommonAttributes" />
+                <xs:attribute name="type">
+                        <xs:simpleType>
+                                <xs:restriction base="xs:token">
+                                        <xs:enumeration value="text" />
+                                        <xs:enumeration value="html" />
+                                </xs:restriction>
+                        </xs:simpleType>
+                </xs:attribute>
+        </xs:attributeGroup>
+        <xs:group name="atomXHTMLTextConstruct">
+                <xs:sequence>
+                        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="http://www.w3.org/1999/xhtml" />
+                </xs:sequence>
+        </xs:group>
+        <xs:attributeGroup name="atomXHTMLTextConstruct">
+                <xs:attributeGroup ref="atom:atomCommonAttributes" />
+                <xs:attribute name="type" use="required">
+                        <xs:simpleType>
+                                <xs:restriction base="xs:token">
+                                        <xs:enumeration value="xhtml" />
+                                </xs:restriction>
+                        </xs:simpleType>
+                </xs:attribute>
+        </xs:attributeGroup>
+        <xs:complexType name="atomTextConstruct" mixed="true">
+                <xs:group minOccurs="0" ref="atom:atomXHTMLTextConstruct" />
+                <xs:attribute name="type">
+                        <xs:simpleType>
+                                <xs:restriction base="xs:token">
+                                        <xs:enumeration value="text" />
+                                        <xs:enumeration value="html" />
+                                        <xs:enumeration value="xhtml" />
+                                </xs:restriction>
+                        </xs:simpleType>
+                </xs:attribute>
+                <xs:attributeGroup ref="atom:atomCommonAttributes" />
+        </xs:complexType>
+        <!-- Person Construct -->
+        <xs:complexType name="atomPersonConstruct">
+                <xs:sequence>
+                        <xs:element ref="atom:name" minOccurs="0" maxOccurs="1" />
+                        <xs:element ref="atom:uri" minOccurs="0" maxOccurs="1" />
+                        <xs:element ref="atom:email" minOccurs="0" maxOccurs="1" />
+                        <xs:group ref="atom:extensionElement" minOccurs="0"
+                                maxOccurs="unbounded" />
+                </xs:sequence>
+                <xs:attributeGroup ref="atom:atomCommonAttributes" />
+        </xs:complexType>
+        <xs:element name="name" type="xs:string" />
+        <xs:element name="uri" type="xs:string" />
+        <xs:element name="email" type="atom:atomEmailAddress" />
+        <!-- Date Construct -->
+        <xs:complexType name="atomDateConstruct">
+                <xs:simpleContent>
+                        <xs:extension base="xs:dateTime">
+                                <xs:attributeGroup ref="atom:atomCommonAttributes" />
+                        </xs:extension>
+                </xs:simpleContent>
+        </xs:complexType>
+        <!-- atom:feed -->
+        <xs:element name="feed" type="atom:feedType"></xs:element>
+        <xs:complexType name="feedType">
+                <xs:sequence>
+                        <xs:choice maxOccurs="unbounded">
+                                <xs:annotation>
+                                        <xs:appinfo>
+                                                <jaxb:property name="items" />
+                                        </xs:appinfo>
+                                </xs:annotation>
+                                <xs:element ref="atom:author" />
+                                <xs:element ref="atom:category" />
+                                <xs:element ref="atom:contributor" />
+                                <xs:element ref="atom:generator" />
+                                <xs:element ref="atom:icon" />
+                                <xs:element ref="atom:id" />
+                                <xs:element ref="atom:link" />
+                                <xs:element ref="atom:logo" />
+                                <xs:element ref="atom:rights" />
+                                <xs:element ref="atom:subtitle" />
+                                <xs:element ref="atom:title" />
+                                <xs:element ref="atom:updated" />
+                        </xs:choice>
+
+                        <!--  original atom extension element -->
+                        <xs:group ref="atom:extensionElement" />
+
+                        <xs:element minOccurs="0" maxOccurs="unbounded" ref="atom:entry" />
+                </xs:sequence>
+                <xs:attributeGroup ref="atom:atomCommonAttributes" />
+        </xs:complexType>
+        <!-- atom:entry -->
+        <xs:element name="entry" type="atom:entryType">
+        </xs:element>
+        <xs:complexType name="entryType">
+                <xs:sequence>
+                        <xs:choice maxOccurs="unbounded">
+                                <xs:annotation>
+                                        <xs:appinfo>
+                                                <jaxb:property name="items" />
+                                        </xs:appinfo>
+                                </xs:annotation>
+                                <xs:element ref="atom:author" />
+                                <xs:element ref="atom:category" />
+                                <xs:element ref="atom:content" />
+                                <xs:element ref="atom:contributor" />
+                                <xs:element ref="atom:id" />
+                                <xs:element ref="atom:link" />
+                                <xs:element ref="atom:published" />
+                                <xs:element ref="atom:rights" />
+                                <xs:element ref="atom:source" />
+                                <xs:element ref="atom:summary" />
+                                <xs:element ref="atom:title" />
+                                <xs:element ref="atom:updated" />
+                        </xs:choice>
+
+                        <!-- Normal ATOM extension element -->
+                        <xs:group ref="atom:extensionElement" />
+                </xs:sequence>
+                <xs:attributeGroup ref="atom:atomCommonAttributes" />
+        </xs:complexType>
+
+        <!-- atom:content -->
+        <xs:attributeGroup name="atomInlineTextConstruct">
+                <xs:attributeGroup ref="atom:atomCommonAttributes" />
+                <xs:attribute name="type">
+                        <xs:simpleType>
+                                <xs:restriction base="xs:token">
+                                        <xs:enumeration value="text" />
+                                        <xs:enumeration value="html" />
+                                </xs:restriction>
+                        </xs:simpleType>
+                </xs:attribute>
+        </xs:attributeGroup>
+        <xs:group name="atomInlineOtherConstruct">
+                <xs:sequence>
+                        <xs:group minOccurs="0" maxOccurs="unbounded" ref="atom:anyElement" />
+                </xs:sequence>
+        </xs:group>
+        <xs:attributeGroup name="atomInlineOtherConstruct">
+                <xs:attributeGroup ref="atom:atomCommonAttributes" />
+                <xs:attribute name="type">
+                        <xs:simpleType>
+                                <xs:union memberTypes="atom:atomMediaType">
+                                        <xs:simpleType>
+                                                <xs:restriction base="xs:token">
+                                                        <xs:enumeration value="xhtml" />
+                                                </xs:restriction>
+                                        </xs:simpleType>
+                                </xs:union>
+                        </xs:simpleType>
+                </xs:attribute>
+        </xs:attributeGroup>
+        <xs:attributeGroup name="atomOutOfLineConstruct">
+                <xs:attributeGroup ref="atom:atomCommonAttributes" />
+                <xs:attribute name="type" type="atom:atomMediaType" />
+                <xs:attribute name="src" use="required" />
+        </xs:attributeGroup>
+        <xs:element name="content">
+                <xs:complexType mixed="true">
+                        <xs:group minOccurs="0" ref="atom:atomInlineOtherConstruct" />
+                        <xs:attribute name="type">
+                                <xs:simpleType>
+                                        <xs:union memberTypes="atom:atomMediaType">
+                                                <xs:simpleType>
+                                                        <xs:restriction base="xs:token">
+                                                                <xs:enumeration value="text" />
+                                                                <xs:enumeration value="html" />
+                                                        </xs:restriction>
+                                                </xs:simpleType>
+                                                <xs:simpleType>
+                                                        <xs:union memberTypes="atom:atomMediaType">
+                                                                <xs:simpleType>
+                                                                        <xs:restriction base="xs:token">
+                                                                                <xs:enumeration value="xhtml" />
+                                                                        </xs:restriction>
+                                                                </xs:simpleType>
+                                                        </xs:union>
+                                                </xs:simpleType>
+                                        </xs:union>
+                                </xs:simpleType>
+                        </xs:attribute>
+                        <xs:attributeGroup ref="atom:atomCommonAttributes" />
+                        <xs:attribute name="src" />
+                </xs:complexType>
+        </xs:element>
+        <!-- atom:author -->
+        <xs:element name="author" type="atom:atomPersonConstruct" />
+        <!-- atom:category -->
+        <xs:element name="category">
+                <xs:complexType>
+                        <xs:complexContent>
+                                <xs:extension base="atom:undefinedContent">
+                                        <xs:attributeGroup ref="atom:atomCommonAttributes" />
+                                        <xs:attribute name="term" use="required" />
+                                        <xs:attribute name="scheme" />
+                                        <xs:attribute name="label" />
+                                </xs:extension>
+                        </xs:complexContent>
+                </xs:complexType>
+        </xs:element>
+        <!-- atom:contributor -->
+        <xs:element name="contributor" type="atom:atomPersonConstruct" />
+        <!-- atom:generator -->
+        <xs:element name="generator">
+                <xs:complexType mixed="true">
+                        <xs:attributeGroup ref="atom:atomCommonAttributes" />
+                        <xs:attribute name="uri" />
+                        <xs:attribute name="version" />
+                </xs:complexType>
+        </xs:element>
+        <!-- atom:icon -->
+        <xs:element name="icon">
+                <xs:complexType mixed="true">
+                        <xs:attributeGroup ref="atom:atomCommonAttributes" />
+                </xs:complexType>
+        </xs:element>
+        <!-- atom:id -->
+        <xs:element name="id">
+                <xs:complexType mixed="true">
+                        <xs:attributeGroup ref="atom:atomCommonAttributes" />
+                </xs:complexType>
+        </xs:element>
+        <!-- atom:logo -->
+        <xs:element name="logo">
+                <xs:complexType mixed="true">
+                        <xs:attributeGroup ref="atom:atomCommonAttributes" />
+                </xs:complexType>
+        </xs:element>
+        <!-- atom:link -->
+        <xs:element name="link">
+                <xs:annotation>
+                        <xs:documentation>
+                                The "atom:link" element defines a reference from an
+                                entry or feed to a Web resource. This specification
+                                assigns no
+                                meaning to the content (if any) of this
+                                element.
+                        </xs:documentation>
+                </xs:annotation>
+
+                <xs:complexType>
+                        <xs:complexContent>
+                                <xs:extension base="atom:undefinedContent">
+                                        <xs:attributeGroup ref="atom:atomCommonAttributes" />
+                                        <xs:attribute name="href" use="required" />
+                                        <xs:attribute name="rel"></xs:attribute>
+                                        <xs:attribute name="type" type="atom:atomMediaType" />
+                                        <xs:attribute name="hreflang" type="atom:atomLanguageTag" />
+                                        <xs:attribute name="title" />
+                                        <xs:attribute name="length" />
+                                </xs:extension>
+                        </xs:complexContent>
+                </xs:complexType>
+        </xs:element>
+        <!-- atom:published -->
+        <xs:element name="published" type="atom:atomDateConstruct" />
+        <!-- atom:rights -->
+        <xs:element name="rights" type="atom:atomTextConstruct" />
+        <!-- atom:source -->
+        <xs:element name="source">
+                <xs:annotation>
+                        <xs:documentation>
+                                atom:source is used to preserve metadata of a feed
+                                when
+                                an entry is copied from a feed to another feed.
+                        </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                <xs:element ref="atom:author" />
+                                <xs:element ref="atom:category" />
+                                <xs:element ref="atom:contributor" />
+                                <xs:element ref="atom:generator" />
+                                <xs:element ref="atom:icon" />
+                                <xs:element ref="atom:id" />
+                                <xs:element ref="atom:link" />
+                                <xs:element ref="atom:logo" />
+                                <xs:element ref="atom:rights" />
+                                <xs:element ref="atom:subtitle" />
+                                <xs:element ref="atom:title" />
+                                <xs:element ref="atom:updated" />
+                                <xs:group ref="atom:extensionElement" />
+                        </xs:choice>
+                        <xs:attributeGroup ref="atom:atomCommonAttributes" />
+                </xs:complexType>
+        </xs:element>
+        <!-- atom:subtitle -->
+        <xs:element name="subtitle" type="atom:atomTextConstruct" />
+        <!-- atom:summary -->
+        <xs:element name="summary" type="atom:atomTextConstruct" />
+        <!-- atom:title -->
+        <xs:element name="title" type="atom:atomTextConstruct">
+                <xs:annotation>
+                        <xs:documentation>
+                                The "atom:title" element is a Text construct that
+                                conveys a human- readable title for an entry or feed.
+                                atomTitle =
+                                element atom:title { atomTextConstruct }.
+                        </xs:documentation>
+                </xs:annotation>
+        </xs:element>
+        <!-- atom:updated -->
+        <xs:element name="updated" type="atom:atomDateConstruct">
+                <xs:annotation>
+                        <xs:documentation>
+                                The "atom:updated" element is a Date construct
+                                indicating the most recent instant in time when an entry
+                                or feed was
+                                modified in a way the publisher considers
+                                significant. Therefore, not
+                                all modifications
+                                necessarily result in a changed atom:updated value.
+                                atomUpdated = element atom:updated { atomDateConstruct
+                                }. Publishers
+                                MAY change the value of this element over
+                                time.
+                        </xs:documentation>
+                </xs:annotation>
+        </xs:element>
+        <!-- Low-level simple types -->
+        <xs:simpleType name="atomNCName">
+                <xs:restriction base="xs:string">
+                        <xs:minLength value="1" />
+                        <xs:pattern value="[^:]*" />
+                </xs:restriction>
+        </xs:simpleType>
+        <!-- Whatever a media type is, it contains at least one slash -->
+        <xs:simpleType name="atomMediaType">
+                <xs:restriction base="xs:string">
+                        <xs:pattern value=".+/.+" />
+                </xs:restriction>
+        </xs:simpleType>
+        <!-- As defined in RFC 3066 -->
+        <xs:simpleType name="atomLanguageTag">
+                <xs:restriction base="xs:string">
+                        <xs:pattern value="[A-Za-z]{1,8}(-[A-Za-z0-9]{1,8})*" />
+                </xs:restriction>
+        </xs:simpleType>
+        <!--
+                Unconstrained; it's not entirely clear how IRI fit into xsd:anyURI so
+                let's not try to constrain it here
+        -->
+        <!-- Whatever an email address is, it contains at least one @ -->
+        <xs:simpleType name="atomEmailAddress">
+                <xs:restriction base="xs:string">
+                        <xs:pattern value=".+@.+" />
+                </xs:restriction>
+        </xs:simpleType>
+
+        <!-- Simple Extension -->
+        <xs:group name="extensionElement">
+                <xs:sequence>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0"
+                                maxOccurs="unbounded">
+                                <xs:annotation>
+                                        <xs:appinfo>
+                                                <jaxb:property name='anyOther' />
+                                        </xs:appinfo>
+                                </xs:annotation>
+                        </xs:any>
+                        <xs:any namespace="##local" processContents="lax" minOccurs="0"
+                                maxOccurs="unbounded">
+                                <xs:annotation>
+                                        <xs:appinfo>
+                                                <jaxb:property name='anyLocal' />
+                                        </xs:appinfo>
+                                </xs:annotation>
+                        </xs:any>
+                </xs:sequence>
+        </xs:group>
+        <xs:attributeGroup name="undefinedAttribute">
+                <xs:anyAttribute namespace="##other" processContents="lax" />
+        </xs:attributeGroup>
+        <xs:complexType name="undefinedContent">
+                <xs:sequence>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0"
+                                maxOccurs="unbounded">
+                                <xs:annotation>
+                                        <xs:appinfo>
+                                                <jaxb:property name='anyOther' />
+                                        </xs:appinfo>
+                                </xs:annotation>
+                        </xs:any>
+                        <xs:any namespace="##local" processContents="lax" minOccurs="0"
+                                maxOccurs="unbounded">
+                                <xs:annotation>
+                                        <xs:appinfo>
+                                                <jaxb:property name='anyLocal' />
+                                        </xs:appinfo>
+                                </xs:annotation>
+                        </xs:any>
+                </xs:sequence>
+
+                <!--
+                        <xs:group minOccurs="0" maxOccurs="unbounded"
+                        ref="atom:anyForeignElement" />
+                -->
+        </xs:complexType>
+        <xs:group name="anyElement">
+                <xs:sequence>
+                        <xs:any processContents="lax" />
+                </xs:sequence>
+        </xs:group>
+        <xs:group name="anyForeignElement">
+                <xs:sequence>
+                        <xs:any namespace="##other" processContents="lax" />
+                        <xs:any namespace="##local" processContents="lax" />
+                </xs:sequence>
+        </xs:group>
+        <!-- XHTML -->
+        <xs:group name="anyXHTML">
+                <xs:sequence>
+                        <xs:any namespace="http://www.w3.org/1999/xhtml"
+                                processContents="lax" />
+                </xs:sequence>
+        </xs:group>
+</xs:schema>

--- a/spec/test_support/xml_schema/xml.xsd
+++ b/spec/test_support/xml_schema/xml.xsd
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+		$Revision: 34 $
+		$Date: 2009-08-07 18:20:47 -0400 (Fri, 07 Aug 2009) $
+		$Author: albertcbrown $
+		$HeadURL: file:///var/lib/subversion/cmis/trunk/SchemaProject/schema/xml.xsd $
+-->
+<xsd:schema targetNamespace="http://www.w3.org/XML/1998/namespace" 
+ xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+ xml:lang="en">
+ 
+ <xsd:attribute name="lang">
+  <xsd:simpleType>
+   <xsd:union memberTypes="xsd:language">
+    <xsd:simpleType>    
+     <xsd:restriction base="xsd:string">
+      <xsd:enumeration value=""/>
+     </xsd:restriction>
+    </xsd:simpleType>
+   </xsd:union>
+  </xsd:simpleType>
+ </xsd:attribute>
+
+ <xsd:attribute name="space">
+  <xsd:simpleType>
+   <xsd:restriction base="xsd:NCName">
+    <xsd:enumeration value="default"/>
+    <xsd:enumeration value="preserve"/>
+   </xsd:restriction>
+  </xsd:simpleType>
+ </xsd:attribute>
+
+ <xsd:attribute name="base" type="xsd:anyURI">
+  <xsd:annotation>
+   <xsd:documentation>See http://www.w3.org/TR/xmlbase/ for
+                     information about this attribute.</xsd:documentation>
+  </xsd:annotation>
+ </xsd:attribute>
+ 
+ <xsd:attribute name="id" type="xsd:ID">
+  <xsd:annotation>
+   <xsd:documentation>See http://www.w3.org/TR/xml-id/ for
+                     information about this attribute.</xsd:documentation>
+  </xsd:annotation>
+ </xsd:attribute>
+
+ <xsd:attributeGroup name="specialAttrs">
+  <xsd:attribute ref="xml:base"/>
+  <xsd:attribute ref="xml:lang"/>
+  <xsd:attribute ref="xml:space"/>
+  <xsd:attribute ref="xml:id"/>
+ </xsd:attributeGroup>
+
+</xsd:schema>


### PR DESCRIPTION
Ref #1758 

We restore Atom formatted search results -- we don't get the Blacklight ones working again, instead we provide our own Atom results implementation, that displays based on the ActiveRecord models (kithe-style), instead of just Solr response documents (Blacklight style). 

While we potentially could have used the Blacklight framework to config a custom "document partial" for each atom result, to keep using the overall Atom template from Blacklight... this was hard to figure out how to do, would use a lot of Blacklight apparatus we don't actually want (like an additional partial template, when we really want to use a ViewComponent)... and the overall atom template is actually fairly simple. So we just copy-paste-and-modify the whole views/catalog/index.atom.builder partial to our local app, to override the blacklight one. 

Note it uses the `.builder` format for the template instead of `.erb`. (Our AtomEntry view component does too!).  That's convenient for XML. 

The Atom response includes <link>s to the .json and .xml (oai-dc) metadata responses for each Work result. This lets these all be used in concert as a kind of (Frankensteinian) API for getting lists of results, and then getting their metadata (in oai_dc xml or local custom json). Note the Atom search results are paginated, and include pagination <link>s in the <feed> too. (Blacklight already did this; I may have written the implementation myself a decade ago!)

We don't have .xml or .json responses for Collections. Collections can appear in Atom search results, they just won't have these <link>s to get machine-readable metadata, at present. Not part of our current use case, and kind of a pain for Reasons. 
