### PR TITLE
Do not tell solr fulltext fields to omitNorms, not sure why we thought this made sense

### DIFF
--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -266,13 +266,13 @@
 
          https://lucene.apache.org/solr/guide/8_0/highlighting.html#Highlighting-SchemaOptionsandPerformanceConsiderations
        -->
-    <field name="searchable_fulltext_en" type="text_en" stored="true" indexed="true" multiValued="true" omitNorms="true" storeOffsetsWithPositions="true"/>
+    <field name="searchable_fulltext_en" type="text_en" stored="true" indexed="true" multiValued="true" storeOffsetsWithPositions="true"/>
 
     <!-- Full text search for works in German -->
-    <field name="searchable_fulltext_de" type="text_de" stored="true" indexed="true" multiValued="true" omitNorms="true" storeOffsetsWithPositions="true"/>
+    <field name="searchable_fulltext_de" type="text_de" stored="true" indexed="true" multiValued="true" storeOffsetsWithPositions="true"/>
 
     <!-- Full text search for works in neither English nor German -->
-    <field name="searchable_fulltext_language_agnostic" type="text" stored="true" indexed="true" multiValued="true" omitNorms="true" storeOffsetsWithPositions="true"/>
+    <field name="searchable_fulltext_language_agnostic" type="text" stored="true" indexed="true" multiValued="true"  storeOffsetsWithPositions="true"/>
 
     <!-- added by Science History Institute, a dynamic field that's good for string facets, using docValues fields -->
     <dynamicField name="*_facet" type="string_dv" multiValued="true"/>


### PR DESCRIPTION
OK when I try this out in staging... it is expected to only effect relevancy ranking of things matching our "fulltext" fields. 

Comparing staging to prod. In everything I think of to search...  it does not effect the first few results. It effects the later results, but minorly... like certain results are in swapped order, etc. 

It doesn't make a huge difference... I have no real way to judge if it's better or worse.  I'm not sure it's worth taking some of @apinkney0696 's time to test it, it's just, like, tiny changes that it's hard to say if they make a difference. 

I'm inclined to merge the change just to make these fields more normal and typical, not have a non-standard configuration that makes a change we actually don't have a reason to think is an improvement. 
