### PR TITLE
Add more margin under bottom pagination

### DIFF
--- a/app/frontend/stylesheets/local/search_results.scss
+++ b/app/frontend/stylesheets/local/search_results.scss
@@ -152,6 +152,9 @@
     display: none;
   }
 }
+.bottom-pagination {
+  margin-bottom: $spacer * 2;
+}
 
 
 

--- a/app/views/catalog/_results_pagination.html.erb
+++ b/app/views/catalog/_results_pagination.html.erb
@@ -3,11 +3,11 @@
 <% if show_pagination? and @response.total_pages > 1 %>
     <%# expanded will be shown by CSS at large screen sizes, else compact %>
 
-    <div class="pagination pagination-alt-expanded">
+    <div class="pagination bottom-pagination pagination-alt-expanded">
       <%= paginate @response, :window => 3, :outer_window => 1, :theme => 'local' %>
     </div>
 
-    <div class="pagination pagination-alt-compact">
+    <div class="pagination bottom-pagination pagination-alt-compact">
       <%= paginate @response, :page_entries_info => page_entries_info(@response), :theme => 'blacklight_compact' %>
     </div>
 

--- a/app/views/catalog/_results_pagination.html.erb
+++ b/app/views/catalog/_results_pagination.html.erb
@@ -1,8 +1,6 @@
 <%# overridden from Blacklight to use customized kaminari theme, and have different pagination at small screen size -%>
 
 <% if show_pagination? and @response.total_pages > 1 %>
- <div class="row record-padding">
-  <div class="col-md-12">
     <%# expanded will be shown by CSS at large screen sizes, else compact %>
 
     <div class="pagination pagination-alt-expanded">
@@ -12,7 +10,6 @@
     <div class="pagination pagination-alt-compact">
       <%= paginate @response, :page_entries_info => page_entries_info(@response), :theme => 'blacklight_compact' %>
     </div>
-  </div>
- </div>
+
 <% end %>
 


### PR DESCRIPTION
Also remove some spurious bootstrap wrapper classes that i noticed weren't making any difference. 

@eddierubeiz Earlier we changed the "highlight" color for current page to red. I think that, together with this extra whitespace to set it off, makes the bottom pagination much more visible/prominent, and may take care of the issue you noted with it being too subtle and easily messed.  But please let me know what you think!

- remove bootstrap row/col that I don't think was doing anything useful
- add more margin under lower pagination
