### PR TITLE
update blacklight to 7.32.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'scout_apm'
 # to spend the time to update Blacklight to latest -- you will usually want to update
 # blacklight_range_limit to latest at same time.
 #
-gem "blacklight", "~> 7.30.0"
+gem "blacklight", "~> 7.32.0"
 gem "blacklight_range_limit", "~> 8.0", ">= 8.2.3" # version no longer sync'd with blacklight, not sure how we tell what version works with what version of BL
 
 # for some code to deal with transcoding video, via AWS MediaConvert

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.18)
     bindex (0.8.1)
-    blacklight (7.30.0)
+    blacklight (7.32.0)
       deprecation
       globalid
       hashdiff
@@ -127,7 +127,7 @@ GEM
       kaminari (>= 0.15)
       ostruct (>= 0.3.2)
       rails (>= 5.1, < 7.1)
-      view_component (~> 2.43)
+      view_component (~> 2.66)
     blacklight_range_limit (8.2.3)
       blacklight (>= 7.25.2, < 9)
     bootsnap (1.13.0)
@@ -380,7 +380,7 @@ GEM
       net-protocol
     net-protocol (0.1.3)
       timeout
-    net-smtp (0.3.2)
+    net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
     nokogiri (1.13.9)
@@ -651,7 +651,7 @@ GEM
       aws-sdk-s3 (~> 1.0)
       content_disposition (~> 1.0)
       roda (>= 2.27, < 4)
-    view_component (2.74.1)
+    view_component (2.77.0)
       activesupport (>= 5.0.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
@@ -690,7 +690,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yell (2.2.2)
-    zeitwerk (2.6.1)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   ruby
@@ -706,7 +706,7 @@ DEPENDENCIES
   aws-sdk-mediaconvert (~> 1.0)
   aws-sdk-s3 (~> 1.0)
   axe-core-rspec (~> 4.3)
-  blacklight (~> 7.30.0)
+  blacklight (~> 7.32.0)
   blacklight_range_limit (~> 8.0, >= 8.2.3)
   bootsnap (>= 1.4.4)
   bootstrap (~> 4.6, >= 4.6.2)


### PR DESCRIPTION
    bundle update blacklight

No newer release of blacklight_range_limit is available.

Just trying to keep things tidy, and because over in vite work we're going to want a verison of blacklight_frontend npm package that is about to be released, so keeps everything sync'd.
