### PR TITLE
have to update scout_apm gem to support redis 5, that we already upgraded to.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -578,7 +578,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scout_apm (5.3.1)
+    scout_apm (5.3.2)
       parser
     scrub_rb (1.0.1)
     selenium-webdriver (4.5.0)


### PR DESCRIPTION
Without this upgrade, we get lots of errors in log from scout
