### PR TITLE
Try a manual GC to reduce overall RAM use in batch fixity check

### DIFF
--- a/lib/tasks/check_fixity.rake
+++ b/lib/tasks/check_fixity.rake
@@ -53,6 +53,11 @@ namespace :scihist do
             progress_bar.increment unless progress_bar.nil?
           end
         end
+        # we're running out of RAM on some fixity check runs on heroku. It may
+        # be that `down`, that we use for fetching bytes from S3, just allocates
+        # a lot of different Strings, necessarily. Perhaps forcing a periodic
+        # GC will help reclaim them?
+        GC.start
       end
     end
 


### PR DESCRIPTION
Kind of a desperate hacky solution, but I think it's all we got. See some analysis at https://github.com/sciencehistory/scihist_digicoll/issues/1854#issuecomment-1262472503
