### PR TITLE
Remove OCR in one call to the DB.

### DIFF
--- a/spec/controllers/admin/works_controller_spec.rb
+++ b/spec/controllers/admin/works_controller_spec.rb
@@ -79,14 +79,12 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
     end
 
     it "deletes all OCR on request" do
-      expect(work.ocr_requested).to be true
       put :update, params: { id: work.friendlier_id, work: { ocr_requested: "0" } }
       expect(flash[:notice]).to match /Work was successfully updated./
       expect(work.reload.members.first.hocr).to be_nil
     end
 
     it "does not delete OCR if the save operation fails" do
-      expect(work.reload.members.first.hocr).to eq "<random ocr/>"
       put :update, params: { id: work.friendlier_id, work: { title: nil } }
       expect(flash[:notice]).to be_nil
       expect(work.reload.members.first.hocr).to eq "<random ocr/>"

--- a/spec/controllers/admin/works_controller_spec.rb
+++ b/spec/controllers/admin/works_controller_spec.rb
@@ -91,7 +91,6 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
     end
   end
 
-
   context "Reorder members", logged_in_user: :editor do
     let(:c)  { create(:asset_with_faked_file, :mp3, title: "c", position: 1) }
     let(:b)  { create(:asset_with_faked_file, :mp3, title: "b", position: 2) }


### PR DESCRIPTION
Ref https://github.com/sciencehistory/scihist_digicoll/issues/2133.

Works with OCR are largely going to be books with lots of pages in them, so we're treating this fairly carefully.
This is a redo of https://github.com/sciencehistory/scihist_digicoll/pull/2135 .

We're not using a transaction to wrap both the update and the deletes, because:
a) we trust PostGres to handle the query correctly.
b) the deletes are unlikely to fail, as this is now only one extra DB call instead of potentially hundreds (as in 2135)
c) even if the deletes were to fail, the nightly cron would get rid of the stray OCR anyway.