### PR TITLE
other search tools phase 2 redesign

### DIFF
--- a/app/frontend/stylesheets/_mixins.scss
+++ b/app/frontend/stylesheets/_mixins.scss
@@ -64,7 +64,7 @@
   line-height: normal;
   letter-spacing: $small-caps-letter-spacing;
   a:not(:focus):not(:hover) {
-    color: $special-label-muted-color;
+    color: $shi-alt-muted-text;
   }
 }
 

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -110,7 +110,6 @@ $special-label-muted-color: $brand-dark-grey;
 // Why do we need so much spacing for it to look reasonable? Good spacing for 14px and weight 600.
 $small-caps-letter-spacing: 0.035em;
 
-$brand-btn-alt-bg: $brand-bright-green;
 $brand-alt-header-weight: 900;
 
 // adelle-sans has a 600 semi-bold available. 700 is standard bold. 500 seems to be the same as 400=normal.

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -83,16 +83,14 @@ $shi-alternate-text-color: #3c3c3c;
 // to browser, prevent SASS from converting it to hex!
 $shi-transparent-dark-bg: #{'rgba(30,36,42,.80)'};
 
-
+// Not official brand color, but at the moment we're using for links. Goes together
+// okay, a varient of previous brand colors.
+$shi-blue-text: #007FAA;
 
 /* OLD rebrand colors */
-$brand-blue:  #007FAA; // #4bb0c7; // #76c3d4; // https://github.com/sciencehistory/scihist_digicoll/issues/1233
 $brand-dark-grey: #646469;
 
 $brand-image-placeholder-color: #AAA; // not a designated brand color, but oh well
-
-//$brand-blue-text: #338EA2; // brand blue is too light for text on white, here's a darker version 3595AA.
-$brand-blue-text: $brand-blue;
 
 // Our brand sans-serif, with fallbacks copied from Bootstrap's default sans-serif.
 $brand-sans-serif: 'sofia-pro', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
@@ -190,7 +188,7 @@ $dark: $shi-dark-blue;
 
 $tooltip-bg: $shi-blackish;
 
-$link-color: $brand-blue-text;
+$link-color: $shi-blue-text;
 $link-hover-color: $shi-blackish;
 $font-family-sans-serif: $brand-sans-serif;
 // default bootstrap code color is a pink. use brand red? Or something else?

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -87,7 +87,6 @@ $shi-transparent-dark-bg: #{'rgba(30,36,42,.80)'};
 
 /* OLD rebrand colors */
 $brand-dark-blue: #050939;
-$brand-bright-green: #a6e5d8;
 $brand-red: #d8262e;
 $brand-yellow: #dbe341;
 $brand-blue:  #007FAA; // #4bb0c7; // #76c3d4; // https://github.com/sciencehistory/scihist_digicoll/issues/1233

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -13,25 +13,68 @@
  */
 
 /* NEW 2023 Brand colors */
+// First, variated colors from the Brand Guide which has 7 colors with four shades each,
+// from 1=lightest to 4=darkest.
+//
+// We leave out `blue` and `purple` because we do not use them at all at present.
+//
+// Secondly, we'll have some semantic/mnemonic aliases for the colors we actually use
+// and how we use them
+
+// Grand guide calls this "black", and recommends it for all(?) black uses,
+// but main website uses pure black for text still.
+$shi-blackish: #1D242b;
+
+$shi-chartreuse-4: #78712e;
+$shi-chartreuse-3: #e4e76d;
+$shi-chartreuse-2: #eff1b6;
+$shi-chartreuse-1: #f7f8d9;
+
+// lighter teals start looking more like turquoise
+$shi-teal-4: #285f70; // NOT what is in Brand Guide, website updated it!
+$shi-teal-3: #a9dbd4;
+$shi-teal-2: #d4ece8;
+$shi-teal-1: #eaf6f3;
+
+$shi-red-4: #6a1d32;
+$shi-red-3: #d7272e;
+$shi-red-2: #eb9396;
+$shi-red-1: #f4c9cb;
+
+// we RARELY use green in digital collections, we have enough colors. But we use it
+// for bootstrap "success"
+$shi-green-4: #004d44;
+$shi-green-3: #a0d5b1;
+$shi-green-2: #d0e9d7;
+$shi-green-1: #e8f4ed;
+
+$shi-gray-4: #313e48;
+$shi-gray-3: #bbbaba;
+$shi-gray-2: #dddddc;
+$shi-gray-1: #efeeed;
+
+// Now we have semantic/mnemonic aliases, concentrating on the subset
+// that we actually want to try to stick to
+
+
 // Mostly background:
-$shi-blackish: #1D242b; // we also use as text color esp for headings, although main site does not
-$shi-teal: #285f70; // as actually used on main site may 2023
-$shi-green: #004d44;
-$shi-dark-blue: #313E48;
-$shi-maroon: #6A1D32;
-$shi-bg-gray: #EFEEED; // as used on mainsite, not in PDF
-$shi-bg-gray-border: #bbbaba; // the bg-gray is so light it needs a border. #bbbaba is used on main site. $bcbcbc or #ccc alts may look better?
-$shi-footer-bg-green: #eaf6f3; // one of several used on mainsite for footer "callouts", not in PDF
-$shi-bg-turquoise: #d4ece8; // an alternate turquoise used for backgrounds, let's try to avoid it though
+$shi-teal: $shi-teal-4; // as actually used on main site may 2023
+$shi-green: $shi-green-4;
+$shi-dark-blue: $shi-gray-4; // TODO change this name it's not considered blue!
+$shi-maroon: $shi-red-4;
+$shi-bg-gray: $shi-gray-1;
+$shi-bg-gray-border: $shi-gray-3; // the bg-gray is so light it needs a border. #bbbaba is used on main site, although also uses $bcbcbc or #ccc alts
+$shi-footer-bg-green: $shi-teal-1; // one of several used on mainsite for footer "callouts", not in PDF. TODO change name?
+$shi-bg-turquoise: $shi-teal-2; // an alternate turquoise used for backgrounds, let's try to avoid it though
 
 // mostly foreground text/highlight
-$shi-turquoise: #A9DBD4; // especially as highlight text over dark blue
-$shi-red: #D7272E;
+$shi-turquoise: $shi-teal-3; // especially as highlight text over dark blue
+$shi-red: $shi-red-3;
 
 // yellow is used as main button background, and also text over blackish and teal
-$shi-yellow: #E4E76D;
+$shi-yellow: $shi-chartreuse-3;
 
-// This is an alternate color used sometimes for text, over pale green or even
+// This is an alternate dark grey used sometimes in main sitefor text, over pale green or even
 // white.
 $shi-alternate-text-color: #3c3c3c;
 
@@ -142,13 +185,13 @@ $headings-line-height: 1.13; // a bit smaller than default 1.2
 $headings-color: $shi-blackish;
 
 // bootstrap brand colors
-$primary: $shi-teal;
+$primary: $shi-teal; // main buttons actually use $shi-yellow, but we don't want to put that everywhere bootstrap primary goes
 $secondary: $shi-blackish;
 $info: $shi-bg-turquoise;
-// success // we don't use in public front-end at present
+$success: $shi-green;
 $warning: $shi-yellow;
 $danger: $shi-red;
-//$light: $shi-bg-gray; // we don't use in public front-end at present
+$light: $shi-bg-gray; // not sure if we use in public front-end at present
 $dark: $shi-dark-blue;
 
 $tooltip-bg: $shi-blackish;

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -60,7 +60,7 @@ $shi-gray-1: #efeeed;
 // Mostly background:
 $shi-teal: $shi-teal-4; // as actually used on main site may 2023
 $shi-green: $shi-green-4;
-$shi-dark-blue: $shi-gray-4; // TODO change this name it's not considered blue!
+$shi-dark-gray: $shi-gray-4; // often used on website
 $shi-maroon: $shi-red-4;
 $shi-bg-gray: $shi-gray-1;
 $shi-bg-gray-border: $shi-gray-3; // the bg-gray is so light it needs a border. #bbbaba is used on main site, although also uses $bcbcbc or #ccc alts
@@ -94,7 +94,7 @@ $shi-blue-text: #007FAA;
 // At lighten 15% it's #506576, which passes AA but not AAA WCAG contrast for small text.
 //
 // (10% would be #465866 -- and WCAG AAA contrast for small text on white.)
-$shi-alt-muted-text: lighten($shi-dark-blue, 15%);
+$shi-alt-muted-text: lighten($shi-dark-gray, 15%);
 
 
 $brand-image-placeholder-color: $shi-gray-3;
@@ -193,7 +193,7 @@ $success: $shi-green;
 $warning: $shi-yellow;
 $danger: $shi-red;
 $light: $shi-bg-gray; // not sure if we use in public front-end at present
-$dark: $shi-dark-blue;
+$dark: $shi-dark-gray;
 
 $tooltip-bg: $shi-blackish;
 

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -192,7 +192,7 @@ $dark: $shi-dark-blue;
 $tooltip-bg: $shi-blackish;
 
 $link-color: $brand-blue-text;
-$link-hover-color: $brand-dark-blue;
+$link-hover-color: $shi-blackish;
 $font-family-sans-serif: $brand-sans-serif;
 // default bootstrap code color is a pink. use brand red? Or something else?
 $code-color: $shi-red;

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -90,7 +90,7 @@ $shi-blue-text: #007FAA;
 /* OLD rebrand colors */
 $brand-dark-grey: #646469;
 
-$brand-image-placeholder-color: #AAA; // not a designated brand color, but oh well
+$brand-image-placeholder-color: $shi-gray-3;
 
 // Our brand sans-serif, with fallbacks copied from Bootstrap's default sans-serif.
 $brand-sans-serif: 'sofia-pro', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -87,7 +87,6 @@ $shi-transparent-dark-bg: #{'rgba(30,36,42,.80)'};
 
 /* OLD rebrand colors */
 $brand-dark-blue: #050939;
-$brand-red: #d8262e;
 $brand-blue:  #007FAA; // #4bb0c7; // #76c3d4; // https://github.com/sciencehistory/scihist_digicoll/issues/1233
 $brand-light-grey: #bcbcbc; // not actually very light
 $brand-dark-grey: #646469;
@@ -200,7 +199,7 @@ $link-color: $brand-blue-text;
 $link-hover-color: $brand-dark-blue;
 $font-family-sans-serif: $brand-sans-serif;
 // default bootstrap code color is a pink. use brand red? Or something else?
-$code-color: $brand-red;
+$code-color: $shi-red;
 
 $text-muted: $brand-dark-grey;
 $dropdown-header-color: $brand-dark-grey;

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -86,7 +86,6 @@ $shi-transparent-dark-bg: #{'rgba(30,36,42,.80)'};
 
 
 /* OLD rebrand colors */
-$brand-dark-blue: #050939;
 $brand-blue:  #007FAA; // #4bb0c7; // #76c3d4; // https://github.com/sciencehistory/scihist_digicoll/issues/1233
 $brand-dark-grey: #646469;
 

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -88,7 +88,6 @@ $shi-transparent-dark-bg: #{'rgba(30,36,42,.80)'};
 /* OLD rebrand colors */
 $brand-dark-blue: #050939;
 $brand-red: #d8262e;
-$brand-yellow: #dbe341;
 $brand-blue:  #007FAA; // #4bb0c7; // #76c3d4; // https://github.com/sciencehistory/scihist_digicoll/issues/1233
 $brand-light-grey: #bcbcbc; // not actually very light
 $brand-dark-grey: #646469;

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -88,7 +88,6 @@ $shi-transparent-dark-bg: #{'rgba(30,36,42,.80)'};
 /* OLD rebrand colors */
 $brand-dark-blue: #050939;
 $brand-blue:  #007FAA; // #4bb0c7; // #76c3d4; // https://github.com/sciencehistory/scihist_digicoll/issues/1233
-$brand-light-grey: #bcbcbc; // not actually very light
 $brand-dark-grey: #646469;
 
 $brand-image-placeholder-color: #AAA; // not a designated brand color, but oh well
@@ -192,9 +191,6 @@ $dark: $shi-dark-blue;
 
 $tooltip-bg: $shi-blackish;
 
-// $btn-primary-border: $brand-primary; // bootstrap 4 has no button borders already I think.
-// $btn-default-border: $brand-light-grey; // bootstrap 4 has no button borders already I think.
-
 $link-color: $brand-blue-text;
 $link-hover-color: $brand-dark-blue;
 $font-family-sans-serif: $brand-sans-serif;
@@ -222,7 +218,7 @@ $card-border-color: $shi-bg-gray-border;
 $breadcrumb-bg: $bg-lightly-shaded;
 $input-group-addon-bg: $bg-lightly-shaded;
 
-$list-group-border-color: $brand-light-grey;
+$list-group-border-color: $shi-bg-gray-border;
 
 $input-color: $brand-dark-grey;
 $input-border-color: $shi-bg-gray-border;
@@ -233,8 +229,8 @@ $input-border-color: $shi-bg-gray-border;
 $input-btn-padding-x-sm: .625rem; // 10px
 $input-btn-padding-y-sm: .3125rem; // 5px
 
-$pagination-active-color:           $body-color;
-$pagination-active-bg:              $brand-light-grey;
+$pagination-active-color:           white;
+$pagination-active-bg:              $shi-red;
 $pagination-active-border-color:    $pagination-active-bg;
 
 $popover-font-size: 1rem;

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -207,10 +207,6 @@ $code-color: $brand-red;
 $text-muted: $brand-dark-grey;
 $dropdown-header-color: $brand-dark-grey;
 
-$navbar-dark-color: $brand-bright-green;
-$navbar-dark-hover-color: #fff;
-$navbar-dark-active-color: #fff;
-
 // new main site styles do not use any rounding on buttons and other elements
 $border-radius: 0;
 $border-radius-sm: 0;

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -87,8 +87,15 @@ $shi-transparent-dark-bg: #{'rgba(30,36,42,.80)'};
 // okay, a varient of previous brand colors.
 $shi-blue-text: #007FAA;
 
-/* OLD rebrand colors */
-$brand-dark-grey: #646469;
+// We need a medium grey for muted text, without a really good one in
+// brand color. We slightly lighten the darkest brand-grey.
+// Previously from old brand colors this was #646469,
+//
+// At lighten 15% it's #506576, which passes AA but not AAA WCAG contrast for small text.
+//
+// (10% would be #465866 -- and WCAG AAA contrast for small text on white.)
+$shi-alt-muted-text: lighten($shi-dark-blue, 15%);
+
 
 $brand-image-placeholder-color: $shi-gray-3;
 
@@ -97,7 +104,9 @@ $brand-sans-serif: 'sofia-pro', -apple-system, BlinkMacSystemFont, "Segoe UI", R
 
 //$bg-lightly-shaded: #f9f9f9; // does not match brand, no suitable color in brand
 $bg-lightly-shaded: $shi-bg-gray; // try brand color
-$special-label-muted-color: $brand-dark-grey;
+
+
+
 //$brand-highlight-color: #f15c2b; // an orange used on (old) Distillations website, perhaps use as an alterante highlight sitewide
 
 // Why do we need so much spacing for it to look reasonable? Good spacing for 14px and weight 600.
@@ -194,8 +203,8 @@ $font-family-sans-serif: $brand-sans-serif;
 // default bootstrap code color is a pink. use brand red? Or something else?
 $code-color: $shi-red;
 
-$text-muted: $brand-dark-grey;
-$dropdown-header-color: $brand-dark-grey;
+$text-muted: $shi-alt-muted-text;
+$dropdown-header-color: $shi-alt-muted-text;
 
 // new main site styles do not use any rounding on buttons and other elements
 $border-radius: 0;
@@ -217,7 +226,7 @@ $input-group-addon-bg: $bg-lightly-shaded;
 
 $list-group-border-color: $shi-bg-gray-border;
 
-$input-color: $brand-dark-grey;
+$input-color: $shi-alt-muted-text;
 $input-border-color: $shi-bg-gray-border;
 
 

--- a/app/frontend/stylesheets/local/accept_cookies_banner.scss
+++ b/app/frontend/stylesheets/local/accept_cookies_banner.scss
@@ -17,7 +17,7 @@ nav.accept-cookies-banner-nav {
       display: block;
       color: white;
       background-color: $shi-red;
-      &:hover { background-color: $brand-blue; }
+      &:hover { background-color: $shi-teal; }
       text-decoration: none;
       font-size: .9em;
       font-weight: 700;

--- a/app/frontend/stylesheets/local/accept_cookies_banner.scss
+++ b/app/frontend/stylesheets/local/accept_cookies_banner.scss
@@ -16,7 +16,7 @@ nav.accept-cookies-banner-nav {
     a.i-accept-link {
       display: block;
       color: white;
-      background-color: $brand-red;
+      background-color: $shi-red;
       &:hover { background-color: $brand-blue; }
       text-decoration: none;
       font-size: .9em;

--- a/app/frontend/stylesheets/local/collection_show.scss
+++ b/app/frontend/stylesheets/local/collection_show.scss
@@ -59,7 +59,7 @@
   // Alternate bg block colors for special types of pages
   &.exhibition {
     .collection-header-title, .collection-mini-header {
-      background-color: $shi-dark-blue;
+      background-color: $shi-dark-gray;
     }
   }
   &.featured-collection-show {

--- a/app/frontend/stylesheets/local/error_pages.scss
+++ b/app/frontend/stylesheets/local/error_pages.scss
@@ -48,7 +48,7 @@
     }
 
     .error-headline {
-      color: $brand-red;
+      color: $shi-red;
       margin-top: 0;
     }
 
@@ -65,7 +65,7 @@
           font-family: FontAwesome;
           content: '\F0A4'; // hand-right
           padding-right: 0.4em;
-          color: $brand-red;
+          color: $shi-red;
         }
       }
     }

--- a/app/frontend/stylesheets/local/error_pages.scss
+++ b/app/frontend/stylesheets/local/error_pages.scss
@@ -53,14 +53,14 @@
     }
 
     .error-subheadline {
-      color: $brand-dark-grey;
+      color: $special-label-muted-color;
       margin-top: 1.375rem;
     }
 
     .error-section {
       margin: 34px 0;
       h2 {
-        color: $brand-dark-blue;
+        color: $shi-blackish;
         &:before {
           font-family: FontAwesome;
           content: '\F0A4'; // hand-right

--- a/app/frontend/stylesheets/local/error_pages.scss
+++ b/app/frontend/stylesheets/local/error_pages.scss
@@ -53,7 +53,7 @@
     }
 
     .error-subheadline {
-      color: $special-label-muted-color;
+      color: $shi-alt-muted-text;
       margin-top: 1.375rem;
     }
 

--- a/app/frontend/stylesheets/local/homepage.scss
+++ b/app/frontend/stylesheets/local/homepage.scss
@@ -187,7 +187,7 @@
     }
 
     .featured-topics {
-        background-color: $shi-dark-blue;
+        background-color: $shi-dark-gray;
 
         .title-div h2, .title-div {
           color: white;
@@ -238,7 +238,7 @@
             letter-spacing: 0.04em;
             text-align: center;
             color: white;
-            background-color: $shi-dark-blue;
+            background-color: $shi-dark-gray;
             padding: 0.625rem;
           }
         }

--- a/app/frontend/stylesheets/local/oh_audio.scss
+++ b/app/frontend/stylesheets/local/oh_audio.scss
@@ -152,27 +152,6 @@
       .ohms-search {
         max-width: $max-readable-width; // doesn't need to be this specifically, but works fine
         margin-top: $spacer;
-
-        .search-heading {
-          margin-bottom: 0;
-
-          a {
-            color: $brand-dark-blue;
-
-            //make appropriate toggle icon show up for state
-            .fa-caret-right.toggle-icon {
-              display: none;
-            }
-            &.collapsed {
-              .fa-caret-right.toggle-icon {
-                display: inline-block;
-              }
-              .fa-caret-down.toggle-icon {
-                display: none;
-              }
-            }
-          }
-        }
       }
 
       .ohms-search-results {

--- a/app/frontend/stylesheets/local/oh_audio.scss
+++ b/app/frontend/stylesheets/local/oh_audio.scss
@@ -187,7 +187,7 @@
 
         .ohms-no-results {
           margin-top: ($paragraph-spacer * 0.5);
-          color: $brand-red;
+          color: $shi-red;
         }
 
         .ohms-result-navigation {
@@ -330,7 +330,7 @@
 }
 
 .ohms-highlight {
-  background-color: $brand-red;
+  background-color: $shi-red;
   color: white;
   padding-left: .1em;
   padding-right: .1em;

--- a/app/frontend/stylesheets/local/oh_audio.scss
+++ b/app/frontend/stylesheets/local/oh_audio.scss
@@ -318,7 +318,7 @@
 .ohms-speaker {
   font-weight: bold;
   @extend %special-label;
-  color: $brand-dark-blue;
+  color: $shi-red;
 }
 
 // make room for and position the timecode links
@@ -358,7 +358,7 @@
         @extend %special-label;
         margin-right: 0.66em;
         font-weight: bold;
-        color: $brand-dark-blue;
+        color: $shi-blackish;
       }
     }
 

--- a/app/frontend/stylesheets/local/oh_audio.scss
+++ b/app/frontend/stylesheets/local/oh_audio.scss
@@ -34,7 +34,7 @@
 
     padding-top: $spacer;
 
-    background-color: $shi-dark-blue;
+    background-color: $shi-dark-gray;
     color: white;
     // material-design-like shadow, sorry we're just hacking it un-DRY.
     // https://stackoverflow.com/questions/30533055/calculating-shadow-values-for-all-material-design-elevations

--- a/app/frontend/stylesheets/local/oral_history_splash.scss
+++ b/app/frontend/stylesheets/local/oral_history_splash.scss
@@ -128,7 +128,7 @@
 
           .number {
             font-size: 1.75rem;
-            background-color: $shi-dark-blue;
+            background-color: $shi-dark-gray;
             color: white;
           }
         }
@@ -137,7 +137,7 @@
   }
 
   .this-day-container {
-    background-color: $shi-dark-blue;
+    background-color: $shi-dark-gray;
 
     .this-day {
       padding-top: 2rem;
@@ -167,7 +167,7 @@
         letter-spacing: $small-caps-letter-spacing;
         background-color: white;
         padding: 1em 1em;
-        border: 1px solid $shi-dark-blue;
+        border: 1px solid $shi-dark-gray;
         border-top: none;
         margin-bottom: 0;
       }
@@ -175,7 +175,7 @@
         @extend .text-muted;
         padding: 1em 1em;
         background-color: white;
-        border: 1px solid $shi-dark-blue;
+        border: 1px solid $shi-dark-gray;
         margin-bottom: 0;
       }
     }
@@ -221,7 +221,7 @@
 
 
           font-size: 120%;
-          background-color: $shi-dark-blue;
+          background-color: $shi-dark-gray;
           color: white;
           border-radius: 3em;
           padding: 0 0.5em;

--- a/app/frontend/stylesheets/local/results_constraints.scss
+++ b/app/frontend/stylesheets/local/results_constraints.scss
@@ -36,7 +36,7 @@
     letter-spacing: $small-caps-letter-spacing;
     font-weight: $semi-bold-weight;
     margin-right: 0.66em;
-    color: $brand-dark-blue;
+    color: $shi-blackish;
     vertical-align: middle;
   }
 

--- a/app/frontend/stylesheets/local/results_constraints.scss
+++ b/app/frontend/stylesheets/local/results_constraints.scss
@@ -99,7 +99,7 @@
       }
     }
     input[type=text] {
-      border-color: $brand-light-grey;
+      border-color: $shi-bg-gray-border;
     }
   }
 

--- a/app/frontend/stylesheets/local/results_constraints.scss
+++ b/app/frontend/stylesheets/local/results_constraints.scss
@@ -53,8 +53,10 @@
   .applied-filter {
     margin-right: 0.33em;
   }
+
+  // Carot separator symbol
   .applied-filter .filter-name:after {
-    color: $brand-dark-grey;
+    color: $shi-alt-muted-text;
     font-size: 100%;
     padding-left: .5em;
     padding-right: .2em;

--- a/app/frontend/stylesheets/local/scihist_viewer.scss
+++ b/app/frontend/stylesheets/local/scihist_viewer.scss
@@ -319,7 +319,7 @@ $scihist_image_viewer_thumb_width: 54px; // Needs to match ImageServiceHelper::T
       padding: 1px;
 
       &.viewer-thumb-selected {
-        border: 2px solid $brand-yellow;
+        border: 2px solid $shi-yellow;
       }
 
       &.lazyload, &.lazyloading, &.lazyloaded {

--- a/app/frontend/stylesheets/local/search_form.scss
+++ b/app/frontend/stylesheets/local/search_form.scss
@@ -26,7 +26,7 @@
       font-weight: 300;
 
       a:not(:focus):not(:hover) {
-        color: $special-label-muted-color;
+        color: $shi-alt-muted-text;
       }
 
 

--- a/app/frontend/stylesheets/local/search_results.scss
+++ b/app/frontend/stylesheets/local/search_results.scss
@@ -156,7 +156,7 @@
 .other-searches {
   .card-header {
     text-transform: uppercase;
-    color: $brand-dark-blue;
+    color: $shi-blackish;
     font-weight: $semi-bold-weight;
     letter-spacing: $small-caps-letter-spacing;
   }

--- a/app/frontend/stylesheets/local/search_results.scss
+++ b/app/frontend/stylesheets/local/search_results.scss
@@ -160,6 +160,10 @@
   .card-header, .list-group-item {
     padding: .625rem .9375rem;
   }
+
+  .list-group {
+    font-size: 1rem; // 16px instead of 17px body font
+  }
   margin-bottom: $paragraph-spacer * 2;
 }
 

--- a/app/frontend/stylesheets/local/search_results.scss
+++ b/app/frontend/stylesheets/local/search_results.scss
@@ -260,7 +260,7 @@
     }
     .scihist-results-list-item-genre {
       @extend %special-label;
-      color: $special-label-muted-color;
+      color: $shi-alt-muted-text;
       margin-bottom: .125rem;
     }
 

--- a/app/frontend/stylesheets/local/search_results.scss
+++ b/app/frontend/stylesheets/local/search_results.scss
@@ -27,10 +27,6 @@
     color: inherit;
 
     padding: .625rem .9375rem;
-
-    &::after { // the arrow
-      color: $brand-dark-grey;
-    }
   }
 
   .card-body {

--- a/app/frontend/stylesheets/local/show.scss
+++ b/app/frontend/stylesheets/local/show.scss
@@ -10,7 +10,7 @@
 
 .show-genre {
   @extend %special-label;
-  color: $special-label-muted-color;
+  color: $shi-alt-muted-text;
   margin-bottom: .125rem;
 }
 

--- a/app/frontend/stylesheets/local/site_wide.scss
+++ b/app/frontend/stylesheets/local/site_wide.scss
@@ -124,7 +124,7 @@ hr.brand {
 }
 
 .popover-citation-help {
-  background-color: $shi-dark-blue;
+  background-color: $shi-dark-gray;
 
   .popover-body {
     font-weight: 300;
@@ -132,7 +132,7 @@ hr.brand {
   }
 
   .arrow:after {
-    border-bottom-color: $shi-dark-blue !important;
+    border-bottom-color: $shi-dark-gray !important;
   }
   a {
     color: $shi-turquoise;

--- a/app/frontend/stylesheets/local/site_wide.scss
+++ b/app/frontend/stylesheets/local/site_wide.scss
@@ -147,8 +147,8 @@ hr.brand {
 }
 
 .panel-default {
-  border-left-color: $brand-light-grey;
-  border-right-color: $brand-light-grey;
+  border-left-color: $shi-bg-gray-border;
+  border-right-color: $shi-bg-gray-border;
 }
 
 // Some custom overrides to bootstrap accordion style, to make it brand-specific

--- a/app/frontend/stylesheets/local/site_wide.scss
+++ b/app/frontend/stylesheets/local/site_wide.scss
@@ -38,7 +38,7 @@ th {
   font-family: $font-family-sans-serif;
   // Adelle font has a slightly less bold 600 that looks good.
   font-weight: 600;
-  color: $brand-dark-blue;
+  color: $shi-blackish;
 }
 
 // chemheritage.org uses these as default/standard h1-h6, but we're not
@@ -173,7 +173,7 @@ hr.brand {
         display: block;
         width: 100%;
         text-align: left;
-        color: $brand-dark-blue;
+        color: $shi-blackish;
         font-weight: bold;
 
         padding-left: 0;

--- a/app/frontend/stylesheets/local/textual_separator.scss
+++ b/app/frontend/stylesheets/local/textual_separator.scss
@@ -16,7 +16,7 @@
 .textual-separator::after {
   content: '';
   flex: 1;
-  border-bottom: 1px solid $shi-dark-blue;
+  border-bottom: 1px solid $shi-dark-gray;
 }
 
 .textual-separator:not(:empty)::before {

--- a/app/frontend/stylesheets/local/textual_separator.scss
+++ b/app/frontend/stylesheets/local/textual_separator.scss
@@ -16,7 +16,7 @@
 .textual-separator::after {
   content: '';
   flex: 1;
-  border-bottom: 1px solid $brand-dark-grey;
+  border-bottom: 1px solid $shi-dark-blue;
 }
 
 .textual-separator:not(:empty)::before {


### PR DESCRIPTION
- reduce font size so list items all fit on one line again without wrapping

I thought about changing the color of the "other search tools" header bar. It did look good aesthetically, but I think made this area TOO prominent attention-grabbing, so left it alone for now. 
