### PR TITLE
Allow user to set / unset `ocr_requested`.

### DIFF
--- a/app/views/admin/works/_work_fields.html.erb
+++ b/app/views/admin/works/_work_fields.html.erb
@@ -10,6 +10,9 @@
       <%= category_and_value(sub_form, category_list: Work::ExternalId::CATEGORY_VALUES) %>
     <% end %>
 
+    <%# ocr_requested does need to be in this form, so that we can include it in batch edits. %>
+    <%= f.input :ocr_requested, label: "Check to request OCR" %>
+
     <%= f.repeatable_attr_input(:creator, build: :at_least_one) do |sub_form| %>
       <%= category_and_value(sub_form, category_list: Work::Creator::CATEGORY_VALUES,
             input_data_attributes: { "scihist-qa-autocomplete" => qa_search_vocab_path("assign_fast", "all")}) %>

--- a/config/locales/work.en.yml
+++ b/config/locales/work.en.yml
@@ -94,5 +94,6 @@ en:
         representative: "Select the file with media that represents this Work and is used as a thumbnail."
         contained_by: >
           The sub-Collection within the Digital Collections Application to which the digital work belongs. Select the named collection that the work is part of, if applicable. If a desired entry is not available, contact the Digital Collections Librarian. Required if applicable.
-
+        ocr_requested: >
+          We add and remove OCR on a nightly basis. Check this box if you'd like OCR to be created for this work next time the job runs. Likewise, uncheck the box if you want to remove existing OCR.
 

--- a/config/locales/work.en.yml
+++ b/config/locales/work.en.yml
@@ -95,5 +95,5 @@ en:
         contained_by: >
           The sub-Collection within the Digital Collections Application to which the digital work belongs. Select the named collection that the work is part of, if applicable. If a desired entry is not available, contact the Digital Collections Librarian. Required if applicable.
         ocr_requested: >
-          We add and remove OCR on a nightly basis. Check this box if you'd like OCR to be created for this work next time the job runs. Likewise, uncheck the box if you want to remove existing OCR.
+          Check this box if you'd like OCR to be created for this work.
 


### PR DESCRIPTION
Ref #2095
Two ways of setting the `ocr_requested` bit:
1) via the standard metadata form
  - Mostly useful for batch edit
  - Close to the top of the form per Annabel's request

Notes:
We're not doing anything with the value of `ocr_requested` or `hocr` in this PR yet.
No tests; they don't seem necessary here at first glance.