### PR TITLE
avoid trip to DB just to make sure home page work exists

### DIFF
--- a/app/views/homepage/_hero_image_and_search_form.html.erb
+++ b/app/views/homepage/_hero_image_and_search_form.html.erb
@@ -4,11 +4,7 @@
             <figure class="hero-image">
                 <%= image_tag "hero_image_2x.jpg", 'aria-labelledby' => "homeHeroCaption" %>
                 <figcaption id="homeHeroCaption">
-                    <%
-                    hero_image_work = Work.find_by_friendlier_id('w6634363x')
-                    hero_image_link = hero_image_work ? work_path(hero_image_work.friendlier_id) : "#"
-                    %>
-                    <%= link_to "Wilson College chemistry club", hero_image_link%>
+                    <%= link_to "Wilson College chemistry club", work_path('w6634363x') %>
                 </figcaption>
             </figure>
         </div>


### PR DESCRIPTION
We were previously doing a query to DB on every single home page view just to verify that the work 'w6634363x' really exists. What did we do if it DIDN'T? Just made a link that did nothing, instead of leading to a 404.  This isn't worth a trip to the DB on every home page view. If somehow that work gets deleted, the link will just be broken if you click on it, big deal, shouldn't happen, no big deal if it does, not worth a DB query on every single home page view.

Encountered while reviewing #2067
