### PR TITLE
Change public label of link category to 'Scientific Biography'

### DIFF
--- a/app/components/related_link_component.rb
+++ b/app/components/related_link_component.rb
@@ -5,7 +5,7 @@ class RelatedLinkComponent < ApplicationComponent
   # special labels if category.humanize isn't good enough.
   # can replace this with i18n or something if we want
   DISPLAY_LABELS = {
-    "institute_biography" => "Historical biography",
+    "institute_biography" => "Scientific Biography",
     "institute_libguide" => "Library Guide",
     "institute_article" => "Article",
     "institute_podcast" => "Podcast",


### PR DESCRIPTION
From previously 'Historical biography'.  (case was inconsistent with other labels).

Per #1867

Note that internal data was and remains `institute_biography` (and staff metadata form was and remains 'Institute Biography'. We just had an alternate label for public view, already. So we can change this easily without a data migration, hooray.
