### PR TITLE
Make vite create .gz (and brotli) alternatives for built assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
+    "rollup-plugin-gzip": "^3.0.1",
     "vite": "^3.0.0",
     "vite-plugin-ruby": "^3.1.0"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,25 @@
 import { defineConfig } from 'vite'
 import RubyPlugin from 'vite-plugin-ruby'
+import { brotliCompressSync } from "zlib";
+import gzipPlugin from "rollup-plugin-gzip";
+
+// gzip and brotli plugin from https://github.com/ElMassimo/vite_ruby/discussions/101#discussioncomment-1019222
+// and https://vite-ruby.netlify.app/guide/deployment.html#compressing-assets-%F0%9F%93%A6
+//
+// if we create .gz alternatives, Rails automatically will serve gzip'd content,
+// in our heroku setup where the Rails app is directly serving assets (cached by CDN)
+//
+// https://github.com/ElMassimo/vite_ruby/discussions/281
 
 export default defineConfig({
   plugins: [
     RubyPlugin(),
+    // Create gzip copies of relevant assets
+    gzipPlugin(),
+    // Create brotli copies of relevant assets
+    gzipPlugin({
+      customCompression: (content) => brotliCompressSync(Buffer.from(content)),
+      fileName: ".br",
+    }),
   ],
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -515,6 +515,11 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+rollup-plugin-gzip@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-gzip/-/rollup-plugin-gzip-3.0.1.tgz#871c5df5cbdf7e0c54a512e166761de55ea87dc2"
+  integrity sha512-yzyrbe5cn/3yTqtGpVb+0kQXiqKLZpNpRTGpItc11b8c9IhawpjZPPLMkh1Q7gl6UsHIVjcw9LeEdvom9H3klw==
+
 rollup@~2.78.0:
   version "2.78.1"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.78.1.tgz#52fe3934d9c83cb4f7c4cb5fb75d88591be8648f"


### PR DESCRIPTION
In our heroku deployment, our Rails app is directly serving assets (then cached by cloudfront).  Under sprockets/webpacker, .gz alternates were created on asset build. And Rails will then automatically use these to serve content-encoded gzip content to clients which advertise accepting that.

We lost that in initial vite migration, resulting in performance loss in deployed apps, as clients were not getting compressed .js and .css. This should fix that.

https://github.com/ElMassimo/vite_ruby/discussions/281
