### PR TITLE
Update to new typekit web project with ONLY sufia pro

### DIFF
--- a/app/frontend/stylesheets/_variables.scss
+++ b/app/frontend/stylesheets/_variables.scss
@@ -116,9 +116,9 @@ $small-caps-letter-spacing: 0.035em;
 
 $brand-alt-header-weight: 900;
 
-// adelle-sans has a 600 semi-bold available. 700 is standard bold. 500 seems to be the same as 400=normal.
+// sofia pro has a 600 semi-bold available. 700 is standard bold. A 500 "medium" is also available
 $semi-bold-weight: 600;
-$badge-font-weight: $semi-bold-weight; // badges look better at our semi-bold with adelle-sans!
+$badge-font-weight: $semi-bold-weight; // bootstrap badges bold by default but look better at our semi-bold
 
 $large-blurb-font-size: 1.25rem; // perhaps will match $h5-font-size
 

--- a/app/frontend/stylesheets/local/site_wide.scss
+++ b/app/frontend/stylesheets/local/site_wide.scss
@@ -48,10 +48,10 @@ dl.info {
   }
 }
 
-// the adelle-sans font has a really nice semi-bold at font-weight 600
+// sofia-pro font has a really nice semi-bold at font-weight 600
 // let's supplement bootstrap;s font-weight-bold
 .font-weight-semi-bold {
-  font-weight: 600 !important;
+  font-weight: $semi-bold-weight !important;
 }
 
 form label {
@@ -60,8 +60,8 @@ form label {
 
 th {
   font-family: $font-family-sans-serif;
-  // Adelle font has a slightly less bold 600 that looks good.
-  font-weight: 600;
+  // Sofia-pro font has a slightly less bold 600 that looks good.
+  font-weight: $semi-bold-weight;
   color: $shi-blackish;
 }
 

--- a/app/views/errors/internal_error.html.erb
+++ b/app/views/errors/internal_error.html.erb
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta charset='utf-8'>
   <%= vite_stylesheet_tag 'application.scss', media: "all" %>
-  <link rel="stylesheet" href="https://use.typekit.net/flv8jrh.css">
+  <link rel="stylesheet" href="https://use.typekit.net/dlz1uwu.css">
 </head>
 <body class='error-page s500'>
 

--- a/app/views/layouts/_head_tag_common.html.erb
+++ b/app/views/layouts/_head_tag_common.html.erb
@@ -1,9 +1,9 @@
 <%# original from chf_sufia ./app/views/_head_tag_extras.html.erb %>
 
-<%# our custom fonts: abril text; adelle sans; sofia pro
+<%# our custom fonts: sofia pro
     From Adobe Fonts account AdobeWebFonts@sciencehistory.org
-    Web Project: 2023 Digital Collections Fonts %>
-<link rel="stylesheet" href="https://use.typekit.net/flv8jrh.css">
+    Web Project: 2023-June Digital Collections Fonts %>
+<link rel="stylesheet" href="https://use.typekit.net/dlz1uwu.css">
 
 <%# favicons for various platforms generated from:
     https://realfavicongenerator.net/favicon_result?file_id=p1c51efkq01d00ttb19efo6ov4c6#.Wm9W45M-dBw %>


### PR DESCRIPTION
We no longer use any of hte old fonts (adelle and abril), we don't need them in the typekit project to be loaded. 

Also remove any references to old fonts that were left in comments. 
