### PR TITLE
Some base style changes for phase 2 redesign

### DIFF
--- a/app/components/search_result/base_component.html.erb
+++ b/app/components/search_result/base_component.html.erb
@@ -67,7 +67,7 @@
           </p>
         </div>
       <% elsif model.description.present? %>
-        <div class="scihist-results-list-item-description">
+        <div class="scihist-results-list-item-description brand-serif">
             <%= DescriptionDisplayFormatter.new(model.description, truncate:true).format %>
         </div>
       <% end %>

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -148,12 +148,15 @@ $layout-expand-up: 'md';
 $h4-font-size: 22px;
 $body-color: #222; // little bit darker
 
+$line-height-base: 1.4; // seems to match main site and work well with sofia-pro
+
 // bootstrap brand colors
 $danger: $brand-red;
 $warning: $brand-yellow;
 $primary: $brand-blue;
 $dark: $brand-dark-blue;
 $secondary: $brand-dark-grey;
+$tooltip-bg: $shi-blackish;
 
 // $btn-primary-border: $brand-primary; // bootstrap 4 has no button borders already I think.
 // $btn-default-border: $brand-light-grey; // bootstrap 4 has no button borders already I think.

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -12,7 +12,31 @@
  *
  */
 
-/* rebrand colors */
+/* NEW 2023 Brand colors */
+// Mostly background:
+$shi-blackish: #1D242b; // we also use as text color esp for headings, although main site does not
+$shi-teal: #285f70; // as actually used on main site may 2023
+$shi-green: #004d44;
+$shi-dark-blue: #313E48;
+$shi-maroon: #6A1D32;
+$shi-bg-gray: #EFEEED; // as used on mainsite, not in PDF
+$shi-footer-bg-green: #eaf6f3; // one of several used on mainsite for footer "callouts", not in PDF
+$shi-bg-turquoise: #d4ece8; // an alternate turquoise used for backgrounds, let's try to avoid it though
+
+// mostly foreground text/highlight
+$shi-turquoise: #A9DBD4; // especially as highlight text over dark blue
+$shi-red: #D7272E;
+
+// yellow is used as main button background, and also text over blackish and teal
+$shi-yellow: #E4E76D;
+
+// This is an alternate color used sometimes for text, over pale green or even
+// white.
+$shi-alternate-text-color: #3c3c3c;
+
+
+
+/* OLD rebrand colors */
 $brand-dark-blue: #050939;
 $brand-bright-green: #a6e5d8;
 $brand-red: #d8262e;

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -51,7 +51,7 @@ $brand-image-placeholder-color: #AAA; // not a designated brand color, but oh we
 $brand-blue-text: $brand-blue;
 
 // Our brand sans-serif, with fallbacks copied from Bootstrap's default sans-serif.
-$brand-sans-serif: 'adelle-sans', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+$brand-sans-serif: 'sofia-pro', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 // fallbacks are useful for weird diacritics that may not be in our main font,
 // especially the weird russian transliteraton stuff seems to be problematic.
 // Times New Roman seems to have them, at least on MacOS.

--- a/app/frontend/stylesheets/local/deai_footer.scss
+++ b/app/frontend/stylesheets/local/deai_footer.scss
@@ -2,24 +2,22 @@
   padding-top: 2em;
   padding-bottom: 2em;
 
-  background-color: #eaf6f3; // officially should be #d4ece8 ?? But this is what site uses. Ask Caitlin.
+  background-color: $shi-footer-bg-green;
 
-  // Our standard BLUE link color isn't sufficient WCAG contrast over the dark grey background.
-  // red is also not sufficient at this background. We'll use the standard new website link,
-  // as they do too over this background...
+  // not sure what link color to use over our green callout
   a {
     color: black;
     font-weight: bold;
-    text-decoration: underline #d7272e;;
+    text-decoration: underline $shi-red;
     &:hover {
-      color: #d7272e;
+      color: $shi-red;
     }
   }
 
   p {
     font-size: 1rem;
     font-family: "sofia-pro", "sans-serif" !important;
-    color: #3c3c3c; // this is what main site uses here, should ask Caitlin
+    color: $shi-alternate-text-color;
 
     line-height: 1.4em;
 

--- a/app/frontend/stylesheets/local/error_pages.scss
+++ b/app/frontend/stylesheets/local/error_pages.scss
@@ -7,8 +7,8 @@
     font-weight: 600;
     margin: 0;
     a {
-      color: #1D242B;
-      text-decoration-color: #D7272E;
+      color: $shi-blackish;
+      text-decoration-color: $shi-red;
     }
   }
 

--- a/app/frontend/stylesheets/local/homepage.scss
+++ b/app/frontend/stylesheets/local/homepage.scss
@@ -35,7 +35,7 @@
     }
 
     .home-right-column {
-        background-color: #285f70;
+        background-color: $shi-teal;
         color: white;
         font-family: "sofia-pro","sans-serif";
         padding: 1rem 0;
@@ -50,7 +50,7 @@
 
     .digital-description {
         h1 {
-            color: #e4e76d;
+            color: $shi-yellow;
             text-transform: uppercase;
             font-weight: 600;
         }

--- a/app/frontend/stylesheets/local/oral_history_splash.scss
+++ b/app/frontend/stylesheets/local/oral_history_splash.scss
@@ -47,12 +47,12 @@
     font-weight: 900;
   }
   .show-genre a:not(:focus):not(:hover), .show-genre a {
-    color: #a9dbd4;
+    color: $shi-turquoise;
   }
   // can get rid of when we have general new design in there?
   .collection-description {
     a {
-      color: #a9dbd4;
+      color: $shi-turquoise;
       text-decoration: underline;
     }
   }
@@ -62,7 +62,7 @@
 
 
   .collection-desc-container {
-    background-color: #313e48;
+    background-color: $shi-dark-blue;
   }
 
   .collection-desc {

--- a/app/frontend/stylesheets/local/scihist_custom_buttons.scss
+++ b/app/frontend/stylesheets/local/scihist_custom_buttons.scss
@@ -23,7 +23,7 @@
 
 // Some new 2023 brand buttons
 .btn-dark-inverse {
-  @include button-variant(#1D242B, #1D242B);
+  @include button-variant($shi-blackish, $shi-blackish);
   color: white;
   text-transform: uppercase;
   font-weight: 700;
@@ -38,8 +38,8 @@
 
 // Eventually will be all/most of buttons, new design really uses this button
 .btn-brand-new {
-  // hover background copied from main site
-  @include button-variant(#e4e76d, #e4e76d, $hover-background: #c6c94f);
+  // hover-background copied from main site
+  @include button-variant($shi-yellow, $shi-yellow, $hover-background: #c6c94f);
   transition: background-color .3s ease,color .3s ease;
 
   text-transform: uppercase;

--- a/app/frontend/stylesheets/local/scihist_custom_buttons.scss
+++ b/app/frontend/stylesheets/local/scihist_custom_buttons.scss
@@ -21,13 +21,16 @@
   color: $brand-dark-blue;
 }
 
-// Some new 2023 brand buttons
+// Some new 2023 brand buttons -- we're using bootstrap button creator mixins, BUT
+// then overriding a lot of bootstrap stuff -- we might want to transition to actually
+// setting bootstrap button default size/weight/etc?
+
 .btn-dark-inverse {
   @include button-variant($shi-blackish, $shi-blackish);
   color: white;
   text-transform: uppercase;
   font-weight: 700;
-  font-size: 0.9375em;
+  font-size: 0.9375em; // slightly smaller than normal to make up for the all-caps? 15px/16px
 
   // nain site topnav bar fades white over dark text using opacity,
   // we use a specific color to do similar and match.
@@ -36,7 +39,8 @@
   }
 }
 
-// Eventually will be all/most of buttons, new design really uses this button
+// The main/only button type actually used in new main site -- this is a temporary
+// name
 .btn-brand-new {
   // hover-background copied from main site
   @include button-variant($shi-yellow, $shi-yellow, $hover-background: #c6c94f);
@@ -44,7 +48,7 @@
 
   text-transform: uppercase;
   font-weight: 700;
-  font-size: 0.8125rem;
+  font-size: 0.9375rem; // slightly smaller than normal to make up for the all-caps? 15px/16px
 
   // won't be necessary once we fix up all bootstrap buttons to match?
   border-radius: 0;

--- a/app/frontend/stylesheets/local/scihist_footer.scss
+++ b/app/frontend/stylesheets/local/scihist_footer.scss
@@ -1,5 +1,5 @@
 #shi-footer-from-main-website {
-  background-color: #1d242b;
+  background-color: $shi-blackish;
   //padding: 2.7em 4.35em 1em;
 
   color: #fff;
@@ -281,7 +281,7 @@
 .dig-col-links {
   font: normal 400 1em/1.2 "sofia-pro","sans-serif";
 
-  background-color: #285f70;
+  background-color: $shi-teal;
   padding-top: 2rem;
   padding-bottom: 2rem;
 

--- a/app/frontend/stylesheets/local/scihist_masthead.scss
+++ b/app/frontend/stylesheets/local/scihist_masthead.scss
@@ -60,7 +60,7 @@
     .shi-top-bar {
         width: 100%;
         padding: 0 4em;
-        background-color: #1D242B;
+        background-color: $shi-blackish;
         color: #fff;
         overflow: hidden
     }
@@ -117,7 +117,7 @@
 
     .shi-top-bar__hours:before {
         content: "";
-        background-color: #285f70;
+        background-color: $shi-teal;
         position: absolute;
         left: 0;
         right: -9999px;
@@ -300,7 +300,7 @@
         left: calc(1.2941176471em - 2px);
         right: calc(1.2941176471em - 4px);
         height: 2px;
-        background: #d7272e;
+        background: $shi-red;
         opacity: 0;
         transition: opacity .3s
     }
@@ -323,7 +323,7 @@
     .header__nav>ul>li.shi-item-bordered>a {
         line-height: 1em;
         padding: .5294117647em .5882352941em;
-        border: 1px solid #d7272e;
+        border: 1px solid $shi-red;
         transition: color .3s,background .3s
     }
 
@@ -355,13 +355,13 @@
         &:hover::after {
             content: "";
             display: block;
-            border-bottom: 2px solid #D7272E;
+            border-bottom: 2px solid $shi-red;
         }
     }
     // And on the bordered 'support' button
     @media (hover: hover) {
        .header__nav>ul>li.shi-item-bordered:hover>a {
-            background: #d7272e;
+            background: $shi-red;
             color: #fff
         }
     }
@@ -520,7 +520,7 @@
         // a `.header_mobile` class, it's not required -- the top bar nav
         // being moved to be inside the header__nav is enough selectivity.
         .header__nav .shi-top-bar-nav {
-            background: #1d242b;
+            background: $shi-blackish;
             color: #fff;
             flex-direction: column;
             margin: 2.25em -1.875em -2.5em;
@@ -600,8 +600,8 @@
         .masthead-title a {
             text-transform: uppercase;
             font-weight: 600;
-            color: #1D242B;
-            text-decoration-color: #D7272E;
+            color: $shi-blackish;
+            text-decoration-color: $shi-red;
         }
 
         .search-form {
@@ -626,6 +626,6 @@
 
     &.staging {
         // was $warning;, could be again after we fix theme
-        background-color: #e4e76d;
+        background-color: $shi-yellow;
     }
 }

--- a/app/frontend/stylesheets/local/site_wide.scss
+++ b/app/frontend/stylesheets/local/site_wide.scss
@@ -127,22 +127,12 @@ hr.brand {
   }
 }
 
-// In new branding, we use the serif as body text, but leave the sans serif as default font for all the controls,
-// just explicitly set it in certain places, restricted to a parent class cause it kind of messes up
-// admin screens.
-//
-// We set 'p' tags within a .branded-body-font -- with some exceptions -- to use our serif font, and have
-// appropriate max-width and spacer for that font.
-.branded-body-font, .scihist-main-layout {
-  p:not(.collection-title):not(.sans-serif), dl:not(.sans-serif) dd, table:not(.sans-serif) td, table:not(.sans-serif) tbody th, .serif {
-    @extend %text-font;
-    // super hacky sorry. :(
-    .btn {
-      font-family: $brand-sans-serif;
-    }
-  }
-  p:not(.collection-title):not(.sans-serif) {
-    // try to keep this readable, abril is particularly hard on long line lengths
+
+// opt into our serif font
+.brand-serif {
+  @extend %text-font;
+
+  p {
     max-width: $max-readable-width;
     // and could use some more spacing, normally in bootstrap $line-height-computed / 2
     margin-bottom: $paragraph-spacer;
@@ -157,6 +147,7 @@ hr.brand {
     margin-bottom: ($paragraph-font-size * $paragraph-line-height-long * 0.5) !important;
   }
 }
+
 
 .text-page {
   max-width: $max-readable-width;

--- a/app/frontend/stylesheets/local/site_wide.scss
+++ b/app/frontend/stylesheets/local/site_wide.scss
@@ -4,7 +4,9 @@
 // but we'll put that in a separate file.
 
 h2, .h2, h3, .h3, h4, .h4, h5, .h5 {
-  color: $brand-dark-blue;
+  // main webiste just uses black here, but we like using a softer color for headings, maybe
+  // this one?
+  color: $shi-blackish;
 }
 
 


### PR DESCRIPTION
Assorted changes to base sstyles mostly effecting whole site, setting the stage for phase 2 redesign. 

There will probably be more PR's like this. 

- new brand color variables
- use variables for new brand colors
- change sans-serif font to new sofia-pro
- try using new off-black for headings; brand-blue is no longer a brand color
- stop trying to universally apply brand-serif font, it's opt-in only
- serif opt-in on results description, for example
- adjustments to default text
- tweak custom buttons
