### PR TITLE
Move collection thumbnail code out of templates

### DIFF
--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -23,6 +23,8 @@ class Admin::AssetsController < AdminController
   def show
     @asset = Asset.find_by_friendlier_id!(params[:id])
     authorize! :read, @asset
+
+    @edit_asset_path = @asset.collection_thumbnail? ? edit_admin_collection_path(@asset.parent) : edit_admin_asset_path(@asset)
     if @asset.stored?
       @checks = @asset.fixity_checks.order('created_at asc')
       @latest_check   = @checks.last
@@ -170,9 +172,17 @@ class Admin::AssetsController < AdminController
   end
 
   def work_is_oral_history?
-    (@asset.parent.is_a? Work) && @asset.parent.genre && @asset.parent.genre.include?('Oral histories')
+    !@asset.collection_thumbnail? && @asset.parent.genre && @asset.parent.genre.include?('Oral histories')
   end
   helper_method :work_is_oral_history?
+
+
+  def parent_path(asset)
+    return nil if asset.parent.nil?
+    asset.collection_thumbnail? ? collection_path(asset.parent) : admin_work_path(asset.parent)
+  end
+  helper_method :parent_path
+
 
   private
 

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -24,7 +24,6 @@ class Admin::AssetsController < AdminController
     @asset = Asset.find_by_friendlier_id!(params[:id])
     authorize! :read, @asset
 
-    @edit_asset_path = @asset.collection_thumbnail? ? edit_admin_collection_path(@asset.parent) : edit_admin_asset_path(@asset)
     if @asset.stored?
       @checks = @asset.fixity_checks.order('created_at asc')
       @latest_check   = @checks.last
@@ -172,14 +171,23 @@ class Admin::AssetsController < AdminController
   end
 
   def work_is_oral_history?
-    !@asset.collection_thumbnail? && @asset.parent.genre && @asset.parent.genre.include?('Oral histories')
+    (@asset.parent.is_a? Work) && @asset.parent.genre && @asset.parent.genre.include?('Oral histories')
   end
   helper_method :work_is_oral_history?
 
+  def asset_is_collection_thumbnail?
+    @asset.parent.is_a? Collection
+  end
+  helper_method :asset_is_collection_thumbnail?
+
+  def edit_path(asset)
+    (asset.parent.is_a? Collection) ? edit_admin_collection_path(asset.parent) : edit_admin_asset_path(asset)
+  end
+  helper_method :edit_path
 
   def parent_path(asset)
     return nil if asset.parent.nil?
-    asset.collection_thumbnail? ? collection_path(asset.parent) : admin_work_path(asset.parent)
+    (asset.parent.is_a? Collection) ? collection_path(asset.parent) : admin_work_path(asset.parent)
   end
   helper_method :parent_path
 

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -281,6 +281,10 @@ class Asset < Kithe::Asset
     end
   end
 
+  def collection_thumbnail?
+    parent&.is_a? Collection
+  end
+
   def log_destroyed
     info = {
       pk: self.id,

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -281,10 +281,6 @@ class Asset < Kithe::Asset
     end
   end
 
-  def collection_thumbnail?
-    parent&.is_a? Collection
-  end
-
   def log_destroyed
     info = {
       pk: self.id,

--- a/app/views/admin/assets/index.html.erb
+++ b/app/views/admin/assets/index.html.erb
@@ -38,11 +38,7 @@
           <%= link_to asset.title, admin_asset_path(asset) %>
         </td>
         <td>
-          <% if asset.parent.is_a? Work %>
-            <%= link_to asset.parent.title, admin_work_path(asset.parent) %>
-          <% else %>
-            <%= link_to asset.parent.title, collection_path(asset.parent) %>
-          <% end %>
+          <%= link_to asset.parent.title, parent_path(asset) %>
         </td>
         <td class="datestamp"><%=  l asset.created_at.to_date, format: :admin %> </td>
       </tr>

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -32,6 +32,7 @@
             class: "btn btn-outline-primary btn-lg mt-4" %>
     <% end %>
 
+
     <% if @asset.transcription.present? || @asset.english_translation.present? %>
       <ul class="nav nav-tabs mt-4" id="myTab" role="tablist">
         <li class="nav-item" role="presentation">
@@ -103,6 +104,7 @@
   </div>
 
   <div class="col-sm-6">
+
       <% if !@asset.published? && work_is_oral_history? && @asset.oh_available_by_request %>
         <div class="row">
           <div class="col-sm-12">

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -1,20 +1,16 @@
-<div>Managing an Asset</div>
+<div>Managing an Asset <%= "(this asset is a collection thumbnail)" if @asset.collection_thumbnail? %></div>
 <h1><%= @asset.title %></h1>
 <%if @asset&.parent %>
-  <% if @asset.parent.is_a? Work %>
-    <p>In work: <%= link_to @asset.parent.title, [:admin, @asset.parent] %> </p>
-  <% else %>
-    <p>Thumbnail for collection: <%= link_to @asset.parent.title, collection_path(@asset.parent) %> </p>
+  <p>Asset is a member of <%= link_to @asset.parent.title, parent_path(@asset) %> </p>
+<% end %>
+
+
+<p>
+  <%= link_to "Edit", @edit_asset_path, class: "btn btn-primary #{"disabled" unless can?(:update, @asset)}"%>
+   <% unless @asset.collection_thumbnail?%>
+      <%= link_to "Convert to child work", convert_to_child_work_admin_asset_path(@asset), method: "put", class: "btn btn-primary #{"disabled" unless can?(:update, @asset)}" %>
   <% end %>
-
-<% end %>
-
-<% if @asset&.parent.is_a?(Work)%>
-  <p>
-    <%= link_to "Edit", edit_admin_asset_path(@asset), class: "btn btn-primary #{"disabled" unless can?(:update, @asset)}"%>
-    <%= link_to "Convert to child work", convert_to_child_work_admin_asset_path(@asset), method: "put", class: "btn btn-primary #{"disabled" unless can?(:update, @asset)}" %>
-  </p>
-<% end %>
+</p>
 
 <div class="row">
   <div class="col-sm-6">
@@ -35,7 +31,6 @@
             @asset.file.url(response_content_disposition: ContentDisposition.format(disposition: :attachment, filename: DownloadFilenameHelper.filename_for_asset(@asset))),
             class: "btn btn-outline-primary btn-lg mt-4" %>
     <% end %>
-
 
     <% if @asset.transcription.present? || @asset.english_translation.present? %>
       <ul class="nav nav-tabs mt-4" id="myTab" role="tablist">
@@ -108,7 +103,6 @@
   </div>
 
   <div class="col-sm-6">
-
       <% if !@asset.published? && work_is_oral_history? && @asset.oh_available_by_request %>
         <div class="row">
           <div class="col-sm-12">
@@ -264,7 +258,9 @@
 
     <h2 class="mt-4">Derivatives</h2>
 
-    <% if @asset&.parent.is_a?(Work)%>
+    <% if @asset.collection_thumbnail? %>
+      <p>Storage type: <code><%= @asset.derivative_storage_type %></code></p>
+    <% else %>
       <p>
         <%= simple_form_for(@asset, wrapper: :horizontal_form) do |f| %>
 

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -1,13 +1,18 @@
-<div>Managing an Asset <%= "(this asset is a collection thumbnail)" if @asset.collection_thumbnail? %></div>
+<div>Managing an Asset <%= "(this asset is a collection thumbnail)" if asset_is_collection_thumbnail? %></div>
 <h1><%= @asset.title %></h1>
+
 <%if @asset&.parent %>
-  <p>Asset is a member of <%= link_to @asset.parent.title, parent_path(@asset) %> </p>
+  <% if asset_is_collection_thumbnail? %>
+    <p>Thumbnail for collection: <%= link_to @asset.parent.title, collection_path(@asset.parent) %> </p>
+  <% else %>
+    <p>In work: <%= link_to @asset.parent.title, [:admin, @asset.parent] %> </p>
+  <% end %>
 <% end %>
 
 
 <p>
-  <%= link_to "Edit", @edit_asset_path, class: "btn btn-primary #{"disabled" unless can?(:update, @asset)}"%>
-   <% unless @asset.collection_thumbnail?%>
+  <%= link_to "Edit", edit_path(@asset), class: "btn btn-primary #{"disabled" unless can?(:update, @asset)}"%>
+  <% unless asset_is_collection_thumbnail?%>
       <%= link_to "Convert to child work", convert_to_child_work_admin_asset_path(@asset), method: "put", class: "btn btn-primary #{"disabled" unless can?(:update, @asset)}" %>
   <% end %>
 </p>
@@ -260,7 +265,7 @@
 
     <h2 class="mt-4">Derivatives</h2>
 
-    <% if @asset.collection_thumbnail? %>
+    <% if asset_is_collection_thumbnail? %>
       <p>Storage type: <code><%= @asset.derivative_storage_type %></code></p>
     <% else %>
       <p>


### PR DESCRIPTION
Ref #1761 

- New asset model method `collection_thumbnail?()`;
- `parent_path(asset)` controller helper method;
- Simplify the templates accordingly;
- When you view a collection thumbnail:
  - Show the storage type, even if you can't edit it (I figure there's no point in *not* displaying it).
  - Show an edit button, which takes you to the edit form for the collection. (Do we need this?)