### PR TITLE
Remove German hyphenization from solr text_de

### DIFF
--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -187,13 +187,22 @@
     <!-- https://github.com/uschindler/german-decompounder -->
     <fieldType name="text_de" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.HyphenationCompoundWordTokenFilterFactory"
+        <tokenizer class="solr.ICUTokenizerFactory"/>
+        <filter class="solr.ICUNormalizer2FilterFactory" name="nfkc_cf" mode="compose"/> <!-- NFKC, case folding, but leave diacritics! -->
+
+        <!-- will produce different number of tokens than text_en, which would
+             make it incompatible for combining in dismax qf.
+
+             See https://github.com/sciencehistory/scihist_digicoll/issues/1883
+
+             We *think* erman normlization and stemming below should be ok.
+        -->
+        <!-- <filter class="solr.HyphenationCompoundWordTokenFilterFactory"
           hyphenator="lang/de_DR.xml"
           dictionary="lang/dictionary-de.txt"
           onlyLongestMatch="true"
-          minSubwordSize="4"/>
+          minSubwordSize="4"/> -->
+
         <filter class="solr.GermanNormalizationFilterFactory"/>
         <filter class="solr.GermanStemFilterFactory"/>
       </analyzer>


### PR DESCRIPTION
Differing number of tokens from text_en broke solr dismax when used together, Ref #1883

Also replaced the tokenization and lowercasing with Solr analyzers more like text_en, just for consistency, just in case.

We believe that the German normalization and stemming filters should not cause a problem, although we aren't 100% sure, we're trying it.
