### PR TITLE
Fix review requested filter

### DIFF
--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -596,7 +596,7 @@ class Admin::WorksController < AdminController
       end
 
       if params[:q][:review_requested].present?
-        scope = scope.where("json_attributes ->> 'review_requested' is not null")
+        scope = scope.jsonb_contains(review_requested: true)
 
         if params[:q][:review_requested] == "by_others"
           scope = scope.not_jsonb_contains(review_requested_by: current_user.email )


### PR DESCRIPTION
Ref #2019

We were looking filtering for "not nil" but in fact our code left json `true` or `false`. We can use `jsonb_contains` to do the casting for us, we actually want to filter for records where value is `true` only, not `not nil`.

Still no tests, sorry, I'm being lazy. Tested manually.
