### PR TITLE
Homepage for Phase 2 Redesign

### DIFF
--- a/app/frontend/stylesheets/local/homepage.scss
+++ b/app/frontend/stylesheets/local/homepage.scss
@@ -21,6 +21,13 @@
         margin-bottom: 0;
         img {
           width: 100%;
+          // for small screens at collapsed size
+          max-height: 20rem;
+          object-fit: cover;
+          @include media-breakpoint-up('lg') {
+            max-height: revert;
+            object-fit: revert; // cause apparently sometimes it's off by 1 pixel!
+          }
         }
         figcaption {
           position: absolute;

--- a/app/frontend/stylesheets/local/homepage.scss
+++ b/app/frontend/stylesheets/local/homepage.scss
@@ -55,8 +55,6 @@
             font-weight: 600;
         }
         .blurb {
-          //max-width: 35rem !important;
-          font-family: "sofia-pro","sans-serif" !important;
           margin-top: $paragraph-spacer !important;
           margin-bottom: $paragraph-spacer * 2 !important;
           font-size: $h5-font-size !important;
@@ -80,21 +78,28 @@
     }
 
     .ribbon-section {
+      @include shi-full-width-outer-mixin;
+
+      padding-top: 3rem;
+      padding-bottom: 3rem;
+
       .title-div {
         display: flex;
         flex-direction: column;
+        text-align: center;
 
         h2 {
-          @extend .brand-alt-h2;
-          padding: 1rem 1rem 1rem 1rem;
-          margin-bottom:0;
+          font-weight: 900;
+          font-size: 2.125rem;
+          padding: 0;
+          margin: 0;
         }
 
         .blurb {
-          // styling copied from some large blurb text on www.sciencehistory.org.
+          text-align: center;
           font-size: 1.5rem;
-          max-width: none;
-          padding: 1rem 1rem 2rem 1rem;
+          margin-top: 1.5rem;
+          margin-bottom: 0;
         }
       }
     }
@@ -103,19 +108,15 @@
     $recent-items-box-width: 10.5rem;
     $recent-items-box-margin: 1.28rem;
 
-    .recent-items {
-        background-color: $brand-light-grey;
-    }
-
     .recent-items-list {
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
       justify-content: center;
       align-items: center;
+      margin-top: 2rem;
       padding-left: 0.9375rem;
       padding-right: 0.9375rem;
-      padding-top: 0.9375rem;
       padding-bottom: 1.875rem;
 
       .recent-item {
@@ -169,56 +170,51 @@
       }
     }
 
-    $featured-topics-box-width: 18rem; // 21.875rem;
-    $featured-topics-box-height: 18rem; // 21.875rem;
-    $featured-topics-box-margin: 2.2rem; // 3.6875rem;
-
     .featured-topics {
-        background-color: $brand-dark-grey;
+        background-color: $shi-dark-blue;
 
         .title-div h2, .title-div {
           color: white;
         }
 
         .featured-topic {
-            position: relative;
+          a {
+            text-decoration: none;
+          }
 
-            .featured-topic-title-wrapper {
-                position: absolute;
-                bottom: -1px;
-                left: 0;
-                width: 100%;
-                height: 3.125rem;
-                color: $brand-dark-blue;
-                background-color: $brand-bright-green;
-                padding: 0.625rem;
-
-                .featured-topic-title {
-                    text-align: center;
-                    font-weight: $semi-bold-weight;
-                    text-transform: uppercase;
-                    font-size: 1.125rem;
-                    font-family: $brand-sans-serif;
-                    line-height: 1.5;
-                }
-            }
+          // supposed to be square, but if it's not let's force it, and
+          // crop to fit
+          .featured-topic-image {
+            aspect-ratio: 1;
+            object-fit: cover;
+          }
+          .featured-topic-title {
+              text-align: center;
+              font-weight: 700;
+              color: $shi-yellow;
+              font-size: $h4-font-size;
+              margin-top: 0.5em;
+              // font-family: $brand-sans-serif;
+              // line-height: 1.4;
+          }
         }
     }
 
 
     .collections, .featured-topics {
-      padding-bottom: 2.2rem;
-
       .collections-list {
         display: flex;
         flex-wrap: wrap;
         justify-content: center;
+        margin-top: 3rem;
+        margin-bottom: 1rem;
 
         .collection {
           display: flex;
           flex-direction: column;
           margin: $collection-index-box-margin;
           max-width: $collection-index-box-width;
+          text-decoration: none;
 
           .title {
             font-size: 1.125rem;
@@ -226,7 +222,7 @@
             letter-spacing: 0.04em;
             text-align: center;
             color: white;
-            background-color: $dark;
+            background-color: $shi-dark-blue;
             padding: 0.625rem;
           }
         }
@@ -236,29 +232,6 @@
         display: flex;
         justify-content: center;
         padding: $collection-index-box-margin $collection-index-box-margin 0 $collection-index-box-margin;
-
-        .chf-callout-button {
-          width: auto;
-          flex-shrink: 1;
-        }
       }
-    }
-
-    .chf-callout-button {
-        width: 100%;
-        text-transform: uppercase;
-        border-radius: 0;
-        letter-spacing: 0.04em;
-        margin-bottom: 1.5625rem;
-        // unlike normal btns, normally it's full width, but if screen is so small
-        // it needs to, it should break.
-        white-space: initial;
-        border-radius: 2px;
-    }
-
-    .i-accept-copy {
-        /* add in extra padding removed from .blacklight-homepage > container-fluid */
-        padding-left: 0.9375rem;
-        padding-right: 0.9375rem;
     }
 }

--- a/app/frontend/stylesheets/local/homepage.scss
+++ b/app/frontend/stylesheets/local/homepage.scss
@@ -45,6 +45,11 @@
             display: flex;
             flex-direction: column;
             justify-content: center;
+
+            .search-container {
+              max-width: 38rem;
+              padding: 0 2rem;
+            }
         }
     }
 
@@ -62,10 +67,11 @@
     }
 
     .search-container {
+        @include shi-full-width-outer-mixin;
         margin-left: auto;
         margin-right: auto;
-        padding-left: 1.25rem  !important;
-        padding-right: 1.25rem !important;
+        padding-top: 2rem;
+        padding-bottom: 2rem;
     }
 
     .search-callouts {

--- a/app/frontend/stylesheets/local/homepage.scss
+++ b/app/frontend/stylesheets/local/homepage.scss
@@ -60,7 +60,7 @@
             font-weight: 600;
         }
         .blurb {
-          margin-top: $paragraph-spacer !important;
+          line-height: 1.2;
           margin-bottom: $paragraph-spacer * 2 !important;
           font-size: $h5-font-size !important;
         }

--- a/app/frontend/stylesheets/local/homepage.scss
+++ b/app/frontend/stylesheets/local/homepage.scss
@@ -60,7 +60,7 @@
             font-weight: 600;
         }
         .blurb {
-          line-height: 1.2;
+          line-height: $headings-line-height;
           margin-bottom: $paragraph-spacer * 2 !important;
           font-size: $h5-font-size !important;
         }
@@ -102,6 +102,7 @@
         }
 
         .blurb {
+          line-height: $headings-line-height;
           text-align: center;
           font-size: 1.5rem;
           margin-top: 1.5rem;

--- a/app/frontend/stylesheets/local/scihist_custom_buttons.scss
+++ b/app/frontend/stylesheets/local/scihist_custom_buttons.scss
@@ -29,7 +29,6 @@
   @include button-variant($shi-blackish, $shi-blackish);
   color: white;
   text-transform: uppercase;
-  font-weight: 700;
   font-size: 0.9375em; // slightly smaller than normal to make up for the all-caps? 15px/16px
 
   // nain site topnav bar fades white over dark text using opacity,

--- a/app/views/homepage/_collections.html.erb
+++ b/app/views/homepage/_collections.html.erb
@@ -35,8 +35,6 @@
   </div>
 
   <div class="button-area">
-    <%= link_to "Browse All Collections", collections_path, class: "btn btn-emphasis btn-lg chf-callout-button" %>
+    <%= link_to "Browse All Collections", collections_path, class: "btn btn-brand-new" %>
   </div>
-
-
 </div>

--- a/app/views/homepage/_featured_topics.html.erb
+++ b/app/views/homepage/_featured_topics.html.erb
@@ -11,7 +11,7 @@
               <%= link_to ft.path do %>
                 <%= image_tag ft.thumb_asset_path, class: "featured-topic-image", width: "100%", alt: "" %>
                 <div class="featured-topic-title-wrapper">
-                  <h3 class="featured-topic-title"><%= ft.title.upcase %></h3>
+                  <h3 class="featured-topic-title"><%= ft.title %></h3>
                 </div>
               <% end %>
             </div>
@@ -20,6 +20,6 @@
       <% end %>
   </div>
   <div class="button-area">
-    <%= link_to "View more topics", featured_topics_path, class: "btn btn-emphasis btn-lg chf-callout-button" %>
+    <%= link_to "View more topics", featured_topics_path, class: "btn btn-brand-new" %>
   </div>
 </div>


### PR DESCRIPTION
- new brand color variables
- use variables for new brand colors
- change sans-serif font to new sofia-pro
- try using new off-black for headings; brand-blue is no longer a brand color
- stop trying to universally apply brand-serif font, it's opt-in only
- serif opt-in on results description, for example
- adjustments to default text
- tweak custom buttons
- homepage redesign first draft pass
