### PR TITLE
A couple additional tweaks to Work public json representation

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -23,7 +23,7 @@ class WorksController < ApplicationController
       }
 
       format.json {
-        render body: WorkJsonApiSerializer.new(
+        render body: WorkJsonSerializer.new(
           @work,
         ).serialize
       }

--- a/app/serializers/work_json_serializer.rb
+++ b/app/serializers/work_json_serializer.rb
@@ -44,6 +44,11 @@ class WorkJsonSerializer
     work.published_at&.iso8601
   end
 
+  attribute :updated_at do |work|
+    work.updated_at&.iso8601
+  end
+
+
   many :creator do
     attributes :category, :value
   end

--- a/app/serializers/work_json_serializer.rb
+++ b/app/serializers/work_json_serializer.rb
@@ -9,7 +9,7 @@
 # Consumers could consider the OAI_DC serialization as more stable (although currently
 # including fewer fields); we could add fields to that serialization with standard
 # identifiers, or consider other future alternate standard serializations.
-class WorkJsonApiSerializer
+class WorkJsonSerializer
   include Alba::Resource
 
   # let's suggest our outward-facing friendlier_id as the main id, but also

--- a/app/serializers/work_json_serializer.rb
+++ b/app/serializers/work_json_serializer.rb
@@ -41,11 +41,11 @@ class WorkJsonSerializer
   end
 
   attribute :published_at do |work|
-    work.published_at&.iso8601
+    work.published_at&.utc&.iso8601
   end
 
   attribute :updated_at do |work|
-    work.updated_at&.iso8601
+    work.updated_at&.utc&.iso8601
   end
 
 

--- a/spec/serializers/work_json_serializer_spec.rb
+++ b/spec/serializers/work_json_serializer_spec.rb
@@ -34,6 +34,7 @@ describe WorkJsonSerializer, type: :model, queue_adapter: :inline do
     expect(serializable_hash[:description_html]).to eq DescriptionDisplayFormatter.new(work.description).format
 
     expect(serializable_hash[:published_at]).to eq work.published_at.iso8601
+    expect(serializable_hash[:updated_at]).to eq work.updated_at.iso8601
 
     expect(serializable_hash[:physical_container].keys).to include(:box, :folder, :volume, :part, :page, :shelfmark, :formatted)
 

--- a/spec/serializers/work_json_serializer_spec.rb
+++ b/spec/serializers/work_json_serializer_spec.rb
@@ -33,8 +33,8 @@ describe WorkJsonSerializer, type: :model, queue_adapter: :inline do
     expect(serializable_hash[:description]).to eq work.description
     expect(serializable_hash[:description_html]).to eq DescriptionDisplayFormatter.new(work.description).format
 
-    expect(serializable_hash[:published_at]).to eq work.published_at.iso8601
-    expect(serializable_hash[:updated_at]).to eq work.updated_at.iso8601
+    expect(serializable_hash[:published_at]).to eq work.published_at.utc.iso8601
+    expect(serializable_hash[:updated_at]).to eq work.updated_at.utc.iso8601
 
     expect(serializable_hash[:physical_container].keys).to include(:box, :folder, :volume, :part, :page, :shelfmark, :formatted)
 

--- a/spec/serializers/work_json_serializer_spec.rb
+++ b/spec/serializers/work_json_serializer_spec.rb
@@ -5,9 +5,9 @@ require 'rails_helper'
 # structures change TOO much we may not be able to. We aren't at present
 # able to actually make guarantees here, we aren't a vendor.
 #
-describe WorkJsonApiSerializer, type: :model, queue_adapter: :inline do
+describe WorkJsonSerializer, type: :model, queue_adapter: :inline do
   let(:work) { create(:work, :published, :with_complete_metadata) }
-  let(:serializable_hash) { WorkJsonApiSerializer.new(work).serializable_hash }
+  let(:serializable_hash) { WorkJsonSerializer.new(work).serializable_hash }
 
   # just a 'macro' to for common tests on a key expecte to have an array of hashes
   # having certain keys.


### PR DESCRIPTION
Ref #1758 

- change name to WorkJsonSerializer since we didn't go with json:api
- add updated_at to Work json serialization
- dates in JSON serialization in UTC
