### PR TITLE
Properly catch attempted delete of Dig Queue Item with attached works

### DIFF
--- a/app/models/admin/digitization_queue_item.rb
+++ b/app/models/admin/digitization_queue_item.rb
@@ -1,7 +1,7 @@
 class Admin::DigitizationQueueItem < ApplicationRecord
   has_many :queue_item_comments, dependent: :destroy
 
-  has_many :works
+  has_many :works, dependent: :restrict_with_exception
 
   scope :open_status, -> { where.not(status: "closed") }
 

--- a/spec/controllers/admin/digitization_queue_items_controller_spec.rb
+++ b/spec/controllers/admin/digitization_queue_items_controller_spec.rb
@@ -54,5 +54,16 @@ RSpec.describe Admin::DigitizationQueueItemsController, :logged_in_user, type: :
       }
     end
 
+    describe "with attached work" do
+      let(:queue_item) { create(:digitization_queue_item, title: "Newly scanned rare book", works: [create(:work)]) }
+
+      it "denies deletion" do
+        delete :destroy, params: { id: queue_item.id }
+
+        expect(response.redirect?).to be true
+        expect(response).to redirect_to(admin_digitization_queue_item_path(queue_item))
+        expect(response.request.flash[:notice]).to eq "Can't delete Digitization Queue Item with attached works"
+      end
+    end
   end
 end


### PR DESCRIPTION
This is just a quick and easy solution to a staff-facing thing that doesn't happen very much.

* There is still potentially a race condition if someone attacches a work RIGHT when someone else is deleting. That will just result in an uncaught exception still. Not gonna happen, not worth writing for.
* If we really wanted to polish this, would maybe make the delete button disappear or become inactive or not even submit in case of attached works -- but not needed, it's fine that it goes to server and comes back with a notice.

We also changed the configuraiton of the relationship to TELL Rails that we want to prevent delete with attachements, on top of the underlying DB constraint ensuring such.

Ref #1952
