### PR TITLE
switch from uglifier to terser for JS compression via sprockets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,8 +83,8 @@ gem "sprockets", "~> 4.0"
 # So don't need a sass gem, we have sass npm package instead.
 # gem 'sassc-rails', '~> 2.0'
 
-# Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
+# Use terser as compressor for any JavaScript assets still used via sprockets
+gem 'terser', '~> 1.1'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'mini_racer', platforms: :ruby
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -625,6 +625,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    terser (1.1.16)
+      execjs (>= 0.3.0, < 3)
     thor (1.2.2)
     thread_safe (0.3.6)
     tilt (2.2.0)
@@ -650,8 +652,6 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
@@ -780,8 +780,8 @@ DEPENDENCIES
   solr_wrapper (~> 4.0)
   sprockets (~> 4.0)
   sprockets-rails (>= 3.4.2)
+  terser (~> 1.1)
   traject (>= 3.5)
-  uglifier (>= 1.3.0)
   uppy-s3_multipart
   view_component (~> 2.49)
   vite_rails (~> 3.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,9 +29,11 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  # browse-everything currently delivers JS in ES6, so uglifier has to be able to
-  # handle it. https://github.com/samvera/browse-everything/issues/257
-  config.assets.js_compressor = Uglifier.new(harmony: true)
+  #
+  # This is not used for our vite-built things, only for remaining sprockets-built things.
+  # But it has to be able to handle ES6, so we've moved from uglifier to the more maintained
+  # terser.
+  config.assets.js_compressor = :terser
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
Uglifier was failing with future versions of blacklight_range_limit JS that we aren't using yet, but let's get ready. 

ruby uglifier gem uses an ancient version of uglifier-js and seems to be unmaintained.

Might as well switch -- if we have to use a sprockets JS minifier at all, which we may not, but for now we'll do this. 
