### PR TITLE
make navbar links somewhat smaller, matching main site better

### DIFF
--- a/app/frontend/stylesheets/local/scihist_masthead.scss
+++ b/app/frontend/stylesheets/local/scihist_masthead.scss
@@ -392,6 +392,10 @@
         .header__right-side {
             padding: 0
         }
+        // This is actually the main size of header nav links at any non-huge screen size!
+        .header__nav ul li a {
+            font-size: 0.96rem; // ~ 15.36px
+        }
     }
 
 


### PR DESCRIPTION
15.4px at most common screen sizes, believe it or not.

Thought about making them even smaller than main site, but more or less matched instead.
