### PR TITLE
Adjust padding/margins/alignment on collection show page (redesign)

### DIFF
--- a/app/frontend/stylesheets/_mixins.scss
+++ b/app/frontend/stylesheets/_mixins.scss
@@ -56,6 +56,14 @@
   }
 }
 
+// A trick to make a div go to full viewport width, even though it's parent is constrained, say,
+// with padding to match bootstrap grid, this makes it go outside it's parent to be full-bleed
+// full-screen.
+@mixin full-bleed {
+    margin-left: calc(50% - 50vw);
+    margin-right: calc(50% - 50vw);
+}
+
 %special-label{
   font-family: $brand-sans-serif;
   font-weight: $semi-bold-weight;
@@ -67,5 +75,6 @@
     color: $shi-alt-muted-text;
   }
 }
+
 
 

--- a/app/frontend/stylesheets/local/collection_show.scss
+++ b/app/frontend/stylesheets/local/collection_show.scss
@@ -89,7 +89,7 @@
       margin-bottom: ($spacer * 2);
     }
   }
-  .collection-header-title, .collection-description {
+  .collection-header-title, .collection-description, .related-links {
     padding-left: 3.5vw;
     padding-right: 4.5vw;
   }
@@ -164,6 +164,7 @@
 
   .related-links {
     max-width: $max-readable-width;
+    box-sizing: content-box;
   }
 
   // match work-show, for our related links

--- a/app/frontend/stylesheets/local/collection_show.scss
+++ b/app/frontend/stylesheets/local/collection_show.scss
@@ -151,6 +151,11 @@
 
     @include media-breakpoint-down(sm) {
       flex-direction: column;
+
+      .collection-description, .related-links {
+        padding-left: 0;
+        padding-right: 0;
+      }
     }
 
     @include media-breakpoint-up(md) {

--- a/app/frontend/stylesheets/local/collection_show.scss
+++ b/app/frontend/stylesheets/local/collection_show.scss
@@ -14,6 +14,8 @@
     @include media-breakpoint-down(sm) {
       flex-direction: column;
 
+      @include full-bleed;
+
       .collection-header-title {
         order: 2;
         padding-top: ($spacer * 2);

--- a/app/frontend/stylesheets/local/collection_show.scss
+++ b/app/frontend/stylesheets/local/collection_show.scss
@@ -22,7 +22,7 @@
       .collection-header-thumb img {
         object-fit: cover;
         width: 100%;
-        max-height: 12rem;
+        max-height: 18rem;
       }
     }
 

--- a/app/frontend/stylesheets/local/collection_show.scss
+++ b/app/frontend/stylesheets/local/collection_show.scss
@@ -89,9 +89,9 @@
       margin-bottom: ($spacer * 2);
     }
   }
-  .collection-header-title {
+  .collection-header-title, .collection-description {
     padding-left: 3.5vw;
-    padding-right: 3.5vw;
+    padding-right: 4.5vw;
   }
   .collection-mini-header {
     padding: $spacer;
@@ -153,7 +153,6 @@
 
     @include media-breakpoint-up(md) {
       .collection-description {
-        padding-right: 3.5vw;
         width: 60%;
         flex-grow: 1; // can take more space if funding is not present
       }

--- a/app/frontend/stylesheets/local/oh_audio.scss
+++ b/app/frontend/stylesheets/local/oh_audio.scss
@@ -40,10 +40,8 @@
     // https://stackoverflow.com/questions/30533055/calculating-shadow-values-for-all-material-design-elevations
     box-shadow: 0px 3px 3px -2px rgba(0, 0, 0, 0.2), 0px 3px 4px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
 
-    // Make it go to full viewport width, even though it's parent is constrained
-    // with padding to match bootstrap grid.
-    margin-left: calc(50% - 50vw);
-    margin-right: calc(50% - 50vw);
+    @include full-bleed;
+
     @include media-breakpoint-up(md) {
       padding-left: $grid-gutter-width * 0.5;
       padding-right: $grid-gutter-width * 0.5;


### PR DESCRIPTION
Per https://github.com/sciencehistory/scihist_digicoll/issues/2119#issuecomment-1588023791 and some other adjustments begged by that change and while i'm looking at it

- collection show, make description text edges line up with title/searchbox inside shaded box
- increase height of hero image on collapsed one-column collection show view
- line related links up with edge of text from earlier description
- extract full-bleed to a mixin
- make collection description full-bleed at small screen one-column collapse
- at small-screen one-column collapse, remove paddings from collection description that is NOT in shaded box
