### PR TITLE
Replace deprecated File.exists? with File.exist?

### DIFF
--- a/spec/services/work_pdf_creator_spec.rb
+++ b/spec/services/work_pdf_creator_spec.rb
@@ -25,7 +25,7 @@ describe WorkZipCreator do
     pdf_file = WorkPdfCreator.new(work).create
 
     expect(pdf_file).to be_kind_of(Tempfile)
-    expect(File.exists?(pdf_file.path)).to be(true)
+    expect(File.exist?(pdf_file.path)).to be(true)
 
     reader = PDF::Reader.new(pdf_file.path)
     expect(reader.pages.count).to eq 3


### PR DESCRIPTION
File.exists? alias is deprecated, for the possibly less grammatical `File.exist?`.  The `exists?` synonym is removed entirely in 3.2, let's prepare for it by using the non-deprecated method name.
