### PR TITLE
MAIN action buttons back to prominent yellow color, et al

### DIFF
--- a/app/components/download_dropdown_component.rb
+++ b/app/components/download_dropdown_component.rb
@@ -135,7 +135,7 @@ class DownloadDropdownComponent < ApplicationComponent
       )
     else
       content_tag("button",
-        "<i class='fa fa-download' aria-hidden='true'></i> Download".html_safe,
+        "Download".html_safe,
         link_or_button_options
       )
     end

--- a/app/components/download_dropdown_component.rb
+++ b/app/components/download_dropdown_component.rb
@@ -40,7 +40,7 @@
 # (This is a bit hacky)
 #
 class DownloadDropdownComponent < ApplicationComponent
-  attr_reader :display_parent_work, :asset, :aria_label
+  attr_reader :display_parent_work, :asset, :aria_label, :btn_class_name
 
 
   # @param asset [Asset] asset to display download links for
@@ -57,11 +57,14 @@ class DownloadDropdownComponent < ApplicationComponent
   # @param aria_label [String] aria_label for the primary "Download" button, we
   #   use to make it more specific like "Download Image 1" to avoid tons of
   #   identical "Download" buttons on page.
+  # @param btn_class_name [String] default "btn-brand-alt", but maybe you want "btn-brand-main".
+  #   The specific btn theme added on to bootstrap `btn` that will be there anyway.
   def initialize(asset,
       display_parent_work:,
       use_link: false,
       viewer_template: false,
-      aria_label: nil)
+      aria_label: nil,
+      btn_class_name: "btn-brand-alt")
 
     if viewer_template
       raise ArgumentError.new("asset must be nil if template_only") unless asset.nil?
@@ -73,6 +76,7 @@ class DownloadDropdownComponent < ApplicationComponent
     @use_link = use_link
     @asset = asset
     @aria_label = aria_label
+    @btn_class_name = btn_class_name
   end
 
   def call
@@ -169,7 +173,7 @@ class DownloadDropdownComponent < ApplicationComponent
       if viewer_template_mode?
         options[:class] = "btn btn-emphasis btn-lg dropdown-toggle"
       else
-        options[:class] = "btn btn-brand-alt dropdown-toggle"
+        options[:class] = "btn #{btn_class_name} dropdown-toggle"
       end
     end
     options

--- a/app/components/member_image_component.rb
+++ b/app/components/member_image_component.rb
@@ -156,15 +156,23 @@ class MemberImageComponent < ApplicationComponent
     end
   end
 
+  # use brand-main for large size thumb, otherwise brand-alt
+  def btn_class_name
+    @btn_class_name ||= (size == :large) ? "btn-brand-main" : "btn-brand-alt"
+  end
+
   def download_button
-    render DownloadDropdownComponent.new(representative_asset, display_parent_work: member.parent, aria_label: ("Download #{image_label}" if image_label))
+    render DownloadDropdownComponent.new(representative_asset,
+                                          display_parent_work: member.parent,
+                                          aria_label: ("Download #{image_label}" if image_label),
+                                          btn_class_name: btn_class_name)
   end
 
   def view_button
     content_tag("div", class: "action-item view") do
       content_tag("a",
         href: view_href,
-        class: "btn btn-brand-alt",
+        class: "btn #{btn_class_name}",
         data: view_data_attributes) do
           "<i class='fa fa-search' aria-hidden='true'></i> View".html_safe
       end
@@ -200,7 +208,7 @@ class MemberImageComponent < ApplicationComponent
     return "" unless member.kind_of?(Work)
 
     content_tag("div", class: "action-item info") do
-      link_to "Info", work_path(member), class: "btn btn-brand-alt", "aria-label" => ("Info on #{member.title}" if member.is_a?(Work))
+      link_to "Info", work_path(member), class: "btn #{btn_class_name}", "aria-label" => ("Info on #{member.title}" if member.is_a?(Work))
     end
   end
 

--- a/app/components/member_image_component.rb
+++ b/app/components/member_image_component.rb
@@ -174,7 +174,7 @@ class MemberImageComponent < ApplicationComponent
         href: view_href,
         class: "btn #{btn_class_name}",
         data: view_data_attributes) do
-          "<i class='fa fa-search' aria-hidden='true'></i> View".html_safe
+          "View".html_safe
       end
     end
   end

--- a/app/frontend/stylesheets/local/work_show.scss
+++ b/app/frontend/stylesheets/local/work_show.scss
@@ -195,6 +195,14 @@
     }
   }
 
+  // a bit more space on action buttons in main large hero image
+  .show-hero .member-image-presentation .action-item-bar {
+    margin-top: 0.5rem;
+    .action-item:not(:last-child) {
+      margin-right: 0.5rem;
+    }
+  }
+
   // A label indicating the thumbnail belongs to a private item.
   .private-badge-div {
     position: absolute;

--- a/spec/components/download_dropdown_component_spec.rb
+++ b/spec/components/download_dropdown_component_spec.rb
@@ -31,7 +31,6 @@ describe DownloadDropdownComponent, type: :component do
     end
   end
 
-
   describe "with image file and derivatives" do
     let(:asset) do
       create(:asset_with_faked_file,
@@ -63,6 +62,28 @@ describe DownloadDropdownComponent, type: :component do
       expect(sample_download_option["data-analytics-label"]).to eq(asset.parent.friendlier_id)
     end
   end
+
+  describe "with btn_class_name" do
+    let(:asset) do
+      create(:asset_with_faked_file,
+        faked_derivatives: {
+          download_small: build(:stored_uploaded_file)
+        },
+        parent: build(:work)
+      )
+    end
+
+    let(:custom_class_name) { "btn-brand-main" }
+    let(:rendered) { render_inline(DownloadDropdownComponent.new(asset, display_parent_work: asset.parent, btn_class_name: custom_class_name)) }
+
+    it "renders proper btn class in html" do
+      btn = div.at_css("button.btn")
+
+      expect(btn).to be_present
+      expect(btn.classes).to include(custom_class_name)
+    end
+  end
+
 
   describe "with a PDF file" do
     let(:asset) do


### PR DESCRIPTION
The Download and View acitons are the most important suspected popular actions on the page, they were getting outshown by other yellow buttons on the page (eg download trasncription/translation pdf), they should be yellow too. 

The 'download' button on smaller thumbs remains less prominent teal. 

A few other tweaks to these buttons while looking at them. 

- DownloadDropdownComponent allows custom CSS btn class arg
- use main yellow buttons for MAIN image action buttons
- a bit more spacing on large main hero image action buttons
- remove icons on download/view buttons. Take up valuable space on small screens especially with increased padding, unclear if they add anything.
