### PR TITLE
Make sort widget line up flush with right margin

### DIFF
--- a/app/frontend/stylesheets/local/search_results.scss
+++ b/app/frontend/stylesheets/local/search_results.scss
@@ -91,6 +91,12 @@
   border: none;
   .search-widgets {
     float: none !important;
+
+    // override blacklight's use of bootstrap -- in our layout we want
+    // this flush with right margin.
+    #sort-dropdown {
+      margin-right: 0 !important;
+    }
   }
   &:after {
     display: none;


### PR DESCRIPTION
By overriding some styles that came from Blacklight's use of bootstrap, in a case where there were more things on screen I guess, or just a different layout. We don't want it.

This makes the right edge of the sort dropdown be nice and flush with other content right edges.
