### PR TITLE
DRY up check for can_see_unpublished_records?

### DIFF
--- a/app/components/oral_history/downloads_list_component.rb
+++ b/app/components/oral_history/downloads_list_component.rb
@@ -1,7 +1,7 @@
 module OralHistory
   # Content of the "Downloads" tab for Oral History pages.
   class DownloadsListComponent < ApplicationComponent
-    delegate :format_ohms_timestamp, :can?, to: :helpers
+    delegate :format_ohms_timestamp, :can_see_unpublished_records?, to: :helpers
 
     # our combined_audio_derivatives helper methods
     delegate :m4a_audio_url, :derivatives_up_to_date?, :m4a_audio_download_url,
@@ -24,7 +24,7 @@ module OralHistory
     def all_members
       @all_members ||= begin
         members = work.members.includes(:leaf_representative)
-        unless (can? :read, Asset) && (can? :read, Work)
+        unless can_see_unpublished_records?
            members = members.where(published: true)
         end
         members.order(:position).to_a

--- a/app/components/work_file_list_show_component.rb
+++ b/app/components/work_file_list_show_component.rb
@@ -11,7 +11,7 @@
 # a single download button.
 #
 class WorkFileListShowComponent < ApplicationComponent
-  delegate :construct_page_title, :can?, to: :helpers
+  delegate :construct_page_title, :can_see_unpublished_records?, to: :helpers
 
   attr_reader :work
 
@@ -24,8 +24,11 @@ class WorkFileListShowComponent < ApplicationComponent
   def member_list_for_display
     @member_list_display ||= begin
       members = all_members
-      show_all_members = (can? :read, Asset) && (can? :read, Work)
-      members = members.find_all(&:published?) unless show_all_members
+
+      unless can_see_unpublished_records?
+        members = members.find_all(&:published?)
+      end
+
       # omit "portrait" role
       members = members.find_all {|m| ! m.role_portrait? }
 

--- a/app/components/work_oh_audio_show_component.rb
+++ b/app/components/work_oh_audio_show_component.rb
@@ -2,7 +2,7 @@
 # show up in a fixed navbar.
 #
 class WorkOhAudioShowComponent < ApplicationComponent
-  delegate :construct_page_title, :can?, to: :helpers
+  delegate :construct_page_title, :can_see_unpublished_records?, to: :helpers
 
   delegate  :m4a_audio_url, :derivatives_up_to_date?, to: :combined_audio_derivatives, prefix: "combined"
 
@@ -20,8 +20,11 @@ class WorkOhAudioShowComponent < ApplicationComponent
   def all_members
     @all_members ||= begin
       members = work.members.includes(:leaf_representative)
-      show_all_members = (can? :read, Asset) && (can? :read, Work)
-      members = members.where(published: true) unless show_all_members
+
+      unless can_see_unpublished_records?
+        members = members.where(published: true)
+      end
+
       members = members.strict_loading # prevent accidental n+1 lazy-loading.
       members.order(:position).to_a
     end

--- a/app/components/work_video_show_component.rb
+++ b/app/components/work_video_show_component.rb
@@ -9,7 +9,7 @@
 # it a separate class instead of trying to use lots of conditionals in one class, betting
 # that will be simpler overall, and allow them to diverge as more features are added.
 class WorkVideoShowComponent < ApplicationComponent
-  delegate :construct_page_title, :can?, to: :helpers
+  delegate :construct_page_title, :can_see_unpublished_records?, to: :helpers
 
   attr_reader :work
 
@@ -32,9 +32,8 @@ class WorkVideoShowComponent < ApplicationComponent
   # the representative, if it's visible to current user, otherwise nil!
   def video_asset
     return @video_asset if defined?(@video_asset)
-    show_all_members = (can? :read, Asset) && (can? :read, Work)
   	@video_asset = (work.leaf_representative &&
-      (work.leaf_representative.published? ||  show_all_members) &&
+      (work.leaf_representative.published? || can_see_unpublished_records?) &&
       work.leaf_representative) || nil
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,4 +34,8 @@ module ApplicationHelper
     end
   end
 
+  # delegating to current_policy, just as a convenience available as a helper too
+  def can_see_unpublished_records?
+    current_policy.can_see_unpublished_records?
+  end
 end

--- a/app/policies/access_policy.rb
+++ b/app/policies/access_policy.rb
@@ -45,6 +45,12 @@ class AccessPolicy
     role :public do
       can :read, Kithe::Model, { published: true }
     end
+  end
 
+  # This is a bit confusing the way we check this with access_granted,
+  # so DRY it up in one place. You can call `current_policy.can_see_unpublished_records?` anywhere,
+  # or we have a rails helper for convenience too.
+  def can_see_unpublished_records?
+    (can? :read, Asset) && (can? :read, Work)
   end
 end


### PR DESCRIPTION
Without changing semantics at all, we're just putting the same logic in a single method. Turns out you can put custom methods on your access_granted policy, so that's a convenient place to keep everything together -- but we also add an application helper for convenience, and actually delegate to that from the view components now. 

(At first i was _just_ going to make the application helper, but realized keeping access policy related logic in teh access policy class was possible, and nice)

Why do we want to DRY in one method? Cause this is kind of a weird call, hard to get right -- write it once right. And because we might want to change how this check for permission works, now one place to change it if we do.
