### PR TITLE
Fix OHMS transcript formatting of speakers

### DIFF
--- a/app/components/oral_history/transcript_component.rb
+++ b/app/components/oral_history/transcript_component.rb
@@ -90,8 +90,8 @@ module OralHistory
       ohms_line_str = line[:text]
       line_number = line[:line_num]
 
-      # catch speaker prefix
-      if ohms_line_str =~ /\A([A-Z]+:) (.*)\Z/
+      # catch speaker prefix, adapted from standard PHP OHMS viewer
+      if ohms_line_str =~ /\A[[:space:]]*([A-Z-.\' ]+:) (.*)\Z/
         ohms_line_str = safe_join([
           content_tag("span", $1, class: "ohms-speaker"),
           " ",


### PR DESCRIPTION
To recognize speakers with spaces or some punctuation in their names. Based on regexp used in standard PHP OHMS Viewer, we went and found it in source.

Ref #2064
