### PR TITLE
slightly lighten bg color of bootstrap .alert-danger, using lightest red theme color

### DIFF
--- a/app/frontend/stylesheets/local/site_wide.scss
+++ b/app/frontend/stylesheets/local/site_wide.scss
@@ -14,6 +14,12 @@ a {
   transition: color 0.25s ease;
 }
 
+// slightly lighten bg of bootstrap alert-danger, using one of our brand
+// colors instead of letting bootstrap automatically generate a shade
+.alert-danger {
+  background-color: $shi-red-1;
+}
+
 // a link class from main site that we use where we can, especially in "text blocks"
 // Use SCSS to apply this to certain areas, like:
 //


### PR DESCRIPTION
We don't use alert-danger very much, but do use it occasionally, including in at least one end-user-facing place (validation errors on OH request form).  We originally set the bootstrap  color to -red-3, and bootstrap by default automatically calculates different shades.  

While the shades it calculates for .alert-danger do pass WCAG contrast tests, I find them a bit hard to read, and we can improve contrast and readability by over-riding with our lightest brand palette red, -red-1.

### before

![Screen Shot 2023-06-22 at 11 05 01 AM](https://github.com/sciencehistory/scihist_digicoll/assets/149304/e4d395fc-1f30-4573-9819-de2e868da7d3)

### after


![Screen Shot 2023-06-22 at 11 05 11 AM](https://github.com/sciencehistory/scihist_digicoll/assets/149304/7cddf6f7-c7aa-42df-bf5d-2703c7f0b350)