### PR TITLE
update version of intermediate JS dependency @xmldom/xmldom

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1221,9 +1221,9 @@
     "@xtuc/long" "4.2.2"
 
 "@xmldom/xmldom@^0.7.2":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.5.tgz#09fa51e356d07d0be200642b0e4f91d8e6dd408d"
-  integrity sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.6.tgz#6f55073fa73e65776bd85826958b98c8cd1457b5"
+  integrity sha512-HHXP9hskkFQHy8QxxUXkS7946FFIhYVfGqsk0WLwllmexN9x/+R4UBLvurHEuyXRfVEObVR8APuQehykLviwSQ==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"


### PR DESCRIPTION
To resolve security warning.

Did it by manually removing the '@xmldom/xmldom' section from `yarn.lock`, then running `yarn install`, and committing changes to yarn.lock file. (Only change was correctly updating xmldom version).

That seems to be the only way to update intermediate dependencies with yarn, which is weird.

Not sure why dependabot couldn't do this update itself.
