### PR TITLE
Adjust link styles for phase 2 redesign

### DIFF
--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -200,7 +200,7 @@ $dark: $shi-dark-gray;
 $tooltip-bg: $shi-blackish;
 
 $link-color: $shi-blue-text;
-$link-hover-color: $shi-blackish;
+$link-hover-color: black;
 $font-family-sans-serif: $brand-sans-serif;
 // default bootstrap code color is a pink. use brand red? Or something else?
 $code-color: $shi-red;

--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -85,7 +85,9 @@ $shi-transparent-dark-bg: #{'rgba(30,36,42,.80)'};
 
 // Not official brand color, but at the moment we're using for links. Goes together
 // okay, a varient of previous brand colors.
-$shi-blue-text: #007FAA;
+// was: #007FAA;
+// Changed to one similar but closer to shi-teal.
+$shi-blue-text: #217391;
 
 // We need a medium grey for muted text, without a really good one in
 // brand color. We slightly lighten the darkest brand-grey.

--- a/app/frontend/stylesheets/local/attribute_table.scss
+++ b/app/frontend/stylesheets/local/attribute_table.scss
@@ -24,6 +24,10 @@ $attribute-table-max-tabular: 22.5em;
     padding: 0.3em; // 5px at 17px font em
   }
 
+  a {
+    text-decoration-line: underline;
+  }
+
 
   // small, break down table
   @media (max-width: $attribute-table-max-tabular) {

--- a/app/frontend/stylesheets/local/collection_show.scss
+++ b/app/frontend/stylesheets/local/collection_show.scss
@@ -147,6 +147,10 @@
       flex-grow: 1;
       flex-basis: 17rem;
       min-width: 17rem;
+
+      a {
+        @extend .text-link;
+      }
     }
 
 

--- a/app/frontend/stylesheets/local/collection_show.scss
+++ b/app/frontend/stylesheets/local/collection_show.scss
@@ -107,6 +107,10 @@
 
     .collection-description-text {
       max-width: $max-readable-width;
+
+      a {
+        @extend .text-link;
+      }
     }
 
     .collection-description-text.short-text {

--- a/app/frontend/stylesheets/local/oral_history_splash.scss
+++ b/app/frontend/stylesheets/local/oral_history_splash.scss
@@ -59,6 +59,9 @@
   .collection-description {
     a {
       color: $shi-yellow;
+      &:hover {
+        text-decoration-color: $shi-yellow;
+      }
     }
   }
 

--- a/app/frontend/stylesheets/local/search_results.scss
+++ b/app/frontend/stylesheets/local/search_results.scss
@@ -311,6 +311,9 @@
         text-indent: -0.66em;
         margin-bottom: $paragraph-spacer * 0.125; // divided by 8 without using deprecated `/`
       }
+      a {
+        text-decoration-line: underline;
+      }
     }
 
     .attribute-label {

--- a/app/frontend/stylesheets/local/site_wide.scss
+++ b/app/frontend/stylesheets/local/site_wide.scss
@@ -19,6 +19,24 @@ a:hover {
   text-decoration-color: $shi-red;
 }
 
+// a link class from main site that we use where we can, especially in "text blocks"
+// Use SCSS to apply this to certain areas, like:
+//
+//     .some-container {
+//        a {
+//          @extend .text-link;
+//        }
+//      }
+.text-link {
+  font-weight: bold;
+  color: black;
+  text-decoration: underline $shi-red;
+
+  &:hover, &:active {
+    color: $shi-red;
+  }
+}
+
 /* informational dls, as on faq, policy page, give them more space */
 dl.info {
   dt {
@@ -128,6 +146,10 @@ hr.brand {
   h1, h2, h3, h4, h5 {
     margin-top: 2rem;
     margin-bottom: 1rem;
+  }
+
+  a {
+    @extend .text-link;
   }
 }
 

--- a/app/frontend/stylesheets/local/site_wide.scss
+++ b/app/frontend/stylesheets/local/site_wide.scss
@@ -14,6 +14,11 @@ a {
   transition: color 0.25s ease;
 }
 
+// override bootstrap to have different text-decoration-color than text color on hover
+a:hover {
+  text-decoration-color: $shi-red;
+}
+
 /* informational dls, as on faq, policy page, give them more space */
 dl.info {
   dt {

--- a/app/frontend/stylesheets/local/work_show.scss
+++ b/app/frontend/stylesheets/local/work_show.scss
@@ -35,6 +35,10 @@
     margin: ($paragraph-spacer * 2) 0;
   }
 
+  .work-description a {
+    @extend .text-link;
+  }
+
   .work-description p {
     margin-top: $paragraph-spacer;
     max-width: $max-readable-width;


### PR DESCRIPTION
Tweak default link style to use a blue that's a bit closer to brand teal, and be black with red underline on hover. This will be used for "control" links like pagination/facet sidebar, and in general be default unless we override. 

Create a "text link style" that is bold black with red underline. Use on text pages (FAQ, rights, etc); on collection and work descriptions (eg https://staging-digital.sciencehistory.org/collections/zya6k9v and https://staging-digital.sciencehistory.org/works/rr171x691), etc. 

This leaves our "metadata property links" though -- which are probably the most common links on our most common pages. 

* "text style" when I tried it just seemed to be way too busy and hard to read to me (although I can demo it again if you're intersted)
* But I was worried for accessibility making these apparent as links with color difference _alone_ was not enough
* So currently trying them out as blue, but _with underline_.  Is this too busy? It's less busy to me than bold black with red underline! eg https://staging-digital.sciencehistory.org/catalog?q=chemistry https://staging-digital.sciencehistory.org/works/zl1tpkz


- slightly change custom blue link-color to be closer to brand teal
- make link hover black instead of blackish, easier to read
- make standard bootstrap link hover have RED underline, fits in with our brand theme better and looks nice
- .text-link style matching main site -- use on text pages
- use text-link style on work and collection description
- add text-link style to collection funding credit links
- tweak oral history splash description link
- metadata attribute links are underlined
