### PR TITLE
upgrade yarn jquery to recently released 3.6.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -474,9 +474,9 @@ is-number@^7.0.0:
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 jquery@>=1.7, "jquery@^ 3.6.0", jquery@^3.3.1, jquery@^3.5.1:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.1.tgz#fab0408f8b45fc19f956205773b62b292c147a16"
-  integrity sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.2.tgz#8302bbc9160646f507bdf59d136a478b312783c4"
+  integrity sha512-/e7ulNIEEYk1Z/l4X0vpxGt+B/dNsV8ghOPAWZaJs8pkGvsSC0tm33aMGylXcj/U7y4IcvwtMXPMyBFZn/gK9A==
 
 "js-yaml@>= 3.13.1":
   version "3.14.0"


### PR DESCRIPTION
Yarn makes it harder than it should to do this reliably. I first ran:

   yarn upgrade jquery

But that resulted in "split" jquery dependencies in yarn.lock that I didn't really want -- indirect dependencies on jquery were not upgraded in yarn.lock. And I'm not sure what that does.  So I had to manually delete the split line from the yarn.lock, then run `yarn install` again, to resolve it.

Probably should document the weird tricks I've learned for upgrading "indirect" dependencies in yarn. Very frustrating.
