### PR TITLE
Use meta name=description as well as property=og:description

### DIFF
--- a/app/views/works/_meta_tags.html.erb
+++ b/app/views/works/_meta_tags.html.erb
@@ -10,7 +10,7 @@
 <meta property="article:author" content="https://www.facebook.com/<%= Rails.application.config.facebook_acct %>" />
 
 <meta property="og:title" content="<%= attributes.simple_title %>"/>
-<meta property="og:description" content="<%= attributes.short_plain_description %>"/>
+<meta name="description" property="og:description" content="<%= attributes.short_plain_description %>"/>
 <meta property="og:image" content="<%= attributes.share_media_url %>"/>
 <%# we know we're delivering a JPG %>
 <meta property="og:image:type" content="image/jpeg" />


### PR DESCRIPTION
While facebook and some other social media uses <meta property="og:description"> for description, standard HTML <meta name="description"> is more standard, and some things may use that. Google lighthouse flagged me for not having a <meta name="description">.

Conveniently, we can put BOTH a `name` AND `property` on the same tag, and have this tag do double-duty. https://stackoverflow.com/questions/20401085/is-it-possible-to-use-the-same-meta-tag-for-opengraph-and-schema-org/20429551#20429551

So easy enough to just add the `name=description` too, and potentially have our description picked up by more things looking for one.
