### PR TITLE
Show no-results content on collection and featured topics pages

### DIFF
--- a/app/views/collection_show/index.html.erb
+++ b/app/views/collection_show/index.html.erb
@@ -1,124 +1,99 @@
 <% provide :page_title, construct_page_title(collection.title) %>
-
 <div itemscope itemtype="http://schema.org/CollectionPage" class="collection-show">
-
-
-  <div class="collection-top">
-    <div class="collection-desc clearfix">
-      <% unless has_search_parameters? %>
-        <div class="collection-thumb">
-          <%= render ThumbComponent.new(collection.leaf_representative, thumb_size: :collection_page, placeholder_img_url: asset_path("default_collection.svg")) %>
-        </div>
-      <% end %>
-
-      <div class="show-title">
-        <header>
-          <div class="show-genre">
-            <% if collection.department != Collection::DEPARTMENT_EXHIBITION_VALUE %>
-              <%= link_to "Collections", collections_path %>
-            <% else %>
-              Exhibitions
-            <% end %>
-          </div>
-          <h1>
-            <%= link_to collection.title, collection_path(collection), class: "title-link" %> <%= publication_badge(collection) %>
-            <% if can? :update, collection %>
-              <%= link_to "Edit", edit_admin_collection_path(collection), class: "btn btn-outline-primary" %>
-            <% end %>
-          </h1>
-        </header>
+<div class="collection-top">
+  <div class="collection-desc clearfix">
+    <% unless has_search_parameters? %>
+      <div class="collection-thumb">
+        <%= render ThumbComponent.new(collection.leaf_representative, thumb_size: :collection_page, placeholder_img_url: asset_path("default_collection.svg")) %>
       </div>
+    <% end %>
 
-
-      <% unless has_search_parameters? %>
-        <%= render CollectionMetadataComponent.new(collection: collection) %>
-      <% end %>
+    <div class="show-title">
+      <header>
+        <div class="show-genre">
+          <% if collection.department != Collection::DEPARTMENT_EXHIBITION_VALUE %>
+            <%= link_to "Collections", collections_path %>
+          <% else %>
+            Exhibitions
+          <% end %>
+        </div>
+        <h1>
+          <%= link_to collection.title, collection_path(collection), class: "title-link" %> <%= publication_badge(collection) %>
+          <% if can? :update, collection %>
+            <%= link_to "Edit", edit_admin_collection_path(collection), class: "btn btn-outline-primary" %>
+          <% end %>
+        </h1>
+      </header>
     </div>
-  </div>
-
-
-
 
 
     <% unless has_search_parameters? %>
-      <div class="collection-control-area">
-
-        <% if collection.funding_credit.present? %>
-          <div class="collection-funding-credit">
-            <% if collection.funding_credit.image.present? %>
-              <%= image_tag collection.funding_credit.image_path, class: "funding-credit-image" %>
-            <% end %>
-
-            <p>
-              <% if collection.department == "Center for Oral History" %>
-                This oral history project
-              <% else %>
-                Digitization and cataloging of this collection
-              <% end %>
-                made possible by the generosity of
-              <%= link_to_if collection.funding_credit.url.present?,
-                    collection.funding_credit.name,
-                    collection.funding_credit.url,
-                    target: "_blank"
-              %>
-            </p>
-          </div>
-        <% end %>
-
-
-        <div class="collection-search-form">
-            <h2 class="search-title">
-                  Search within the <%= collection.title %>
-            </h2>
-
-            <%= form_tag "", method: :get do |f| %>
-             <div class="input-group">
-                <%= search_field_tag :q, '', class: "q form-control",
-                    id: "collectionQ",
-                    autocomplete: "off",
-                    placeholder: t("collection.search_form.search_field.placeholder"),
-                    :"aria-label" => t('collection.search_form.search_field.label')
-                %>
-
-                <label class="sr-only" for="collectionQ"><%= t('collection.search_form.search_field.label') %></label>
-
-                <div class="input-group-append">
-                  <button type="submit" class="btn btn-emphasis" title="Search">
-                    <i class="fa fa-search" aria-hidden="true"></i>
-                    <%= t('blacklight.search.form.submit') %>
-                  </button>
-                </div>
-              </div>
-
-              <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>
-            <% end %>
-        </div>
-      </div>
-    <% end %>
-
-  <%= render 'catalog/constraints' %>
-
-
-  <div class="row">
-    <% if @response.documents.present? %>
-      <div class="sidebar-col">
-        <%= render 'facets' %>
-      </div>
-      <div class="content-col">
-        <%# per-page and sort controls, from Blacklight partial %>
-        <%= render 'search_header' %>
-        <%= render "document_list", documents: @response.documents %>
-        <%= render 'catalog/results_pagination' %>
-      </div>
-    <% else %>
-      <%# Force display of our zero-results content. %>
-      <%= render 'catalog/zero_results' %>
+      <%= render CollectionMetadataComponent.new(collection: collection) %>
     <% end %>
   </div>
-
-
-
-
-  </div><%# TODO this closing div looks like it doesn't belong here  - remove in another PR. %>
-
+</div>
+<% unless has_search_parameters? %>
+  <div class="collection-control-area">
+    <% if collection.funding_credit.present? %>
+      <div class="collection-funding-credit">
+        <% if collection.funding_credit.image.present? %>
+          <%= image_tag collection.funding_credit.image_path, class: "funding-credit-image" %>
+        <% end %>
+        <p>
+          <% if collection.department == "Center for Oral History" %>
+            This oral history project
+          <% else %>
+            Digitization and cataloging of this collection
+          <% end %>
+            made possible by the generosity of
+          <%= link_to_if collection.funding_credit.url.present?,
+                collection.funding_credit.name,
+                collection.funding_credit.url,
+                target: "_blank"
+          %>
+        </p>
+      </div>
+    <% end %>
+    <div class="collection-search-form">
+        <h2 class="search-title">
+          Search within the <%= collection.title %>
+        </h2>
+        <%= form_tag "", method: :get do |f| %>
+         <div class="input-group">
+            <%= search_field_tag :q, '', class: "q form-control",
+                id: "collectionQ",
+                autocomplete: "off",
+                placeholder: t("collection.search_form.search_field.placeholder"),
+                :"aria-label" => t('collection.search_form.search_field.label')
+            %>
+            <label class="sr-only" for="collectionQ"><%= t('collection.search_form.search_field.label') %></label>
+            <div class="input-group-append">
+              <button type="submit" class="btn btn-emphasis" title="Search">
+                <i class="fa fa-search" aria-hidden="true"></i>
+                <%= t('blacklight.search.form.submit') %>
+              </button>
+            </div>
+          </div>
+          <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>
+        <% end %>
+    </div>
+  </div>
+<% end %>
+<%= render 'catalog/constraints' %>
+<div class="row">
+  <% if @response.documents.present? %>
+    <div class="sidebar-col">
+      <%= render 'facets' %>
+    </div>
+    <div class="content-col">
+      <%# per-page and sort controls, from Blacklight partial %>
+      <%= render 'search_header' %>
+      <%= render "document_list", documents: @response.documents %>
+      <%= render 'catalog/results_pagination' %>
+    </div>
+  <% else %>
+    <div class="ml-3">
+      <%= render 'catalog/zero_results' %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/collection_show/index.html.erb
+++ b/app/views/collection_show/index.html.erb
@@ -102,21 +102,23 @@
   <div class="row">
     <% if @response.documents.present? %>
       <div class="sidebar-col">
-       <%= render 'facets' %>
+        <%= render 'facets' %>
       </div>
+      <div class="content-col">
+        <%# per-page and sort controls, from Blacklight partial %>
+        <%= render 'search_header' %>
+        <%= render "document_list", documents: @response.documents %>
+        <%= render 'catalog/results_pagination' %>
+      </div>
+    <% else %>
+      <%# Force display of our zero-results content. %>
+      <%= render 'catalog/zero_results' %>
     <% end %>
-    <div class="content-col">
-      <%# per-page and sort controls, from Blacklight partial %>
-      <%= render 'search_header' %>
-      <%= render "document_list", documents: @response.documents %>
-      <%= render 'catalog/results_pagination' %>
-    </div>
   </div>
 
 
 
 
-
-  </div>
+  </div><%# TODO this closing div looks like it doesn't belong here  - remove in another PR. %>
 
 </div>

--- a/app/views/featured_topic/index.html.erb
+++ b/app/views/featured_topic/index.html.erb
@@ -60,11 +60,15 @@
       <div class="sidebar-col">
         <%= render 'facets' %>
       </div>
-    <% end %>
-    <div class="content-col">
-      <%= render 'search_header' %>
-      <%= render "document_list", documents: @response.documents %>
-      <%= render 'catalog/results_pagination' %>
-    </div>
+      <div class="content-col">
+        <%= render 'search_header' %>
+        <%= render "document_list", documents: @response.documents %>
+        <%= render 'catalog/results_pagination' %>
+      </div>
+      <% else %>
+        <div class="ml-3">
+          <%= render 'catalog/zero_results' %>
+        </div>
+      <% end %>
   </div>
 </div>

--- a/spec/system/collection_show_spec.rb
+++ b/spec/system/collection_show_spec.rb
@@ -48,6 +48,15 @@ describe "Collection show page", solr: true, indexable_callbacks: true do
         expect(page).to have_selector(:link_or_button, "Subject")
       end
     end
+
+    describe "no results" do
+      let(:collection) { create(:collection, department: CollectionShowController::ORAL_HISTORY_DEPARTMENT_VALUE) }
+      it "displays correct no-results content", js: true, solr: true, indexable_callbacks: true do      
+        visit collection_path(collection, q: 'abc123')
+        expect(page).to have_content("Sorry, we couldn't find any records for your search.")
+        expect(page).to have_content("Ever Bumped by Dead Weight?")
+      end
+    end
   end
 
   describe "generic oral history collection" do

--- a/spec/system/featured_topic_spec.rb
+++ b/spec/system/featured_topic_spec.rb
@@ -49,11 +49,15 @@ describe "Featured Topic show page", type: :system, js: false, solr:true, indexa
 
   it "searches, and keeps total count accurate" do
     visit featured_topic_path(:instruments_and_innovation.to_s.dasherize, q: "artillery")
-
     expect(page).to have_text("1 entry found")
-
     expect(page).to have_content("artillery")
     expect(page).not_to have_content("lithographs")
+  end
+
+  it "shows customized no-results content" do
+    visit featured_topic_path(:instruments_and_innovation.to_s.dasherize, q: "abc123")
+    expect(page).to have_content("Sorry, we couldn't find any records for your search.")
+    expect(page).to have_content("Ever Bumped by Dead Weight?")
   end
 
   it "can be set to an arbitrary URL by setting the path variable" do


### PR DESCRIPTION
The friendly no-results page we created in https://github.com/sciencehistory/scihist_digicoll/pull/2067 was not getting used on the collection or featured topics search, because we aren't calling  render 'search_results'.

See ref https://github.com/sciencehistory/scihist_digicoll/issues/2106 .

I'm not thrilled about explicitly including ```<%= render 'catalog/zero_results' %>``` here. But we're constrained here by
- Blacklight
- the fact that these two searches show the **title** of the search -- which we feel needs to show up _above_ the search constraints.
- the reality that we don't want to mess with the generic blacklight search and how it's shown in `application.html.erb`, for what's ultimately a pretty small problem.

I was able to work out a sort of compromise in a different attempt (see https://github.com/sciencehistory/scihist_digicoll/pull/2112/ ) but we decided against it, given the risk of more problems later, due to Blacklight shifting again under our feet.

Cleaned up the template too - it was quite messy and had some broken HTML in it.

Includes basic tests.