### PR TITLE
Bug fix: in interviewee job dates, if start and end dates are both blank, don't show anything

### DIFF
--- a/app/components/oral_history/biographical_component.rb
+++ b/app/components/oral_history/biographical_component.rb
@@ -62,7 +62,7 @@ module OralHistory
 
     # See discussion at https://github.com/sciencehistory/scihist_digicoll/issues/2045
     def formatted_job_dates(start_date, end_date)
-      if end_date.blank?
+      if start_date.present? && end_date.blank?
         # A blank end date means the job is still considered current.
         "#{FormatSimpleDate.new(start_date).display} to present"
       else

--- a/spec/components/oral_history/biographical_component_spec.rb
+++ b/spec/components/oral_history/biographical_component_spec.rb
@@ -37,8 +37,12 @@ describe OralHistory::BiographicalComponent, type: :component do
       expect(presenter.formatted_job_dates('1910', '1910')).to eq "1910"
     end
 
-    it "supplies `present` if the end date is blank" do
+    it "supplies `present` if there is a start date, but the end date is blank" do
       expect(presenter.formatted_job_dates('1910', '')).to eq "1910 to present"
+    end
+
+    it "shows nothing both dates are blank" do
+      expect(presenter.formatted_job_dates('', '')).to eq ""
     end
   end
 end


### PR DESCRIPTION
Oops - oversight on my part; quick fix.
Ref #2096 