### PR TITLE
Update content for Oral History requests

### DIFF
--- a/app/components/video_test.html
+++ b/app/components/video_test.html
@@ -1,0 +1,31 @@
+
+<head>
+  <link href="https://vjs.zencdn.net/8.3.0/video-js.css" rel="stylesheet" />
+
+  <!-- If you'd like to support IE8 (for Video.js versions prior to v7) -->
+  <!-- <script src="https://vjs.zencdn.net/ie8/1.1.2/videojs-ie8.min.js"></script> -->
+</head>
+
+<body>
+  <video
+    id="my-video"
+    class="video-js"
+    controls
+    preload="auto"
+    width="640"
+    height="264"
+    poster="MY_VIDEO_POSTER.jpg"
+    data-setup="{}"
+  >
+    <source src="https://samplelib.com/lib/preview/mp4/sample-5s.mp4" type="video/mp4" />
+    <p class="vjs-no-js">
+      To view this video please enable JavaScript, and consider upgrading to a
+      web browser that
+      <a href="https://videojs.com/html5-video-support/" target="_blank"
+        >supports HTML5 video</a
+      >
+    </p>
+  </video>
+
+  <script src="https://vjs.zencdn.net/8.3.0/video.min.js"></script>
+</body>

--- a/app/components/work_file_list_show_component.html.erb
+++ b/app/components/work_file_list_show_component.html.erb
@@ -29,35 +29,55 @@
     <% if available_by_request_assets.present? %>
       <h2 class="attribute-sub-head mt-0">Access this interview</h2>
       <div class="show-sub-head-body request-section">
-        <div class="pr-2">
+        <div class="pr-2 mt-3">
 
-
-          <p>Available upon request
-            <%= multiple_files? ? "are" : "is" %>
-            <%= available_by_request_summary %>.
+            <% if @work.oral_history_content.available_by_request_automatic? %>
+              <p>
+                Fill out a brief form to <span class="text-danger">receive immediate access</span> to these files.
+              </p>
+            <% else %>
+              <p>Fill out a brief form and a staff member will review your request for these files.
+                 <span class="text-danger">You should receive an email within 3 business days</span>.
+              </p>
+            <% end %>
           </p>
 
-          <div class="text-nowrap mb-3 text-center">
-            <%= link_to "Request Access",
+          <ul class="list-unstyled by-request-file-list">
+            <% if available_by_request_pdf_count.nonzero? %>
+              <li>
+                <i class="fa fa-file-pdf-o" aria-hidden="true"></i>
+                <%= available_by_request_pdf_count %> PDF Transcript <%= "File".pluralize(available_by_request_pdf_count) %>
+              </li>
+            <% end %>
+
+            <% if available_by_request_audio_count.nonzero? %>
+              <li>
+                <i class="fa fa-file-audio-o" aria-hidden="true"></i>
+                <%= available_by_request_audio_count %> Audio Recording <%= "File".pluralize(available_by_request_audio_count) %>
+              </li>
+            <% end %>
+
+            <% if available_by_request_pdf_count.zero? && available_by_request_audio_count.zero? %>
+              <li><span class="text-danger">No files available? Something has gone wrong with our system!</span>/li>
+            <% end %>
+          </ul>
+
+          <% unless @work.oral_history_content.available_by_request_automatic? %>
+            <p>Usage is subject to restrictions set by the interviewee.</p>
+          <% end %>
+
+          <div class="text-nowrap mt-4 mb-3 text-center">
+            <%= link_to request_button_name,
               request_oral_history_access_form_path(@work.friendlier_id),
               class: "btn btn-brand-main mb-2"
             %>
           </div>
 
+          <p class="alert alert-primary mt-4 mb-4">
+            If you have any questions about transcripts, recordings, or usage permissions, contact the Center for Oral History at
+            <%= link_to ScihistDigicoll::Env.lookup!(:oral_history_email_address), "mailto:#{ScihistDigicoll::Env.lookup!(:oral_history_email_address)}", class: "alert-link" %>.
+          </p>
 
-          <% if @work.oral_history_content.available_by_request_automatic? %>
-            <p class="alert alert-primary">After submitting a brief form, you will receive immediate access to
-              <%= multiple_files? ? "these files" : "this file" %>.
-              If you have any questions about transcripts, recordings, or usage permissions, contact the Center for Oral History at <%= link_to ScihistDigicoll::Env.lookup!(:oral_history_email_address), "mailto:#{ScihistDigicoll::Env.lookup!(:oral_history_email_address)}", class: "alert-link" %>.
-            </p>
-          <% else # manual review %>
-            <div class="alert alert-primary">
-              <p>After submitting a brief form, your request will be reviewed and you will receive an email, usually within 3 business days. Usage may be subject to restrictions by agreement with interviewee.</p>
-
-              <p>If you have any questions about transcripts, recordings, or usage permissions, please contact the Center for Oral History at <%= link_to ScihistDigicoll::Env.lookup!(:oral_history_email_address), "mailto:#{ScihistDigicoll::Env.lookup!(:oral_history_email_address)}", class: "alert-link" %>.
-              </p>
-            </div>
-          <% end %>
         </div>
       </div>
     <% end %>

--- a/app/components/work_file_list_show_component.rb
+++ b/app/components/work_file_list_show_component.rb
@@ -48,20 +48,6 @@ class WorkFileListShowComponent < ApplicationComponent
     work.oral_history_content&.interviewee_biographies || []
   end
 
-  def available_by_request_summary
-    parts = []
-
-    if available_by_request_pdf_count > 0
-      parts << helpers.pluralize(available_by_request_pdf_count,  "PDF transcript")
-    end
-
-    if available_by_request_audio_count > 0
-      parts << helpers.pluralize(available_by_request_audio_count,  "audio recording file")
-    end
-
-    helpers.safe_join(parts, " and ")
-  end
-
   def available_by_request_pdf_count
     @available_by_request_pdf_count ||= available_by_request_assets.find_all { |asset| asset.content_type == "application/pdf" }.count
   end
@@ -70,8 +56,12 @@ class WorkFileListShowComponent < ApplicationComponent
     @available_by_request_audio_count ||= available_by_request_assets.find_all { |asset| asset.content_type&.start_with?("audio/") }.count
   end
 
-  def multiple_files?
-    (available_by_request_pdf_count + available_by_request_audio_count > 1)
+  def request_button_name
+    if @work.oral_history_content.available_by_request_automatic?
+      "Get Access"
+    else
+      "Request Access"
+    end
   end
 
   def available_by_request_assets

--- a/app/controllers/oral_history_access_requests_controller.rb
+++ b/app/controllers/oral_history_access_requests_controller.rb
@@ -4,7 +4,7 @@ class OralHistoryAccessRequestsController < ApplicationController
   # GET /works/4j03d09fr7t/request_oral_history_access
   def new
     @work = load_work(params['work_friendlier_id'])
-    @oral_history_access_request = Admin::OralHistoryAccessRequest.new
+    @oral_history_access_request = Admin::OralHistoryAccessRequest.new(work: @work)
   end
 
   # POST "/request_oral_history_access"

--- a/app/frontend/stylesheets/local/show-layout.scss
+++ b/app/frontend/stylesheets/local/show-layout.scss
@@ -179,3 +179,16 @@
     word-break: break-word;
   }
 }
+
+.by-request-file-list {
+  padding-left: $spacer * 1.5;
+  li {
+    display: flex;
+    vertical-align: middle;
+    margin-bottom: 0.66rem;
+    i {
+      font-size: 1.4em;
+      margin-right: 0.66rem;
+    }
+  }
+}

--- a/app/models/admin/oral_history_access_request.rb
+++ b/app/models/admin/oral_history_access_request.rb
@@ -3,7 +3,10 @@ class Admin::OralHistoryAccessRequest < ApplicationRecord
   belongs_to :work
   validates :patron_name, presence: true
   validates :patron_email, presence: true
-  validates :intended_use, presence: true
+
+  validates :intended_use, presence: true, if: -> {
+    work&.oral_history_content&.available_by_request_manual_review?
+  }
 
   enum delivery_status: %w{pending automatic approved rejected}.map {|v| [v, v]}.to_h, _prefix: :delivery_status
 

--- a/app/views/oral_history_access_requests/_form.html.erb
+++ b/app/views/oral_history_access_requests/_form.html.erb
@@ -55,7 +55,7 @@
         <%= f.input :intended_use,
           as: :text,
           label: "Intended use",
-          hint: "So that we can better understand our audience, please tell us how you plan to use the oral history you have requested.",
+          hint: (@work.oral_history_content.available_by_request_automatic? ? "So that we can better understand our audience, please tell us how you plan to use the oral history you have requested." : "Please tell us how you intend to use this oral history interview so that we may inform you about any relevant interviewee restrictions."),
           required: @oral_history_access_request.work&.oral_history_content&.available_by_request_manual_review?
         %>
       </div>

--- a/app/views/oral_history_access_requests/_form.html.erb
+++ b/app/views/oral_history_access_requests/_form.html.erb
@@ -55,7 +55,7 @@
         <%= f.input :intended_use,
           as: :text,
           label: "Intended use",
-          hint: (@work.oral_history_content.available_by_request_automatic? ? "So that we can better understand our audience, please tell us how you plan to use the oral history you have requested." : "Please tell us how you intend to use this oral history interview so that we may inform you about any relevant interviewee restrictions."),
+          hint: (@work.oral_history_content.available_by_request_automatic? ? "So that we can better understand our audience, please tell us how you plan to use the oral history you have requested." : "Please tell us how you intend to use this oral history interview to help us inform you about any relevant interviewee restrictions."),
           required: @oral_history_access_request.work&.oral_history_content&.available_by_request_manual_review?
         %>
       </div>

--- a/app/views/oral_history_access_requests/_form.html.erb
+++ b/app/views/oral_history_access_requests/_form.html.erb
@@ -55,7 +55,9 @@
         <%= f.input :intended_use,
           as: :text,
           label: "Intended use",
-          hint: "So that we can better understand our audience, please tell us how you plan to use the oral history you have requested." %>
+          hint: "So that we can better understand our audience, please tell us how you plan to use the oral history you have requested.",
+          required: @oral_history_access_request.work&.oral_history_content&.available_by_request_manual_review?
+        %>
       </div>
     </div>
 

--- a/app/views/oral_history_access_requests/_form.html.erb
+++ b/app/views/oral_history_access_requests/_form.html.erb
@@ -1,45 +1,20 @@
 <%= simple_form_for @oral_history_access_request,  :url => :request_oral_history_access  do |f| %>
 
-  <p class="mb-4">
-    To
+  <div class="mb-5 mt-4">
+    <p>
+      To receive files for "<%= @work.title %>" by email, please fill out the form below.
 
-      <% if @work.oral_history_content.available_by_request_manual_review? %>
-        request access to
+      <% if @work.oral_history_content.available_by_request_automatic? %>
+        <span class="text-danger">You will receive these files immediately after submitting this form.</span>
       <% else %>
-        receive
+        <span class="text-danger">After your request is received, you will receive an email response, usually within
+          3 business days. If permission is granted to access this interview, you will receive the files by email.
+        </span>
       <% end %>
-
-    files for "<%= @work.title %>" by email, please fill out the form below.
-  </p>
-
-
-  <div class="alert alert-info mb-4" role="alert">
-    <p class="sans-serif">
-      Your receipt of an electronic copy of this oral history indicates your agreement to abide by U.S. copyright law and terms of licensing:
-
-        <% if @work.rights.present? %>
-          <%= link_to RightsTerm.label_for(@work.rights), @work.rights, class: "alert-link" %>.
-        <% else %>
-          <p>[Missing rights information, please contact the Center for Oral History.]</p>
-        <% end %>
-
-      Please credit the "Science History Institute."
     </p>
 
-    <p class="sans-serif mt-3">We consider your personal information confidential. We will only use it for our records, and we will not share it with anyone outside the Science History Institute.
-    </p>
-
-    <% if @work.oral_history_content.available_by_request_manual_review? %>
-      <p class="sans-serif">
-        After submitting a brief form, your request will be reviewed and you will receive an email, usually within 3 business days. Usage may be subject to restrictions by agreement with interviewee.
-      </p>
-    <% end %>
-
-    <p class="sans-serif mb-0">
-      If you have any questions about transcripts, recordings, or usage permissions, please contact the Center for Oral History at <%= link_to ScihistDigicoll::Env.lookup!(:oral_history_email_address), "mailto:#{ScihistDigicoll::Env.lookup!(:oral_history_email_address)}", class: "alert-link" %>.
-    </p>
+    <p>Accessing this oral history requires a request due to privacy restritions stipulated by the interviewee.</p>
   </div>
-
 
   <% if @oral_history_access_request.errors.any? %>
     <div class="kithe-form-errors-top alert alert-danger mb-4" role="alert">
@@ -86,9 +61,18 @@
 
     <%= f.hidden_field :work_friendlier_id, value: @work.friendlier_id %>
 
-  <div class="form-actions mb-5 mt-3">
-    <%= link_to "Cancel", work_path(@work.friendlier_id), class: "btn btn-brand-secondary mr-3" %>
-    <%= f.button :submit, value: "Submit request", class: "btn btn-brand-main" %>
+    <div class="form-actions mt-3">
+      <%= link_to "Cancel", work_path(@work.friendlier_id), class: "btn btn-brand-secondary mr-3" %>
+      <%= f.button :submit, value: "Submit request", class: "btn btn-brand-main" %>
+    </div>
   </div>
-</div>
+
+  <div class="alert alert-info mt-5 mb-5" role="alert">
+    <p>We consider your personal information confidential. We will only use it for our records, and we will not share it with anyone outside the Science History Institute.
+    </p>
+
+    <p class="mb-0">
+      If you have any questions about transcripts, recordings, or usage permissions, please contact the Center for Oral History at <%= link_to ScihistDigicoll::Env.lookup!(:oral_history_email_address), "mailto:#{ScihistDigicoll::Env.lookup!(:oral_history_email_address)}", class: "alert-link" %>.
+    </p>
+  </div>
 <% end %>

--- a/app/views/oral_history_access_requests/new.html.erb
+++ b/app/views/oral_history_access_requests/new.html.erb
@@ -1,2 +1,2 @@
-<h1>Request Oral History Access</h1>
+<h1 class="brand-alt-h1">Request Oral History Access</h1>
 <%= render 'form', oral_history_access_request: @oral_history_access_request %>

--- a/app/views/oral_history_access_requests/new.html.erb
+++ b/app/views/oral_history_access_requests/new.html.erb
@@ -1,2 +1,8 @@
-<h1 class="brand-alt-h1">Request Oral History Access</h1>
+<h1 class="brand-alt-h1">
+  <% if @work.oral_history_content.available_by_request_manual_review? %>
+    Request Oral History Access
+  <% else %>
+    Get Oral History Access
+  <% end %>
+</h1>
 <%= render 'form', oral_history_access_request: @oral_history_access_request %>

--- a/spec/system/oral_history_by_request_spec.rb
+++ b/spec/system/oral_history_by_request_spec.rb
@@ -66,7 +66,7 @@ describe "Oral History with by-request delivery", type: :system, js: true, queue
       all("#{pr}patron_name").first.fill_in  with: 'Joe Schmo'
       all("#{pr}patron_email").first.fill_in with: 'patron@library.org'
       all("#{pr}patron_institution").first.fill_in with: 'Some Library'
-      all("#{pr}intended_use").first.fill_in with: 'Fun & games'
+      # leave out intended use, because not required for this request type, make sure it goes through
 
       expect(Admin::OralHistoryAccessRequest.count).to eq 0
       click_on 'Submit request'
@@ -76,7 +76,6 @@ describe "Oral History with by-request delivery", type: :system, js: true, queue
       expect(new_req.patron_name).to eq "Joe Schmo"
       expect(new_req.patron_email).to eq "patron@library.org"
       expect(new_req.patron_institution).to eq "Some Library"
-      expect(new_req.intended_use).to eq "Fun & games"
       expect(new_req.delivery_status_automatic?).to be(true)
 
       expect(page).to have_text("We are sending you links to the files you requested")

--- a/spec/system/oral_history_by_request_spec.rb
+++ b/spec/system/oral_history_by_request_spec.rb
@@ -113,7 +113,7 @@ describe "Oral History with by-request delivery", type: :system, js: true, queue
       click_on 'Request Access'
       pr = '#admin_oral_history_access_request_'
 
-      expect(page).to have_text("After submitting a brief form, your request will be reviewed and you will receive an email, usually within 3 business days.")
+      expect(page).to have_text("After your request is received, you will receive an email response, usually within 3 business days. ")
 
       all("#{pr}patron_name").first.fill_in  with: 'Joe Schmo'
       all("#{pr}patron_email").first.fill_in with: 'patron@library.org'

--- a/spec/system/oral_history_by_request_spec.rb
+++ b/spec/system/oral_history_by_request_spec.rb
@@ -49,17 +49,18 @@ describe "Oral History with by-request delivery", type: :system, js: true, queue
       ## File request
 
       expect(page).to have_selector("h2", text: "Access this interview")
-      expect(page).to have_text("1 PDF transcript and 1 audio recording file")
-      expect(page).to have_selector(:link_or_button, 'Request Access')
+      expect(page).to have_text("1 PDF Transcript File")
+      expect(page).to have_text("1 Audio Recording File")
+      expect(page).to have_selector(:link_or_button, 'Get Access')
 
       within(".show-member-file-list-item") do
         expect(page).to have_selector(:link, preview_pdf.title)
         expect(page).to have_selector(:link_or_button, "Download")
       end
 
-      expect(page).to have_text("After submitting a brief form, you will receive immediate access to these files.")
+      expect(page).to have_text("Fill out a brief form to receive immediate access to these files.")
 
-      click_on 'Request Access'
+      click_on 'Get Access'
       pr = '#admin_oral_history_access_request_'
 
       all("#{pr}patron_name").first.fill_in  with: 'Joe Schmo'
@@ -98,7 +99,8 @@ describe "Oral History with by-request delivery", type: :system, js: true, queue
       expect(page).to have_selector("h1", text: work.title)
 
       expect(page).to have_selector("h2", text: "Access this interview")
-      expect(page).to have_text("1 PDF transcript and 1 audio recording file")
+      expect(page).to have_text("1 PDF Transcript File")
+      expect(page).to have_text("1 Audio Recording File")
       expect(page).to have_selector(:link_or_button, 'Request Access')
 
       within(".show-member-file-list-item") do
@@ -106,7 +108,7 @@ describe "Oral History with by-request delivery", type: :system, js: true, queue
         expect(page).to have_selector(:link_or_button, "Download")
       end
 
-      expect(page).to have_text("After submitting a brief form, your request will be reviewed and you will receive an email, usually within 3 business days.")
+      expect(page).to have_text("Fill out a brief form and a staff member will review your request for these files. You should receive an email within 3 business days.")
 
       click_on 'Request Access'
       pr = '#admin_oral_history_access_request_'


### PR DESCRIPTION
Per #2100 and #2101

Redesign based on mock-ups from @apinkney0696  linked to there. 

Requires review by @apinkney0696  and possibly other stakeholders before we merge/deploy. 

## Note on "intended use" field

Previously we had intended use as a required field on all requests, as OH staff wanted this for reporting/analysis. 

However, I agree the fewer required fields the better, only requiring it for "manual review" requests seems like an improvement. 

HOWEVER, if we are requiring this for manual review only, it makes me wonder about the prompt:

> So that we can better understand our audience, please tell us how you plan to use the oral history you have requested.

Does that accurately describe why we are requiring this field? In fact, for "manual review" items, is the answer being used to determine access/compliance with interviewee restrictions? Should the prompt say that, in some way?

Should we have a different prompt here depending on whether the item is "automatic" or "manual review"

