### PR TITLE
Initial OCR/Tesseract

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -17,7 +17,7 @@ poppler-utils
 # Tesseract for OCR, along with language packs for our top-languages...
 # we might not REALLY need all these languages? Yet? But let's start
 # with em
-# eng=English  deu=German  fra=French lat=Latin   spa=Spanish
+# eng=English  deu=German  fra=French   spa=Spanish
 #
 # These language packs from apt are the tesserat "FAST" models,
 # not the larger slower "BEST" models!
@@ -25,7 +25,6 @@ tesseract-ocr
 tesseract-ocr-eng
 tesseract-ocr-deu
 tesseract-ocr-fra
-tesseract-ocr-lat
 tesseract-ocr-spa
 
 # apt tesseract on heroku requires libarchive13 , not sure

--- a/Aptfile
+++ b/Aptfile
@@ -18,6 +18,9 @@ poppler-utils
 # we might not REALLY need all these languages? Yet? But let's start
 # with em
 # eng=English  deu=German  fra=French lat=Latin   spa=Spanish
+#
+# These language packs from apt are the tesserat "FAST" models,
+# not the larger slower "BEST" models!
 tesseract-ocr
 tesseract-ocr-eng
 tesseract-ocr-deu

--- a/Aptfile
+++ b/Aptfile
@@ -24,3 +24,8 @@ tesseract-ocr-deu
 tesseract-ocr-fra
 tesseract-ocr-lat
 tesseract-ocr-spa
+
+# apt tesseract on heroku requires libarchive13 , not sure
+# why this isn't an automatic dependency, but it seems to work
+# https://stackoverflow.com/questions/66087588/tesseract-error-while-loading-shared-libraries-libarchive-so-13-python
+libarchive13

--- a/Aptfile
+++ b/Aptfile
@@ -13,3 +13,14 @@ libpoppler-glib8
 # heroku stacks/buildpacks).  Supplying it here on top of activestorage-preview buildpack
 # doesn't seem to hurt, and does seem to get us a working poppler reliably.
 poppler-utils
+
+# Tesseract for OCR, along with language packs for our top-languages...
+# we might not REALLY need all these languages? Yet? But let's start
+# with em
+# eng=English  deu=German  fra=French lat=Latin   spa=Spanish
+tesseract-ocr
+tesseract-ocr-eng
+tesseract-ocr-deu
+tesseract-ocr-fra
+tesseract-ocr-lat
+tesseract-ocr-spa

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ To set up a development instance on your workstation.
 * `mediainfo` installed for fallback contnet type detection -- on MacOS, `brew install mediainfo`
 * vips installed --  on MacOS `brew install vips`
 * ffmpeg installed -- on MacOS `brew install ffmpeg`
+* tesseract for OCR -- `brew install tesseract tesseract-lang`. Will not be same version as
+  production, see https://sciencehistory.atlassian.net/l/cp/ucUvKjk3
 * You'll need Java installed to run Solr. If you don't already have it, on MacOS `brew install java`, then follow post-install instructions, such as `sudo ln -sfn /opt/homebrew/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk`
 
 

--- a/app/jobs/create_asset_hocr_job.rb
+++ b/app/jobs/create_asset_hocr_job.rb
@@ -1,0 +1,5 @@
+class CreateAssetHocrJob < ApplicationJob
+  def perform(asset)
+    AssetHocrCreator.new(asset).call
+  end
+end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -64,6 +64,9 @@ class Asset < Kithe::Asset
   attr_json :transcription, :text
   attr_json :english_translation, :text
 
+  # OCR data in hOCR format, for the image asset
+  attr_json :hocr, :text
+
 
   validates :derivative_storage_type, inclusion: { in: ["public", "restricted"] }
 

--- a/app/services/asset_hocr_creator.rb
+++ b/app/services/asset_hocr_creator.rb
@@ -1,0 +1,91 @@
+# For a specific asset, run image through OCR with tesseract, to get HOCR output,
+# attach to asset.
+#
+# Will overwrite any existing #hocr on asset, will run whether or not there is existing.
+#
+# * We run on the full-res TIFF, although this is slower, it will give us best results.
+#
+# * While some versions of tesseract are supposed to be able to read directly from URI,
+#   the 4.1.1 we currently have on heroku cannot, so we have to download temp copy,
+#   which does make this even slower. (Wait, should we pipe curl to it instead?)
+class AssetHocrCreator
+  class_attribute :tesseract_executable, default: "tesseract"
+
+  # key is language in our metadata language field, value
+  # is language as tesseract labels it. For languages we
+  # currently handle.
+  TESS_LANGS = {
+    "English" => "eng",
+    "German"  => "deu",
+    "French"  => "fra",
+    "Spanish" => "spa"
+  }.freeze
+
+  attr_accessor :asset
+
+  def initialize(asset)
+    unless asset&.content_type&.start_with?("image/")
+      raise ArgumentError, "Can only use with content type begining `image/`, not #{asset.content_type}"
+    end
+
+    @asset = asset
+  end
+
+  def call
+    asset.hocr = get_hocr
+    asset.save!
+  end
+
+  def get_hocr
+    # while some versions of tesseract can read directly from URL, the one
+    # we currently have needs a local file, so we need to download it locally.
+    # This is a lot slower with all the disk writing and reading.
+    local_original = asset.file.download
+
+    tesseract_extract_hocr_from_local_file(local_original.path)
+  ensure
+    local_original&.unlink
+  end
+
+  # @param input_path local filepath of input file
+  # @returns String hOCR
+  def tesseract_extract_hocr_from_local_file(input_path)
+    unless tesseract_languages.present?
+      raise TypeError.new("Work languages don't include any we can recognize: #{work.languages.inspect}. We need one of #{TESS_LANGS.keys.inspect}")
+    end
+
+    result = tty_command.run(
+      tesseract_executable,
+      input_path,
+      "-", # output to stdout
+      "-l",
+      tesseract_languages.join("+"),
+      "hocr" # in hocr format
+    )
+
+    result.stdout
+  end
+
+
+  private
+
+  def work_languages
+    @work_languages ||= (asset.parent.language || [])
+  end
+
+  # Tesseract needs to know the expected language(s); it defaults to English.
+  # We'll use our metadata languages on the associated work.
+  #
+  # ORDER matters for Tesseract, it's going to think they are in order of predominance
+  # in the source, and use that to try to guess what things are. Our language metadata
+  # may not be in that order, but it's all we have.
+  def tesseract_languages
+    @tesseract_languages ||= work_languages.collect { |our_lang| TESS_LANGS[our_lang] }.compact
+  end
+
+
+  def tty_command
+    @tty_command ||= TTY::Command.new(printer: :null)
+  end
+
+end

--- a/spec/services/asset_hocr_creator_spec.rb
+++ b/spec/services/asset_hocr_creator_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe AssetHocrCreator, type: :model do
+  describe "with mocked tesseract" do
+    let(:asset) { create(:asset_with_faked_file, parent: create(:work, language: ["German", "English", "Japanese"])) }
+    let(:creator) { AssetHocrCreator.new(asset) }
+    let(:creator_tty_command_obj) { creator.send(:tty_command) }
+    let(:mocked_response) { TTY::Command::Result.new(0, "mocked HOCR output", "whatever tesseract prints to stderr") }
+
+    before do
+      allow(creator_tty_command_obj).to receive(:run).and_return(mocked_response)
+    end
+
+
+    it "calls proper tesseract command and persists output" do
+      expect(creator_tty_command_obj).to receive(:run) do |*args|
+        cli = args.join(" ")
+
+        # just what we expect a cli call to be, including proper language tags,
+        # in order, ignoring Japanese that we aren't prepared to OCR.
+        expect(cli).to match( /\Atesseract [\/\.\-\w]+ - -l deu\+eng hocr\z/ )
+
+        mocked_response
+      end
+
+      creator.call
+
+      asset.reload
+      expect(asset.hocr).to eq mocked_response.stdout
+    end
+
+  end
+end


### PR DESCRIPTION
Code that can run OCR and store it in our db. Along with necessary in-repo setup for tesseract on heroku. 

     AssetHocrCreator.new(asset).call

=> Will do an ocr with a shell-out to command-line tesseract, and store the hOCR results in the Asset at attribute `hocr`. 

     CreateAssetHocrJob.perform_later(asset)

=> Will just call the above in a bg ActiveJob!

Nothing is in this PR to actually call those things, they are just logic made available. 

`AssetHocrCreator` has some tests that do not actually call out to CLI tesseract, the mock the call. They just test that the CLI tesseract call looks like we expect, and that the results of it are stored in the Asset. 

We don't have an actual integration test that proves what we call out to tesseract with _works_. We're tying to avoid having to have tesseract installed to run tests (on eg CI)... but might resort to it in the future?
