### PR TITLE
Replace btn-outline-primary with btn-outline-secondary in admin screens

### DIFF
--- a/app/views/admin/assets/display_attach_form.html.erb
+++ b/app/views/admin/assets/display_attach_form.html.erb
@@ -14,7 +14,7 @@
           <div class="row">
             <div class="col-md-12 mt-2 mb-2">
               <button type="button" data-toggle="kithe-browse-everything" data-route="<%=browse_everything_engine.root_path%>"
-                      class="btn btn-outline-primary w-100" id="browse">
+                      class="btn btn-outline-secondary w-100" id="browse">
                     Add from Cloud
               </button>
             </div>

--- a/app/views/admin/assets/edit.html.erb
+++ b/app/views/admin/assets/edit.html.erb
@@ -10,7 +10,7 @@
     </div>
 
     <div class="form-actions">
-      <%= link_to 'Cancel', admin_asset_path(@asset), class: "btn btn-outline-primary" %>
+      <%= link_to 'Cancel', admin_asset_path(@asset), class: "btn btn-outline-secondary" %>
       <%= f.button :submit %>
     </div>
   </div>

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -34,7 +34,7 @@
     <% if @asset.file %>
       <%= link_to "Download Original",
             @asset.file.url(response_content_disposition: ContentDisposition.format(disposition: :attachment, filename: DownloadFilenameHelper.filename_for_asset(@asset))),
-            class: "btn btn-outline-primary btn-lg mt-4" %>
+            class: "btn btn-outline-secondary btn-lg mt-4" %>
     <% end %>
 
 

--- a/app/views/admin/batch_create/add_files.html.erb
+++ b/app/views/admin/batch_create/add_files.html.erb
@@ -21,7 +21,7 @@ Very un-DRY, maybe refactor later. %>
           <div class="row">
             <div class="col-md-12 mt-2 mb-2">
               <button type="button" data-toggle="kithe-browse-everything" data-route="<%=browse_everything_engine.root_path%>"
-                      class="btn btn-outline-primary w-100" id="browse">
+                      class="btn btn-outline-secondary w-100" id="browse">
                     Add from Cloud
               </button>
             </div>

--- a/app/views/admin/batch_create/new.html.erb
+++ b/app/views/admin/batch_create/new.html.erb
@@ -8,7 +8,7 @@
     </div>
 
     <div class="form-actions">
-      <%= link_to 'Cancel', cancel_url, class: "btn btn-outline-primary" %>
+      <%= link_to 'Cancel', cancel_url, class: "btn btn-outline-secondary" %>
       <%= f.button :submit, value: "Proceed to Select Files" %>
     </div>
   </div>

--- a/app/views/admin/collections/_form.html.erb
+++ b/app/views/admin/collections/_form.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <div class="form-actions">
-      <%= link_to 'Cancel', admin_collections_url, class: "btn btn-outline-primary" %>
+      <%= link_to 'Cancel', admin_collections_url, class: "btn btn-outline-secondary" %>
       <%= f.button :submit %>
     </div>
   </div>

--- a/app/views/admin/digitization_queue_items/_form.html.erb
+++ b/app/views/admin/digitization_queue_items/_form.html.erb
@@ -101,7 +101,7 @@
   </div>
 
   <div class="form-actions mb-3">
-    <%= link_to "Cancel", admin_digitization_queue_items_path(collecting_area), class: "btn btn-outline-primary" %>
+    <%= link_to "Cancel", admin_digitization_queue_items_path(collecting_area), class: "btn btn-outline-secondary" %>
     <%= f.button :submit %>
   </div>
 

--- a/app/views/admin/digitization_queue_items/index.html.erb
+++ b/app/views/admin/digitization_queue_items/index.html.erb
@@ -61,7 +61,7 @@
       <% @admin_digitization_queue_items.each do |admin_digitization_queue_item| %>
         <tr>
           <td>
-            <%= link_to 'Edit', edit_admin_digitization_queue_item_path(admin_digitization_queue_item), class: "btn btn-sm btn-outline-primary" %>
+            <%= link_to 'Edit', edit_admin_digitization_queue_item_path(admin_digitization_queue_item), class: "btn btn-sm btn-outline-secondary" %>
           </td>
           <td>
             <%= link_to admin_digitization_queue_item.title, admin_digitization_queue_item_path(admin_digitization_queue_item) %>

--- a/app/views/admin/digitization_queue_items/show.html.erb
+++ b/app/views/admin/digitization_queue_items/show.html.erb
@@ -101,7 +101,7 @@
 
     <p>
       <%= link_to "Create new attached work", new_admin_work_path(digitization_queue_item: @admin_digitization_queue_item.id), class: "btn btn-primary mb-1" %>
-      <%= link_to "Batch create attached works", admin_batch_create_path(digitization_queue_item: @admin_digitization_queue_item.id), class: "btn btn-outline-primary" %>
+      <%= link_to "Batch create attached works", admin_batch_create_path(digitization_queue_item: @admin_digitization_queue_item.id), class: "btn btn-outline-secondary" %>
     </p>
 
     <h2>Comments</h2>

--- a/app/views/admin/interviewee_biographies/_form.html.erb
+++ b/app/views/admin/interviewee_biographies/_form.html.erb
@@ -14,7 +14,7 @@
       </h1>
     </div>
     <div class="form-actions">
-      <%= link_to 'Cancel', admin_interviewee_biographies_path, class: "btn btn-outline-primary my-1" %>
+      <%= link_to 'Cancel', admin_interviewee_biographies_path, class: "btn btn-outline-secondary my-1" %>
       <%= submit_tag "Save", class: "btn btn-primary my-1" %>
     </div>
   </div>

--- a/app/views/admin/interviewee_biographies/index.html.erb
+++ b/app/views/admin/interviewee_biographies/index.html.erb
@@ -2,7 +2,7 @@
 
 <h1>Oral History: Interviewee Biographies</h1>
 
-<%= link_to 'New Interviewee Biography', new_admin_interviewee_biography_path, class: "btn btn-outline-primary mb-3" %>
+<%= link_to 'New Interviewee Biography', new_admin_interviewee_biography_path, class: "btn btn-outline-secondary mb-3" %>
 
 <%= form_with(url: admin_interviewee_biographies_path, method: :get, class: 'edit-work admin-edit') do |f| %>
   <div class="row">
@@ -37,7 +37,7 @@
       <tr>
         <td><%= interviewee_biography.name %></td>
         <td>
-          <%= link_to 'Edit', edit_admin_interviewee_biography_path(interviewee_biography), class: "btn btn-sm btn-outline-primary" %>
+          <%= link_to 'Edit', edit_admin_interviewee_biography_path(interviewee_biography), class: "btn btn-sm btn-outline-secondary" %>
           <%= link_to 'Destroy', admin_interviewee_biography_path(interviewee_biography), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-sm btn-outline-danger" %>
         </td>
       </tr>

--- a/app/views/admin/interviewer_profiles/index.html.erb
+++ b/app/views/admin/interviewer_profiles/index.html.erb
@@ -2,7 +2,7 @@
 
 <h1>Interviewer Profiles</h1>
 
-<%= link_to 'New Interviewer Profile', new_admin_interviewer_profile_path, class: "btn btn-outline-primary mb-3" %>
+<%= link_to 'New Interviewer Profile', new_admin_interviewer_profile_path, class: "btn btn-outline-secondary mb-3" %>
 
 <%= form_with(url: admin_interviewer_profiles_path, method: :get, class: 'edit-work admin-edit') do |f| %>
   <div class="row">
@@ -38,7 +38,7 @@
       <tr>
         <td><%= interviewer_profile.name %></td>
         <td>
-          <%= link_to 'Edit', edit_admin_interviewer_profile_path(interviewer_profile), class: "btn btn-sm btn-outline-primary" %>
+          <%= link_to 'Edit', edit_admin_interviewer_profile_path(interviewer_profile), class: "btn btn-sm btn-outline-secondary" %>
           <%= link_to 'Destroy', admin_interviewer_profile_path(interviewer_profile), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-sm btn-outline-danger" %>
         </td>
       </tr>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -10,7 +10,7 @@
   </div>
 
   <div class="form-actions">
-    <%= link_to 'Cancel', admin_users_path, class: "btn btn-outline-primary" %>
+    <%= link_to 'Cancel', admin_users_path, class: "btn btn-outline-secondary" %>
     <%= f.button :submit %>
   </div>
 <% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -36,8 +36,8 @@
           <% end %>
         </td>
         <td>
-          <%= link_to 'Edit', edit_admin_user_path(user), class: "btn btn-sm btn-outline-primary" %>
-          <%= link_to 'Send password reset', send_password_reset_admin_user_path(user), method: "post", class: "btn btn-sm btn-outline-primary" %>
+          <%= link_to 'Edit', edit_admin_user_path(user), class: "btn btn-sm btn-outline-secondary" %>
+          <%= link_to 'Send password reset', send_password_reset_admin_user_path(user), method: "post", class: "btn btn-sm btn-outline-secondary" %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/works/_form.html.erb
+++ b/app/views/admin/works/_form.html.erb
@@ -29,7 +29,7 @@
     </div>
 
     <div class="form-actions">
-      <%= link_to 'Cancel', cancel_url, class: "btn btn-outline-primary" %>
+      <%= link_to 'Cancel', cancel_url, class: "btn btn-outline-secondary" %>
       <%= f.button :submit %>
     </div>
   </div>

--- a/app/views/admin/works/batch_update_form.html.erb
+++ b/app/views/admin/works/batch_update_form.html.erb
@@ -4,7 +4,7 @@
       <h1 class="h5">Batch Edit <small>— <%= current_user.works_in_cart.count %> Works in Cart</small></h1>
     </div>
     <div class="form-actions">
-      <%= link_to 'Cancel', admin_cart_items_path, class: "btn btn-outline-primary" %>
+      <%= link_to 'Cancel', admin_cart_items_path, class: "btn btn-outline-secondary" %>
       <%= f.button :submit, value: "Update #{current_user.works_in_cart.count} Works" %>
     </div>
   </div>

--- a/app/views/admin/works/index.html.erb
+++ b/app/views/admin/works/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Works</h1>
   <p>
     <%= link_to 'Create new work', new_admin_work_path, class: "btn btn-primary #{"disabled" unless can?(:create, Kithe::Model) }" %>
-    <%= link_to 'Batch create works', admin_batch_create_path, class: "btn btn-outline-primary #{"disabled" unless can?(:create, Kithe::Model) }" %>
+    <%= link_to 'Batch create works', admin_batch_create_path, class: "btn btn-outline-secondary #{"disabled" unless can?(:create, Kithe::Model) }" %>
   </p>
 
 <%# this is ransack %>

--- a/app/views/admin/works/oh_biography_form.html.erb
+++ b/app/views/admin/works/oh_biography_form.html.erb
@@ -14,7 +14,7 @@
       </h1>
     </div>
     <div class="form-actions">
-      <%= link_to 'Cancel', admin_work_path(@work, :anchor => "tab=nav-oral-histories"), class: "btn btn-outline-primary my-1" %>
+      <%= link_to 'Cancel', admin_work_path(@work, :anchor => "tab=nav-oral-histories"), class: "btn btn-outline-secondary my-1" %>
       <%= submit_tag "Save", class: "btn btn-primary my-1" %>
     </div>
   </div>

--- a/app/views/admin/works/reorder_members_form.html.erb
+++ b/app/views/admin/works/reorder_members_form.html.erb
@@ -6,7 +6,7 @@
   <div class="while-sorting-actions">
     <h2 class="h3">Drag to re-order for '<%= @work.title %>'</h2>
     <div>
-      <%= link_to "Cancel", admin_work_path(@work, anchor: "nav-members"), class: "btn btn-outline-primary" %>
+      <%= link_to "Cancel", admin_work_path(@work, anchor: "nav-members"), class: "btn btn-outline-secondary" %>
       <button type="submit" class="btn btn-danger" disabled data-trigger="member-sort-save">Save</button>
     </div>
   </div>

--- a/app/views/admin/works/show.html.erb
+++ b/app/views/admin/works/show.html.erb
@@ -7,7 +7,7 @@
       <% end %>
       <div>
         <div>Managing a Work</div>
-        <h1><%= @work.title %> <%= publication_badge(@work) %>   <%= link_to "Public view", work_path(@work), class: "btn btn-sm btn-outline-primary" %></h1>
+        <h1><%= @work.title %> <%= publication_badge(@work) %>   <%= link_to "Public view", work_path(@work), class: "btn btn-sm btn-outline-secondary" %></h1>
         <% if @work.parent.present? %>
           <p class="h4">Member in: <%= link_to "#{@work.parent.title} (#{@work.parent.friendlier_id})", admin_work_path(@work.parent) %></p>
         <% end %>
@@ -97,11 +97,11 @@
         <%= link_to "Demote to Asset",
               demote_to_asset_admin_work_path(@work),
               method: "put",
-              class: "btn btn-outline-primary #{'disabled' unless can?(:destroy, @work)}",
+              class: "btn btn-outline-secondary #{'disabled' unless can?(:destroy, @work)}",
               data: { confirm: "All work metadata on #{@work.title} will be lost, this is not reversible. Are you sure?" } %>
       <% end %>
     </p>
-  
+
     <%= render "metadata", work: @work %>
 
   </div>


### PR DESCRIPTION
In new redesign colors, after resetting bootstrap colors to what made sense for our uses: btn-outline-primary is now a teal outline;  btn-outline-secondary is a black outline. The black outline is actually in new site styles, and looks good. The teal outline is not, and does not look as good.  More consistency with new site styles, and looks better.

These are all in admin screens.
