### PR TITLE
Re-enable redis deprecation warnings, as resque has fixed the issue causing so many of them

### DIFF
--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,5 +1,1 @@
 Resque.redis = ScihistDigicoll::Env.persistent_redis_connection!
-
-# Silence copious deprecation warnings until resque fixes them
-# https://github.com/sciencehistory/scihist_digicoll/issues/1745
-Redis.silence_deprecations = true


### PR DESCRIPTION
Fixed in resque 2.3.0, which we are already using. https://github.com/resque/resque/pull/1806#issuecomment-1222454598
