### PR TITLE
Remove browser JS polyfills no longer required for current supported browsers

### DIFF
--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -27,14 +27,6 @@ console.log('Visit the guide for more information: ', 'https://vite-ruby.netlify
 // Example: Import a stylesheet in app/frontend/index.css
 // import '~/index.css'
 
-
-
-// fetch polyfill for IE11, used by viewer, on-demand downlaods, and other local code.
-import 'whatwg-fetch';
-// The whatwg-fetch polyfill requires a promise polyfill too, for browsers that don't
-// have promises, and IE11 is one, so.
-import 'promise-polyfill/src/polyfill';
-
 import "../javascript/responsive-tabs/responsive-tabs.js"
 
 import '../javascript/init_popovers.js';

--- a/app/frontend/javascript/admin/member_sortable.js
+++ b/app/frontend/javascript/admin/member_sortable.js
@@ -1,6 +1,5 @@
 import domready from 'domready';
 import { Sortable } from '@shopify/draggable';
-import 'mdn-polyfills/Element.prototype.closest'
 
 domready(function() {
   const sortForm = document.querySelector("[data-trigger='member-sort']")

--- a/package.json
+++ b/package.json
@@ -9,11 +9,9 @@
     "lazysizes": "^5.1.0",
     "mdn-polyfills": "^5.15.0",
     "openseadragon": "^2.4.1",
-    "promise-polyfill": "^8.1.3",
     "tom-select": "^1.4.3",
     "video.js": "^7.18.1",
-    "videojs-seek-buttons": "^2.2.0",
-    "whatwg-fetch": "^3.0.0"
+    "videojs-seek-buttons": "^2.2.0"
   },
   "devDependencies": {
     "vite": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "domready": "^1.0.8",
     "js-yaml": ">= 3.13.1",
     "lazysizes": "^5.1.0",
-    "mdn-polyfills": "^5.15.0",
     "openseadragon": "^2.4.1",
     "tom-select": "^1.4.3",
     "video.js": "^7.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,11 +486,6 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
-promise-polyfill@^8.1.3:
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.3.tgz#8c99b3cf53f3a91c68226ffde7bde81d7f904116"
-  integrity sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==
-
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
@@ -633,8 +628,3 @@ vite@^3.0.0:
     rollup "~2.78.0"
   optionalDependencies:
     fsevents "~2.3.2"
-
-whatwg-fetch@^3.0.0:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.3.1.tgz#6c1acf37dec176b0fd6bc9a74b616bec2f612935"
-  integrity sha512-faXTmGDcLuEPBpJwb5LQfyxvubKiE+RlbmmweFGKjvIPFj4uHTTfdtTIkdTRhC6OSH9S9eyYbx8kZ0UEaQqYTA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -392,11 +392,6 @@ m3u8-parser@4.7.0:
     "@videojs/vhs-utils" "^3.0.0"
     global "^4.4.0"
 
-mdn-polyfills@^5.15.0:
-  version "5.20.0"
-  resolved "https://registry.yarnpkg.com/mdn-polyfills/-/mdn-polyfills-5.20.0.tgz#ca8247edf20a4f60dec6804372229812b348260b"
-  integrity sha512-AbTv1ytcoOUAkxw6u5oo2QPf27kEZgxBAQr49jFb4i2VnTnFGfJbcIQ9UDBOdfNECeXsgkYFwB2BkdeTfOzztw==
-
 merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"


### PR DESCRIPTION
- remove fetch and promise polyfills for IE, we no longer support IE
- remove polyfill for 'closest', no longer required by any browser we support, we think

Doing in vite refactor feature branch. 