### PR TITLE
Add :see_unpublished_items permission

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,3 +1,8 @@
 class ApplicationComponent < ViewComponent::Base
+  delegate :current_user, to: :helpers
+
+  def can_see_unpublished_items?
+	AccessPolicy.new(current_user).can? :see_unpublished_items
+  end
 
 end

--- a/app/components/collection_metadata_component.html.erb
+++ b/app/components/collection_metadata_component.html.erb
@@ -1,5 +1,5 @@
 <div class="show-metadata">
-  <% if current_staff_user? %>
+  <% if can_see_unpublished_items? %>
     <p class="show-item-count">
       <%= "#{number_with_delimiter(public_count)} public #{'item'.pluralize(public_count)}, #{number_with_delimiter(all_count)} total" %>
     </p>

--- a/app/components/oral_history/downloads_list_component.rb
+++ b/app/components/oral_history/downloads_list_component.rb
@@ -1,7 +1,7 @@
 module OralHistory
   # Content of the "Downloads" tab for Oral History pages.
   class DownloadsListComponent < ApplicationComponent
-    delegate :format_ohms_timestamp, :current_user, to: :helpers
+    delegate :format_ohms_timestamp, to: :helpers
 
     # our combined_audio_derivatives helper methods
     delegate :m4a_audio_url, :derivatives_up_to_date?, :m4a_audio_download_url,
@@ -24,7 +24,7 @@ module OralHistory
     def all_members
       @all_members ||= begin
         members = work.members.includes(:leaf_representative)
-        members = members.where(published: true) if current_user.nil?
+        members = members.where(published: true) unless can_see_unpublished_items?
         members.order(:position).to_a
       end
     end

--- a/app/components/work_file_list_show_component.rb
+++ b/app/components/work_file_list_show_component.rb
@@ -11,7 +11,7 @@
 # a single download button.
 #
 class WorkFileListShowComponent < ApplicationComponent
-  delegate :construct_page_title, :current_user, to: :helpers
+  delegate :construct_page_title, to: :helpers
 
   attr_reader :work
 
@@ -24,11 +24,7 @@ class WorkFileListShowComponent < ApplicationComponent
   def member_list_for_display
     @member_list_display ||= begin
       members = all_members
-
-      if current_user.nil?
-        members = members.find_all(&:published?)
-      end
-
+      members = members.find_all(&:published?) unless can_see_unpublished_items?
       # omit "portrait" role
       members = members.find_all {|m| ! m.role_portrait? }
 

--- a/app/components/work_oh_audio_show_component.rb
+++ b/app/components/work_oh_audio_show_component.rb
@@ -2,7 +2,7 @@
 # show up in a fixed navbar.
 #
 class WorkOhAudioShowComponent < ApplicationComponent
-  delegate :construct_page_title, :current_user, to: :helpers
+  delegate :construct_page_title, to: :helpers
 
   delegate  :m4a_audio_url, :derivatives_up_to_date?, to: :combined_audio_derivatives, prefix: "combined"
 
@@ -20,7 +20,7 @@ class WorkOhAudioShowComponent < ApplicationComponent
   def all_members
     @all_members ||= begin
       members = work.members.includes(:leaf_representative)
-      members = members.where(published: true) if current_user.nil?
+      members = members.where(published: true) unless can_see_unpublished_items?
       members = members.strict_loading # prevent accidental n+1 lazy-loading.
       members.order(:position).to_a
     end

--- a/app/components/work_video_show_component.rb
+++ b/app/components/work_video_show_component.rb
@@ -9,7 +9,7 @@
 # it a separate class instead of trying to use lots of conditionals in one class, betting
 # that will be simpler overall, and allow them to diverge as more features are added.
 class WorkVideoShowComponent < ApplicationComponent
-  delegate :construct_page_title, :current_user, to: :helpers
+  delegate :construct_page_title, to: :helpers
 
   attr_reader :work
 
@@ -34,7 +34,7 @@ class WorkVideoShowComponent < ApplicationComponent
     return @video_asset if defined?(@video_asset)
 
   	@video_asset = (work.leaf_representative &&
-      (work.leaf_representative.published? || current_user.present?) &&
+      (work.leaf_representative.published? || can_see_unpublished_items?) &&
       work.leaf_representative) || nil
   end
 

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -31,7 +31,7 @@ class WorksController < ApplicationController
   end
 
   def viewer_images_info
-    render json: ViewerMemberInfoSerializer.new(@work, current_user: current_user).as_hash
+    render json: ViewerMemberInfoSerializer.new(@work, show_unpublished: (can? :see_unpublished_items)).as_hash
   end
 
   def transcription

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,6 +13,10 @@ module ApplicationHelper
     "#{title} - #{application_name}"
   end
 
+  def can_see_unpublished_items?
+    AccessPolicy.new(current_user).can? :see_unpublished_items
+  end
+
   # for now any logged in user is a staff user
   def current_staff_user?
     current_user.present?
@@ -31,12 +35,12 @@ module ApplicationHelper
     path
   end
 
-    def visibility_facet_labels(value)
-      case value.to_s
-      when "true" ; "published"
-      when "false" ; "private"
-      else ; value
-      end
+  def visibility_facet_labels(value)
+    case value.to_s
+    when "true" ; "published"
+    when "false" ; "private"
+    else ; value
     end
+  end
 
 end

--- a/app/models/search_builder/access_control_filter.rb
+++ b/app/models/search_builder/access_control_filter.rb
@@ -12,11 +12,16 @@ class SearchBuilder
     end
 
     def access_control_filter(solr_params)
-      if scope.context[:current_user].nil?
-        # Only apply this filter if the user is not logged in.
+      unless can_see_unpublished?
         solr_params[:fq] ||= []
         solr_params[:fq] << "{!term f=published_bsi}1"
       end
     end
+
+    def can_see_unpublished?
+      user = scope.context[:current_user]
+      AccessPolicy.new(user).can? :see_unpublished_items
+    end
+
   end
 end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -121,7 +121,9 @@ class Work < Kithe::Work
   # with proper pre-fetches.
   def ordered_viewable_members(current_user:)
     members = self.members.includes(:leaf_representative)
-    members = members.where(published: true) if current_user.nil?
+    unless AccessPolicy.new(current_user).can? :see_unpublished_items
+      members = members.where(published: true)
+    end
     members = members.order(:position)
 
     # the point of this is to avoid n+1's, so let's set strict_loading, which

--- a/app/policies/access_policy.rb
+++ b/app/policies/access_policy.rb
@@ -22,6 +22,7 @@ class AccessPolicy
 
       can :admin, User
 
+      can :see_unpublished_items
       can :destroy, Admin::QueueItemComment do |comment, user|
         comment.user_id == user.id
       end
@@ -31,6 +32,8 @@ class AccessPolicy
     role :staff, proc { |user| !user.nil? } do
       can :read, Kithe::Model # whether publisehd or not
       can :update, Kithe::Model
+
+      can :see_unpublished_items
 
       can :destroy, Admin::QueueItemComment do |comment, user|
         comment.user_id == user.id

--- a/app/serializers/viewer_member_info_serializer.rb
+++ b/app/serializers/viewer_member_info_serializer.rb
@@ -9,11 +9,11 @@ class ViewerMemberInfoSerializer
 
   THUMB_DERIVATIVE = :thumb_mini
 
-  attr_reader :work, :current_user
+  attr_reader :work, :show_unpublished
 
-  def initialize(work, current_user:nil)
+  def initialize(work, show_unpublished: false)
     @work = work
-    @current_user = current_user
+    @show_unpublished = show_unpublished
   end
 
   def as_hash
@@ -40,7 +40,7 @@ class ViewerMemberInfoSerializer
   def included_members
     @included_members ||= begin
       members = work.members.order(:position)
-      members = members.where(published: true) if current_user.nil?
+      members = members.where(published: true) unless @show_unpublished
       members.includes(:leaf_representative).select do |member|
         member.leaf_representative &&
         member.leaf_representative.content_type&.start_with?("image/") &&
@@ -52,8 +52,6 @@ class ViewerMemberInfoSerializer
   def download_options(asset)
     DownloadOptions::ImageDownloadOptions.new(asset).options
   end
-
-
 
   def thumb_src_attributes(asset)
     derivative_1x_url = asset.file_url(THUMB_DERIVATIVE)

--- a/spec/serializers/viewer_member_info_serializer_spec.rb
+++ b/spec/serializers/viewer_member_info_serializer_spec.rb
@@ -47,7 +47,8 @@ describe ViewerMemberInfoSerializer, type: :model, queue_adapter: :inline do
 
   describe "with logged-in user" do
     let(:current_user) { create(:user) }
-    let(:serializer) { ViewerMemberInfoSerializer.new(work, current_user: current_user) }
+    let(:can_see_unpublished) { AccessPolicy.new(current_user).can? :see_unpublished_items }
+    let(:serializer) { ViewerMemberInfoSerializer.new(work, show_unpublished: can_see_unpublished) }
 
     it "includes non-published asset" do
       serialized = serializer.as_hash


### PR DESCRIPTION
In preparation to some upcoming changes to our permissions scheme, this adds a new :see_unpublished_items permission to our access policy.
All logged in users have this permission (and we don't actually foresee that changing). But instead of checking whether we can find a logged-in user, we'll be checking for this permission instead, which is tidier.
In addition, I made a small refactor of `ViewerMemberInfoSerializer`, which was taking `current_user` as an initializer argument. I think the new structure just makes more sense.