### PR TITLE
Add oral_history_assets to work json api response

### DIFF
--- a/app/serializers/work_json_serializer.rb
+++ b/app/serializers/work_json_serializer.rb
@@ -118,6 +118,7 @@ class WorkJsonSerializer
       member.kind_of?(Asset) && member.published? && member.role.in?(["transcript", "front_matter"])
     end.map do |asset|
       {
+        id: asset.friendlier_id,
         role: asset.role.to_s,
         content_type: asset.content_type,
         url: download_url(asset.file_category, asset),

--- a/spec/factories/work_factory.rb
+++ b/spec/factories/work_factory.rb
@@ -232,13 +232,25 @@ FactoryBot.define do
         genre { ["Oral histories"] }
       end
 
+      trait :public_files do
+        members {[
+          build(:asset_with_faked_file, :pdf, published: true, title: 'transcript', role: "transcript"),
+          build(:asset_with_faked_file, :mp3,
+                  title: "audio_recording.mp3",
+                  published: true,
+                  faked_filename: "#{generate(:oh_filename)}.mp3",
+                  faked_size: 21.2.megabytes,
+                  faked_derivatives: {} ),
+        ]}
+      end
+
       trait :available_by_request do
         transient do
           available_by_request_mode { :manual_review }
         end
 
         members {[
-          build(:asset_with_faked_file, :pdf, published: true, title: 'Front matter'),
+          build(:asset_with_faked_file, :pdf, published: true, title: 'Front matter', role: "front_matter"),
           build(:asset_with_faked_file, :mp3,
                   title: "audio_recording.mp3",
                   published: false,
@@ -246,7 +258,7 @@ FactoryBot.define do
                   faked_filename: "#{generate(:oh_filename)}.mp3",
                   faked_size: 21.2.megabytes,
                   faked_derivatives: {} ),
-          build(:asset_with_faked_file, :pdf, title: "transcript.pdf", published: false, oh_available_by_request: true)
+          build(:asset_with_faked_file, :pdf, title: "transcript.pdf", published: false, role: "transcript", oh_available_by_request: true)
         ]}
         after(:build) do |work, evaluator|
           work.representative = work.members.to_a.find {|w| w.published? } if work.representative.nil?

--- a/spec/serializers/work_json_serializer_spec.rb
+++ b/spec/serializers/work_json_serializer_spec.rb
@@ -61,7 +61,7 @@ describe WorkJsonSerializer, type: :model, queue_adapter: :inline do
   end
 
   describe "for Oral History" do
-    let(:work) { create(:oral_history_work, published: true) }
+    let(:work) { create(:oral_history_work, :public_files, published: true) }
 
     it "includes interviewer profile" do
       expect(serializable_hash[:interviewer_profile]).to eq (work.oral_history_content.interviewer_profiles.collect do |profile|
@@ -83,6 +83,40 @@ describe WorkJsonSerializer, type: :model, queue_adapter: :inline do
         expect_to_many_shape(bio_hash, :education, keys: [:date, :institution, :degree, :discipline])
         expect_to_many_shape(bio_hash, :job, keys: [:institution, :role, :start_date, :end_date])
         expect_to_many_shape(bio_hash, :honor, keys: [:honor, :start_date, :end_date])
+      end
+    end
+
+    it "includes oral_history_assets" do
+      transcript_asset = work.members.find { |m| m.role == "transcript" }
+
+      expect(serializable_hash[:oral_history_assets]).to be_present
+      expect(serializable_hash[:oral_history_assets]).to eq([
+        {
+          role: "transcript",
+          content_type: transcript_asset.content_type,
+          original_filename: transcript_asset.original_filename,
+          url: Rails.application.routes.url_helpers.download_url(transcript_asset.file_category, transcript_asset, host: ScihistDigicoll::Env.lookup(:app_url_base))
+        }
+      ])
+    end
+
+    describe "work with by-request assets" do
+      let(:work) { create(:oral_history_work, :available_by_request) }
+
+      it "does not include URLs to non-public files" do
+        front_matter_asset = work.members.find { |m| m.role == "front_matter" }
+
+        expect(serializable_hash[:oral_history_assets]).to be_present
+        expect(serializable_hash[:oral_history_assets].select { |hash| hash[:role] == "transcript" }).to be_empty
+
+        expect(serializable_hash[:oral_history_assets]).to eq([
+          {
+            role: "front_matter",
+            content_type: front_matter_asset.content_type,
+            original_filename: front_matter_asset.original_filename,
+            url: Rails.application.routes.url_helpers.download_url(front_matter_asset.file_category, front_matter_asset, host: ScihistDigicoll::Env.lookup(:app_url_base))
+          }
+        ])
       end
     end
   end

--- a/spec/serializers/work_json_serializer_spec.rb
+++ b/spec/serializers/work_json_serializer_spec.rb
@@ -92,6 +92,7 @@ describe WorkJsonSerializer, type: :model, queue_adapter: :inline do
       expect(serializable_hash[:oral_history_assets]).to be_present
       expect(serializable_hash[:oral_history_assets]).to eq([
         {
+          id: transcript_asset.friendlier_id,
           role: "transcript",
           content_type: transcript_asset.content_type,
           original_filename: transcript_asset.original_filename,
@@ -111,6 +112,7 @@ describe WorkJsonSerializer, type: :model, queue_adapter: :inline do
 
         expect(serializable_hash[:oral_history_assets]).to eq([
           {
+            id: front_matter_asset.friendlier_id,
             role: "front_matter",
             content_type: front_matter_asset.content_type,
             original_filename: front_matter_asset.original_filename,


### PR DESCRIPTION
Instead of providing a general solution for API access to work members, we just go with a kind of hacky custom-fit solution that meets Max Planck needs for oral histories. Just for OH's, we put transcript and front_matter PDFs (identified by asset #role) info in the respresponse, for now only for public assets, including a download URL. (local app url that will redirect to S3).

We also include the original_filename... testing this out for expansion to non-public assets, we might just include metadata including original file name (but no download url), to help Max Planck cross-reference to files supplied via another source.

Ref #1758
