### PR TITLE
Change related_link categories from distillations_* to institute_*

### DIFF
--- a/app/components/related_link_component.rb
+++ b/app/components/related_link_component.rb
@@ -7,6 +7,9 @@ class RelatedLinkComponent < ApplicationComponent
   DISPLAY_LABELS = {
     "institute_biography" => "Historical biography",
     "institute_libguide" => "Library Guide",
+    "institute_article" => "Article",
+    "institute_podcast" => "Podcast",
+    "institute_video" => "Video",
     "other_external" => "Link",
     "other_internal" => "Link"
   }.freeze

--- a/app/models/related_link.rb
+++ b/app/models/related_link.rb
@@ -5,8 +5,8 @@
 class RelatedLink
   include AttrJson::Model
 
-  CATEGORY_VALUES = %w{finding_aid distillations_article distillations_podcast
-                      distillations_video
+  CATEGORY_VALUES = %w{finding_aid institute_article institute_podcast
+                      institute_video
                       institute_biography institute_blog_post institute_libguide
                       related_work other_external other_internal}
 

--- a/lib/tasks/data_fixes/change_related_links_categories.rake
+++ b/lib/tasks/data_fixes/change_related_links_categories.rake
@@ -1,0 +1,27 @@
+namespace :scihist do
+  namespace :data_fixes do
+    desc """
+      Change distillations_* related link cateogries to institute_*
+    """
+    task :change_distillations_categories => :environment do
+
+      delta = {
+        "distillations_article" => "institute_article",
+        "distillations_podcast" => "institute_podcast",
+        "distillations_video" => "institute_video"
+      }
+
+      Kithe::Indexable.index_with(batching: true) do
+        # could be a Work or a Collection
+        Kithe::Model.where("json_attributes -> 'related_link' is not NULL").find_each do |model|
+          if model.related_link.collect(&:category).intersection(delta.keys).present?
+            model.related_link.each do |rl|
+              rl.category = delta.fetch(rl.category, rl.category)
+            end
+            model.save!
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Displying on front-end as just "Article", "Podcast", "Video". 

Ref #1892

Data migration rake task to be run after deploy:

    heroku run rake scihist:data_fixes:change_distillations_categories -r production
