### PR TITLE
Revert custom github action to install Apt packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,9 @@ jobs:
             # have a checked in Gemfile.lock
 
         - name: Install apt dependencies
-          uses: awalsh128/cache-apt-pkgs-action@latest
-          with:
-            packages: libvips-tools ffmpeg mediainfo poppler-utils
-            version: 1.0
+          run: |
+            sudo apt-get update
+            sudo apt-get -y install libvips-tools ffmpeg mediainfo poppler-utils
 
         - name: Set up app
           run: |


### PR DESCRIPTION
This fixes a problem with ffmpeg loading libvorbis shared libraries, which started breaking yesterday. (Description of the problem is at ref: https://github.com/sciencehistory/scihist_digicoll/issues/1978 ).

This simply reverts https://github.com/sciencehistory/scihist_digicoll/pull/1911 .