### PR TITLE
update to ransack 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,7 +124,7 @@ gem "content_disposition", "~> 1.0"
 
 gem 'faster_s3_url', "< 2" # for generating s3 urls faster!
 
-gem "ransack", "~> 3.0"
+gem "ransack", "~> 4.0" # used as an aid for ADMIM dashboard search/sorting -- we'd like to move away from it
 gem "kaminari", "~> 1.2"
 gem 'bootstrap4-kaminari-views'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -495,7 +495,7 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
-    ransack (3.2.1)
+    ransack (4.0.0)
       activerecord (>= 6.1.5)
       activesupport (>= 6.1.5)
       i18n
@@ -762,7 +762,7 @@ DEPENDENCIES
   rack-attack (~> 6.6)
   rails (~> 7.0.0)
   rails-controller-testing
-  ransack (~> 3.0)
+  ransack (~> 4.0)
   reline (>= 0.2.1)
   resque (~> 2.0)
   resque-heroku-signals

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -4,9 +4,13 @@ class Admin::CollectionsController < AdminController
   # GET /collections
   # GET /collections.json
   def index
-    # No authorize! call here. We're assuming if you can view the
-    # index, you can see all published and unpublished collections.
+    # No authorize! call here to filter viewable items in the list.
+    # We're assuming if you can view the index, you can see all published and
+    # unpublished collections.
 
+
+    # NOTE WELL: To use ransack, all attributes we want ransack to search or sort
+    # on NEED TO be listed in Colletion.ransackable_attributes and/or Collection.ransackable_associations
     @q = Collection.ransack(params[:q]).tap do |ransack|
       ransack.sorts = 'title asc' if ransack.sorts.empty?
     end

--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -564,6 +564,10 @@ class Admin::WorksController < AdminController
     #
     # https://github.com/activerecord-hackery/ransack
     #
+    # NOTE: While currently poorly documented, all attributes or associations
+    #       we want to use with ransack NEED TO  be listed in an allowlist
+    #       in method Work.ransackable_attributes and Work.ransackable_associations
+    #
     # that includes our sorting, and also
     # 'published' and "include or exclude Child Works that match query"
     #

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -59,4 +59,15 @@ class Collection < Kithe::Collection
   def build_representative
     self.representative = CollectionThumbAsset.new(title: "collection-thumbnail-placeholder", parent: self)
   end
+
+  # For ransack use, we need to list all attributes we want to use ransack to SEARCH or SORT by.
+  #
+  # We really probably oughta stop using ransack, I hate having this in the model.
+  def self.ransackable_attributes(auth_obj=nil)
+    ["title", "id", "created_at", "updated_at"]
+  end
+  # We don't use ransack with associations, but still have to include this method
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
 end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -247,4 +247,16 @@ class Work < Kithe::Work
     genre && genre.include?("Oral histories")
   end
 
+
+  # For ransack use, we need to list all attributes we want to use ransack to SEARCH or SORT by.
+  #
+  # We really probably oughta stop using ransack, I hate having this in the model.
+  def self.ransackable_attributes(auth_obj=nil)
+    ["id", "title", "created_at", "updated_at", "parent_id", "published"]
+  end
+  # We don't use ransack with associations, but still have to include this method
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
+
 end

--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -1,0 +1,13 @@
+Ransack.configure do |c|
+  # Raise errors if a query contains an unknown predicate or attribute.
+  # Default is true (do not raise error on unknown conditions).
+  #
+  # we TRY to raise on a non-allowed atribute in development or test envs, so we
+  # can catch that we forgot to list them!
+  #
+  # However, ransack does not actually raise when we are SORTING on an unlisted
+  # properly, so we can still easily miss those. Better than nothing.
+  # https://github.com/activerecord-hackery/ransack/issues/1427
+  #
+  c.ignore_unknown_conditions = Rails.env.production?
+end


### PR DESCRIPTION
Re-PR of #2224

That already got approved, but merged to wrong branch. 

- update ransack gem to 4.0
- allowlist Work attributes for ransack 4.x
- allowlist Collection attributes for ransack 4.x
- try to have ransack error in dev/test when we missed an allowlist item, in cases where it can do so
