### PR TITLE
Override Blacklight's application_name helper with a simple fixed string

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,13 @@
 module ApplicationHelper
 
+  # Override Blacklight helper method to be MUCH more efficient, no going to cache_store and/or i18n for
+  # unclear benefit -- it's caching with a locale-independent key anyway, so the original
+  # implementation won't even vary by locale either!
+  # https://github.com/projectblacklight/blacklight/blob/13a8122fc6495e52acabc33875b80b51613d8351/app/helpers/blacklight/blacklight_helper_behavior.rb#L15-L22
+  def application_name
+    "Science History Institute Digital Collections"
+  end
+
   # What we show next to things that are not published, currently used
   # in management screens and possibly end-user front-end (although only managers,
   # if anyone, can see non-public things in end-user front-end).


### PR DESCRIPTION
Original implementation uses i18n lookup and/or Rails.cache_store lookup. Both can be expensive. Rails.cache_store lookup can require a network call, depending on cache store setup. When our cache store (eg memcached) is down, cache store lookup can result in a LOT of reported errors.

I discovered this when trying to investigate why we were getting so many Dalli::RingErrors for a single request that could not connect to our memcached.

This simplifies things, avoids some errors being reported, and possibly improves performance in some circumstances slightly.
