### PR TITLE
Get Oral History sub-collections to have customized OH facet config

### DIFF
--- a/app/controllers/collection_show_controller.rb
+++ b/app/controllers/collection_show_controller.rb
@@ -8,7 +8,7 @@
 # There may be a less hacky way to do this, esp in Blacklight 7, but this is a port of
 # what was in chf_sufia. There also may not be.
 class CollectionShowController < CatalogController
-  before_action :check_auth
+  before_action :collection, :check_auth
 
   ORAL_HISTORY_DEPARTMENT_VALUE = "Center for Oral History"
 

--- a/app/controllers/collection_show_controller.rb
+++ b/app/controllers/collection_show_controller.rb
@@ -10,6 +10,8 @@
 class CollectionShowController < CatalogController
   before_action :check_auth
 
+  ORAL_HISTORY_DEPARTMENT_VALUE = "Center for Oral History"
+
   # index action inherited from CatalogController, that's what we use.
 
   # This method can be overridden from blacklight to provide *dynamic* blacklight
@@ -19,7 +21,7 @@ class CollectionShowController < CatalogController
     # with it's own config and templates --  we have sub-collections that get
     # this generic controller.  If we have one here, use the config from that
     # main OH Controller, to get OH-customized facets and any other search config.
-    if collection.department == "Center for Oral History"
+    if collection.department == ORAL_HISTORY_DEPARTMENT_VALUE
       CollectionShowControllers::OralHistoryCollectionController.blacklight_config
     else
       super

--- a/app/controllers/collection_show_controller.rb
+++ b/app/controllers/collection_show_controller.rb
@@ -8,9 +8,23 @@
 # There may be a less hacky way to do this, esp in Blacklight 7, but this is a port of
 # what was in chf_sufia. There also may not be.
 class CollectionShowController < CatalogController
-  before_action :set_collection, :check_auth
+  before_action :check_auth
 
   # index action inherited from CatalogController, that's what we use.
+
+  # This method can be overridden from blacklight to provide *dynamic* blacklight
+  # config
+  def blacklight_config
+    # While the main Oral History collection gets it's own custom controller,
+    # with it's own config and templates --  we have sub-collections that get
+    # this generic controller.  If we have one here, use the config from that
+    # main OH Controller, to get OH-customized facets and any other search config.
+    if collection.department == "Center for Oral History"
+      CollectionShowControllers::OralHistoryCollectionController.blacklight_config
+    else
+      super
+    end
+  end
 
   def facet
     # Note: params[:id] is being hogged by Blacklight; it refers to the
@@ -58,12 +72,7 @@ class CollectionShowController < CatalogController
   end
 
   def collection
-    @collection
+    @collection ||= Collection.find_by_friendlier_id!(params[:collection_id])
   end
   helper_method :collection
-
-  def set_collection
-    @collection = Collection.find_by_friendlier_id!(params[:collection_id])
-  end
-
 end

--- a/spec/factories/work_factory.rb
+++ b/spec/factories/work_factory.rb
@@ -210,7 +210,6 @@ FactoryBot.define do
       place  { [{category: "place_of_interview", value:"University of Maryland, College Park"}] }
       format { ['text'] }
       genre { ["Oral histories"] }
-      subject { ["Chemistry"] }
       extent { ['50 pages'] }
       language { ['English'] }
       department { 'Center for Oral History' }

--- a/spec/factories/work_factory.rb
+++ b/spec/factories/work_factory.rb
@@ -210,6 +210,7 @@ FactoryBot.define do
       place  { [{category: "place_of_interview", value:"University of Maryland, College Park"}] }
       format { ['text'] }
       genre { ["Oral histories"] }
+      subject { ["Chemistry"] }
       extent { ['50 pages'] }
       language { ['English'] }
       department { 'Center for Oral History' }

--- a/spec/system/collection_show_spec.rb
+++ b/spec/system/collection_show_spec.rb
@@ -51,7 +51,7 @@ describe "Collection show page", solr: true, indexable_callbacks: true do
   end
 
   describe "generic oral history collection" do
-    let(:collection) { create(:collection, department: "Center for Oral History") }
+    let(:collection) { create(:collection, department: CollectionShowController::ORAL_HISTORY_DEPARTMENT_VALUE) }
     let!(:oral_history) { create(:oral_history_work, published: true, contained_by: [collection]) }
 
     it "displays custom OH facets" do

--- a/spec/system/collection_show_spec.rb
+++ b/spec/system/collection_show_spec.rb
@@ -15,7 +15,7 @@ describe "Collection show page", solr: true, indexable_callbacks: true do
         # on save, so to get indexed properly
         #
         # Different dates to make sure we exersize blacklight_range_limit a bit.
-        create(:public_work, title: "public work one", date_of_work: Work::DateOfWork.new(start: "2019"), contained_by: [col])
+        create(:public_work, title: "public work one", subject: ["Some subject"], date_of_work: Work::DateOfWork.new(start: "2019"), contained_by: [col])
         create(:public_work, title: "public work two", date_of_work: Work::DateOfWork.new(start: "1900"), contained_by: [col])
         create(:private_work, title: "private work", contained_by: [col])
       end
@@ -39,6 +39,40 @@ describe "Collection show page", solr: true, indexable_callbacks: true do
       expect(page).to have_content("public work one")
       expect(page).to have_content("public work two")
       expect(page).not_to have_content("private_work")
+
+      within(".facets") do
+        expect(page).to have_selector(:link_or_button, "Date")
+        expect(page).to have_selector(:link_or_button, "Genre")
+        expect(page).to have_selector(:link_or_button, "Format")
+        expect(page).to have_selector(:link_or_button, "Rights")
+        expect(page).to have_selector(:link_or_button, "Subject")
+      end
+    end
+  end
+
+  describe "generic oral history collection" do
+    let(:collection) { create(:collection, department: "Center for Oral History") }
+    let!(:oral_history) { create(:oral_history_work, published: true, contained_by: [collection]) }
+
+    it "displays custom OH facets" do
+      visit collection_path(collection)
+
+      expect(page).to have_content(oral_history.title)
+
+      within(".facets") do
+        expect(page).to have_selector(:link_or_button, "Interview Date")
+        expect(page).to have_selector(:link_or_button, "Interviewer")
+        expect(page).to have_selector(:link_or_button, "Institution")
+        expect(page).to have_selector(:link_or_button, "Birth Country")
+        expect(page).to have_selector(:link_or_button, "Features")
+        expect(page).to have_selector(:link_or_button, "Availability")
+        expect(page).to have_selector(:link_or_button, "Subject")
+
+        expect(page).not_to have_selector(:link_or_button, text: /^Date$/)
+        expect(page).not_to have_selector(:link_or_button, "Genre")
+        expect(page).not_to have_selector(:link_or_button, "Format")
+        expect(page).not_to have_selector(:link_or_button, "Rights")
+      end
     end
   end
 end

--- a/spec/system/collection_show_spec.rb
+++ b/spec/system/collection_show_spec.rb
@@ -52,7 +52,7 @@ describe "Collection show page", solr: true, indexable_callbacks: true do
 
   describe "generic oral history collection" do
     let(:collection) { create(:collection, department: CollectionShowController::ORAL_HISTORY_DEPARTMENT_VALUE) }
-    let!(:oral_history) { create(:oral_history_work, published: true, contained_by: [collection]) }
+    let!(:oral_history) { create(:oral_history_work, published: true, subject: ["Chemistry"], contained_by: [collection]) }
 
     it "displays custom OH facets" do
       visit collection_path(collection)


### PR DESCRIPTION
Ref #1886 

Previously, we have supplied custom facet or other blacklight config to specific collections by:  1) Giving them a custom controller just for that collection (which also can have custom templates if desired), and 2) *routing* based on collection ID, URLs for that specific collection to that controller. 

This doesn't work well for "all collections in Oral History department should have the standard custom facet config for oral histories", because to put the list of collection IDs in routing, we'd need to change it all the time if new collections are created. 

So instead, we have these collections still handled by our overall standard Collection controller -- but override the `blacklight_config` instance method (another supported Blacklight override point, we believe), which can dynamically change blacklight config ona. per-request basis -- to do so if the collection loaded has a department set to oral history!  By getting the blacklight_config from the standard (class-level) custom Oral History collection show controller. 

It's a bit weird that we have so many different ways of doing things here. And that we have a dynamic config in `CollectionShowController` reading the class-level config from `CollectionShowControllers::OralHistoryCollectionController` -- when the latter itself inherits from `CollectionShowController`!  But it all works, and is fairly straightforward code in the end. 

I couldn't figure out any great way to test except slow system tests, so that's what I did. 

