### PR TITLE
Keep header nav sizes from getting too big

### DIFF
--- a/app/frontend/stylesheets/local/scihist_masthead.scss
+++ b/app/frontend/stylesheets/local/scihist_masthead.scss
@@ -23,19 +23,16 @@
 
 
 
-    // This only ends up used at screens larger htan 1199px (see below)
     //
-    // We've hacked it from original source to be similar but better, using min and max
+    // We've hacked it from original source to be similar but simpler, using min and max
     // which seems to have browser support.
     //
     //  Base of 1.389vw (from original)
     //
     // But no bigger than 20px -- which the original did with a media query at 1440px
-    // And no smaller than 1.19rem, which avoids a discontinuity at 1199px, where
-    // previously font was getting smaller before getting larger again.
     //
     // This base font is used for a lot of other things expressed in ems
-    font-size: max(min(1.389vw, 20px), 1.19rem);
+    font-size: min(1.389vw, 20px);
 
     @media screen and (max-width: 1199px) {
         font-size:1.6vw

--- a/app/frontend/stylesheets/local/scihist_masthead.scss
+++ b/app/frontend/stylesheets/local/scihist_masthead.scss
@@ -17,7 +17,11 @@
 */
 
 #shi-masthead-from-main-website {
-    font: normal 400 1em/1.2 "sofia-pro","sans-serif";
+    // re-set font on this wrapper, to 1rem etc -- so SCSS in following in terms of `em` is
+    // in terms of this, that we reset.
+    font: normal 400 1rem/1.2 "sofia-pro","sans-serif";
+
+
 
     // This only ends up used at screens larger htan 1199px (see below)
     //

--- a/app/frontend/stylesheets/local/scihist_masthead.scss
+++ b/app/frontend/stylesheets/local/scihist_masthead.scss
@@ -35,7 +35,9 @@
     font-size: min(1.389vw, 20px);
 
     @media screen and (max-width: 1199px) {
-        font-size:1.6vw
+        // added `max` to keep it from getting too big where there's a discontinuity where it then
+        // gets small again, don't know what's going on.
+        font-size: min(1.6vw, 1.045rem);
     }
 
     line-height: 1.2;


### PR DESCRIPTION
The header nav size CSS we copied from main site is responsive to screen size in really complex ways with interacting rules, probably more than is needed. But we copied it, and then modified it to simplify it somewhat, but still have a lot of complexity. 

There were some screen size cases where we were getting way BIGGER than main site, which we tried to correct. 

And other cases where main site was in my opinion too big -- like as you drag screen bigger, it got bigger, and then smaller again, a discontinuity. Which we tried to fix to keep things more consistent, no need for that jump in bigness.

Basically, this is too complex, but seems to be working better after this. Made sure to drag screen size all over the place while watching it.  

- reset to rem instead of em, for consistent reliable reset. We don't want things we're setting on body to affect it.
- eliminate extra hack with additional  that we don't seem to have needed? I can't find it doing anything anywhere.
- keep nav links from getting too big before a discontinuity where they get smaller again as screen gets bigger
