### PR TITLE
Default text-link style to p was catching OH born on this day which we didn't want

### DIFF
--- a/app/frontend/stylesheets/local/oral_history_splash.scss
+++ b/app/frontend/stylesheets/local/oral_history_splash.scss
@@ -164,6 +164,8 @@
         width: $standard-thumb-width;
       }
       .this-day-label {
+        display: block;
+
         font-family: $brand-sans-serif;
         font-weight: $semi-bold-weight;
         text-transform: uppercase;

--- a/app/frontend/stylesheets/local/site_wide.scss
+++ b/app/frontend/stylesheets/local/site_wide.scss
@@ -33,9 +33,10 @@ a {
     color: $shi-red;
   }
 }
-// and since it's meant for text, let's give <p> tag links it by default, limited
-// in an attempt not to overshoot.
-p > a:not(.btn) {
+// and since it's meant for text, let's give <p> tag links it by default. Can opt-out
+// by putting class .default-link-style. We may still be overshooting and styling
+// more than we want.
+p > a:not(.btn,.default-link-style) {
   @extend .text-link;
 }
 

--- a/app/views/collection_show_controllers/oral_history_collection/_splash_page.html.erb
+++ b/app/views/collection_show_controllers/oral_history_collection/_splash_page.html.erb
@@ -110,12 +110,10 @@ we want the full width of the screen, no margins or padding. %>
                 <% end %>
               <% end %>
 
-              <p class="this-day-label">
-                <%= link_to work_path(bio.oral_history_content.first.work) do %>
-                  <%= bio.name %><br>
-                  Born <%= FormatSimpleDate.new(bio.birth.date).display  %>
-                <% end %>
-              </p>
+              <%= link_to work_path(bio.oral_history_content.first.work), class: "default-link-style, this-day-label" do %>
+                <%= bio.name %><br>
+                Born <%= FormatSimpleDate.new(bio.birth.date).display  %>
+              <% end %>
 
               <% if bio.oral_history_content.first.work&.leaf_representative&.content_type.blank? ||
                     bio.oral_history_content.first.work&.leaf_representative&.content_type == "application/pdf" %>


### PR DESCRIPTION
Provide a CSS class to opt-out, but in this case actually making the <a> block level and not inside a <p> gives a bigger link target and works better anyway, so did that. 
