### PR TITLE
Add :see_admin_pages permission

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,7 +1,3 @@
 class ApplicationComponent < ViewComponent::Base
-  delegate :current_user, to: :helpers
 
-  def can_access_staff_functions?
-       AccessPolicy.new(current_user).can? :access_staff_functions
-  end
 end

--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,7 +1,7 @@
 class ApplicationComponent < ViewComponent::Base
   delegate :current_user, to: :helpers
 
-  def can_see_admin_pages?
-       AccessPolicy.new(current_user).can? :see_admin_pages
+  def can_access_staff_functions?
+       AccessPolicy.new(current_user).can? :access_staff_functions
   end
 end

--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,3 +1,7 @@
 class ApplicationComponent < ViewComponent::Base
+  delegate :current_user, to: :helpers
 
+  def can_see_admin_pages?
+       AccessPolicy.new(current_user).can? :see_admin_pages
+  end
 end

--- a/app/components/collection_metadata_component.html.erb
+++ b/app/components/collection_metadata_component.html.erb
@@ -1,5 +1,5 @@
 <div class="show-metadata">
-  <% if current_staff_user? %>
+  <% if can?(:read, Asset) && can?(:read, Work) %>
     <p class="show-item-count">
       <%= "#{number_with_delimiter(public_count)} public #{'item'.pluralize(public_count)}, #{number_with_delimiter(all_count)} total" %>
     </p>

--- a/app/components/collection_metadata_component.rb
+++ b/app/components/collection_metadata_component.rb
@@ -1,7 +1,8 @@
 # A little section wtih some brief description of the collection, on a collection
 # show page.
 class CollectionMetadataComponent < ApplicationComponent
-  delegate :current_staff_user?, to: :helpers
+
+  delegate :can?, to: :helpers
 
   attr_reader :collection, :show_links
 

--- a/app/components/search_result/base_component.rb
+++ b/app/components/search_result/base_component.rb
@@ -11,7 +11,7 @@ module SearchResult
 
     attr_reader :model, :child_counter, :cart_presence, :solr_document
 
-    delegate :current_user, :publication_badge, :search_on_facet_path, to: :helpers
+    delegate :can?, :publication_badge, :search_on_facet_path, to: :helpers
 
     # @param work [Work]
     # @param child_counter [ChildCountDisplayFetcher]

--- a/app/components/search_result/work_component.rb
+++ b/app/components/search_result/work_component.rb
@@ -83,7 +83,7 @@ module SearchResult
     end
 
     def show_cart_control?
-      current_user.present?
+      can? :access_staff_functions
     end
   end
 end

--- a/app/components/work_show_info_component.html.erb
+++ b/app/components/work_show_info_component.html.erb
@@ -109,7 +109,8 @@
 
 <table class="work chf-attributes">
   <%= render AttributeTable::RowComponent.new(:department, values: [department], link_to_facet: "department_facet") %>
-  <%= render AttributeTable::RowComponent.new(:exhibition, values: exhibition, link_to_facet: "exhibition_facet", alpha_sort: true) if current_staff_user? %>
+
+  <%= render AttributeTable::RowComponent.new(:exhibition, values: exhibition, link_to_facet: "exhibition_facet", alpha_sort: true) if can? :access_staff_functions%>
 
   <% if public_collections.present? %>
     <tr>

--- a/app/components/work_show_info_component.rb
+++ b/app/components/work_show_info_component.rb
@@ -22,7 +22,7 @@ class WorkShowInfoComponent < ApplicationComponent
     :rights, :rights_holder, :series_arrangement,
     :source, :subject, :title, to: :work
 
-  delegate :current_staff_user?, to: :helpers
+  delegate :can?, to: :helpers
 
   attr_reader :work
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -6,7 +6,7 @@ class AdminController < ApplicationController
 
   # For now, admin controllers allow anyone who is logged in
   def authorize_access
-    unless current_user.present?
+    unless can? :see_admin_pages
       # raise the error from `access_granted` to be consistent.
       raise AccessGranted::AccessDenied.new("Only logged-in users can access admin screens")
     end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -6,7 +6,7 @@ class AdminController < ApplicationController
 
   # For now, admin controllers allow anyone who is logged in
   def authorize_access
-    unless can? :see_admin_pages
+    unless can? :access_staff_functions
       # raise the error from `access_granted` to be consistent.
       raise AccessGranted::AccessDenied.new("Only logged-in users can access admin screens")
     end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -52,6 +52,13 @@ class CatalogController < ApplicationController
     }
   end
 
+  # Should be equivalent to:
+  # ->(controller, field) { controller.can?(:access_staff_functions) }
+  # but was not able to get this syntax to work.
+  def can_see_all_search_facets?
+    can? :access_staff_functions
+  end
+
 
   self.search_service_class = Kithe::BlacklightTools::BulkLoadingSearchService
   Kithe::BlacklightTools::BulkLoadingSearchService.bulk_load_scope =
@@ -307,8 +314,16 @@ class CatalogController < ApplicationController
     config.add_facet_field 'language_facet', label: "Language", limit: 5
     config.add_facet_field "rights_facet", helper_method: :rights_label, label: "Rights", limit: 5
     config.add_facet_field 'department_facet', label: "Department", limit: 5
-    config.add_facet_field 'exhibition_facet', label: "Exhibition (Staff-only)", limit: 5, show: :current_user
-    config.add_facet_field 'published_bsi',    label: "Visibility (Staff-only)", show: :current_user, helper_method: :visibility_facet_labels
+
+    config.add_facet_field 'exhibition_facet',
+      label: "Exhibition (Staff-only)",
+      limit: 5,
+      show: :can_see_all_search_facets?
+
+    config.add_facet_field 'published_bsi',
+      label: "Visibility (Staff-only)",
+      helper_method: :visibility_facet_labels,
+      show: :can_see_all_search_facets?
 
 
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -55,7 +55,7 @@ class CatalogController < ApplicationController
   # Should be equivalent to:
   # ->(controller, field) { controller.can?(:access_staff_functions) }
   # but was not able to get this syntax to work.
-  def can_see_all_search_facets?
+  def access_staff_only_facets?
     can? :access_staff_functions
   end
 
@@ -318,12 +318,12 @@ class CatalogController < ApplicationController
     config.add_facet_field 'exhibition_facet',
       label: "Exhibition (Staff-only)",
       limit: 5,
-      show: :can_see_all_search_facets?
+      show: :access_staff_only_facets?
 
     config.add_facet_field 'published_bsi',
       label: "Visibility (Staff-only)",
       helper_method: :visibility_facet_labels,
-      show: :can_see_all_search_facets?
+      show: :access_staff_only_facets?
 
 
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -52,6 +52,13 @@ class CatalogController < ApplicationController
     }
   end
 
+
+  # If you're allowed to see the admin pages,
+  # you're also allowed to see e.g. sort by date modified or created.
+  def can_see_extra_sort_orders?
+    can? :see_admin_pages
+  end
+
   self.search_service_class = Kithe::BlacklightTools::BulkLoadingSearchService
   Kithe::BlacklightTools::BulkLoadingSearchService.bulk_load_scope =
     -> { includes(:parent, :leaf_representative)  }
@@ -456,7 +463,7 @@ class CatalogController < ApplicationController
     config.add_sort_field("date_modified_desc") do |field|
       field.label = "date modified \u25BC"
       field.sort = "date_modified_dtsi desc"
-      field.if = ->(controller, field) { controller.current_user }
+      field.if = :can_see_extra_sort_orders?
     end
 
     # oldest first
@@ -464,7 +471,7 @@ class CatalogController < ApplicationController
     config.add_sort_field("date_modified_asc") do |field|
       field.label = "date modified \u25B2"
       field.sort = "date_modified_dtsi asc"
-      field.if = ->(controller, field) { controller.current_user }
+      field.if = :can_see_extra_sort_orders?
     end
 
     # newest first
@@ -472,7 +479,7 @@ class CatalogController < ApplicationController
     config.add_sort_field("date_created_desc") do |field|
       field.label = "date created \u25BC"
       field.sort = "date_created_dtsi desc"
-      field.if = ->(controller, field) { controller.current_user }
+      field.if = :can_see_extra_sort_orders?
     end
 
     # oldest first
@@ -480,7 +487,7 @@ class CatalogController < ApplicationController
     config.add_sort_field("date_created_asc") do |field|
       field.label = "date created \u25B2"
       field.sort = "date_created_dtsi asc"
-      field.if = ->(controller, field) { controller.current_user }
+      field.if = :can_see_extra_sort_orders?
     end
 
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -53,12 +53,6 @@ class CatalogController < ApplicationController
   end
 
 
-  # If you're allowed to see the admin pages,
-  # you're also allowed to see e.g. sort by date modified or created.
-  def can_see_extra_sort_orders?
-    can? :access_staff_functions
-  end
-
   self.search_service_class = Kithe::BlacklightTools::BulkLoadingSearchService
   Kithe::BlacklightTools::BulkLoadingSearchService.bulk_load_scope =
     -> { includes(:parent, :leaf_representative)  }
@@ -463,7 +457,7 @@ class CatalogController < ApplicationController
     config.add_sort_field("date_modified_desc") do |field|
       field.label = "date modified \u25BC"
       field.sort = "date_modified_dtsi desc"
-      field.if = :can_see_extra_sort_orders?
+      field.if = ->(controller, field) { controller.can?(:access_staff_functions) }
     end
 
     # oldest first
@@ -471,7 +465,7 @@ class CatalogController < ApplicationController
     config.add_sort_field("date_modified_asc") do |field|
       field.label = "date modified \u25B2"
       field.sort = "date_modified_dtsi asc"
-      field.if = :can_see_extra_sort_orders?
+      field.if = ->(controller, field) { controller.can?(:access_staff_functions) }
     end
 
     # newest first
@@ -479,7 +473,7 @@ class CatalogController < ApplicationController
     config.add_sort_field("date_created_desc") do |field|
       field.label = "date created \u25BC"
       field.sort = "date_created_dtsi desc"
-      field.if = :can_see_extra_sort_orders?
+      field.if = ->(controller, field) { controller.can?(:access_staff_functions) }
     end
 
     # oldest first
@@ -487,7 +481,7 @@ class CatalogController < ApplicationController
     config.add_sort_field("date_created_asc") do |field|
       field.label = "date created \u25B2"
       field.sort = "date_created_dtsi asc"
-      field.if = :can_see_extra_sort_orders?
+      field.if = ->(controller, field) { controller.can?(:access_staff_functions) }
     end
 
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -56,7 +56,7 @@ class CatalogController < ApplicationController
   # If you're allowed to see the admin pages,
   # you're also allowed to see e.g. sort by date modified or created.
   def can_see_extra_sort_orders?
-    can? :see_admin_pages
+    can? :access_staff_functions
   end
 
   self.search_service_class = Kithe::BlacklightTools::BulkLoadingSearchService

--- a/app/controllers/collection_show_controllers/oral_history_collection_controller.rb
+++ b/app/controllers/collection_show_controllers/oral_history_collection_controller.rb
@@ -33,14 +33,6 @@ module CollectionShowControllers
       end
     end
 
-    # Should be equivalent to:
-    # ->(controller, field) { controller.can?(:access_staff_functions) }
-    # but was not able to get this syntax to work.
-    def can_see_all_search_facets?
-      can? :access_staff_functions
-    end
-
-
     # Collections we want to list as "projects", ordered by same order as their ids in
     # PROJECT_COLLECTION_FRIENDLIER_IDS
     helper_method def project_list

--- a/app/controllers/collection_show_controllers/oral_history_collection_controller.rb
+++ b/app/controllers/collection_show_controllers/oral_history_collection_controller.rb
@@ -123,7 +123,7 @@ module CollectionShowControllers
 
       # Make "Rights" staff-only, at least fo rnow, with label matching
       config.facet_fields["rights_facet"].tap do |facet_config|
-        facet_config.if = :can_see_all_search_facets?
+        facet_config.if = :access_staff_only_facets?
         facet_config.label = "Rights (Staff-only)"
       end
 

--- a/app/controllers/collection_show_controllers/oral_history_collection_controller.rb
+++ b/app/controllers/collection_show_controllers/oral_history_collection_controller.rb
@@ -33,6 +33,14 @@ module CollectionShowControllers
       end
     end
 
+    # Should be equivalent to:
+    # ->(controller, field) { controller.can?(:access_staff_functions) }
+    # but was not able to get this syntax to work.
+    def can_see_all_search_facets?
+      can? :access_staff_functions
+    end
+
+
     # Collections we want to list as "projects", ordered by same order as their ids in
     # PROJECT_COLLECTION_FRIENDLIER_IDS
     helper_method def project_list
@@ -123,7 +131,7 @@ module CollectionShowControllers
 
       # Make "Rights" staff-only, at least fo rnow, with label matching
       config.facet_fields["rights_facet"].tap do |facet_config|
-        facet_config.if = :current_user
+        facet_config.if = :can_see_all_search_facets?
         facet_config.label = "Rights (Staff-only)"
       end
 

--- a/app/models/search_builder/admin_only_search_fields.rb
+++ b/app/models/search_builder/admin_only_search_fields.rb
@@ -17,10 +17,16 @@ class SearchBuilder
     end
 
     def include_admin_only_search_fields(solr_params)
-      if scope.context[:current_user]
+      if can_access_staff_functions?
         solr_params["qf"] << " " << admin_only_search_fields.join(" ")
         solr_params["qf"] << " " << admin_only_search_fields.join(" ")
       end
     end
+
+    def can_access_staff_functions?
+      user = scope.context[:current_user]
+      AccessPolicy.new(user).can? :access_staff_functions
+    end
+
   end
 end

--- a/app/policies/access_policy.rb
+++ b/app/policies/access_policy.rb
@@ -22,7 +22,7 @@ class AccessPolicy
 
       can :admin, User
 
-      can :see_admin_pages
+      can :access_staff_functions
       can :destroy, Admin::QueueItemComment do |comment, user|
         comment.user_id == user.id
       end
@@ -33,7 +33,7 @@ class AccessPolicy
       can :read, Kithe::Model # whether publisehd or not
       can :update, Kithe::Model
 
-      can :see_admin_pages
+      can :access_staff_functions
       can :destroy, Admin::QueueItemComment do |comment, user|
         comment.user_id == user.id
       end

--- a/app/policies/access_policy.rb
+++ b/app/policies/access_policy.rb
@@ -21,11 +21,6 @@ class AccessPolicy
       can :publish, Asset
 
       can :admin, User
-
-      #can :access_staff_functions
-      #an :destroy, Admin::QueueItemComment do |comment, user|
-      #  comment.user_id == user.id
-      #end
     end
 
     # Any logged-in staff considered staff at present

--- a/app/policies/access_policy.rb
+++ b/app/policies/access_policy.rb
@@ -22,6 +22,7 @@ class AccessPolicy
 
       can :admin, User
 
+      can :see_admin_pages
       can :destroy, Admin::QueueItemComment do |comment, user|
         comment.user_id == user.id
       end
@@ -32,6 +33,7 @@ class AccessPolicy
       can :read, Kithe::Model # whether publisehd or not
       can :update, Kithe::Model
 
+      can :see_admin_pages
       can :destroy, Admin::QueueItemComment do |comment, user|
         comment.user_id == user.id
       end

--- a/app/policies/access_policy.rb
+++ b/app/policies/access_policy.rb
@@ -22,10 +22,10 @@ class AccessPolicy
 
       can :admin, User
 
-      can :access_staff_functions
-      can :destroy, Admin::QueueItemComment do |comment, user|
-        comment.user_id == user.id
-      end
+      #can :access_staff_functions
+      #an :destroy, Admin::QueueItemComment do |comment, user|
+      #  comment.user_id == user.id
+      #end
     end
 
     # Any logged-in staff considered staff at present

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,8 +70,9 @@
       <%= render 'ie_unsupported_warning' %>
     <% end %>
 
-    <%= render 'front_end_admin_navbar' if can? :access_staff_functions %>
-
+    <% if can? :access_staff_functions %>
+      <%= render 'front_end_admin_navbar' %>
+    <% end %>
     <%= render 'layouts/scihist_masthead' %>
 
     <%# Blacklight put a search form here, we include our own local one in scihist_masthead instead,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,7 +70,7 @@
       <%= render 'ie_unsupported_warning' %>
     <% end %>
 
-    <%= render 'front_end_admin_navbar' if can? :see_admin_pages %>
+    <%= render 'front_end_admin_navbar' if can? :access_staff_functions %>
 
     <%= render 'layouts/scihist_masthead' %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,9 +70,7 @@
       <%= render 'ie_unsupported_warning' %>
     <% end %>
 
-    <% if current_user %>
-      <%= render 'front_end_admin_navbar' %>
-    <% end %>
+    <%= render 'front_end_admin_navbar' if can? :see_admin_pages %>
 
     <%= render 'layouts/scihist_masthead' %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
-  class CanSeeAdminConstraint
+  class CanAccessStaffFunctionsConstraint
     def self.matches?(request)
       AccessPolicy.new(request.env['warden'].user).can? :access_staff_functions
     end
@@ -334,7 +334,7 @@ Rails.application.routes.draw do
     # These 'sub-apps' are for admin-use only, but since they are sub-apps
     # aren't protected by the AdminController. We have Rails routing only
     # provide the routes if the user is allowed to see the admin pages.
-    constraints CanSeeAdminConstraint do
+    constraints CanAccessStaffFunctionsConstraint do
       mount Resque::Server, at: '/queues'
 
       mount Kithe::AssetUploader.upload_endpoint(:cache) => "/direct_upload", as: :direct_app_upload
@@ -348,7 +348,7 @@ Rails.application.routes.draw do
   # We can't put browse-everything in the routing namespace, cause it breaks
   # browse-everything, alas. We'll still make it route as if it were, and
   # add a routing constraint to protect to users allowed to see the admin pages.
-  constraints CanSeeAdminConstraint do
+  constraints CanAccessStaffFunctionsConstraint do
     mount BrowseEverything::Engine => '/admin/browse'
 
     # Don't know if we really need qa to be limited to logged-in users, but

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   class CanSeeAdminConstraint
     def self.matches?(request)
-      AccessPolicy.new(request.env['warden'].user).can? :see_admin_pages
+      AccessPolicy.new(request.env['warden'].user).can? :access_staff_functions
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,7 +228,7 @@ Rails.application.routes.draw do
   # End Blacklight-generated routes
   ##
 
-  # Routes will even only _show up_ to can_see_admin users, this applies
+  # Routes will even only _show up_ for users who can :access_staff_functions; this applies
   # to internal rack apps we're mounting here too, like shrine upload endpoints,
   # is one reason to use a constraint.
   namespace :admin do


### PR DESCRIPTION
In preparation to some upcoming changes to our permissions scheme, this adds a new `:see_admin_pages` permission to our access policy.
All logged in users have this permission (and we don't actually foresee that changing). But instead of checking whether we can find a logged-in user, we'll be checking for this permission instead, which is tidier.