### PR TITLE
Limit request rate with rack-attack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -167,6 +167,8 @@ gem "irb", ">= 1.3.1"
 gem "reline", ">= 0.2.1"
 gem "warning", "~> 1.2" # managing ruby warning output
 
+gem "rack-attack", "~> 6.6" # throttling excessive requests
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'pry-byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -45,12 +45,15 @@ gem 'pg', '>= 0.18', '< 2.0'
 # Use Puma as the app server
 gem 'puma', '~> 5.6'
 
-# resque+redis being used for activejob, maybe later for Rails.cache
+# resque+redis being used for activejob.
 # resque-pool currently does not support resque 2.0 alas.
 # https://github.com/nevans/resque-pool/issues/170
 gem "resque", "~> 2.0"
 gem "resque-pool"
 gem "resque-heroku-signals" # gah, weirdly needed for graceful shutdown on heroku. https://github.com/resque/resque#heroku
+
+# using memcached for Rails.cache in production, requires dalli
+gem "dalli", "~> 3.2"
 
 gem 'honeybadger', '~> 4.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,7 @@ GEM
       csl (~> 2.0)
     css_parser (1.11.0)
       addressable
+    dalli (3.2.2)
     database_cleaner (2.0.1)
       database_cleaner-active_record (~> 2.0.0)
     database_cleaner-active_record (2.0.1)
@@ -726,6 +727,7 @@ DEPENDENCIES
   cocoon
   content_disposition (~> 1.0)
   csl-styles (~> 2.0)
+  dalli (~> 3.2)
   database_cleaner (~> 2.0)
   db-query-matchers (< 2.0)
   device_detector (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,6 +455,8 @@ GEM
       rdf
     racc (1.6.0)
     rack (2.2.4)
+    rack-attack (6.6.1)
+      rack (>= 1.0, < 3)
     rack-protection (2.2.2)
       rack
     rack-proxy (0.7.2)
@@ -755,6 +757,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 5.6)
   qa (~> 5.2)
+  rack-attack (~> 6.6)
   rails (~> 6.1.1)
   rails-controller-testing
   ransack (~> 3.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,7 +74,17 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  #
+  # On heroku we use memcachedcloud plugin which provides `MEMCACHEDCLOUD_SERVERS`
+  # env. https://devcenter.heroku.com/articles/memcachedcloud#using-memcached-from-ruby
+  #
+  # Caching is not normally turned on in test or dev, but config/environments/development.rb
+  # has some standard Rails code that lets you turn it on in dev with in-memory store,
+  # with `./bin/rails dev:cache` toggle.
+  if ENV["MEMCACHEDCLOUD_SERVERS"]
+    config.cache_store = :mem_cache_store, ENV["MEMCACHEDCLOUD_SERVERS"].split(','), { :username => ENV["MEMCACHEDCLOUD_USERNAME"], :password => ENV["MEMCACHEDCLOUD_PASSWORD"] }
+  end
+
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   config.active_job.queue_adapter     = :resque

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -33,7 +33,7 @@ end
 
 # But we're also going to TRACK at somewhat lower limits, for ease
 # of understanding what's going on in our logs
-Rack::Attack.track("req_per_second_over_5_min", limit: 300, period: 5.minutes) do |req|
+Rack::Attack.track("req/ip_track", limit: 60, period: 1.minute) do |req|
   req.ip unless req.path.start_with?('/assets')
 end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -28,15 +28,11 @@ Rack::Attack.throttle('req/ip', limit: 120, period: 1.minutes) do |req|
   req.ip unless req.path.start_with?('/assets')
 end
 
-
 # But we're also going to TRACK at somewhat lower limits, for ease
 # of understanding what's going on in our logs
 Rack::Attack.track("req_per_second_over_5_min", limit: 300, period: 5.minutes) do |req|
   req.ip unless req.path.start_with?('/assets')
 end
-
-
-
 
 # And we want to log all rack-attack related notifications... but only log once
 # per rate-limit-application, don't keep logging every additional blocked request...

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -55,7 +55,7 @@ ActiveSupport::Notifications.subscribe(/throttle\.rack_attack|track\.rack_attack
   current_count = match_data[:count]
 
   # only log if we have a new count, not if we're still incrementing the count!
-  if !last_logged_count || current_count <= last_logged_count
+  if !last_logged_count || current_count <= last_logged_count.to_i
     # `name` will be throttle.rack_attack or track.rack_attack
     # `match_name` will be name of rule like 'req/ip'
     # `discriminator` will generally be IP address, or what you are grouping by to limit

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,12 +1,7 @@
-# We need a cache, in development/test, by default cache to
-# local memory store, unless you set
-#
-# In production, that won't really work if we have
-# more than one puma worker, so we use a heroku memcached.
-
-if Rails.env.development?
-  Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
-end
+# We need a cache for throttling! Uses Rails.cache by default,
+# which we set in config/application.rb. In development/test,
+# may be in-memory cache, may have to toggle dev caching
+# with `./bin/rails dev:cache`
 
 
 # If any single client IP is making tons of requests, then they're

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -2,7 +2,10 @@
 # which we set in config/application.rb. In development/test,
 # may be in-memory cache, may have to toggle dev caching
 # with `./bin/rails dev:cache`
-
+if Rails.env.production? && (Rack::Attack.cache.nil? || Rack::Attack.cache.store.kind_of?(ActiveSupport::Cache::NullStore))
+  # log with `rack_attack` token so our log watcher will catch it.
+  Rails.logger.warn("rack_attack: rack-attack is not throttling, as we do not have a real Rails.cache available!")
+end
 
 # If any single client IP is making tons of requests, then they're
 # probably malicious or a poorly-configured scraper. Either way, they

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -40,6 +40,8 @@ end
 ActiveSupport::Notifications.subscribe(/rack_attack/) do |name, start, finish, request_id, payload|
   rack_request = payload[:request]
   rack_env     = rack_request.env
+  match_data   = rack_env["rack.attack.match_data"]
+  match_data_formatted = match_data.slice(:count, :limit, :period).map { |k, v| "#{k}=#{v}"}.join(" ")
 
-  Rails.logger.warn("rack_attack: #{name}: #{env["rack.attack.matched"]}: key=#{env["rack.attack.match_discriminator"]} request_id=#{request_id}  start=#{start.iso8601} finish=#{finish.iso8601}")
+  Rails.logger.warn("rack_attack: #{name}: #{rack_env["rack.attack.match_discriminator"]}: #{rack_env["rack.attack.matched"]}: key=#{match_data_formatted} request_id=#{request_id}  start=#{start.iso8601} finish=#{finish.iso8601}")
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,50 @@
+# We need a cache, in development/test, by default cache to
+# local memory store, unless you set
+#
+# In production, that won't really work if we have
+# more than one puma worker, so we use a heroku memcached.
+
+if Rails.env.development?
+  Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+end
+
+
+# If any single client IP is making tons of requests, then they're
+# probably malicious or a poorly-configured scraper. Either way, they
+# don't deserve to hog all of the app server's CPU. Cut them off!
+#
+# Note: If you're serving assets through rack, those requests may be
+# counted by rack-attack and this throttle may be activated too
+# quickly. If so, enable the condition to exclude them from tracking.
+
+# Throttle all requests by IP (60rpm)
+#
+# Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
+#
+# -------------------------
+#
+# Rack-attack docs suggested averaging one request per second over
+# 5 minutes: limit: 300, period: 5.minutes
+#
+# But we're going to try a more generous 2 per second over
+# 1 minute instead.
+Rack::Attack.throttle('req/ip', limit: 120, period: 1.minutes) do |req|
+  # On heroku, we may be delivering assets via rack, I think.
+  req.ip unless req.path.start_with?('/assets')
+end
+
+
+# But we're also going to TRACK at somewhat lower limits, for ease
+# of understanding what's going on in our logs
+Rack::Attack.track("req_per_second_over_5_min", limit: 300, period: 5.minutes) do |req|
+  req.ip unless req.path.start_with?('/assets')
+end
+
+
+# And we want to log all rack-attack related notifications...
+ActiveSupport::Notifications.subscribe(/rack_attack/) do |name, start, finish, request_id, payload|
+  rack_request = payload[:request]
+  rack_env     = rack_request.env
+
+  Rails.logger.warn("rack_attack: #{name}: #{env["rack.attack.matched"]}: key=#{env["rack.attack.match_discriminator"]} request_id=#{request_id}  start=#{start.iso8601} finish=#{finish.iso8601}")
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -28,7 +28,14 @@ end
 # 1 minute instead.
 Rack::Attack.throttle('req/ip', limit: 120, period: 1.minutes) do |req|
   # On heroku, we may be delivering assets via rack, I think.
-  req.ip unless req.path.start_with?('/assets')
+  # We also try to exempt our "api" responses from rate limit, although
+  # we still include them in tracking logging below.
+  req.ip unless (
+                  req.path.start_with?('/assets') ||
+                  req.path.end_with?(".atom") ||
+                  req.path.end_with?(".xml") ||
+                  req.path.end_with?(".json")
+                 )
 end
 
 # But we're also going to TRACK at somewhat lower limits, for ease


### PR DESCRIPTION
* in production, set up Rails.cache to use heroku memecachedcloud plugin, if available. Rack attack needs a cache, and uses Rails.cache by default
* set up rack-attack to limit to 2 req per sec over a minute
* also log at a lower limit, without limiting
* some kind of fancy obtuse code to keep from logging *every* time a request is blocked or tracked, which is what rack-attack does by default. We only want to log once per "block period'.  https://github.com/rack/rack-attack/discussions/592

