### PR TITLE
Remove obsolete & unused method from combined_audio_derivative_creator.

### DIFF
--- a/app/services/combined_audio_derivative_creator.rb
+++ b/app/services/combined_audio_derivative_creator.rb
@@ -55,15 +55,6 @@ class CombinedAudioDerivativeCreator
     Tempfile.new(['output', ".#{format}"], :encoding => 'binary')
   end
 
-  # Use ffprobe to determine the length of an audio file.
-  def duration_of_audio_file_in_seconds(path)
-    options = ['ffprobe', '-v', 'error',
-      '-show_entries', 'format=duration', '-of',
-      'default=noprint_wrappers=1:nokey=1'
-    ] + [ path ]
-    cmd.run(*options).out.strip.to_f
-  end
-
   def components
     @components ||= begin
       logger.debug("#{self.class}: downloading original assets")


### PR DESCRIPTION
Ref #2050 
I thought we were still using `duration_of_audio_file_in_seconds(path)`. We're not.

Instead, we've been using metadata from the ingest characterization routine (`Kithe::FfprobeCharacterization.characterize_from_uploader(source_io, context)`) in the `AssetUploader` class.

This is the way it should be; we're just removing the unused method now.