### PR TITLE
Be willing to re-run OnDemandDerivativeCreatorJob idempotently on error

### DIFF
--- a/app/jobs/on_demand_derivative_creator_job.rb
+++ b/app/jobs/on_demand_derivative_creator_job.rb
@@ -2,6 +2,9 @@
 class OnDemandDerivativeCreatorJob < ApplicationJob
   queue_as :on_demand_derivatives
 
+  # This really will perform work to create the derivative, regardless of status --
+  # whoever enqueued the job is responsible for not enqueing it if we have had an
+  # error and haven't waited the timeout period, etc.
   def perform(work, derivative_type)
     OnDemandDerivativeCreator.new(work, derivative_type: derivative_type).attach_derivative!
   end


### PR DESCRIPTION
Our overall ActiveJob setup was retrying on error, but our code in the OnDemandDerivativeCreator was complaining about this. Make it work, while adding some more tests ensuriung our desired (but a bit confusing) behavior.

We're trying NOT to re-run this infinitely all the time if there is some error that is going to keep re-occuring, but in a nice clean way where the user gets a clean error message and we get the actual error reported too. It's kind of messy, not sure if there's a better design here... we're dealing with the tools straight ActiveJob gives us.

Ref #2055
