### PR TITLE
Typography resets for Phase 2 Redesign

### DIFF
--- a/app/components/collection_metadata_component.html.erb
+++ b/app/components/collection_metadata_component.html.erb
@@ -7,7 +7,7 @@
     <p class="show-item-count"><%= "#{number_with_delimiter(public_count)} #{'item'.pluralize(public_count)}" %></p>
   <% end %>
 
-  <div class="collection-description long-text-line-height">
+  <div class="collection-description">
     <%= DescriptionDisplayFormatter.new(collection.description).format %>
   </div>
 

--- a/app/components/oral_history/biographical_component.html.erb
+++ b/app/components/oral_history/biographical_component.html.erb
@@ -49,7 +49,7 @@
   <div class="mb-3">
     <% grouped_jobs.each_pair do |institution, jobs| %>
       <h4 class="h6 mb-0 pt-2 border-top font-weight-semi-bold"><%= institution %></h4>
-        <ul class="d-table list-unstyled text-brand-serif mb-2 pl-3">
+        <ul class="d-table list-unstyled mb-2 pl-3">
           <% jobs.each do |job| %>
             <li class="d-table-row">
               <span class="d-table-cell p-2 text-nowrap"><%= formatted_job_dates(job.start, job.end) %></span>

--- a/app/components/oral_history/ohms_index_component.html.erb
+++ b/app/components/oral_history/ohms_index_component.html.erb
@@ -11,7 +11,7 @@
         </h3>
       </div>
 
-      <div id="<%= accordion_element_id(index) %>" class="collapse card-body ohms-index-list long-text-line-height" aria-labelledby="<%= accordion_header_id(index) %>" data-parent="#ohmsIndexAccordionParent">
+      <div id="<%= accordion_element_id(index) %>" class="collapse card-body ohms-index-list" aria-labelledby="<%= accordion_header_id(index) %>" data-parent="#ohmsIndexAccordionParent">
           <p>
             <a href="#t=<%= index_point.timestamp %>" class="btn btn-secondary" data-ohms-timestamp-s="<%= index_point.timestamp %>">
               <i class="fa fa-play-circle mr-1" aria-hidden="true"></i> Play segment

--- a/app/components/search_result/base_component.html.erb
+++ b/app/components/search_result/base_component.html.erb
@@ -67,7 +67,7 @@
           </p>
         </div>
       <% elsif model.description.present? %>
-        <div class="scihist-results-list-item-description brand-serif">
+        <div class="scihist-results-list-item-description">
             <%= DescriptionDisplayFormatter.new(model.description, truncate:true).format %>
         </div>
       <% end %>

--- a/app/components/transcription_tabs_component.html.erb
+++ b/app/components/transcription_tabs_component.html.erb
@@ -66,7 +66,7 @@
             <% end %>
           </h3>
         <% end %>
-        <div class="long-text-line-height text-pages">
+        <div class="text-pages">
           <%= simple_format text_obj.text %>
         </div>
       <% end %>
@@ -102,7 +102,7 @@
             <% end %>
           </h3>
         <% end %>
-        <div class="long-text-line-height text-pages">
+        <div class="text-pages">
           <%= simple_format text_obj.text %>
         </div>
       <% end %>

--- a/app/components/work_file_list_show_component.html.erb
+++ b/app/components/work_file_list_show_component.html.erb
@@ -38,20 +38,20 @@
         </div>
 
 
-          <p class="text-brand-serif">Available upon request
+          <p>Available upon request
             <%= multiple_files? ? "are" : "is" %>
             <%= available_by_request_summary %>.
           </p>
 
 
           <% if @work.oral_history_content.available_by_request_automatic? %>
-            <p class="alert alert-primary text-brand-serif">After submitting a brief form, you will receive immediate access to
+            <p class="alert alert-primary">After submitting a brief form, you will receive immediate access to
               <%= multiple_files? ? "these files" : "this file" %>.
               If you have any questions about transcripts, recordings, or usage permissions, contact the Center for Oral History at <%= link_to ScihistDigicoll::Env.lookup!(:oral_history_email_address), "mailto:#{ScihistDigicoll::Env.lookup!(:oral_history_email_address)}", class: "alert-link" %>.
             </p>
           <% else # manual review %>
             <div class="alert alert-primary">
-              <p class="text-brand-serif">After submitting a brief form, your request will be reviewed and you will receive an email, usually within 3 business days. Usage may be subject to restrictions by agreement with interviewee.</p>
+              <p>After submitting a brief form, your request will be reviewed and you will receive an email, usually within 3 business days. Usage may be subject to restrictions by agreement with interviewee.</p>
 
               <p>If you have any questions about transcripts, recordings, or usage permissions, please contact the Center for Oral History at <%= link_to ScihistDigicoll::Env.lookup!(:oral_history_email_address), "mailto:#{ScihistDigicoll::Env.lookup!(:oral_history_email_address)}", class: "alert-link" %>.
               </p>

--- a/app/components/work_file_list_show_component.html.erb
+++ b/app/components/work_file_list_show_component.html.erb
@@ -10,7 +10,7 @@
     <%= render WorkTitleAndDatesComponent.new(@work) %>
 
     <%# up here so it stays above request button in single-column mode %>
-    <div class="work-description long-text-line-height">
+    <div class="work-description">
       <% if portrait_asset.present? %>
         <figure class="figure oh-portrait">
           <%= render ThumbComponent.new(portrait_asset) %>
@@ -29,7 +29,7 @@
     <% if available_by_request_assets.present? %>
       <h2 class="attribute-sub-head mt-0">Access this interview</h2>
       <div class="show-sub-head-body request-section">
-        <div class="pr-2 long-text-line-height">
+        <div class="pr-2">
         <div class="pb-sm-3 pl-sm-3 text-nowrap float-sm-right">
           <%= link_to "Request Access",
             request_oral_history_access_form_path(@work.friendlier_id),

--- a/app/components/work_image_show_component.html.erb
+++ b/app/components/work_image_show_component.html.erb
@@ -24,7 +24,7 @@
                                 ),
             should_wrap: has_transcription_or_translation?) do %>
 
-        <div class="work-description long-text-line-height">
+        <div class="work-description">
           <%= DescriptionDisplayFormatter.new(work.description).format  %>
         </div>
         <%= render WorkShowInfoComponent.new(work: work) %>

--- a/app/components/work_oh_audio_show_component.html.erb
+++ b/app/components/work_oh_audio_show_component.html.erb
@@ -136,7 +136,7 @@
               </figure>
             <% end %>
 
-            <div class="work-description long-text-line-height">
+            <div class="work-description">
               <%= DescriptionDisplayFormatter.new(work.description).format  %>
             </div>
           </div>
@@ -165,7 +165,7 @@
         <% end %>
 
         <% if has_ohms_transcript? %>
-          <div class="tab-pane long-text-line-height" id="ohTranscript" role="tabpanel" aria-labelledby="ohTranscriptTab">
+          <div class="tab-pane" id="ohTranscript" role="tabpanel" aria-labelledby="ohTranscriptTab">
             <%= render OralHistory::TranscriptComponent.new(work.oral_history_content.ohms_xml) %>
           </div>
         <% end %>

--- a/app/components/work_show_info_component.html.erb
+++ b/app/components/work_show_info_component.html.erb
@@ -98,7 +98,7 @@
 <% if oral_history_interviewer_profiles.present? %>
   <h2 class="attribute-sub-head">About the <%= "Interviewer".pluralize(oral_history_interviewer_profiles.count) %></h2>
 
-  <div class="show-sub-head-body long-text-line-height">
+  <div class="show-sub-head-body">
     <% oral_history_interviewer_profiles.each do |profile| %>
       <%= DescriptionDisplayFormatter.new(profile.profile).format %>
     <% end %>

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -65,7 +65,7 @@
   </div>
 
   <div class="show-metadata">
-    <div class="work-description long-text-line-height">
+    <div class="work-description">
       <%= DescriptionDisplayFormatter.new(work.description).format  %>
     </div>
 

--- a/app/frontend/stylesheets/_mixins.scss
+++ b/app/frontend/stylesheets/_mixins.scss
@@ -70,7 +70,4 @@
   font-size: 1.0625rem; // 17px if 16px==1rem;
   line-height: $paragraph-line-height;
 }
-.text-brand-serif {
-  @extend %text-font;
-}
 

--- a/app/frontend/stylesheets/_mixins.scss
+++ b/app/frontend/stylesheets/_mixins.scss
@@ -64,10 +64,4 @@
   }
 }
 
-%text-font {
-  font-family: $brand-serif;
-  // 16px in abril is really small, 17px looks more like 16px in other fonts.
-  font-size: 1.0625rem; // 17px if 16px==1rem;
-  line-height: $paragraph-line-height;
-}
 

--- a/app/frontend/stylesheets/_mixins.scss
+++ b/app/frontend/stylesheets/_mixins.scss
@@ -74,12 +74,3 @@
   @extend %text-font;
 }
 
-// Try to make our date field that has mostly numbers legible with abril
-%text-font-numerals {
- font-family: $brand-serif;
-  // 16px in abril is really small, 17px looks more like 16px in other fonts.
- font-size: 1.0625rem; // 17px if 16px==1rem;
- line-height: normal;
- font-variant-numeric: lining-nums;
- letter-spacing: 0.025em;
-}

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -140,15 +140,15 @@ $layout-expand-up: 'md';
  *
  */
 
-// In chf_sufia, we set font-size-base to 16px. In Bootstrap 4, this needs to be in
-// `rem` units, and defaults to 1. Which should be 16px on most browsers. It is considered
-// by some to be better for accessibility to leave this defaulting to browser standard,
-// so we will try it unset with default for now.
-//$font-size-base: 16px;
+// We will leave the font-size base 1rem (usually 16px), to leave a nice round
+// number for calclulations based on it... BUT we elsehwere set defualt body
+// text size to 1.0625rem (usually 17px)
+$font-size-base: 1rem;
 $h4-font-size: 22px;
 $body-color: #222; // little bit darker
 
-$line-height-base: 1.4; // seems to match main site and work well with sofia-pro
+//$line-height-base: 1.5; // default 1.5 works for us, liked better than smaller
+$headings-line-height: 1.13; // a bit smaller than default 1.2
 
 // bootstrap brand colors
 $danger: $brand-red;

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -100,7 +100,6 @@ $thumb-horizontal-margin: 4px;
 // but briefer text is generally better with the other one, which for legacy reasons
 // ends up the default in lots of places.
 $paragraph-line-height: 1.2941176471; // 1.0625rem * this line-height is 22px if 1rem is 16px
-$paragraph-line-height-long: 1.625; // based on values on sciencehistory.org
 $paragraph-spacer: 1rem; // should be same as bootstrap $spacer, different variable for legacy reasons
 
 $navbar-margin-bottom: 22px;

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -95,14 +95,13 @@ $thumb-horizontal-margin: 4px;
 // bootstrap wants us to use rem, rather than fixed point size, for accessibility
 // user-resizing purposes.
 //
-$paragraph-font-size: 1.0625rem; // 17px if 1rem is 16px
 
 // We really need two differnet line spacing, LOTS of text needs the bigger -long one,
 // but briefer text is generally better with the other one, which for legacy reasons
 // ends up the default in lots of places.
 $paragraph-line-height: 1.2941176471; // 1.0625rem * this line-height is 22px if 1rem is 16px
 $paragraph-line-height-long: 1.625; // based on values on sciencehistory.org
-$paragraph-spacer: $paragraph-font-size * $paragraph-line-height * 0.5; // Should be about 22/2=11px if 1rem=16px
+$paragraph-spacer: 1rem; // should be same as bootstrap $spacer, different variable for legacy reasons
 
 $navbar-margin-bottom: 22px;
 

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -52,10 +52,6 @@ $brand-blue-text: $brand-blue;
 
 // Our brand sans-serif, with fallbacks copied from Bootstrap's default sans-serif.
 $brand-sans-serif: 'sofia-pro', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-// fallbacks are useful for weird diacritics that may not be in our main font,
-// especially the weird russian transliteraton stuff seems to be problematic.
-// Times New Roman seems to have them, at least on MacOS.
-$brand-serif: 'abril-text', "Times New Roman", Times, serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 
 //$bg-lightly-shaded: #f9f9f9; // does not match brand, no suitable color in brand
 $bg-lightly-shaded: $brand-light-grey; // try brand color

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -87,19 +87,6 @@ $transparent-background: rgba(0,0,0,0.25);
 
 $thumb-horizontal-margin: 4px;
 
-// These "paragraph" settings are all meant for use with our serif font, abril,
-// which we use for body/paragraph/'text' copy.
-//
-// abril is far too small at 16px, it's a small font. 17px abril looks more like
-// 16px other fonts. 1.0625rem is 17px if 1rem is 16px --
-// bootstrap wants us to use rem, rather than fixed point size, for accessibility
-// user-resizing purposes.
-//
-
-// We really need two differnet line spacing, LOTS of text needs the bigger -long one,
-// but briefer text is generally better with the other one, which for legacy reasons
-// ends up the default in lots of places.
-$paragraph-line-height: 1.2941176471; // 1.0625rem * this line-height is 22px if 1rem is 16px
 $paragraph-spacer: 1rem; // should be same as bootstrap $spacer, different variable for legacy reasons
 
 $navbar-margin-bottom: 22px;

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -62,7 +62,7 @@ $special-label-muted-color: $brand-dark-grey;
 $small-caps-letter-spacing: 0.035em;
 
 $brand-btn-alt-bg: $brand-bright-green;
-$brand-alt-header-weight: 700;
+$brand-alt-header-weight: 900;
 
 // adelle-sans has a 600 semi-bold available. 700 is standard bold. 500 seems to be the same as 400=normal.
 $semi-bold-weight: 600;
@@ -127,10 +127,10 @@ $layout-expand-up: 'md';
 // number for calclulations based on it... BUT we elsehwere set defualt body
 // text size to 1.0625rem (usually 17px)
 $font-size-base: 1rem;
+$body-font-size: 1.0625rem; // not a bootstrap variable
+
 $h4-font-size: 22px;
 $body-color: #222; // little bit darker
-                   //
-$body-font-size: 1.0625rem; // not a bootstrap variable
 
 //$line-height-base: 1.5; // default 1.5 works for us, liked better than smaller
 $headings-line-height: 1.13; // a bit smaller than default 1.2

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -87,7 +87,10 @@ $transparent-background: rgba(0,0,0,0.25);
 
 $thumb-horizontal-margin: 4px;
 
-$paragraph-spacer: 1rem; // should be same as bootstrap $spacer, different variable for legacy reasons
+// really be same as bootstrap $spacer, different variable for legacy reasons,
+// but still 16px 1rem (winds up slightly smaller than our 17px body font, but
+// better for math)
+$paragraph-spacer: 1rem;
 
 $navbar-margin-bottom: 22px;
 
@@ -131,6 +134,8 @@ $layout-expand-up: 'md';
 $font-size-base: 1rem;
 $h4-font-size: 22px;
 $body-color: #222; // little bit darker
+                   //
+$body-font-size: 1.0625rem; // not a bootstrap variable
 
 //$line-height-base: 1.5; // default 1.5 works for us, liked better than smaller
 $headings-line-height: 1.13; // a bit smaller than default 1.2

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -62,7 +62,6 @@ $special-label-muted-color: $brand-dark-grey;
 $small-caps-letter-spacing: 0.035em;
 
 $brand-btn-alt-bg: $brand-bright-green;
-$brand-alt-header-font: $brand-sans-serif;
 $brand-alt-header-weight: 700;
 
 // adelle-sans has a 600 semi-bold available. 700 is standard bold. 500 seems to be the same as 400=normal.

--- a/app/frontend/stylesheets/local/collection_show.scss
+++ b/app/frontend/stylesheets/local/collection_show.scss
@@ -88,7 +88,6 @@
     .collection-funding-credit {
       margin: $spacer 0;
 
-      @extend .long-text-line-height;
       display: flex;
 
       .funding-credit-image {

--- a/app/frontend/stylesheets/local/collections.scss
+++ b/app/frontend/stylesheets/local/collections.scss
@@ -10,12 +10,6 @@ $collection-index-box-margin: 17px;
     @extend .mt-3;
   }
 
-
-  .show-item-count {
-    @extend %text-font-numerals;
-    font-variant-numeric: lining-nums;
-  }
-
   .collections-index-list {
     display: flex;
     flex-direction: row;

--- a/app/frontend/stylesheets/local/deai_footer.scss
+++ b/app/frontend/stylesheets/local/deai_footer.scss
@@ -15,11 +15,8 @@
   }
 
   p {
-    font-size: 1rem;
     font-family: "sofia-pro", "sans-serif" !important;
     color: $shi-alternate-text-color;
-
-    line-height: 1.4em;
 
     // I guess we'll make this match max-width of the dig-col-links supra-footer?
     // This is a bit screwy.

--- a/app/frontend/stylesheets/local/deai_footer.scss
+++ b/app/frontend/stylesheets/local/deai_footer.scss
@@ -20,7 +20,7 @@
 
     // I guess we'll make this match max-width of the dig-col-links supra-footer?
     // This is a bit screwy.
-    max-width: 40rem !important;
+    max-width: 42rem !important;
     text-align: justify;
     margin-left: auto;
     margin-right: auto;

--- a/app/frontend/stylesheets/local/oh_audio.scss
+++ b/app/frontend/stylesheets/local/oh_audio.scss
@@ -172,7 +172,6 @@
         }
 
         ol {
-          @extend %text-font-numerals;
           list-style-position: inside;
           padding-left: 0;
 

--- a/app/frontend/stylesheets/local/oh_audio.scss
+++ b/app/frontend/stylesheets/local/oh_audio.scss
@@ -336,8 +336,6 @@
     margin-top: $paragraph-spacer;
     max-width: $max-readable-width;
 
-    @extend %text-font;
-
     p {
       margin-bottom: $paragraph-spacer * 2;
     }

--- a/app/frontend/stylesheets/local/results_constraints.scss
+++ b/app/frontend/stylesheets/local/results_constraints.scss
@@ -89,7 +89,6 @@
     .input-group-prepend .input-group-text {
       border-bottom-left-radius: $btn-border-radius;
       border-top-left-radius: $btn-border-radius;
-      font-size: $font-size-base;
     }
     .input-group-append{
       a:last-child, button:last-child {

--- a/app/frontend/stylesheets/local/rights_statements.scss
+++ b/app/frontend/stylesheets/local/rights_statements.scss
@@ -32,8 +32,6 @@
   }
 
   &.creative-commons-org  {
-    line-height: $paragraph-line-height;
-
     .rights-statement-label {
       display: block;
       @extend .small;

--- a/app/frontend/stylesheets/local/scihist_footer.scss
+++ b/app/frontend/stylesheets/local/scihist_footer.scss
@@ -291,7 +291,7 @@
     flex-wrap: wrap;
     justify-content: space-between;
     gap: $grid-gutter-width;
-    max-width: 40em;
+    max-width: 42rem;
     margin: auto;
   }
 

--- a/app/frontend/stylesheets/local/scihist_viewer.scss
+++ b/app/frontend/stylesheets/local/scihist_viewer.scss
@@ -109,7 +109,6 @@ $scihist_image_viewer_thumb_width: 54px; // Needs to match ImageServiceHelper::T
       padding: 0;
       margin: 0 15px;
 
-      font-family: $brand-alt-header-font;
       font-size: $h3-font-size;
       line-height: normal;
       overflow: hidden;

--- a/app/frontend/stylesheets/local/search_results.scss
+++ b/app/frontend/stylesheets/local/search_results.scss
@@ -276,7 +276,6 @@
     .scihist-results-list-values {
       margin-top: $paragraph-spacer;
       li {
-        @extend %text-font;
         // hanging indent, serving to add margin to subsequent lines
         padding-left: 0.66em;
         text-indent: -0.66em;

--- a/app/frontend/stylesheets/local/search_results.scss
+++ b/app/frontend/stylesheets/local/search_results.scss
@@ -22,7 +22,6 @@
   }
 
   .card-header {
-    font-size: $font-size-base;
     font-weight: normal;
     line-height: 1.4;
     color: inherit;

--- a/app/frontend/stylesheets/local/search_results.scss
+++ b/app/frontend/stylesheets/local/search_results.scss
@@ -267,9 +267,6 @@
         @extend .list-unstyled;
         margin-top: $paragraph-spacer;
       }
-      li {
-        @extend %text-font-numerals;
-      }
     }
 
     .scihist-results-list-item-description, .scihist-results-list-item-highlights {

--- a/app/frontend/stylesheets/local/search_results.scss
+++ b/app/frontend/stylesheets/local/search_results.scss
@@ -252,7 +252,6 @@
       ul {
         @extend .list-unstyled;
         @include font-size($h4-font-size);
-        font-family: $brand-alt-header-font;
         line-height: $headings-line-height;
         margin-top: 0;
       }

--- a/app/frontend/stylesheets/local/site_wide.scss
+++ b/app/frontend/stylesheets/local/site_wide.scss
@@ -13,7 +13,7 @@ h2, .h2, h3, .h3, h4, .h4, h5, .h5 {
 // other padding and sizing calculations, but let's actually set default starting
 // font size to 17px (1.0625rem for 16px==1rem)
 body {
-  font-size: 1.0625rem;
+  font-size: $body-font-size;
 }
 
 

--- a/app/frontend/stylesheets/local/site_wide.scss
+++ b/app/frontend/stylesheets/local/site_wide.scss
@@ -134,28 +134,6 @@ hr.brand {
   }
 }
 
-
-// opt into our serif font
-.brand-serif {
-  @extend %text-font;
-
-  p {
-    max-width: $max-readable-width;
-    // and could use some more spacing, normally in bootstrap $line-height-computed / 2
-    margin-bottom: $paragraph-spacer;
-  }
-
-  // Longer text passages in our serif Abril font really need bigger line-height.
-  // For legacy reasons we have to do this as an !important override.
-  //
-  // p inside a div.long-text-line-height, or a p.long-text-line-height itself.
-  .long-text-line-height p, p.long-text-line-height {
-    line-height: $paragraph-line-height-long !important;
-    margin-bottom: ($paragraph-font-size * $paragraph-line-height-long * 0.5) !important;
-  }
-}
-
-
 .text-page {
   max-width: $max-readable-width;
   margin-right: auto;

--- a/app/frontend/stylesheets/local/site_wide.scss
+++ b/app/frontend/stylesheets/local/site_wide.scss
@@ -64,7 +64,6 @@ th {
 // chemheritage.org uses these as default/standard h1-h6, but we're not
 // ready to there yet, keep them in classes.
 .brand-alt-h1, .brand-alt-h2, .brand-alt-h3, .brand-alt-h4, .brand-alt-h5, .brand-alt-h6 {
-  font-family: $brand-alt-header-font;
   font-weight: $brand-alt-header-weight;
 }
 .brand-alt-h4, .brand-alt-h5, .brand-alt-h6 {

--- a/app/frontend/stylesheets/local/site_wide.scss
+++ b/app/frontend/stylesheets/local/site_wide.scss
@@ -9,6 +9,13 @@ h2, .h2, h3, .h3, h4, .h4, h5, .h5 {
   color: $shi-blackish;
 }
 
+// We left bootstrap $font-size-base at 1rem (usually 16px) for the base of various
+// other padding and sizing calculations, but let's actually set default starting
+// font size to 17px (1.0625rem for 16px==1rem)
+body {
+  font-size: 1.0625rem;
+}
+
 
 // We set more-rounded corners, but only for buttons not input elements,
 // make sure buttons in input groups match original less rounded.

--- a/app/frontend/stylesheets/local/site_wide.scss
+++ b/app/frontend/stylesheets/local/site_wide.scss
@@ -139,8 +139,7 @@ hr.brand {
   margin-right: auto;
   margin-left: auto;
   p, dd, dt {
-    line-height: $paragraph-line-height-long !important;
-    margin-bottom: ($paragraph-line-height-long * 0.5) !important;
+    margin-bottom: ($paragraph-spacer) !important;
     max-width: $max-readable-width;
   }
 }

--- a/app/frontend/stylesheets/local/work_show.scss
+++ b/app/frontend/stylesheets/local/work_show.scss
@@ -20,7 +20,6 @@
   }
 
   .show-date {
-    @extend %text-font-numerals;
     ul {
       @extend .list-unstyled;
       margin-bottom: 0;

--- a/app/frontend/stylesheets/local/work_show.scss
+++ b/app/frontend/stylesheets/local/work_show.scss
@@ -8,7 +8,6 @@
   .additional-titles, .part-of {
     margin-bottom: 0;
     &, h2 {
-      font-family: $brand-alt-header-font;
       font-weight: normal;
       @extend h3;
       margin-bottom: 0;

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -48,10 +48,10 @@
         </li>
       </ul>
       <div class="tab-content pt-2 pb-2 border-bottom" id="myTabContent">
-        <div class="tab-pane text-brand-serif show active" id="transcriptionText" role="tabpanel" aria-labelledby="transcription--tab">
+        <div class="tab-pane show active" id="transcriptionText" role="tabpanel" aria-labelledby="transcription--tab">
           <%= simple_format(html_escape(@asset.transcription)) %>
         </div>
-        <div class="tab-pane text-brand-serif" id="englishTranslationText" role="tabpanel" aria-labelledby="english-translation-tab">
+        <div class="tab-pane" id="englishTranslationText" role="tabpanel" aria-labelledby="english-translation-tab">
           <%= simple_format(html_escape(@asset.english_translation)) %>
         </div>
       </div>

--- a/app/views/collection_show_controllers/oral_history_collection/_splash_page.html.erb
+++ b/app/views/collection_show_controllers/oral_history_collection/_splash_page.html.erb
@@ -126,7 +126,7 @@ we want the full width of the screen, no margins or padding. %>
     </div>
   <% end %>
 
-  <div class="projects long-text-line-height">
+  <div class="projects">
     <h2 class="brand-alt-h2">Projects</h2>
     <p>While individual oral histories can contribute to specific research goals and agendas, the strength of an oral history collection relies on the ability of individual oral histories to “speak” to each other. Learning about patterns of relationships and activities through the study of collective histories reveals much more about the scientific process and its products than any one oral history could do on its own.</p>
 

--- a/app/views/featured_topic/index.html.erb
+++ b/app/views/featured_topic/index.html.erb
@@ -18,7 +18,7 @@
       <% unless has_search_parameters? %>
         <div class="show-metadata">
             <p class="show-item-count"><%= number_with_delimiter(total_count) + ' item'.pluralize(total_count) %></p>
-            <div class="collection-description long-text-line-height">
+            <div class="collection-description">
               <%= DescriptionDisplayFormatter.new(@featured_topic.description).format %>
             </div>
         </div>

--- a/app/views/static/policy.html.erb
+++ b/app/views/static/policy.html.erb
@@ -61,7 +61,7 @@
 
   <h2>Excluded Items</h2>
   <p>Excluded items may be revisited later for inclusion if capacity increases and priorities shift, but the following materials currently fall outside the scope of the Science History Institute's Digital Collections:</p>
-  <ul class="text-font">
+  <ul>
     <li>Institutional records or educational materials created by the Institute that are not part of the library, archives, museum, or oral-history collections (documentary videos, magazine materials, etc.)</li>
     <li>Websites created by the Institute or others</li>
     <li>Datasets created by the Institute, researchers, or others</li>

--- a/app/views/works/_citation.html.erb
+++ b/app/views/works/_citation.html.erb
@@ -1,7 +1,7 @@
 <h2 class="attribute-sub-head">Cite as</h2>
   <div class="show-sub-head-body">
     <% if ! work.is_oral_history? %>
-      <p class="citation long-text-line-height">
+      <p class="citation">
          <%=CitationDisplay.new(work).display %>
       </p>
       <p class="btn-group" role="group">


### PR DESCRIPTION
* remove all references to the serif abril font, and mechanisms for sizing it appropriately -- we're going to one single sans-serif font
* where we DID use serif abril before, we had it at 17px instead of 16px. Let's make 17px our actual general default body font now.
  * but we DON'T actually reset the bootstrap $base-font-size variable -- that messed up too many other things derived from it, and the 16px base-font-size is nice for 16 being such a round arithmetic number, where multiplying it by various things generally gives nice round results. This seems to work out. 

* line-height is standard bootstrap 1.5, generally, without lots of overrides. we liked this nice large line height. 
 
* headings line height is 1.13, slightly smaller than bootstrap default 1.2. This seems to look good to me, and maybe matches main site in many headings contexts -- main site is not always consistent and it can depend on heading size, but seems to generally be a bit less than 1.2. 


* our extra-heavy headings go all the way to weight 900, matching main site
