### PR TITLE
Fix between-result-item spacing (phase 2 redesign)

### DIFF
--- a/app/components/search_result/base_component.html.erb
+++ b/app/components/search_result/base_component.html.erb
@@ -85,7 +85,7 @@
       <% end %>
 
       <% if show_cart_control? %>
-        <p><%= render CartControlComponent.new(model.friendlier_id, cart_presence: cart_presence) %></p>
+        <%= render CartControlComponent.new(model.friendlier_id, cart_presence: cart_presence) %>
       <% end %>
 
     </div>

--- a/app/frontend/stylesheets/local/search_results.scss
+++ b/app/frontend/stylesheets/local/search_results.scss
@@ -172,7 +172,7 @@
 .documents-list {
   .document.scihist-results-list-item {
     display: flex;
-    margin-bottom: 2.8125rem;
+    margin-bottom: ($spacer * 4);
     border-bottom: none;
     margin-top: 0;
     padding-top: 0;

--- a/app/frontend/stylesheets/local/search_results.scss
+++ b/app/frontend/stylesheets/local/search_results.scss
@@ -309,6 +309,10 @@
       color: $shi-blackish;
       margin-right: 0.66em;
     }
+
+    .cart-toggle-form {
+      margin-top: $spacer;
+    }
   }
 }
 


### PR DESCRIPTION
remove spurious `<p>` around cart control `<div>`:

`<p>` around a `<div>` probably isn't even legal HTML, and resulted in browsers adding an extra `<p>` on the end, making controlling between-item spacing weird.

Then add whitespace above cart control with CSS. 

Then adjust between-item whitespace to add some more, with or without cart-control. 
