### PR TITLE
Remove html no-js class -- not used, causes undesirable side effect

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
       can be re-used by any JS that needs a modal.
 %>
 
-<html lang="en" class="no-js">
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">


### PR DESCRIPTION
This class is on <html> tag as part of a scheme inherited from Blacklight to provide non-JS fallback UI for browsers without JS enabled. However, it does not actually seem to have been kept up in Blacklight, I haven't been able to identify something useful Blacklight is actually doing with it. We don't use it locally.

And it can have bad effects, including a flash of badly styled content before JS is loaded, that moves around the page once JS is loaded (and removes the `no-js` class) -- on a slow network, that can be more visible.

So just going to remove it from our local layout, so we no longer get the failed attempt at a non-JS UI showing on page before JS is loaded.
