### PR TITLE
update OpenSeadragon JS dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "jquery": "^ 3.6.0",
     "js-yaml": ">= 3.13.1",
     "lazysizes": "^5.1.0",
-    "openseadragon": "^2.4.1",
+    "openseadragon": "^4.0.0",
     "popper.js": "^ 1.16.1",
     "tom-select": "^1.4.3",
     "video.js": "^7.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -572,10 +572,10 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
-openseadragon@^2.4.1:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/openseadragon/-/openseadragon-2.4.2.tgz#f25d833d0ab9941599d65a3e2b44bec546c9f15c"
-  integrity sha512-398KbZwRtOYA6OmeWRY4Q0737NTacQ9Q6whmr9Lp1MNQO3p0eBz5LIASRne+4gwequcSM1vcHcjfy3dIndQziw==
+openseadragon@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/openseadragon/-/openseadragon-4.0.0.tgz#1832f2048f786c69fd1ced3dee8368487f212d3e"
+  integrity sha512-HsjSgqiiPwLkW5576GxDJ7Rax96iLUET8fnTsJvu7uYYkd+qzen3bflxHyph0OVVgZBKP9SpGH1nPdU4Mz0Z2A==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Just edited `package.json` manually, then ran `yarn install` to update yarn.lock. Ref #1964

Tested in dev and staging, the new version of OpenSeadragon seems to be working fine?
