### PR TITLE
just a bit of space between noresults text and image

### DIFF
--- a/app/frontend/stylesheets/local/search_results.scss
+++ b/app/frontend/stylesheets/local/search_results.scss
@@ -328,6 +328,10 @@
     }
   }
 
+  .noresults-text {
+    margin-bottom: $spacer * 2;
+  }
+
   figure {
     img {
       width: 100%;


### PR DESCRIPTION
matters only on mobile screen hwere it's collapsed to one column, but it def needs it there.
