### PR TITLE
Adding create permission

### DIFF
--- a/app/policies/access_policy.rb
+++ b/app/policies/access_policy.rb
@@ -16,7 +16,7 @@ class AccessPolicy
     end
 
     role :staff, proc { |user| !user.nil? } do
-      can [:read, :update], Kithe::Model # whether published or not
+      can [:create, :read, :update], Kithe::Model # whether published or not
       can :access_staff_functions
       can :destroy, Admin::QueueItemComment do |comment, user|
         comment.user_id == user.id

--- a/spec/policies/access_policy_spec.rb
+++ b/spec/policies/access_policy_spec.rb
@@ -26,6 +26,9 @@ describe "access policies:" do
     it "can destroy any Kithe::Model" do
       expect(policy.can?(:destroy, Kithe::Model)).to be true
     end
+    it "can create any Kithe::Model" do
+      expect(policy.can?(:create, Kithe::Model)).to be true
+    end
     it "can manage users" do
       expect(policy.can?(:admin, User)).to be true
     end
@@ -65,6 +68,9 @@ describe "access policies:" do
     it "can read a Kithe::Model" do
       expect(policy.can?(:read, Kithe::Model)).to be true
     end
+    it "can create any Kithe::Model" do
+      expect(policy.can?(:create, Kithe::Model)).to be true
+    end
     it "cannot destroy a Kithe::Model" do
       expect(policy.can?(:destroy, Kithe::Model)).to be false
     end
@@ -86,6 +92,15 @@ describe "access policies:" do
     end
     it "cannot read an unpublished asset" do
       expect(policy.can?(:read, unpublished_asset)).to be false
+    end
+    it "cannot create a Kithe::Model" do
+      expect(policy.can?(:create, Kithe::Model)).to be false
+    end
+    it "cannot update a Kithe::Model" do
+      expect(policy.can?(:update, Kithe::Model)).to be false
+    end
+    it "cannot delete a Kithe::Model" do
+      expect(policy.can?(:delete, Kithe::Model)).to be false
     end
     it "cannot access staff functions" do
       expect(policy.can?(:access_staff_functions)).to be false


### PR DESCRIPTION
Staff and admin are allowed to create works, collections and assets. This was always true but we're making it explicitly true (and will be checking against it soon.)