### PR TITLE
Use `->>` and `is not null` when counting assets that have OCR

### DIFF
--- a/app/components/work_show_ocr_component.rb
+++ b/app/components/work_show_ocr_component.rb
@@ -15,11 +15,8 @@ class WorkShowOcrComponent < ApplicationComponent
   end
 
   def assets_with_and_without_ocr
-    # Check that the value exists and is a string.
-    has_ocr_sql = "json_typeof((json_attributes->'hocr')::json)='string'"
-
-    query = """SELECT #{has_ocr_sql}
-    AS has_ocr
+    query = """SELECT
+    (json_attributes->>'hocr' IS NOT NULL) AS has_ocr
     FROM kithe_models
     WHERE type = 'Asset'
     AND parent_id = '#{@work.id}'"""


### PR DESCRIPTION
More readable and generally better.
Ref #2095 