### PR TITLE
be more limited in where we auto-apply the text-link link style

### DIFF
--- a/app/frontend/stylesheets/local/site_wide.scss
+++ b/app/frontend/stylesheets/local/site_wide.scss
@@ -22,6 +22,8 @@ a {
 //          @extend .text-link;
 //        }
 //      }
+//
+// Or apply to individual <a class="text-link"> directly
 .text-link {
   font-weight: bold;
   color: black;
@@ -31,9 +33,9 @@ a {
     color: $shi-red;
   }
 }
-// and since it's meant for text, let's give <p> tag links it by default?
-// hope this doesn't overshoot
-p a {
+// and since it's meant for text, let's give <p> tag links it by default, limited
+// in an attempt not to overshoot.
+p > a:not(.btn) {
   @extend .text-link;
 }
 


### PR DESCRIPTION
It was appylying on top of a .btn in the admin screen, which was wrong. Now only if a DIRECT descendent of a <p> as well as not .btn class, to try to keep the red underline from accidentally applying to any bootstrap styled controls etc
