### PR TITLE
[WIP] [Do not review yet] remove pgcrypto

### DIFF
--- a/db/migrate/20220926155354_move_extensions_to_heroku_ext.rb
+++ b/db/migrate/20220926155354_move_extensions_to_heroku_ext.rb
@@ -1,0 +1,18 @@
+class MoveExtensionsToHerokuExt < ActiveRecord::Migration[6.1]
+
+  def up
+    execute <<~SQL
+      ALTER TABLE kithe_models ALTER COLUMN id SET DEFAULT gen_random_uuid();
+      DROP EXTENSION IF EXISTS pgcrypto;
+
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      CREATE EXTENSION IF NOT EXISTS pgcrypto;
+    SQL
+  end
+end
+
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_10_145124) do
+ActiveRecord::Schema.define(version: 2022_09_26_155354) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_enum :available_by_request_mode_type, [


### PR DESCRIPTION
It does appear that it may be possible to drop `pgcrypto` entirely from our database once we move to postgres 14 in staging and prod.
Do not run this migration on postgres < 14.
Ref #1817 
Ref #1764 