### PR TITLE
Use qa gem to auto-complete medium field to Getty AAT

### DIFF
--- a/app/views/admin/works/_work_fields.html.erb
+++ b/app/views/admin/works/_work_fields.html.erb
@@ -41,7 +41,13 @@
     <% end %>
 
 
-    <%= f.repeatable_attr_input :medium, build: :at_least_one %>
+    <%= f.repeatable_attr_input :medium, build: :at_least_one,
+          html_attributes: {
+            data: {
+              "scihist-qa-autocomplete" => qa_search_vocab_path("getty", "aat")
+            }
+          }
+    %>
 
     <%= f.repeatable_attr_input :extent, build: :at_least_one %>
 

--- a/spec/system/work/new_work_spec.rb
+++ b/spec/system/work/new_work_spec.rb
@@ -3,6 +3,23 @@ require 'pp'
 
 RSpec.describe "New Work form", logged_in_user: :editor, type: :system, js: true do
 
+  # stub out our FAST and Getty qa-based autocomplete to return 0-result responses,
+  # using WebMock methods, so we aren't making HTTP requests in test, which we prohibit.
+  # We aren't actually testing the qa autocomplete here.
+  before do
+    stub_request(:get, %r{\Ahttps?://fast.oclc.org}).to_return(
+      status: 200,
+      body: {response: { docs: [] }}.to_json,
+      headers: {}
+    )
+
+    stub_request(:get, %r{\Ahttps?://vocab\.getty\.edu/sparql\.json\?}).to_return(
+      status: 200,
+      body: {results: { bindings: [] }}.to_json,
+      headers: {}
+    )
+  end
+
   # As of Chrome/chromedriver 74.0, chromedriver will refuse to click on something
   # if it's covered up by something with "position: sticky", even if scrolling
   # could uncover it. Chromedriver will normally scroll to reveal something to click


### PR DESCRIPTION
The QA getty AAT autocomplete doesn't actually work very well, it's somewhat unrepdictable when and what it will autocomplete -- some things I believe are valid terms just never autocomplete?

But apparently some institutions are using it anyway? Northwestern is. But I haven't actually talked to metadata staff there to see if they find it useful, just software developers who confirm they are using a getty AAT search that works wonkily like this one does.

Let's demo this and see if it's "good enough"/"better than nothing". The other option is spending more development time trying to improve the samvera qa getty AAT search -- I think it's just not written to do a search of getty AAT as well as it could be, although it may be hard to make it work how we want because of limitations in getty api. 

Ref #1494, @apinkney0696
.
