### PR TITLE
Bug fix in the combined audio deriv creator: `bitrate` vs `audio_bitrate`

### DIFF
--- a/app/services/combined_audio_derivative_creator.rb
+++ b/app/services/combined_audio_derivative_creator.rb
@@ -163,7 +163,7 @@ class CombinedAudioDerivativeCreator
         if file.metadata['duration_seconds'].nil?  || file.metadata['duration_seconds'] == 0
           errors << "#{filename}: audio duration is unavailable or zero" 
         end
-        if file.metadata['audio_bitrate'].nil? || file.metadata['audio_sample_rate'].nil?
+        if file.metadata['bitrate'].nil? || file.metadata['audio_sample_rate'].nil?
           errors << "#{filename}: audio bitrate or sample rate is unavailable"
         end
       end

--- a/spec/factories/asset_factory.rb
+++ b/spec/factories/asset_factory.rb
@@ -62,10 +62,11 @@ FactoryBot.define do
         faked_width { 30 }
         faked_height { 30 }
         faked_bitrate { nil }
+        faked_audio_bitrate { nil }
+        faked_video_bitrate { nil }
         faked_filename { nil }
         faked_size { nil }
         faked_duration_seconds  { nil }
-        faked_audio_bitrate     { nil }
         faked_audio_sample_rate { nil }
         faked_md5 { Digest::MD5.hexdigest rand(10000000).to_s }
         faked_sha512 { Digest::SHA512.hexdigest rand(10000000).to_s }
@@ -125,8 +126,9 @@ FactoryBot.define do
         faked_file { File.open((Rails.root + "spec/test_support/audio/5-seconds-of-silence.mp3")) }
         faked_content_type { "audio/mpeg" }
         faked_duration_seconds { "00:00:05" }
-        faked_audio_bitrate { "8 kb/s" }
-        faked_audio_sample_rate { "8.0 kHz"}
+        faked_bitrate { 8002 }
+        faked_audio_bitrate { 8000 }
+        faked_audio_sample_rate { 44100 }
         faked_height { nil }
         faked_width { nil }
         faked_derivatives { nil }
@@ -136,8 +138,9 @@ FactoryBot.define do
         faked_file { File.open((Rails.root + "spec/test_support/audio/5-seconds-of-silence.m4a")) }
         faked_content_type { "audio/mp4" }
         faked_duration_seconds { "00:00:05" }
-        faked_audio_bitrate { "8 kb/s" }
-        faked_audio_sample_rate { "8.0 kHz"}
+        faked_bitrate { 8002 }
+        faked_audio_bitrate { 8000 }
+        faked_audio_sample_rate { 44100 }
         faked_height { nil }
         faked_width { nil }
       end
@@ -147,8 +150,9 @@ FactoryBot.define do
         faked_file { File.open((Rails.root + "spec/test_support/audio/5-seconds-of-silence.flac")) }
         faked_content_type { "audio/flac" }
         faked_duration_seconds { "00:00:05" }
-        faked_audio_bitrate { "14 kb/s" }
-        faked_audio_sample_rate { "8.0 kHz"}
+        faked_bitrate { 8002 }
+        faked_audio_bitrate { 8000 }
+        faked_audio_sample_rate { 44100 }
         faked_height { nil }
         faked_width { nil }
       end
@@ -161,9 +165,10 @@ FactoryBot.define do
           content_type: evaluator.faked_content_type,
           width: evaluator.faked_width,
           height: evaluator.faked_height,
+          bitrate:           evaluator.faked_bitrate,
+          audio_bitrate:     evaluator.faked_audio_bitrate,
           video_bitrate:     evaluator.faked_bitrate,
           duration_seconds:  evaluator.faked_duration_seconds,
-          audio_bitrate:     evaluator.faked_audio_bitrate,
           audio_sample_rate: evaluator.faked_audio_sample_rate,
           md5: evaluator.faked_md5,
           sha512: evaluator.faked_sha512,

--- a/spec/factories/uploaded_file_factory.rb
+++ b/spec/factories/uploaded_file_factory.rb
@@ -14,8 +14,9 @@ FactoryBot.define do
       content_type { "image/png" }
       width { 30 }
       height { 30 }
-      video_bitrate     { nil }
+      bitrate     { nil }
       audio_bitrate     { nil }
+      video_bitrate     { nil }
       audio_sample_rate { nil }
       duration_seconds  { nil }
       md5 { Digest::MD5.hexdigest rand(10000000).to_s }
@@ -35,9 +36,10 @@ FactoryBot.define do
         "height"=> height,
         "md5" => md5,
         "duration_seconds" => duration_seconds,
+        "bitrate"       => bitrate,
         "audio_bitrate" => audio_bitrate,
-        "audio_sample_rate" => audio_sample_rate,
         "video_bitrate" => video_bitrate,
+        "audio_sample_rate" => audio_sample_rate,
         "sha512" => sha512
       }.compact
     end

--- a/spec/services/work_combined_audio_creator_spec.rb
+++ b/spec/services/work_combined_audio_creator_spec.rb
@@ -15,7 +15,9 @@ describe "Combined Audio" do
       expect(work.members.map(&:stored?)).to match([true])
       audio_file = work.members.first.file
       expect(audio_file.metadata['bitrate']).to be_a_kind_of(Integer)
-      combined_audio_info = CombinedAudioDerivativeCreator.new(work).generate
+      creator = CombinedAudioDerivativeCreator.new(work)
+      expect(creator.audio_metadata_errors).to eq []
+      combined_audio_info = creator.generate
       expect(combined_audio_info.start_times.count).to eq 1
       expect(combined_audio_info.start_times).to match([[mp3.id, 0]])
       expect(combined_audio_info.m4a_file.class).to eq Tempfile
@@ -50,7 +52,10 @@ describe "Combined Audio" do
       expect(work.members.first.file.metadata['bitrate']).to be_a_kind_of(Integer)
       expect(work.members.second.file.metadata['bitrate']).to be_a_kind_of(Integer)
 
-      combined_audio_info = CombinedAudioDerivativeCreator.new(work).generate
+      creator = CombinedAudioDerivativeCreator.new(work)
+      expect(creator.audio_metadata_errors).to eq []
+
+      combined_audio_info = creator.generate
       expect(combined_audio_info.start_times.count).to eq 2
 
       # The lengths should be correct:
@@ -135,6 +140,10 @@ describe "Combined Audio" do
       expect(work.members.first.file.metadata['bitrate']).to be_nil
       expect(work.members.second.file.metadata['bitrate']).to be_nil
       creator = CombinedAudioDerivativeCreator.new(work)
+      expect(creator.audio_metadata_errors).to eq [
+        "bad_metadata.flac: audio duration is unavailable or zero",
+        "bad_metadata.flac: audio bitrate or sample rate is unavailable"
+      ]
       combined_audio_info = creator.generate
       # The first empty mp3 should not even be counted as an available audio member:
       expect(creator.available_members_count).to eq 1

--- a/spec/services/work_combined_audio_creator_spec.rb
+++ b/spec/services/work_combined_audio_creator_spec.rb
@@ -14,7 +14,7 @@ describe "Combined Audio" do
     it "creates combined audio derivative", queue_adapter: :inline do
       expect(work.members.map(&:stored?)).to match([true])
       audio_file = work.members.first.file
-      expect(audio_file.metadata['bitrate']).to eq 8402
+      expect(audio_file.metadata['bitrate']).to be_a_kind_of(Integer)
       combined_audio_info = CombinedAudioDerivativeCreator.new(work).generate
       expect(combined_audio_info.start_times.count).to eq 1
       expect(combined_audio_info.start_times).to match([[mp3.id, 0]])
@@ -47,8 +47,8 @@ describe "Combined Audio" do
 
     it "creates combined audio derivatives", queue_adapter: :inline do
       expect(work.members.map(&:stored?)).to match([true, true])
-      expect(work.members.first.file.metadata['bitrate']).to eq 8402
-      expect(work.members.second.file.metadata['bitrate']).to eq 8205
+      expect(work.members.first.file.metadata['bitrate']).to be_a_kind_of(Integer)
+      expect(work.members.second.file.metadata['bitrate']).to be_a_kind_of(Integer)
 
       combined_audio_info = CombinedAudioDerivativeCreator.new(work).generate
       expect(combined_audio_info.start_times.count).to eq 2


### PR DESCRIPTION
Ref #2044 .

All of our audio originals in production are characterized with a ```file.metadata['bitrate']``` value.
(See
https://github.com/sciencehistory/scihist_digicoll/blob/master/lib/tasks/reports/audio_originals_metadata.rake 
and https://github.com/sciencehistory/scihist_digicoll/issues/2054#issuecomment-1442054581 .
)

Confusingly, the characterization software sometimes also offers an `audio_bitrate` number (which characterizes just the audio streams). 

In #1652 I wrote `file.metadata['audio_bitrate']` - I should have written `file.metadata['bitrate']`.

