### PR TITLE
Changes to the collection page search

### DIFF
--- a/app/views/collection_show/_collection_top.html.erb
+++ b/app/views/collection_show/_collection_top.html.erb
@@ -1,0 +1,31 @@
+<div class="collection-show">
+  <div class="collection-top mb-4">
+    <div class="collection-desc clearfix">
+      <% unless has_search_parameters? %>
+        <div class="collection-thumb">
+          <%= render ThumbComponent.new(collection.leaf_representative, thumb_size: :collection_page, placeholder_img_url: asset_path("default_collection.svg")) %>
+        </div>
+      <% end %>
+      <div class="show-title">
+        <header>
+          <div class="show-genre">
+            <% if collection.department != Collection::DEPARTMENT_EXHIBITION_VALUE %>
+              <%= link_to "Collections", collections_path %>
+            <% else %>
+              Exhibitions
+            <% end %>
+          </div>
+          <h1>
+            <%= link_to collection.title, collection_path(collection), class: "title-link" %> <%= publication_badge(collection) %>
+            <% if can? :update, collection %>
+              <%= link_to "Edit", edit_admin_collection_path(collection), class: "btn btn-outline-primary" %>
+            <% end %>
+          </h1>
+        </header>
+      </div>
+      <% unless has_search_parameters? %>
+        <%= render CollectionMetadataComponent.new(collection: collection) %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/collection_show/_search_within_collection.html.erb
+++ b/app/views/collection_show/_search_within_collection.html.erb
@@ -1,0 +1,55 @@
+  <% unless has_search_parameters? %>
+    <div class="collection-control-area">
+
+      <% if collection.funding_credit.present? %>
+        <div class="collection-funding-credit">
+          <% if collection.funding_credit.image.present? %>
+            <%= image_tag collection.funding_credit.image_path, class: "funding-credit-image" %>
+          <% end %>
+
+          <p>
+            <% if collection.department == "Center for Oral History" %>
+              This oral history project
+            <% else %>
+              Digitization and cataloging of this collection
+            <% end %>
+              made possible by the generosity of
+            <%= link_to_if collection.funding_credit.url.present?,
+                  collection.funding_credit.name,
+                  collection.funding_credit.url,
+                  target: "_blank"
+            %>
+          </p>
+        </div>
+      <% end %>
+
+
+      <div class="collection-search-form">
+          <h2 class="search-title">
+                Search within the <%= collection.title %>
+          </h2>
+
+          <%= form_tag "", method: :get do |f| %>
+           <div class="input-group">
+              <%= search_field_tag :q, '', class: "q form-control",
+                  id: "collectionQ",
+                  autocomplete: "off",
+                  placeholder: t("collection.search_form.search_field.placeholder"),
+                  :"aria-label" => t('collection.search_form.search_field.label')
+              %>
+
+              <label class="sr-only" for="collectionQ"><%= t('collection.search_form.search_field.label') %></label>
+
+              <div class="input-group-append">
+                <button type="submit" class="btn btn-emphasis" title="Search">
+                  <i class="fa fa-search" aria-hidden="true"></i>
+                  <%= t('blacklight.search.form.submit') %>
+                </button>
+              </div>
+            </div>
+
+            <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>
+          <% end %>
+      </div>
+    </div>
+  <% end %>

--- a/app/views/collection_show/index.html.erb
+++ b/app/views/collection_show/index.html.erb
@@ -1,122 +1,17 @@
 <% provide :page_title, construct_page_title(collection.title) %>
-
+<% provide :above_container_header do %>
+  <%= render 'collection_show/collection_top' %>
+<% end %>
 <div itemscope itemtype="http://schema.org/CollectionPage" class="collection-show">
-
-
-  <div class="collection-top">
-    <div class="collection-desc clearfix">
-      <% unless has_search_parameters? %>
-        <div class="collection-thumb">
-          <%= render ThumbComponent.new(collection.leaf_representative, thumb_size: :collection_page, placeholder_img_url: asset_path("default_collection.svg")) %>
-        </div>
-      <% end %>
-
-      <div class="show-title">
-        <header>
-          <div class="show-genre">
-            <% if collection.department != Collection::DEPARTMENT_EXHIBITION_VALUE %>
-              <%= link_to "Collections", collections_path %>
-            <% else %>
-              Exhibitions
-            <% end %>
-          </div>
-          <h1>
-            <%= link_to collection.title, collection_path(collection), class: "title-link" %> <%= publication_badge(collection) %>
-            <% if can? :update, collection %>
-              <%= link_to "Edit", edit_admin_collection_path(collection), class: "btn btn-outline-primary" %>
-            <% end %>
-          </h1>
-        </header>
-      </div>
-
-
-      <% unless has_search_parameters? %>
-        <%= render CollectionMetadataComponent.new(collection: collection) %>
-      <% end %>
-    </div>
-  </div>
-
-
-
-
-
-    <% unless has_search_parameters? %>
-      <div class="collection-control-area">
-
-        <% if collection.funding_credit.present? %>
-          <div class="collection-funding-credit">
-            <% if collection.funding_credit.image.present? %>
-              <%= image_tag collection.funding_credit.image_path, class: "funding-credit-image" %>
-            <% end %>
-
-            <p>
-              <% if collection.department == "Center for Oral History" %>
-                This oral history project
-              <% else %>
-                Digitization and cataloging of this collection
-              <% end %>
-                made possible by the generosity of
-              <%= link_to_if collection.funding_credit.url.present?,
-                    collection.funding_credit.name,
-                    collection.funding_credit.url,
-                    target: "_blank"
-              %>
-            </p>
-          </div>
-        <% end %>
-
-
-        <div class="collection-search-form">
-            <h2 class="search-title">
-                  Search within the <%= collection.title %>
-            </h2>
-
-            <%= form_tag "", method: :get do |f| %>
-             <div class="input-group">
-                <%= search_field_tag :q, '', class: "q form-control",
-                    id: "collectionQ",
-                    autocomplete: "off",
-                    placeholder: t("collection.search_form.search_field.placeholder"),
-                    :"aria-label" => t('collection.search_form.search_field.label')
-                %>
-
-                <label class="sr-only" for="collectionQ"><%= t('collection.search_form.search_field.label') %></label>
-
-                <div class="input-group-append">
-                  <button type="submit" class="btn btn-emphasis" title="Search">
-                    <i class="fa fa-search" aria-hidden="true"></i>
-                    <%= t('blacklight.search.form.submit') %>
-                  </button>
-                </div>
-              </div>
-
-              <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>
-            <% end %>
-        </div>
-      </div>
-    <% end %>
-
-  <%= render 'catalog/constraints' %>
-
-
+  <%= render 'collection_show/search_within_collection' %>
   <div class="row">
     <% if @response.documents.present? %>
       <div class="sidebar-col">
-       <%= render 'facets' %>
+         <%= render 'facets' %>
       </div>
     <% end %>
     <div class="content-col">
-      <%# per-page and sort controls, from Blacklight partial %>
-      <%= render 'search_header' %>
-      <%= render "document_list", documents: @response.documents %>
-      <%= render 'catalog/results_pagination' %>
+      <%= render 'search_results' %>
     </div>
   </div>
-
-
-
-
-
-  </div>
-
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -82,6 +82,7 @@
         integrated into the masthead -%>
 
     <main id="mainContainer" class="container-fluid">
+      <%= content_for(:above_container_header) %>
       <%= content_for(:container_header) %>
       <%= render 'flash_message_display' %>
       <% if content_for? :full_width_layout %>


### PR DESCRIPTION
The friendly no-results page we created in #2067 isn't  getting used on the collection search, because we aren't calling ` render 'search_results'`. See ref #2106 . 

The goal here is to refactor these templates, to make everything more similar to the generic `catalog/index` template, without making unnecessary changes or breaking anything.

This is a rough draft that can probably be turned into something workable:

- Break up collection index page into partials to make it easier to read and understand. (There was an extra closing div in there - it's getting a little messy.)
- Create a new section in `application.html` called `<%= content_for(:above_container_header) %>`
- Call `<%= render 'search_results' %>` in the collection index template, just as we do in the generic `catalog/index` template.
- Move the collection thumbnail and title into the new :above_container_header, so it shows up *above* the search constraints.

See also #2111 - simpler but uglier.