### PR TITLE
Tweaks to header/footer links for Phase 1

### DIFF
--- a/app/components/scihist_footer_component.html.erb
+++ b/app/components/scihist_footer_component.html.erb
@@ -138,7 +138,7 @@
                     <li id="menu-item-19135" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-19135"><a>Registered 501(c)(3)</a></li>
                     <li id="menu-item-19136" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-19136"><a>EIN: 22-2817365</a></li>
                     <li id="menu-item-19121" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-19121"><a href="<%= URI::join(ScihistDigicoll::Env.lookup(:main_website_base), '/privacy-policy') %>">Privacy Policy</a></li>
-                    <li id="menu-item-19134" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-19134"><a href="#">Terms of Use</a></li>
+                    <li id="menu-item-19134" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-19134"><a href="<%= URI::join(ScihistDigicoll::Env.lookup(:main_website_base), '/terms-of-use') %>">Terms of Use</a></li>
                     <li id="menu-item-19122" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-19122"><a href="<%= URI::join(ScihistDigicoll::Env.lookup(:main_website_base), '/visit/accessibility') %>">Accessibility</a></li>
                 </ul>
             </div>

--- a/app/components/scihist_masthead.html.erb
+++ b/app/components/scihist_masthead.html.erb
@@ -10,7 +10,7 @@
                 <a class="shi-top-bar-nav__item shi-hover" href="<%= URI::join(ScihistDigicoll::Env.lookup(:main_website_base), "/stories/magazine") %>"  target="_self">
                     Magazine
                 </a>
-                <a class="shi-top-bar-nav__item shi-hover" href="<%= URI::join(ScihistDigicoll::Env.lookup(:main_website_base), "/stories/distillations-pod") %>" target="_self">
+                <a class="shi-top-bar-nav__item shi-hover" href="<%= URI::join(ScihistDigicoll::Env.lookup(:main_website_base), "/stories#podcasts") %>" target="_self">
                     Podcasts
                 </a>
                 <a class="shi-top-bar-nav__item shi-hover" href="<%= URI::join(ScihistDigicoll::Env.lookup(:main_website_base), "/visit/events") %>" target="_self">


### PR DESCRIPTION
- terms of use link
- updated link for 'podcast' in header nav, from main site

Note this is a PR into the **Phase 1** branch, redesign_header_footer.   Just a couple link changes from Caitlin. 
