### PR TITLE
Add poppler-utils BACK to Aptfile

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -7,6 +7,9 @@ libglib2.0-0
 libglib2.0-dev
 libpoppler-glib8
 
-# We need `pdfunite` command line; Currently the `heroku-buildpack-activestorage-preview`
-# is providing it, but in the past `poppler-utils` in Aptfile has, and could again:
-# poppler-utils
+# We need `pdfunite` command line thatcomes from poppler; While the `heroku-buildpack-activestorage-preview`
+# should provide it too, it seems to be unpredictable as to whether it does, in ways that
+# actually disturb our understanding of heroku reproducibility (different results on identical
+# heroku stacks/buildpacks).  Supplying it here on top of activestorage-preview buildpack
+# doesn't seem to hurt, and does seem to get us a working poppler reliably.
+poppler-utils


### PR DESCRIPTION
`pdfunite` disturbingly has stopped working on heroku staging, while it works on a heroku production with identical stack and buildpacks. This is disturbing my understanding of what should be reproducible on heroku.

Currently on staging:

```
$ pdfunite --version
pdfunite: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by pdfunite)
pdfunite: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.35' not found (required by /app/.heroku/activestorage-preview/usr/lib/x86_64-linux-gnu/libpoppler.so.118)
pdfunite: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /app/.heroku/activestorage-preview/usr/lib/x86_64-linux-gnu/libpoppler.so.118)
pdfunite: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /app/.heroku/activestorage-preview/usr/lib/x86_64-linux-gnu/libpoppler.so.118)
pdfunite: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /app/.heroku/activestorage-preview/usr/lib/x86_64-linux-gnu/libpoppler.so.118)
```

This happened after I changed the stack/buildpack on staging to experiment with heroku-22, then changed it back -- it should be identical now. See #2055

However, we can add poppler-util back to Aptfile -- it formerly appeared unnecesssary because heroku/heroku-buildpack-activestorage-preview provided it... but doesn't hurt to re-install it with apt buildpack?
