### PR TITLE
Fix atom results for custom controller collections

### DIFF
--- a/app/views/catalog/index.atom.builder
+++ b/app/views/catalog/index.atom.builder
@@ -44,9 +44,14 @@ xml.feed("xmlns" => "http://www.w3.org/2005/Atom",
 
   # "search" doesn't seem to actually be legal, but is very common, and
   # used as an example in opensearch docs
-  xml.link( "rel" => "search",
-            "type" => "application/opensearchdescription+xml",
-            "href" => url_for(controller: 'catalog',action: 'opensearch', format: 'xml', only_path: false))
+  #
+  # Actually, our opensearch response may or may not be fully working at ALL, but def
+  # isn't for collection pages. Only output this for base catalog controller, sorry hacky.
+  if controller.instance_of?(CatalogController)
+    xml.link( "rel" => "search",
+              "type" => "application/opensearchdescription+xml",
+              "href" => url_for(action: 'opensearch', format: 'xml', only_path: false))
+  end
 
   # opensearch response elements
   xml.opensearch :totalResults, @response.total.to_s

--- a/spec/requests/catalog_search_atom_spec.rb
+++ b/spec/requests/catalog_search_atom_spec.rb
@@ -15,32 +15,50 @@ RSpec.describe CatalogController, solr: true, indexable_callbacks: true, type: :
     }
   end
 
+  describe "for main catalog page" do
+    let!(:work1) do
+      create(:public_work, :with_complete_metadata, title: "priceless work")
+    end
 
-  let!(:work1) do
-    create(:public_work, :with_complete_metadata, title: "priceless work")
+    let!(:work2) do
+      create(:public_work, :with_complete_metadata, title: "ordinary work")
+    end
+
+    let!(:collection) do
+      create(:collection, published: true, title: 'a nice collection')
+    end
+
+    before do
+      get search_catalog_path(format: :atom)
+    end
+
+    it "produces valid Atom XML" do
+      xsd = Nokogiri::XML::Schema(File.open(Rails.root + "spec/test_support/xml_schema/atom.xsd"))
+      expect(xsd.valid?(parsed_response))
+
+      expect(parsed_response.xpath("./atom:feed/atom:entry", namespaces).count).to eq 3
+
+      expect(parsed_response.at_xpath("./atom:feed/atom:link[@rel='alternate'][@type='text/html']", namespaces)["href"]).to eq(
+        search_catalog_url
+      )
+      expect(parsed_response.at_xpath("./atom:feed/opensearch:totalResults", namespaces).text).to eq "3"
+    end
   end
 
-  let!(:work2) do
-    create(:public_work, :with_complete_metadata, title: "ordinary work")
-  end
+  describe "searching in a custom controller collection" do
+    let!(:collection) do
+      create(:collection,
+              friendlier_id: ScihistDigicoll::Env.lookup(:oral_history_collection_id)
+      ).tap do |col|
+        # need to create with existing collection so it gets Solr indexed
+        create(:public_work, contained_by: [col])
+        create(:public_work, contained_by: [col])
+      end
+    end
 
-  let!(:collection) do
-    create(:collection, published: true, title: 'a nice collection')
-  end
-
-  before do
-    get search_catalog_path(format: :atom)
-  end
-
-  it "produces valid Atom XML" do
-    xsd = Nokogiri::XML::Schema(File.open(Rails.root + "spec/test_support/xml_schema/atom.xsd"))
-    expect(xsd.valid?(parsed_response))
-
-    expect(parsed_response.xpath("./atom:feed/atom:entry", namespaces).count).to eq 3
-
-    expect(parsed_response.at_xpath("./atom:feed/atom:link[@rel='alternate'][@type='text/html']", namespaces)["href"]).to eq(
-      search_catalog_url
-    )
-    expect(parsed_response.at_xpath("./atom:feed/opensearch:totalResults", namespaces).text).to eq "3"
+    it "produces expected atom results" do
+      get collection_path(collection.friendlier_id, format: :atom)
+      expect(parsed_response.xpath("./atom:feed/atom:entry", namespaces).count).to eq 2
+    end
   end
 end


### PR DESCRIPTION
By elminating attempt to link to (broken) opensearch description for all collections. Even in cases where it was linking to something, it was not a correct opensearch description, for our custom use of searchable collection controllers

Ref #1869
