### PR TITLE
Remove Work#exhibition attribute

### DIFF
--- a/app/components/work_show_info_component.html.erb
+++ b/app/components/work_show_info_component.html.erb
@@ -110,8 +110,6 @@
 <table class="work chf-attributes">
   <%= render AttributeTable::RowComponent.new(:department, values: [department], link_to_facet: "department_facet") %>
 
-  <%= render AttributeTable::RowComponent.new(:exhibition, values: exhibition, link_to_facet: "exhibition_facet", alpha_sort: true) if can? :access_staff_functions%>
-
   <% if public_collections.present? %>
     <tr>
       <th scope='row'>Collection</th>

--- a/app/components/work_show_info_component.rb
+++ b/app/components/work_show_info_component.rb
@@ -16,7 +16,7 @@ class WorkShowInfoComponent < ApplicationComponent
   # Delegate through to WORK
   delegate :additional_credit, :additional_title,
     :contained_by, :date_of_work, :department,
-    :description, :digitization_funder, :extent, :exhibition,
+    :description, :digitization_funder, :extent,
     :format, :genre, :inscription, :language, :medium,
     :parent, :physical_container, :provenance, :published?,
     :rights, :rights_holder, :series_arrangement,

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -315,11 +315,6 @@ class CatalogController < ApplicationController
     config.add_facet_field "rights_facet", helper_method: :rights_label, label: "Rights", limit: 5
     config.add_facet_field 'department_facet', label: "Department", limit: 5
 
-    config.add_facet_field 'exhibition_facet',
-      label: "Exhibition (Staff-only)",
-      limit: 5,
-      show: :access_staff_only_facets?
-
     config.add_facet_field 'published_bsi',
       label: "Visibility (Staff-only)",
       helper_method: :visibility_facet_labels,
@@ -632,8 +627,7 @@ class CatalogController < ApplicationController
     "place_facet_sim" => "place_facet",
     "language_sim" => "language_facet",
     "rights_sim" => "rights_facet",
-    "division_sim" => "department_facet",
-    "exhibition_sim" => "exhibition_facet"
+    "division_sim" => "department_facet"
   }
 
   # When posting on facebook, it modifies our facet params from eg `?f[facet_name][]=value` to

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -52,7 +52,6 @@ class WorkIndexer < Kithe::Indexer
     # We put these in a separate field, cause we only allow logged in users
     # to search them
     to_field "admin_only_text_tesim", obj_extract("admin_note")
-    to_field ["admin_only_text_tesim", "exhibition_facet"], obj_extract("exhibition")
 
     # for date/year range facet
     to_field "year_facet_isim" do |record, acc|

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -34,7 +34,6 @@ class Work < Kithe::Work
   validates :rights, inclusion: { in: RightsTerm.all_ids, allow_blank: true }
   validates :format, array_inclusion: { in: ControlledLists::FORMAT }
   validates :genre, array_inclusion: { in: ControlledLists::GENRE  }
-  validates :exhibition, array_inclusion: { in: ControlledLists::EXHIBITION  }
   validates :related_url, array_inclusion: {
     proc: ->(v) { ScihistDigicoll::Util.valid_url?(v) } ,
     message: "is not a valid url: %{rejected_values}"
@@ -70,7 +69,6 @@ class Work < Kithe::Work
   attr_json :subject, :string, array: true, default: -> { [] }
 
   attr_json :department, :string
-  attr_json :exhibition, :string, array: true, default: -> { [] }
   attr_json :series_arrangement, :string, array: true, default: -> { [] }
   attr_json :physical_container, Work::PhysicalContainer.to_type
 

--- a/app/models/work/controlled_lists.rb
+++ b/app/models/work/controlled_lists.rb
@@ -106,26 +106,5 @@ class Work
       'Tobias, Gregory',
       'Voelkel, James',
     ]
-
-    EXHIBITION = [
-      "Age of Alchemy",
-      "Books of Secrets",
-      "Elemental Matters",
-      "ExhibitLab",
-      "Inspiring Youth in Chemistry",
-      "Lobby 2017",
-      "Making Modernity",
-      "Marvels and Ciphers",
-      "Molecules That Matter",
-      "Object Explorer",
-      "Science at Play",
-      "Second Skin",
-      "Sensing Change",
-      "The Alchemical Quest",
-      "The Sky's the Limit",
-      "The Whole of Nature and the Mirror of Art",
-      "Things Fall Apart",
-      "Transmutations"
-    ]
   end
 end

--- a/app/serializers/work_json_serializer.rb
+++ b/app/serializers/work_json_serializer.rb
@@ -38,7 +38,7 @@ class WorkJsonSerializer
   end
 
   attributes :title, :additional_title, :format, :genre, :medium, :extent, :language,
-    :provenance, :subject, :department, :exhibition, :series_arrangement,
+    :provenance, :subject, :department, :series_arrangement,
     :rights, :rights_holder, :digitization_funder, :file_creator
 
   attribute :description do |work|

--- a/app/views/admin/works/_metadata.html.erb
+++ b/app/views/admin/works/_metadata.html.erb
@@ -193,15 +193,6 @@
       <%= work.department %>
     </dd>
 
-    <dt>Exhibition</dt>
-    <dd>
-      <ul class="list-unstyled">
-        <% work.exhibition.each do |item| %>
-          <li><%= item %></li>
-        <% end %>
-      </ul>
-    </dd>
-
     <dt>Series Arrangement</dt>
     <dd>
       <ul class="list-unstyled">

--- a/app/views/admin/works/_work_fields.html.erb
+++ b/app/views/admin/works/_work_fields.html.erb
@@ -61,16 +61,6 @@
 
     <%= f.input :department, required: (true if f.object.published?), collection: Work::ControlledLists::DEPARTMENT  %>
 
-    <%= f.repeatable_attr_input(:exhibition, build: :at_least_one) do |input_name, value| %>
-      <%= f.input_field :exhibition,
-            name: input_name,
-            id: nil,
-            selected: value,
-            collection: Work::ControlledLists::EXHIBITION,
-            include_blank: true,
-            class: "form-control input-primitive" %>
-    <% end %>
-
     <%= f.repeatable_attr_input :series_arrangement, build: :at_least_one %>
 
     <%# single, not array, so we need some slightly weird setup. Including we need at least one to exist:  %>

--- a/lib/tasks/data_fixes/remove_exhibition_attribute_data.rake
+++ b/lib/tasks/data_fixes/remove_exhibition_attribute_data.rake
@@ -1,0 +1,25 @@
+namespace :scihist do
+  namespace :data_fixes do
+
+    desc """
+      Remove data from #exhibitions attribute, by directly editing json_attributes hash
+    """
+    task :remove_exhibition_attribute_data => :environment do
+      # note we operate directly on json_attributes hash, so this task can be
+      # run even after we remove "exhibition" attribute
+
+      scope = Work.where("json_attributes -> 'exhibition' is not null")
+
+      progress_bar = ProgressBar.create(total: scope.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+
+      Kithe::Indexable.index_with(batching: true) do
+        scope.find_each do |work|
+          work.json_attributes.delete("exhibition")
+          work.save!
+
+          progress_bar.increment
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/work_factory.rb
+++ b/spec/factories/work_factory.rb
@@ -95,9 +95,6 @@ FactoryBot.define do
       department {
         "Center for Oral History"
       }
-      exhibition {
-        ["Making Modernity", "Lobby 2017"]
-      }
       description {
         "Description 1"
       }

--- a/spec/system/work/new_work_spec.rb
+++ b/spec/system/work/new_work_spec.rb
@@ -92,20 +92,6 @@ RSpec.describe "New Work form", logged_in_user: :editor, type: :system, js: true
       find("div.work_#{p} select option[value='#{val}']").select_option
     end
 
-    #Custom single-value selects (1)
-    %w(exhibition).each do |p|
-      scrollToTop
-
-      attr_name = Work.human_attribute_name(p)
-      all_items = work.send(p)
-      all_items.length.times do |i|
-        click_link("Add another #{attr_name}")
-        val = all_items[i]
-        all("fieldset.work_#{p} select")[i].
-          find("option[value='#{val}']").select_option
-      end
-    end
-
     # Dates:
     %w(date_of_work).each do |property|
       attr_name = Work.human_attribute_name(property)
@@ -192,7 +178,6 @@ RSpec.describe "New Work form", logged_in_user: :editor, type: :system, js: true
       file_creator genre inscription language medium
       physical_container place rights
       rights_holder subject title related_link
-      exhibition
     ).each do |prop|
       expect(newly_added_work.send(prop)).to eq work.send(prop)
     end

--- a/spec/system/work_show_spec.rb
+++ b/spec/system/work_show_spec.rb
@@ -114,7 +114,6 @@ describe "Public work show page", type: :system, js: false do
 
       expect_attribute_row("Department", work.department, as_links: true)
 
-      expect(page).not_to have_text(work.exhibition)
       expect_attribute_row("Series arrangement", work.series_arrangement)
 
       expect_attribute_row("Physical container", work.physical_container.display_as)


### PR DESCRIPTION
We don't record exhibitions that way anymore, instead we use a feature built on Collection model. Ref #1949, #1920.

Wow there were a lot of places here and there that referenced it! Hope I got em all, tests pass anyway. 

Includes a rake task that must be run to remove all data from this attribute in DB. Rake task operates through #json_attributes only, without referencing exhibition attribute itself, so can be run even after this is merged and exhibition attribute does not exist. 

        ./bin/rake scihist:data_fixes:remove_exhibition_attribute_data

Person who merges should be prepared to deploy and run rake task. 

- [ ] rake task run in production