### PR TITLE
Fix regexp, escaping hyphen

### DIFF
--- a/app/components/oral_history/transcript_component.rb
+++ b/app/components/oral_history/transcript_component.rb
@@ -91,7 +91,7 @@ module OralHistory
       line_number = line[:line_num]
 
       # catch speaker prefix, adapted from standard PHP OHMS viewer
-      if ohms_line_str =~ /\A[[:space:]]*([A-Z-.\' ]+:) (.*)\Z/
+      if ohms_line_str =~ /\A[[:space:]]*([A-Z\-.\' ]+:) (.*)\Z/
         ohms_line_str = safe_join([
           content_tag("span", $1, class: "ohms-speaker"),
           " ",


### PR DESCRIPTION
Prviously resulted in warning from ruby:

> /app/components/oral_history/transcript_component.rb:94: warning: character class has '-' without escape: /\A[[:space:]]*([A-Z-.\' ]+:) (.*)\Z/

This regex was copied from ohms viewer php, I think it is meant to mean A-Z (range), plus some punctuation including literal hyphen `-`, and this new escaped version is correct. Thanks ruby. Wonder what it was doing before and how it worked in php.

Ref #2064 where we implemented this regexp in the first place. 
