### PR TITLE
Simple version of work-level OCR display.

### DIFF
--- a/app/components/work_show_ocr_component.html.erb
+++ b/app/components/work_show_ocr_component.html.erb
@@ -1,0 +1,5 @@
+<div class="alert alert-secondary mx-1">
+  <h2 class="h4 alert-heading">OCR</h2>
+  <p><small>OCR has <% unless @work.ocr_requested %> not <%end%> been requested for this work.</small></p>
+  <p><small><%= assets_with_ocr %> out of <%= total_assets %> assets currently have OCR.</small></p>
+</div>

--- a/app/components/work_show_ocr_component.rb
+++ b/app/components/work_show_ocr_component.rb
@@ -1,5 +1,4 @@
-# Display the provenance of a work on the front end:
-# WorkProvenanceComponent.new(work.provenance).display
+# Display stats about work's OCR members.
 class WorkShowOcrComponent < ApplicationComponent
   attr_reader :work
 

--- a/app/components/work_show_ocr_component.rb
+++ b/app/components/work_show_ocr_component.rb
@@ -1,0 +1,23 @@
+# Display the provenance of a work on the front end:
+# WorkProvenanceComponent.new(work.provenance).display
+class WorkShowOcrComponent < ApplicationComponent
+  attr_reader :work
+
+  def initialize(work)
+    @work = work
+  end
+
+  def assets_with_ocr
+    assets_with_and_without_ocr.count {|a| a['has_ocr']}
+  end
+  
+  def total_assets
+    assets_with_and_without_ocr.length
+  end
+
+  def assets_with_and_without_ocr
+    query = "SELECT json_attributes ? 'hocr' AS has_ocr FROM kithe_models WHERE type = 'Asset' AND parent_id = '#{@work.id}'"
+    @assets_with_and_without_ocr ||= ActiveRecord::Base.
+      connection.exec_query(query).to_a
+  end
+end

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -309,18 +309,13 @@
       <% end %>
     </ul>
 
-    <h3>OCR</h3>
+    <h3><a id="ocr">OCR</a></h3>
     <% if @asset.hocr.present? %>
-      <a class="btn btn-primary mt-3 mb-3 mr-3" data-toggle="collapse" href="#ocrCollapse" role="button" aria-expanded="false" aria-controls="ocrCollapse">
-        Show / hide OCR
-      </a>
-      <div class="collapse mb-3 p-3 border" id="ocrCollapse">
-        <small>
-          <span class="text-monospace text-muted admin-ocr-display">
-            <%= HocrComponent.new(@asset.hocr).html_body_without_ids %>
-          </span>
-        </small>
-      </div>
+      <small>
+        <span class="text-monospace text-muted admin-ocr-display">
+          <%= HocrComponent.new(@asset.hocr).html_body_without_ids %>
+        </span>
+      </small>
     <% else %>
       <p class="mt-3 mb-3">No OCR for this asset.</p>
     <% end %>

--- a/app/views/admin/works/_member_list_table.html.erb
+++ b/app/views/admin/works/_member_list_table.html.erb
@@ -33,6 +33,9 @@
               <% if member.kind_of?(Kithe::Asset) %>
                 <li ><small><%= member.content_type %></small></li>
                 <li><small><%= ScihistDigicoll::Util.simple_bytes_to_human_string(member.size) %></small></li>
+                <% if member.hocr.present? %>
+                  <li><small><%=link_to("OCR", admin_asset_path(member, anchor: "ocr"), class: "ocr-link") %></small></li>
+                <% end %>
               <% end %>
             </ul>
           </td>

--- a/app/views/admin/works/show.html.erb
+++ b/app/views/admin/works/show.html.erb
@@ -81,11 +81,9 @@
   <div class="nav nav-tabs" id="nav-tab" role="tablist">
     <a class="nav-item nav-link active" id="nav-metadata-tab" data-toggle="tab" href="#nav-metadata" role="tab" aria-controls="nav-home" aria-selected="true">Metadata</a>
     <a class="nav-item nav-link" id="nav-members-tab" data-toggle="tab" href="#nav-members" role="tab" aria-controls="nav-profile" aria-selected="false">Members</a>
-
     <% if @work.is_oral_history? %>
       <a class="nav-item nav-link" id="nav-oral-histories-tab" data-toggle="tab" href="#nav-oral-histories" role="tab" aria-controls="nav-profile" aria-selected="false">Oral History</a>
     <% end %>
-
   </div>
 </nav>
 
@@ -128,13 +126,15 @@
         <%= link_to "Manual", reorder_members_admin_work_path(@work), class: "btn btn-primary #{'disabled' unless can?(:update, @work)}" %>
         <%= link_to "Alphabetical", reorder_members_admin_work_path(@work), method: "put", class: "btn btn-primary #{'disabled' unless can?(:update, @work)}", data: { confirm: "Re-ordering members alphabetically by title can't be undone" } %>
       </div>
+
+      <%= render WorkShowOcrComponent.new(@work)%>
     </div>
 
     <p><%= @work.members.count  %> members</p>
 
     <%= render "member_list_table", work: @work %>
   </div>
-
+  
   <% if @work.is_oral_history? %>
     <div class="tab-pane" id="nav-oral-histories" role="tabpanel" aria-labelledby="nav-oral-histories-tab">
       <%= render OralHistory::Admin::CombinedAudioDerivativesComponent.new(work: @work) %>

--- a/app/views/admin/works/show.html.erb
+++ b/app/views/admin/works/show.html.erb
@@ -81,9 +81,11 @@
   <div class="nav nav-tabs" id="nav-tab" role="tablist">
     <a class="nav-item nav-link active" id="nav-metadata-tab" data-toggle="tab" href="#nav-metadata" role="tab" aria-controls="nav-home" aria-selected="true">Metadata</a>
     <a class="nav-item nav-link" id="nav-members-tab" data-toggle="tab" href="#nav-members" role="tab" aria-controls="nav-profile" aria-selected="false">Members</a>
+
     <% if @work.is_oral_history? %>
       <a class="nav-item nav-link" id="nav-oral-histories-tab" data-toggle="tab" href="#nav-oral-histories" role="tab" aria-controls="nav-profile" aria-selected="false">Oral History</a>
     <% end %>
+
   </div>
 </nav>
 
@@ -126,7 +128,6 @@
         <%= link_to "Manual", reorder_members_admin_work_path(@work), class: "btn btn-primary #{'disabled' unless can?(:update, @work)}" %>
         <%= link_to "Alphabetical", reorder_members_admin_work_path(@work), method: "put", class: "btn btn-primary #{'disabled' unless can?(:update, @work)}", data: { confirm: "Re-ordering members alphabetically by title can't be undone" } %>
       </div>
-
       <%= render WorkShowOcrComponent.new(@work)%>
     </div>
 
@@ -134,7 +135,7 @@
 
     <%= render "member_list_table", work: @work %>
   </div>
-  
+
   <% if @work.is_oral_history? %>
     <div class="tab-pane" id="nav-oral-histories" role="tabpanel" aria-labelledby="nav-oral-histories-tab">
       <%= render OralHistory::Admin::CombinedAudioDerivativesComponent.new(work: @work) %>

--- a/spec/system/work/ocr_info_spec.rb
+++ b/spec/system/work/ocr_info_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe "Member list displays OCR info", logged_in_user: :editor do
+  let(:image_asset_without_hocr) { create(:asset_with_faked_file, title: "No OCR", position: 1) }
+  let(:image_asset_with_hocr)    { create(:asset_with_faked_file, title: "Has OCR", hocr: "This is the HOCR", position: 2) }
+  let(:sound_asset) { create(:asset_with_faked_file, :m4a, title: "Sound file", position: 3 ) }
+  let(:child_work)  { create(:public_work, representative: create(:asset_with_faked_file), title: "Child work", position: 4) }
+
+  let(:work) do
+    create(:public_work,
+      language: 'en',
+      ocr_requested: true,
+      members: [ image_asset_without_hocr, image_asset_with_hocr, sound_asset, child_work]
+    )
+  end
+
+  describe "Work with OCR requested" do
+    it "Summarizes assets with OCR correctly; displays show OCR button" do
+      visit admin_work_path(work)
+      click_on "Members"
+      expect(page).to have_text("OCR has been requested for this work.")
+      expect(page).to have_text("1 out of 3 assets currently have OCR.")
+
+      path_to_ocr = admin_asset_path(image_asset_with_hocr, anchor: "ocr")
+      expect(page.find_all('table.member-list a.ocr-link').count).to eq 1
+      expect(page).to have_link(:href=>path_to_ocr)
+    end
+  end
+end


### PR DESCRIPTION
- A simpler version of the UI in https://github.com/sciencehistory/scihist_digicoll/pull/2115 in response to @jrochkind's comments.
- No work-level OCR tab for now; we can bring it back later if we want.
- To keep things simple, this PR does not (and will not) include the feature of viewing the concatenated OCR (or HOCR) from the entire work.
- Ref #2095.
- Simple test included; could add more, I suppose.