### PR TITLE
Rake task using Open3 needs to explicitly require it

### DIFF
--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -1,3 +1,5 @@
+require 'open3'
+
 namespace :scihist do
   namespace :heroku do
 


### PR DESCRIPTION
Not sure why this used to work -- probably some other dependency loaded used to require it, which made it available on boot, but that dependency stopped and we need to explicitly require it, liek I guess we should ahve been all along.
