### PR TITLE
on_demand_downloader.js: Can't use JS var without declaring it

### DIFF
--- a/app/frontend/javascript/scihist_on_demand_downloader.js
+++ b/app/frontend/javascript/scihist_on_demand_downloader.js
@@ -46,7 +46,7 @@ $( document ).ready(function() {
           _self.fetchForStatus();
         }, 2000);
       } else {
-        json_error = JSON.parse(json.error_info);
+        var json_error = JSON.parse(json.error_info);
         if (json_error) {
           throw json_error.class + ": " + json_error.message;
         } else {


### PR DESCRIPTION
In our move to vite, our JS all ends up being executed in a more modern stricter mode, where you can't use a variable without declaring it first. I guess we may keep finding some of these bugs in our edge cases of untested JS.

This fixes the:

> Error fetching on-demand derivative: ReferenceError: json_error is not defined

Part of #2055 -- this here does not fix the main problem there, it's just a secondary problem triggered when trying to run our JS error reporting code for the main problem.
