### PR TITLE
Use new user_type column to determine permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,9 @@ jobs:
             # have a checked in Gemfile.lock
 
         - name: Install apt dependencies
-          uses: awalsh128/cache-apt-pkgs-action@latest
-          with:
-            packages: libvips-tools ffmpeg mediainfo poppler-utils
-            version: 1.0
+          run: |
+            sudo apt-get update
+            sudo apt-get -y install libvips-tools ffmpeg mediainfo poppler-utils
 
         - name: Set up app
           run: |

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ If you tag a test with `logged_in_user: true`, the test framework will create a 
      # or
      it "does something", logged_in_user: true do ...
 
-You can also do `logged_in_user: :admin` to get a user with `admin?` permissions. (superusers)
+You can also do `logged_in_user: :admin` to get a user with `admin` permissions. (superusers)
 
 #### ActiveJob queue adapter
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -64,6 +64,6 @@ class Admin::UsersController < AdminController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def user_params
-      params.require(:user).permit(:email, :name, :admin, :locked_out)
+      params.require(:user).permit(:email, :name, :user_type, :locked_out)
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ApplicationRecord
 
 
   def admin?
-    raise RuntimeError.new("Deprecated. Use admin_user?")
+    raise RuntimeError.new("Don't use this method. Use admin_user? instead.")
     user_type == "admin"
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,9 +12,30 @@ class User < ApplicationRecord
   devise :database_authenticatable,
          :recoverable, :rememberable, :validatable
 
-
   has_many :cart_items, dependent: :delete_all
   has_many :works_in_cart, through: :cart_items, source: :work
+
+  # This will correspond to a "role" in the AccessPolicy class.
+  # "editor" will replace the current "staff" role.
+  # A new "reader" type will be added in a future PR.
+  USER_TYPES = %w{admin editor}.freeze
+  enum user_type: USER_TYPES.collect {|v| [v, v]}.to_h
+  validates :user_type, presence: true
+
+
+  def admin?
+    raise RuntimeError.new("Deprecated. Use admin_user?")
+    user_type == "admin"
+  end
+
+  def admin_user?
+    user_type == "admin"
+  end
+
+  # This is the same as the old "logged-in but not admin" user type.
+  def editor_user?
+    user_type == "editor"
+  end
 
   # Only used by devise validatable, we want to allow user accounts
   # to be saved with nil password, means they won't be able to log in

--- a/app/policies/access_policy.rb
+++ b/app/policies/access_policy.rb
@@ -10,7 +10,7 @@ class AccessPolicy
   def configure
     # The most important admin role, gets checked first
 
-    role :admin, proc { |user| !user.nil? && user.admin? } do
+    role :admin, proc { |user| !user.nil? && user.admin_user? } do
       can :destroy, Work
       can :publish, Work
 

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -5,7 +5,7 @@
   <div class="form-inputs">
     <%= f.input :email %>
     <%= f.input :name %>
-    <%= f.input :admin %>
+    <%= f.input :user_type, collection: User::USER_TYPES, :include_blank => false  %>
     <%= f.input :locked_out %>
   </div>
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -7,28 +7,30 @@
 <table class="table">
   <thead>
     <tr>
-      <th>email</th>
-      <th>name</th>
-      <th></th>
+      <th>Who</th>
+      <th>User type</th>
+      <th>Locked out?</th>
+      <th>Actions</th>
     </tr>
   </thead>
 
   <tbody>
     <% @users.each do |user| %>
       <tr>
+        <td><%= user.name %><br/><small class="text-monospace text-muted"><%= user.email %></small></td>
         <td>
-          <%= user.email %>
-          <% if user.locked_out? %>
-            <span class="badge badge-danger">Locked out</span>
-          <% end %>
           <% if user.admin_user? %>
             <span class="badge badge-primary">Admin</span>
           <% end %>
           <% if user.editor_user? %>
-            <span class="badge badge-primary">Editor</span>
+            <span class="badge badge-light">Editor</span>
           <% end %>
         </td>
-        <td><%= user.name %></td>
+        <td>
+          <% if user.locked_out? %>
+            🚫
+          <% end %>
+        </td>
         <td>
           <%= link_to 'Edit', edit_admin_user_path(user), class: "btn btn-sm btn-outline-primary" %>
           <%= link_to 'Send password reset', send_password_reset_admin_user_path(user), method: "post", class: "btn btn-sm btn-outline-primary" %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -21,8 +21,11 @@
           <% if user.locked_out? %>
             <span class="badge badge-danger">Locked out</span>
           <% end %>
-          <% if user.admin? %>
+          <% if user.admin_user? %>
             <span class="badge badge-primary">Admin</span>
+          <% end %>
+          <% if user.editor_user? %>
+            <span class="badge badge-primary">Editor</span>
           <% end %>
         </td>
         <td><%= user.name %></td>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -8,8 +8,7 @@
   <thead>
     <tr>
       <th>Who</th>
-      <th>User type</th>
-      <th>Locked out?</th>
+      <th>Permissions</th>
       <th>Actions</th>
     </tr>
   </thead>
@@ -25,15 +24,13 @@
           <% if user.editor_user? %>
             <span class="badge badge-light">Editor</span>
           <% end %>
-        </td>
-        <td>
           <% if user.locked_out? %>
-            🚫
+            <span class="badge badge-danger">Locked out</span>
           <% end %>
         </td>
         <td>
           <%= link_to 'Edit', edit_admin_user_path(user), class: "btn btn-sm btn-outline-primary" %>
-          <%= link_to 'Send password reset', send_password_reset_admin_user_path(user), method: "post", class: "btn btn-sm btn-outline-primary" %>
+          <%= link_to 'Reset password', send_password_reset_admin_user_path(user), method: "post", class: "btn btn-sm btn-outline-primary" %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -30,7 +30,7 @@
         </td>
         <td>
           <%= link_to 'Edit', edit_admin_user_path(user), class: "btn btn-sm btn-outline-primary" %>
-          <%= link_to 'Reset password', send_password_reset_admin_user_path(user), method: "post", class: "btn btn-sm btn-outline-primary" %>
+          <%= link_to 'Send password reset', send_password_reset_admin_user_path(user), method: "post", class: "btn btn-sm btn-outline-primary" %>
         </td>
       </tr>
     <% end %>

--- a/lib/tasks/scihist.rake
+++ b/lib/tasks/scihist.rake
@@ -70,23 +70,23 @@ namespace :scihist do
       desc 'Grant admin role to existing user'
       task :grant, [:email] => :environment do |t, args|
         begin
-          User.find_by_email!(args[:email]).update(admin: true)
+          User.find_by_email!(args[:email]).update(user_type: 'admin')
         rescue ActiveRecord::RecordNotFound
-          abort("User #{args[:email]} does not exist. Only an existing user can be promoted to admin")
+          abort("User #{args[:email]} does not exist. Only an existing user can be promoted to admin.")
         end
         puts "User: #{args[:email]} is an admin."
       end
 
       desc 'Revoke admin role from user'
       task :revoke, [:email] => :environment do |t, args|
-        User.find_by_email!(args[:email]).update(admin: false)
-        puts "User: #{args[:email]} is no longer an admin."
+        User.find_by_email!(args[:email]).update(user_type: 'editor')
+        puts "User: #{args[:email]} is no longer an admin; they are an editor instead."
       end
 
       desc 'List all admin users'
       task list: :environment do
         puts "Admin users:"
-        User.where(admin: true).each { |u| puts "  #{u.email}" }
+        User.where(user_type: 'admin').each { |u| puts "  #{u.email}" }
       end
     end
   end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -3,7 +3,11 @@ FactoryBot.define do
     email { "no-reply@sciencehistory.org"}
 
     factory :admin_user do
-      admin { true }
+      user_type { "admin" }
+    end
+
+    factory :editor_user do
+      user_type { "editor" }
     end
   end
 end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -5,9 +5,5 @@ FactoryBot.define do
     factory :admin_user do
       user_type { "admin" }
     end
-
-    factory :editor_user do
-      user_type { "editor" }
-    end
   end
 end


### PR DESCRIPTION
- Decide if someone is "staff" (now renamed "editor") or "admin" based on the new column.
- And allow edits to the new `user_type` column in the admin screens.
- I already updated the values of the column in prod and staging to reflect the current contents of the old admin column, so we can push this to prod whenever.
- Does not modify the behavior of the app in any way, other than to provide a way to set a user to "editor".