### PR TITLE
vite gzip assets: condition needs to be on string

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,7 @@ let vitePlugins = [
 // https://github.com/ElMassimo/vite_ruby/discussions/281
 //
 // But in development autoBuild mode, it slows things down, and doesn't help, so not there.
-if (!process.env.VITE_RUBY_AUTO_BUILD) {
+if (! (process.env.VITE_RUBY_AUTO_BUILD == "true")) {
   vitePlugins = vitePlugins.concat([
     // Create gzip copies of relevant assets
     gzipPlugin(),


### PR DESCRIPTION
We wanted to create gzip and brotli assets only in produciton build not vite autoBuild -- but the value we were checking to determine this is, it turns out, string 'true' or 'false', so our condition was always matching and we were never getting gzip and brotli.
