### PR TITLE
rollback OpenSeadragon from 4.0.0 to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "jquery": "^ 3.6.0",
     "js-yaml": ">= 3.13.1",
     "lazysizes": "^5.1.0",
-    "openseadragon": "^4.0.0",
+    "openseadragon": "^3.1.0",
     "popper.js": "^ 1.16.1",
     "tom-select": "^1.4.3",
     "video.js": "^7.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -572,10 +572,10 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
-openseadragon@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/openseadragon/-/openseadragon-4.0.0.tgz#1832f2048f786c69fd1ced3dee8368487f212d3e"
-  integrity sha512-HsjSgqiiPwLkW5576GxDJ7Rax96iLUET8fnTsJvu7uYYkd+qzen3bflxHyph0OVVgZBKP9SpGH1nPdU4Mz0Z2A==
+openseadragon@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/openseadragon/-/openseadragon-3.1.0.tgz#152b1ed8b6b03296feeed4e0ddf084cea7d0c1f2"
+  integrity sha512-0zCbRIWUbCto7xm1tv2ZLEiSl84cDU659W/sfs2zqqTqVRa4CRHzhy7i9nsv6dHA1DryFR8IzjStjmWOqRs9Rg==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Partial rollback of #2017

Until we resolve #2279, a problem we found with changed behavior in OSD 4.0.0
