### PR TITLE
Fix cookie banner for phase 2 redesign

### DIFF
--- a/app/frontend/javascript/accept_cookies_banner.js
+++ b/app/frontend/javascript/accept_cookies_banner.js
@@ -6,12 +6,9 @@ $( document ).ready(function() {
 
 function setUpAcceptCookiesBanner() {
     if (! cookiesAlreadyAcceptedByUser()) {
-        setTimeout(function() {
             jQuery('.accept-cookies-banner-nav')
                 .css("display", "flex")
-                .hide()
-                .fadeIn(500);
-        }, 1000);
+                .show();
     }
     jQuery ('.i-accept-link').click(userAcceptsOurCookies);
 }
@@ -27,7 +24,7 @@ function userAcceptsOurCookies(event) {
         .getFullYear() + 3))
         .toString();
     document.cookie = "userAcceptsOurCookies=true; path=/; expires=" + expiratonStr
-    jQuery('.accept-cookies-banner-nav').fadeOut(1000);
+    jQuery('.accept-cookies-banner-nav').hide();
 }
 
 // This is useful for testing; just call this function

--- a/app/frontend/stylesheets/local/accept_cookies_banner.scss
+++ b/app/frontend/stylesheets/local/accept_cookies_banner.scss
@@ -1,41 +1,33 @@
 nav.accept-cookies-banner-nav {
-  display: none;
+  display: none; // will be flex when shown
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+
+  gap: $spacer * 1.5;
   min-height: 1px;
-  padding: 0;
-  align-items: stretch;
-  background-color: white;
+  padding: $spacer * 1.5;
+
+  border-top: 1px solid $shi-bg-gray-border; // to make it show up over black well
+
+  background-color:  $shi-blackish;
+  color: white;
+
+  .i-accept-copy {
+    flex-basis: 25rem;
+    flex-shrink: 0;
+    flex-grow: 1;
+  }
+
+  .i-accept-copy a {
+    color: white;
+    text-decoration: underline;
+  }
+
   div.i-accept-copy {
-    border-top: 1px solid $table-border-color;
-    line-height: 1.3;
-    padding-top: 0.05rem;
-    color: $text-muted;
+    font-size: 0.9375rem;
+    line-height: 1.2;
   }
   div.i-accept-button-div {
-    padding: 0;
-    margin: 0;
-    a.i-accept-link {
-      display: block;
-      color: white;
-      background-color: $shi-red;
-      &:hover { background-color: $shi-teal; }
-      text-decoration: none;
-      font-size: .9em;
-      font-weight: 700;
-      border: 0;
-      white-space: nowrap;
-      line-height: 3;
-
-      /* hack: for 23 pixels of width, the text wraps to *four* lines. */
-      @media only screen and (min-width: 767px) and (max-width: 790px){
-        line-height: 6 !important;
-      }
-
-      @include media-breakpoint-between(md, lg) {
-         line-height: 5;
-      }
-      @include media-breakpoint-between(xs, sm) {
-        margin-top:0.5rem;
-      }
-    }
   }
 }

--- a/app/views/application/_accept_cookies_banner.html.erb
+++ b/app/views/application/_accept_cookies_banner.html.erb
@@ -1,23 +1,22 @@
 <% unless Rails.application.config.hide_accept_cookies_banner %>
 
-    <nav class="navbar fixed-bottom accept-cookies-banner-nav"
+    <nav class="fixed-bottom accept-cookies-banner-nav"
         role="dialog" aria-live="polite" aria-label="Accept Cookies"
         aria-describedby="accept-cookies-copy" >
 
-        <div class="col-md-10 i-accept-copy" id="accept-cookies-copy">
-            This website uses cookies to perform analytics,
-            improve functionality, and enhance user experience.
-            You may set your browser to
+        <div class="i-accept-copy" id="accept-cookies-copy">
+            This website uses cookies to perform analytics, improve functionality, and enhance user experience. You may set your browser to
             <a href="https://www.wikihow.com/Disable-Cookies">decline cookies</a>,
             but some content on our site may not display properly.
+
             For more information, please visit our
-            <a href="https://www.sciencehistory.org/site-terms">privacy policy</a>.
+            <a href="https://www.sciencehistory.org/privacy-policy/">privacy policy</a>.
         </div>
 
-        <div class="col-md-2 i-accept-button-div text-center">
-            <a href="#" class="i-accept-link"
+        <div class="i-accept-button-div text-center">
+            <a href="#" class="i-accept-link btn btn-emphasis"
                 role="button"
-                tabindex="0">I Accept</a>
+                tabindex="0">Accept</a>
         </div>
 
     </nav>


### PR DESCRIPTION
- model cookie banner on new site cookie banner, but no decline button (yet). See #2167 
- remove fade in/out on cookie banner -- matches new site and less annoying
