### PR TITLE
Remove focus style from viewer prev/next button

### DIFF
--- a/app/frontend/stylesheets/local/scihist_viewer.scss
+++ b/app/frontend/stylesheets/local/scihist_viewer.scss
@@ -170,7 +170,7 @@ $scihist_image_viewer_thumb_width: 54px; // Needs to match ImageServiceHelper::T
         }
       }
 
-      &:hover, &:focus {
+      &:hover {
         i {
           background-color: transparentize($shi-yellow, 0.2);
           border-color: #212529; // darken($shi-yellow, 12%);


### PR DESCRIPTION
I added it as part of redesign here: https://github.com/sciencehistory/scihist_digicoll/commit/03bb45780765ce64af132eff8bf343e49bffb32c#diff-173b38230ffe4b45b5d92bb4269328451fb352aab4e89153fdb3e6b22f7e8a1cR173

I thought it might be good for accessibility. But it's resulted in soemwhat annoying behavior where after you press a next or previous button, it remains yellow until you manage to remove the focus elsewhere. This is annoying. I'm not sure what the right thing to do is, but when unsure let's just undo that thing I did, put it back to how it was before that part of redesign.
