### PR TITLE
Collection tweaks for exhibitions

### DIFF
--- a/app/components/work_show_info_component.html.erb
+++ b/app/components/work_show_info_component.html.erb
@@ -111,12 +111,27 @@
   <%= render AttributeTable::RowComponent.new(:department, values: [department], link_to_facet: "department_facet") %>
   <%= render AttributeTable::RowComponent.new(:exhibition, values: exhibition, link_to_facet: "exhibition_facet", alpha_sort: true) if current_staff_user? %>
 
-  <% if contained_by.present? %>
+  <% if public_collections.present? %>
     <tr>
       <th scope='row'>Collection</th>
       <td>
         <ul>
           <% public_collections.each do |collection| %>
+            <li class="attribute">
+              <%= link_to collection.title, collection_path(collection) %>
+            </li>
+          <% end %>
+        </ul>
+      </td>
+    </tr>
+  <% end %>
+
+  <% if public_exhibitions.present? %>
+    <tr>
+      <th scope='row'>Exhibited in</th>
+      <td>
+        <ul>
+          <% public_exhibitions.each do |collection| %>
             <li class="attribute">
               <%= link_to collection.title, collection_path(collection) %>
             </li>

--- a/app/components/work_show_info_component.rb
+++ b/app/components/work_show_info_component.rb
@@ -127,9 +127,18 @@ class WorkShowInfoComponent < ApplicationComponent
     @more_like_this_works ||= MoreLikeThisGetter.new(work, max_number_of_works: 3).works
   end
 
-  def public_collections
-    work.contained_by.where(published: true)
+  def public_contained_by
+    @public_contained_by ||= work.contained_by.where(published: true)
   end
+
+  def public_collections
+    @public_collections ||= public_contained_by.find_all { |c| c.department != Collection::DEPARTMENT_EXHIBITION_VALUE }
+  end
+
+  def public_exhibitions
+    @public_exhibitions ||= public_contained_by.find_all { |c| c.department == Collection::DEPARTMENT_EXHIBITION_VALUE }
+  end
+
 
   def oral_history_interviewer_profiles
     return @oral_history_interviewer_profiles if defined?(@oral_history_interviewer_profiles)

--- a/app/controllers/collections_list_controller.rb
+++ b/app/controllers/collections_list_controller.rb
@@ -5,6 +5,7 @@ class CollectionsListController < ApplicationController
   def index
     @collections = Collection.
       where("published = true").
+      not_jsonb_contains(department: Collection::DEPARTMENT_EXHIBITION_VALUE).
       order(:title).
       includes(:leaf_representative)
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -8,6 +8,9 @@ class Collection < Kithe::Collection
 
   include RecordPublishedAt
 
+  DEPARTMENT_EXHIBITION_VALUE = "Exhibition"
+  DEPARTMENTS = (Work::ControlledLists::DEPARTMENT + [DEPARTMENT_EXHIBITION_VALUE]).freeze
+
   # automatic Solr indexing on save
   if ScihistDigicoll::Env.lookup(:solr_indexing) == 'true'
     self.kithe_indexable_mapper = CollectionIndexer.new
@@ -29,7 +32,7 @@ class Collection < Kithe::Collection
   attr_json :related_link, RelatedLink.to_type, array: true, default: -> { [] }
 
   attr_json :department, :string
-  validates :department, presence: {}, inclusion: { in: Work::ControlledLists::DEPARTMENT, allow_blank: true }
+  validates :department, presence: {}, inclusion: { in: DEPARTMENTS, allow_blank: true }
 
   attr_json :funding_credit, FundingCredit.to_type
 

--- a/app/models/work/controlled_lists.rb
+++ b/app/models/work/controlled_lists.rb
@@ -85,7 +85,7 @@ class Work
       'Center for Oral History',
       'Museum',
       'Library',
-    ]
+    ].freeze
 
     FILE_CREATOR = [
       'Auerbach, Jahna',

--- a/app/views/admin/collections/_form.html.erb
+++ b/app/views/admin/collections/_form.html.erb
@@ -30,7 +30,7 @@
   <div class="form-inputs">
     <%= f.input :title %>
 
-    <%= f.input :department, collection: Work::ControlledLists::DEPARTMENT  %>
+    <%= f.input :department, collection: Collection::DEPARTMENTS  %>
 
     <%= f.repeatable_attr_input(:external_id, build: :at_least_one) do |sub_form| %>
       <%= category_and_value(sub_form, category_list: Work::ExternalId::CATEGORY_VALUES) %>

--- a/app/views/collection_show/index.html.erb
+++ b/app/views/collection_show/index.html.erb
@@ -13,7 +13,13 @@
 
       <div class="show-title">
         <header>
-          <div class="show-genre"><%= link_to "Collections", collections_path %></div>
+          <div class="show-genre">
+            <% if collection.department != Collection::DEPARTMENT_EXHIBITION_VALUE %>
+              <%= link_to "Collections", collections_path %>
+            <% else %>
+              Exhibitions
+            <% end %>
+          </div>
           <h1>
             <%= link_to collection.title, collection_path(collection), class: "title-link" %> <%= publication_badge(collection) %>
             <% if can? :update, collection %>

--- a/spec/components/work_show_info_component_spec.rb
+++ b/spec/components/work_show_info_component_spec.rb
@@ -14,4 +14,17 @@ describe WorkShowInfoComponent, type: :component do
       expect(page).to have_text(/Oral history number\s+0012/)
     end
   end
+
+  context "exhibitions and collections" do
+    let(:exhibition) { build(:collection, department: Collection::DEPARTMENT_EXHIBITION_VALUE) }
+    let(:collection) { build(:collection) }
+    let(:work) { create(:public_work, :with_complete_metadata, contained_by: [exhibition, collection])}
+
+    it "displays exhibition separately" do
+      rendered = render_inline WorkShowInfoComponent.new(work: work)
+
+      expect(page).to have_text(/Collection\s+#{collection.title}/)
+      expect(page).to have_text(/Exhibited in\s+#{exhibition.title}/)
+    end
+  end
 end

--- a/spec/system/collection_list_spec.rb
+++ b/spec/system/collection_list_spec.rb
@@ -19,6 +19,13 @@ describe "Collection list page", type: :system do
       title: "B Published"
     )
   end
+  let!(:exhibition) do
+    FactoryBot.create(:collection,
+      published: true,
+      title: "Exhibition",
+      department: Collection::DEPARTMENT_EXHIBITION_VALUE
+    )
+  end
 
   it "shows published items, doesn't show others." do
     visit collections_path
@@ -29,5 +36,6 @@ describe "Collection list page", type: :system do
     expect(page).to have_selector(".collection-title", text: 'A Published')
     expect(page).to have_selector(".collection-title", text: 'B Published')
     expect(page).not_to have_content('Private')
+    expect(page).not_to have_content('Exhibition')
   end
 end

--- a/spec/system/collection_show_spec.rb
+++ b/spec/system/collection_show_spec.rb
@@ -54,7 +54,7 @@ describe "Collection show page", solr: true, indexable_callbacks: true do
     let(:collection) { create(:collection, department: CollectionShowController::ORAL_HISTORY_DEPARTMENT_VALUE) }
     let!(:oral_history) { create(:oral_history_work, published: true, subject: ["Chemistry"], contained_by: [collection]) }
 
-    it "displays custom OH facets" do
+    it "displays custom OH facets", js: false do
       visit collection_path(collection)
 
       expect(page).to have_content(oral_history.title)
@@ -75,4 +75,14 @@ describe "Collection show page", solr: true, indexable_callbacks: true do
       end
     end
   end
+
+  describe "Exhibiton collection" do
+    let(:collection) { create(:collection, department: Collection::DEPARTMENT_EXHIBITION_VALUE) }
+
+    it "displays", js: false do
+      visit collection_path(collection)
+      expect(page).to have_selector(".show-genre", text: "Exhibitions")
+    end
+  end
+
 end


### PR DESCRIPTION
Ref #1920

- add 'Exhibition' value for 'Department', just for Collections
- Collection show page for Exhibitions shows correct pre-sub-head
- keep Exhibitions off Collections list page
- split exhibition out from collection on work show metadata
