### PR TITLE
Keep museum hours from wrapping on various screen sizes

### DIFF
--- a/app/frontend/stylesheets/local/scihist_masthead.scss
+++ b/app/frontend/stylesheets/local/scihist_masthead.scss
@@ -129,6 +129,13 @@
         margin-right: .5em
     }
 
+    @media screen and (max-width: 1158px) {
+        // give it more space at smaller screen size, so it doesn't wrap.
+        .shi-top-bar__hours {
+            max-width: 47%;
+        }
+    }
+
     @media screen and (max-width: 991px) {
         // at this screen-size, we copy this to a different part of the DOM
         // top show in the collapsable menu, we don't want it here at all.

--- a/app/frontend/stylesheets/local/scihist_masthead.scss
+++ b/app/frontend/stylesheets/local/scihist_masthead.scss
@@ -136,6 +136,11 @@
             display: none;
         }
 
+        .shi-top-bar {
+            padding-left: 1rem;
+            padding-right: 1rem;
+        }
+
         .shi-top-bar .shi-top-bar__hours {
             width: 100%;
             font-size: .89375em;
@@ -149,6 +154,13 @@
             top: 0;
             bottom: 0;
             left: -9999px
+        }
+    }
+
+    @media screen and (max-width: 575px) {
+        // ensure "museum hours" does NOT wrap on very small screens
+        .shi-top-bar .shi-top-bar__hours {
+            font-size: 0.8125rem; // 13px
         }
     }
 


### PR DESCRIPTION
- follow mainsite lead in keeping museum hours from wrapping on very small screens
  - copied from main website, at very very small screens (when museum hours is whole top bar), font and padding need to be reduced to fit it

- keep museum hours from wrapping at medium size where there is still two columns of top bar
  - an improvement on main site. At "medium" sizes where there are still top nav links next to museum hours, museum hours needs to be allowed to take up more of screen, to allow both sides room without wrapping
