### PR TITLE
Permissions adjustments

### DIFF
--- a/app/policies/access_policy.rb
+++ b/app/policies/access_policy.rb
@@ -14,11 +14,11 @@ class AccessPolicy
   def configure
     role :admin, proc { |user| user&.has_admin_permissions? } do
       can :admin, User
-      can [:destroy, :publish], Kithe::Model
+      can [:destroy], Kithe::Model
     end
 
     role :editor, proc { |user| user&.has_editor_permissions? } do
-      can [:create, :update], Kithe::Model
+      can [:create, :update, :publish], Kithe::Model
     end
 
     role :staff_viewer, proc { |user| user&.has_staff_viewer_permissions? } do

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -71,8 +71,10 @@
               <% end %>
               <li><%= link_to "Public Search", search_catalog_path %></li>
               <li>
-                <%= link_to admin_cart_items_path if can?(:update, @work) do %>
-                  Cart <span class="badge badge-secondary" data-role="cart-counter"><%= current_user.works_in_cart.count %></span>
+                <% if can?(:update, Kithe::Model) %>
+                  <%= link_to admin_cart_items_path do %>
+                    Cart <span class="badge badge-secondary" data-role="cart-counter"><%= current_user.works_in_cart.count %></span>
+                  <% end %>
                 <% end %>
               </li>
 

--- a/spec/policies/access_policy_spec.rb
+++ b/spec/policies/access_policy_spec.rb
@@ -88,8 +88,8 @@ describe "access policies:" do
     it "can read a Kithe::Model" do
       expect(policy.can?(:read, Kithe::Model)).to be true
     end
-    it "cannot publish a collection" do
-      expect(policy.can?(:publish, collection)).to be false
+    it "can publish a collection" do
+      expect(policy.can?(:publish, collection)).to be true
     end
     it "can create any Kithe::Model" do
       expect(policy.can?(:create, Kithe::Model)).to be true

--- a/spec/system/batch_edit_spec.rb
+++ b/spec/system/batch_edit_spec.rb
@@ -47,6 +47,10 @@ describe "Cart and Batch Edit", solr: true, indexable_callbacks: true, logged_in
     expect(page).to have_selector("h1", text: "Admin Cart")
     click_on("Batch Edit")
 
+    within find(".admin-nav") do
+      find_link('Cart')
+    end
+
     # Batch Update Form
     expect(page).to have_selector("h1", text: /Batch Edit/)
 


### PR DESCRIPTION
After pushing the first round of changes for our new permissions(ref #1948 ) we found a couple bugs; this PR fixes them.
* Editors should be able to publish and unpublish (per the PR).
* Fix a bug in the left-hand admin menu. (ref #2014 )
Adding tests for both these bugs.
