### PR TITLE
[WIP] Experment: check audio files on ingest

### DIFF
--- a/app/services/audio_file_metadata_checker.rb
+++ b/app/services/audio_file_metadata_checker.rb
@@ -1,0 +1,24 @@
+class AudioFileMetadataChecker
+
+  # Checks if an audio file is empty or otherwise unplayable.
+  attr_reader :file
+  
+  # @param asset [Asset] an audio asset. We assume it's an audio asset - no checks performed here.
+  def initialize(file)
+    @file = file
+  end
+
+  # Returns an array of errors
+  def file_errors
+    return ["empty file"] if @file.size == 0
+    errors = []
+    metadata =  @file.metadata
+    if metadata['duration_seconds'].nil?  || metadata['duration_seconds'] == 0
+      errors << "audio duration is unavailable or zero" 
+    end
+    if metadata['bitrate'].nil? || metadata['audio_sample_rate'].nil?
+      errors << "audio bitrate or sample rate is unavailable"
+    end
+    errors
+  end
+end

--- a/app/services/combined_audio_derivative_creator.rb
+++ b/app/services/combined_audio_derivative_creator.rb
@@ -154,21 +154,11 @@ class CombinedAudioDerivativeCreator
   end
 
   def audio_metadata_errors
-    @audio_metadata_errors ||= begin
-      errors = []
-      published_audio_members.each do |mem|
-        file = mem.file
-        filename = mem.file_data['metadata']['filename']
-        errors << "#{filename}: empty file" if file.size == 0
-        if file.metadata['duration_seconds'].nil?  || file.metadata['duration_seconds'] == 0
-          errors << "#{filename}: audio duration is unavailable or zero" 
-        end
-        if file.metadata['bitrate'].nil? || file.metadata['audio_sample_rate'].nil?
-          errors << "#{filename}: audio bitrate or sample rate is unavailable"
-        end
-      end
-      errors
-    end
+    @audio_metadata_errors ||= published_audio_members.map { |mem|
+      AudioFileMetadataChecker.new(mem.file).file_errors.map { |err|
+        "#{mem.file.metadata['filename']}: #{err}"
+      }
+    }.compact.flatten
   end
 
   # If this checksum changes, you need to regenerate the audio

--- a/app/uploaders/asset_uploader.rb
+++ b/app/uploaders/asset_uploader.rb
@@ -24,6 +24,15 @@ class AssetUploader < Kithe::AssetUploader
     Kithe::FfprobeCharacterization.characterize_from_uploader(source_io, context)
   end
 
+  plugin :validation
+  Attacher.validate do
+    refresh_metadata!
+    if file.mime_type.match /^audio/
+      AudioFileMetadataChecker.new(file).file_errors.each { |err| errors << err }
+    end
+  end
+
+
   # Re-set shrine derivatives setting, to put DERIVATIVES on restricted storage
   # if so configured. Only effects initial upload, if setting changes, some code
   # needs to manually move files.

--- a/spec/services/work_combined_audio_creator_spec.rb
+++ b/spec/services/work_combined_audio_creator_spec.rb
@@ -133,18 +133,20 @@ describe "Combined Audio" do
   end
 
   context "two broken flacs" do
-    let!(:flac_zero_bytes)  { create(:asset, :inline_promoted_file,
-        position: 1,
-        parent_id: work.id,
-        file: File.open((Rails.root + "spec/test_support/audio/zero_bytes.flac"))
-      )
+    let!(:flac_zero_bytes)  {
+        a = build(:asset, :inline_promoted_file,
+          position: 1,
+          parent_id: work.id,
+          file: File.open((Rails.root + "spec/test_support/audio/zero_bytes.flac"))
+        ).save(validate:false)
     }
 
-    let!(:flac_bad_metadata)  { create(:asset, :inline_promoted_file,
-        position: 2,
-        parent_id: work.id,
-        file: File.open((Rails.root + "spec/test_support/audio/bad_metadata.flac"))
-      )
+    let!(:flac_bad_metadata)  {
+        a = build(:asset, :inline_promoted_file,
+          position: 2,
+          parent_id: work.id,
+          file: File.open((Rails.root + "spec/test_support/audio/bad_metadata.flac"))
+        ).save(validate:false)
     }
 
     it "accurately detects broken files", queue_adapter: :inline do


### PR DESCRIPTION
Ref #1652  Ref #2044
I'm moving the audio metadata check code out into its own service, and using it on asset ingest.
~~Actually seems to work pretty well.~~ ◀️ Not so much : the validation errors are not shown to the user.