### PR TITLE
Try update to attr_json 2.0.0.rc1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,10 +106,11 @@ gem 'font-awesome-rails', '~> 4.7'
 gem "lograge", "< 2"
 gem "device_detector", "~> 1.0" # user-agent parsing we use for logging
 
-gem 'kithe', "~> 2.7", ">= 2.7.1"
-# attr_son is a dependency of kithe, but we want to make sure it gets require'd directly
-# to avoid weird auto-loading issues.
-gem "attr_json", "~> 1.0"
+
+# Try with attr-json 2.0 pre-release, which temporarily requires kithe off master
+gem "attr_json", "2.0.0.rc1"
+gem 'kithe', "~> 2.7", ">= 2.7.1", github: "sciencehistory/kithe"
+
 gem "traject", ">= 3.5" # to include support for HTTP basic auth in Solr url
 
 gem 'simple_form', "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,23 @@
+GIT
+  remote: https://github.com/sciencehistory/kithe.git
+  revision: 294e19de6788c001e96d3bf13e01a17aad1da3da
+  specs:
+    kithe (2.7.1)
+      attr_json (< 2.0.0)
+      fastimage (~> 2.0)
+      fx (>= 0.6.0, < 1)
+      marcel
+      mini_mime
+      pdf-reader (~> 2.0)
+      rails (>= 5.2.1, < 7.1)
+      rsolr (~> 2.2)
+      ruby-progressbar (~> 1.0)
+      shrine (~> 3.3)
+      shrine-url (~> 2.0)
+      simple_form (>= 4.0, < 6.0)
+      traject (~> 3.0, >= 3.1.0.rc1)
+      tty-command (>= 0.8.2, < 2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -82,8 +102,8 @@ GEM
     alba (2.1.0)
     ansi (1.5.0)
     ast (2.4.2)
-    attr_json (1.5.0)
-      activerecord (>= 5.0.0, < 7.1)
+    attr_json (2.0.0.rc1)
+      activerecord (>= 6.0.0, < 7.1)
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
     aws-eventstream (1.2.0)
@@ -315,21 +335,6 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    kithe (2.7.1)
-      attr_json (< 2.0.0)
-      fastimage (~> 2.0)
-      fx (>= 0.6.0, < 1)
-      marcel
-      mini_mime
-      pdf-reader (~> 2.0)
-      rails (>= 5.2.1, < 7.1)
-      rsolr (~> 2.2)
-      ruby-progressbar (~> 1.0)
-      shrine (~> 3.3)
-      shrine-url (~> 2.0)
-      simple_form (>= 4.0, < 6.0)
-      traject (~> 3.0, >= 3.1.0.rc1)
-      tty-command (>= 0.8.2, < 2)
     launchy (2.5.2)
       addressable (~> 2.8)
     ldpath (1.2.0)
@@ -706,7 +711,7 @@ DEPENDENCIES
   active_encode (~> 1.0)
   activerecord-postgres_enum (~> 2.0)
   alba (~> 2.0)
-  attr_json (~> 1.0)
+  attr_json (= 2.0.0.rc1)
   aws-sdk-cloudwatchevents (~> 1.0)
   aws-sdk-cloudwatchlogs (~> 1.0)
   aws-sdk-mediaconvert (~> 1.0)
@@ -740,7 +745,7 @@ DEPENDENCIES
   irb (>= 1.3.1)
   jbuilder (~> 2.5)
   kaminari (~> 1.2)
-  kithe (~> 2.7, >= 2.7.1)
+  kithe (~> 2.7, >= 2.7.1)!
   listen (~> 3.3)
   lockbox
   lograge (< 2)

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -51,8 +51,7 @@ class Asset < Kithe::Asset
   # that won't be published may need derivatives kept in a separate restricted access
   # bucket. Intended for non-published Oral History assets, eg "free access no internet release"
   #
-  # Set rails_attribute true so we get rails dirty tracking.
-  attr_json :derivative_storage_type, :string, default: "public", rails_attribute: true
+  attr_json :derivative_storage_type, :string, default: "public"
 
   # alt_text was added for Oral Histories portraits and migrating existing data,
   # but can be used for any asset.
@@ -175,7 +174,7 @@ class Asset < Kithe::Asset
     else
       # an ordinary save (including create), did any attributes of interest CHANGE? (Including removal)
       # then we need to reindex parent to get them updated in index.
-      indexed_attributes.any? { |attr| self.attr_json_changes.saved_change_to_attribute(attr).present? }
+      indexed_attributes.any? { |attr| self.saved_change_to_attribute(attr).present? }
     end
   end
 


### PR DESCRIPTION
* Since I'm the maintainer, I want to run it in prod a bit ourselves before releasing 2.0.0 final
* Temporarily requires using an unreleased `kithe` off github master branch. With only minor changes, but eventually we'll have to release a kithe that allows 2.0.0 final in it's gemspec
* attr_json 2.0 gets rid of custom dirty tracking, and makes standard rails dirty tracking work. Required one tiny change here.

attr_json 2.0 changelog here: https://github.com/jrochkind/attr_json/blob/dev_v2/CHANGELOG.md

