### PR TITLE
Link change in the OH collection page.

### DIFF
--- a/app/views/collection_show_controllers/oral_history_collection/_splash_page.html.erb
+++ b/app/views/collection_show_controllers/oral_history_collection/_splash_page.html.erb
@@ -152,7 +152,9 @@ we want the full width of the screen, no margins or padding. %>
       </div>
     <% end %>
 
-    <%= link_to "More oral history projects...", "https://www.sciencehistory.org/oral-history-projects", class: "more-projects", target: "_blank" %>
+    <%= link_to "More oral history projects...",
+      collections_path(department_filter: "center-for-oral-history"),
+      class: "more-projects" %>
   </div>
 
 


### PR DESCRIPTION
"More oral history projects..." link at the bottom of the oral history collection page should point to the collections page, but filtered by "Center for Oral History".

No longer opens a new window.

Ref #2060 