### PR TITLE
Fix jQuery sending of Rails csrf_token under vite

### DIFF
--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -28,11 +28,18 @@ console.log('Visit the guide for more information: ', 'https://vite-ruby.netlify
 // import '~/index.css'
 
 
-// We're still using rails-ujs for now. Rails-ujs 6.x will auto-start itself on import.
-import Rails from '@rails/ujs';
+
+
 
 import '../javascript/jquery_setup.js'
 import '../javascript/bootstrap_setup.js'
+
+// We're still using rails-ujs for now. Rails-ujs 6.x will auto-start itself on import.
+//
+// This needs to be imported AFTER jquery is set up so it will properly
+// patch jQuery.ajax with CSRF token, although it's not supposed to be this way,
+// and strangely this order is only required in vite dev and not vite build.
+import Rails from '@rails/ujs';
 
 // used by kithe, for forms with add/remove fields
 import "@nathanvda/cocoon";


### PR DESCRIPTION
Noticed in #1943 that browse_everything JS was causing Rails CSRF authenticity token failures after our move to vite.

Discovered that the rails_ujs JS package was not succesfully configuring JQuery.ajax to send Rails CSRF token on every .Ajax call.

Changing the ORDER of our imports in our vite file fixes this. This whole thing doesn't make any sense -- it was only broken in `vite dev` not `vite build`, why was only one of those setups so order-dependent? Also our pre-vite setup using sprockets was still "require"ing rails_ujs *before* jquery -- we left the order the same when we moved to vite, but it somehow became order-dependent requiring a different order? (That last one might be more explainable because of the hacky way we're setting window.jQuery in the export itself).

Don't completely understand what's going on, but somehow found a a fix anyway. Left warning comments in source code that does the imports where order has become important.
