### PR TITLE
Use prefixSearch only when needed

### DIFF
--- a/app/services/s3_console_uri.rb
+++ b/app/services/s3_console_uri.rb
@@ -43,13 +43,16 @@ class S3ConsoleUri
     @checked_uri_in_s3_console ||= begin
       if has_console_uri?
         region = ScihistDigicoll::Env.lookup(:aws_region)
-
         key_path_components = keypath.delete_prefix("/").split("/")
-
-        base_key_path = key_path_components.slice(0, key_path_components.length - 1)&.join("/").chomp("/").concat("/")
         end_key = key_path_components.last
 
-        "https://s3.console.aws.amazon.com/s3/buckets/#{bucket}?region=#{region}&prefix=#{base_key_path}&prefixSearch=#{end_key}"
+        # Don't need prefixSearch URL parameter for a folder at the top of the bucket (only occurs in the case of a folder of orphaned DZI files.)
+        if key_path_components.count > 1
+          base_key_path = key_path_components.slice(0, key_path_components.length - 1)&.join("/").chomp("/").concat("/")
+          "https://s3.console.aws.amazon.com/s3/buckets/#{bucket}?region=#{region}&prefix=#{base_key_path}&prefixSearch=#{end_key}"
+        else
+          "https://s3.console.aws.amazon.com/s3/buckets/#{bucket}?region=#{region}&prefixSearch=#{end_key}"
+        end
       else
         nil
       end


### PR DESCRIPTION
Ref #1826 .
Tested the fix in both dev and staging.
Note that the buggy method is strictly used as a convenience method, to provide URLs to orphaned files or directories.
`s3_console_uri.rb` could use some refactoring, but that's out of scope; we just want to fix a bug here.