### PR TITLE
fix favicon link

### DIFF
--- a/app/views/layouts/_head_tag_common.html.erb
+++ b/app/views/layouts/_head_tag_common.html.erb
@@ -7,7 +7,7 @@
     https://realfavicongenerator.net/favicon_result?file_id=p1c51efkq01d00ttb19efo6ov4c6#.Wm9W45M-dBw %>
 <link rel="apple-touch-icon" sizes="180x180" href="<%= image_url 'favicons/apple-touch-icon.png' %>">
 <link rel="icon" type="image/png" sizes="32x32" href="<%= image_url 'favicons/favicon-32x32.png' %>">
-<link rel="icon" type="image/png" sizes="16x16" href="<%= image_url '/favicons/favicon-16x16.png' %>">
+<link rel="icon" type="image/png" sizes="16x16" href="<%= image_url 'favicons/favicon-16x16.png' %>">
 <link rel="manifest" href="<%= image_url 'favicons/manifest.json' %>">
 <link rel="mask-icon" href="<%= image_url 'favicons/safari-pinned-tab.svg' %>" color="#4bb0c7">
 <link rel="shortcut icon" href="<%= image_url 'favicons/favicon.ico' %>">


### PR DESCRIPTION
was generating a bad favicon link, causing firefox to not pick up 

Somehow Chrome was still getting it from somewhere else not this broken url in this tag, but when looking at something in firefox I notice the dev console error message, and traced back to this.