### PR TITLE
Fix for nil height or width bug

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -81,6 +81,26 @@ class Admin::CollectionsController < AdminController
     end
   end
 
+  def representative
+    @collection&.representative
+  end
+  helper_method :representative
+
+  def representative_is_image?
+    representative.file.present? && representative&.content_type&.start_with?("image/")
+  end
+  helper_method :representative_is_image?
+
+  def representative_dimensions_correct?
+    [ representative.width.present?,
+      representative.height.present?,
+      representative.width == representative.height,
+      representative.width >= CollectionThumbAsset::COLLECTION_PAGE_THUMB_SIZE * 2,
+    ].all?
+  end
+  helper_method :representative_dimensions_correct?
+
+
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_collection

--- a/app/views/admin/collections/_form.html.erb
+++ b/app/views/admin/collections/_form.html.erb
@@ -63,14 +63,14 @@
     <div class="form-group form-group-valid">
       <label class="form-control-label string" for="collection_thumbnail">Thumbnail</label>
       <small class="form-text text-muted scihist-hint mb-2 mt-0">Image for collection, should be <b>square and at least
-        <%= CollectionThumbAsset::COLLECTION_PAGE_THUMB_SIZE * 2 %>x<%= CollectionThumbAsset::COLLECTION_PAGE_THUMB_SIZE * 2%> pixels</b>. No need to resize—full-size crop is great for possible future uses.</small>
+        <%= CollectionThumbAsset::COLLECTION_PAGE_THUMB_SIZE * 2 %>x<%= CollectionThumbAsset::COLLECTION_PAGE_THUMB_SIZE * 2%> pixels</b>. No need to resize- full-size crop is great for possible future uses.</small>
 
       <%= f.fields_for :representative, (f.object.representative || f.object.build_representative) do |representative_f| %>
 
         <%# file field gets handled by js in simple_uppy_file_input.js %>
 
         <%= representative_f.hidden_field :file,
-                value: collection&.representative&.cached_file_data,
+                value: representative&.cached_file_data,
                 id: "collection-thumbnail-upload-result",
                 data: {
                   toggle: "scihist-simple-uppy-file-hidden"
@@ -85,27 +85,24 @@
                 upload_result_element: "album-cover-photo-upload-result"
               }.merge(UploadUtil.kithe_upload_data_config(toggle_value: "scihist-simple-uppy-file"))
         %>
+
         <div class="image-preview mb-2" data-toggle="scihist-simple-uppy-file-preview">
-          <% if collection.representative.cached_file_data  %>
-            <p>Will be saved: <%= collection.representative.original_filename %></p>
-          <% elsif collection.representative.file.present? %>
-            <%= thumb_image_tag(collection.leaf_representative, size: :collection_page, image_missing_text: true) %>
-
-            <br><i><%= collection.representative.title %></i>
-
-            <% if collection.representative.file &&
-              ( !collection.representative.content_type.start_with?("image/") ||
-                collection.representative.width != collection.representative.height ||
-              collection.representative.width < 532 ) %>
-              <p class="text-danger small">Uploaded asset should be a square image at least of at least <%= CollectionThumbAsset::COLLECTION_PAGE_THUMB_SIZE * 2%> pixels.
-                The saved file type <%= collection.representative.content_type %>,
-                <%= collection.representative.width %>x<%= collection.representative.height %>px. It is recommended
-                you upload a different file, of appropriate dimensions.
+          <% if representative.cached_file_data  %>
+            <p>Will be saved: <%= representative.original_filename %></p>
+          <% elsif representative_is_image? %>
+            <%= thumb_image_tag(representative, size: :collection_page, image_missing_text: true) %>
+            <br/><i><%= representative.title %></i>
+            <% unless representative_dimensions_correct? %>
+              <p class="text-danger small">
+                This file is an <%= representative&.content_type %> of size
+                <%= representative&.width %> x <%= representative&.height %> px;
+                please upload a square image at least of at least
+                <%= CollectionThumbAsset::COLLECTION_PAGE_THUMB_SIZE * 2 %> px.
               </p>
             <% end %>
-
           <% end %>
         </div>
+
       <% end %>
     </div>
 

--- a/app/views/admin/collections/_form.html.erb
+++ b/app/views/admin/collections/_form.html.erb
@@ -63,7 +63,7 @@
     <div class="form-group form-group-valid">
       <label class="form-control-label string" for="collection_thumbnail">Thumbnail</label>
       <small class="form-text text-muted scihist-hint mb-2 mt-0">Image for collection, should be <b>square and at least
-        <%= CollectionThumbAsset::COLLECTION_PAGE_THUMB_SIZE * 2 %>x<%= CollectionThumbAsset::COLLECTION_PAGE_THUMB_SIZE * 2%> pixels</b>. No need to resize- full-size crop is great for possible future uses.</small>
+        <%= CollectionThumbAsset::COLLECTION_PAGE_THUMB_SIZE * 2 %>x<%= CollectionThumbAsset::COLLECTION_PAGE_THUMB_SIZE * 2%> pixels</b>. No need to resize—full-size crop is great for possible future uses.</small>
 
       <%= f.fields_for :representative, (f.object.representative || f.object.build_representative) do |representative_f| %>
 
@@ -96,7 +96,7 @@
               <p class="text-danger small">
                 This file is an <%= representative&.content_type %> of size
                 <%= representative&.width %> x <%= representative&.height %> px;
-                please upload a square image at least of at least
+                please upload a square image of at least
                 <%= CollectionThumbAsset::COLLECTION_PAGE_THUMB_SIZE * 2 %> px.
               </p>
             <% end %>


### PR DESCRIPTION
Ref #1930

@jrochkind - I'm inclined to just add in this check and not pursue this further, but open to suggestions.

My underlying assumption is that the file wasn't fully characterized by the time the collection edit page was loaded, and thus the value of the file's width and height evaluated to`nil`, causing [this error](https://app.honeybadger.io/projects/58989/faults/90140357).

That said, I wasn't able to reproduce the bug in dev, so it's difficult to say for sure whether this will fix the problem.

