### PR TITLE
Rack-attack re-configure

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -24,9 +24,9 @@ end
 # Rack-attack docs suggested averaging one request per second over
 # 5 minutes: limit: 300, period: 5.minutes
 #
-# But we're going to try a more generous 2 per second over
+# But we're going to try a more generous 3 per second over
 # 1 minute instead.
-Rack::Attack.throttle('req/ip', limit: 120, period: 1.minutes) do |req|
+Rack::Attack.throttle('req/ip', limit: 180, period: 1.minutes) do |req|
   # On heroku, we may be delivering assets via rack, I think.
   # We also try to exempt our "api" responses from rate limit, although
   # we still include them in tracking logging below.
@@ -40,7 +40,7 @@ end
 
 # But we're also going to TRACK at somewhat lower limits, for ease
 # of understanding what's going on in our logs
-Rack::Attack.track("req/ip_track", limit: 60, period: 1.minute) do |req|
+Rack::Attack.track("req/ip_track", limit: 90, period: 1.minute) do |req|
   req.ip unless req.path.start_with?('/assets')
 end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -44,29 +44,63 @@ Rack::Attack.track("req/ip_track", limit: 90, period: 1.minute) do |req|
   req.ip unless req.path.start_with?('/assets')
 end
 
-# And we want to log all rack-attack related notifications... but only log once
-# per rate-limit-application, don't keep logging every additional blocked request...
-# kind of tricky to write logic to gate that.
+# And we want to log rack-attack track and throttle  notifications. But we get
+# a notification every time an IP has exceeded the limit -- that's far too
+# many to log every time, could be many per second when it's exceeding limits.
+#
+# We want to log once per period of our limits -- eg one minute, for records.
+#
+# But we want to ALERT us even less than that -- say once per day -- so we
+# log a special log line with 'ALERT' in it even less frequently, that we
+# can have papertrail set an alert for us on, on the string: `rack_attack: ALERT`.
+# We also do reverse IP lookup on the less frequent ALERTS.
+#
+# To do this, we need to store and consult some state about the last time(s)
+# we logged, which we do in the cache that rack-attackc is already using
+# (probably the Rails.cache which is probably a memcached)
+#
+# The implementation of all of this is currently kind of squirrely and hard
+# to follow, sorry.
+alert_only_per = 1.day
 ActiveSupport::Notifications.subscribe(/throttle\.rack_attack|track\.rack_attack/) do |name, start, finish, request_id, payload|
   rack_request = payload[:request]
   rack_env     = rack_request.env
   match_data   = rack_env["rack.attack.match_data"]
   match_data_formatted = match_data.slice(:count, :limit, :period).map { |k, v| "#{k}=#{v}"}.join(" ")
 
-  period = match_data[:period] || 60.seconds
   match_name = rack_env["rack.attack.matched"]
-  discriminator = rack_env["rack.attack.match_discriminator"]
-  last_logged_key = "rack_attack_notification_#{name}_#{match_name}_#{discriminator}_count"
+  discriminator = rack_env["rack.attack.match_discriminator"] # generally the IP address
+  last_logged_key = "rack_attack_notification_#{name}_#{match_name}_#{discriminator}"
 
-  last_logged_count = Rack::Attack.cache.read(last_logged_key)
+  last_logged_info = Rack::Attack.cache.read(last_logged_key) || {}
+  last_logged_count = last_logged_info[:count]
+  last_alerted_time = last_logged_info[:last_alerted_time]
   current_count = match_data[:count]
 
   # only log if we have a new count, not if we're still incrementing the count!
   if !last_logged_count || current_count <= last_logged_count.to_i
+    last_logged_info[:count] = current_count
+
+    # if it's been longer than our alert window, we log a special ALERT
+    # that papertrail can be configured to notify us on
+    #
     # `name` will be throttle.rack_attack or track.rack_attack
     # `match_name` will be name of rule like 'req/ip'
     # `discriminator` will generally be IP address, or what you are grouping by to limit
-    Rails.logger.warn("#{name}: #{match_name}: #{discriminator}: #{match_data_formatted} request_id=#{request_id}")
-    Rack::Attack.cache.write(last_logged_key, current_count, period + 1)
+    current_time = Time.now
+    if !last_alerted_time || (current_time - last_alerted_time) > alert_only_per
+      last_logged_info[:last_alerted_time] = current_time # record time so we don't do it again soon
+      hostname = Resolv.getname(discriminator) rescue nil
+
+      # eg: track.rack_attack: ALERT: req/ip_track: 66.249.66.21 (crawl-66-249-66-21.googlebot.com) count=91 limit=90 period=60
+      Rails.logger.warn("#{name}: ALERT: #{match_name}: #{discriminator} (#{hostname || "no hostname"}) #{match_data_formatted}")
+    else
+      # eg: track.rack_attack: req/ip_track: 66.249.66.21 count=91 limit=90 period=60
+      Rails.logger.warn("#{name}: #{match_name}: #{discriminator}: #{match_data_formatted} request_id=#{request_id}")
+    end
+
+    # we put it in cache for up to our total alert window, so we can make sure
+    # not to alert more than that.
+    Rack::Attack.cache.write(last_logged_key, last_logged_info, alert_only_per)
   end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -96,7 +96,7 @@ ActiveSupport::Notifications.subscribe(/throttle\.rack_attack|track\.rack_attack
       Rails.logger.warn("#{name}: ALERT: #{match_name}: #{discriminator} (#{hostname || "no hostname"}) #{match_data_formatted}")
     else
       # eg: track.rack_attack: req/ip_track: 66.249.66.21 count=91 limit=90 period=60
-      Rails.logger.warn("#{name}: #{match_name}: #{discriminator}: #{match_data_formatted} request_id=#{request_id}")
+      Rails.logger.warn("#{name}: #{match_name}: #{discriminator}: #{match_data_formatted}")
     end
 
     # we put it in cache for up to our total alert window, so we can make sure


### PR DESCRIPTION
The code is a bit convoluted, sorry. Once a day per IP trigger a different log line that says `rack_attack: ALERT`, so we can configure papertrail alerting only on that, not on every rack-attack log line. 

Also bump up rack attack limits just a bit. 

- increase rack-attack limits
- speical alert-triggering rack-attack logging
- that request_id is not Rails request ID and is not useful
