### PR TITLE
Use Kithe::Model in access policy instead of Collection / Work / Asset.

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -113,7 +113,7 @@ class Admin::CollectionsController < AdminController
     # enough for now.
     def collection_params
       permitted_attributes = [:title, :description, :department]
-      permitted_attributes << :published if can?(:publish, @collection || Collection)
+      permitted_attributes << :published if can?(:publish, @collection || Kithe::Model)
 
       Kithe::Parameters.new(params).
         require(:collection).

--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -383,7 +383,7 @@ class Admin::WorksController < AdminController
   end
 
   def batch_publish_toggle
-    authorize! :publish, Work
+    authorize! :publish, Kithe::Model
 
     unless params[:publish].in?(["on", "off"])
       raise ArgumentError.new("Need `publish` param to be `on` or off`")

--- a/app/policies/access_policy.rb
+++ b/app/policies/access_policy.rb
@@ -8,31 +8,19 @@ class AccessPolicy
   include AccessGranted::Policy
 
   def configure
-    # The most important admin role, gets checked first
 
-    role :admin, proc { |user| !user.nil? && user.admin_user? } do
-      can :destroy, Work
-      can :publish, Work
-
-      can :destroy, Collection
-      can :publish, Collection
-
-      can :destroy, Asset
-      can :publish, Asset
-
+    role :admin, proc { |user| user&.admin_user? } do
+      can [:destroy, :publish], Kithe::Model
+      can :access_staff_functions
       can :admin, User
     end
 
-    # Any logged-in staff considered staff at present
     role :staff, proc { |user| !user.nil? } do
-      can :read, Kithe::Model # whether publisehd or not
-      can :update, Kithe::Model
-
+      can [:read, :update], Kithe::Model # whether published or not
       can :access_staff_functions
       can :destroy, Admin::QueueItemComment do |comment, user|
         comment.user_id == user.id
       end
-
     end
 
     role :public do


### PR DESCRIPTION
Ref #1948
This will greatly simplify our access policy.
We can change the two calls  to authorize! that mention `Collection` and `Work` back to the way they are now once https://github.com/chaps-io/access-granted/pull/56 is merged -- if we want.