### PR TITLE
Give up quicker on slower/unresponsive memcache Rails.cache

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,7 +90,7 @@ Rails.application.configure do
     config.cache_store = :mem_cache_store, ENV["MEMCACHEDCLOUD_SERVERS"].split(','), {
       :username => ENV["MEMCACHEDCLOUD_USERNAME"],
       :password => ENV["MEMCACHEDCLOUD_PASSWORD"],
-      :socket_timeout => 0.15, # default was 1
+      :socket_timeout => (ENV["MEMCACHE_TIMEOUT"] || 0.15).to_f, # default was 1
       :socket_failure_delay => false # don't retry failures
     }
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,8 +81,18 @@ Rails.application.configure do
   # Caching is not normally turned on in test or dev, but config/environments/development.rb
   # has some standard Rails code that lets you turn it on in dev with in-memory store,
   # with `./bin/rails dev:cache` toggle.
+  #
+  # We tune the timeouts to give up really quickly -- we don't want the server
+  # waiting too long on a slow memcached, especially with rack-attack accessing
+  # it on every request. It's just a cache, give up if it's slow!
+  # https://github.com/petergoldstein/dalli/blob/5588d98f79eb04a9abcaeeff3263e08f93468b30/lib/dalli/protocol/connection_manager.rb
   if ENV["MEMCACHEDCLOUD_SERVERS"]
-    config.cache_store = :mem_cache_store, ENV["MEMCACHEDCLOUD_SERVERS"].split(','), { :username => ENV["MEMCACHEDCLOUD_USERNAME"], :password => ENV["MEMCACHEDCLOUD_PASSWORD"] }
+    config.cache_store = :mem_cache_store, ENV["MEMCACHEDCLOUD_SERVERS"].split(','), {
+      :username => ENV["MEMCACHEDCLOUD_USERNAME"],
+      :password => ENV["MEMCACHEDCLOUD_PASSWORD"],
+      :socket_timeout => 0.15, # default was 1
+      :socket_failure_delay => false # don't retry failures
+    }
   end
 
 


### PR DESCRIPTION
 Since we access memcache multiple times on every request for rack-attack, it could potentially be disastrous if it's slow. We want to give up quick.


Ref #1914

I tried experimenting with a very very small timeout to see what happens when it is exceeded...

* It doens't seem to interupt anything, it just acts like nothing was in cache. 
* Which means we ma not notice if the cache isn't working, thus rack-attack limiting isn't working. But this seems better than a slow memcached causing our app to error?
* There are some kind of cryptic messages in heroku papertrail log. Eg: 

      Nov 14 13:12:35 app/web.1 WARN: [c6864fc2-9932-475c-b1c7-bd6b386def37] memcached-19928.c100.us-east-1-4.ec2.cloud.redislabs.com:19928 failed (count: 4) Timeout::Error: execution expired


