### PR TITLE
in development, limit the threads of the default async ActiveJob adapter

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,6 +49,14 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # using the default async (in process thread pool) queue adapter for dev,
+  # but let's set the pool sizes please to avoid running out of db connections
+  # if we create a lot of jobs.
+  config.active_job.queue_adapter = ActiveJob::QueueAdapters::AsyncAdapter.new(
+    min_threads: 1,
+    max_threads: (ENV.fetch("RAILS_MAX_THREADS") { 5 }).to_i - 1
+  )
+
   # use ActionMailer previews feature, with previews in our rspec folder.
   # https://guides.rubyonrails.org/action_mailer_basics.html#previewing-emails
   config.action_mailer.preview_path = "#{Rails.root}/spec/mailers/previews"


### PR DESCRIPTION
The default adapter in development is async -- it just executes ActiveJobs in a thread pool in the same process as web app. This is fine for development. But by default it's level of concurrency was unbounded -- if you sent 40 jobs, it'd try doing them all at once concurrently. And would end up using far too many database connections, running out, things would fail.

Ran into this trying to test some OCR stuff that was using lots of parallel jobs. To do REAL work sure you want a real ActiveJob adapter we don't have here. But async works out -- so long as we limit it's max concurrency!  We can use the same ENV variable that's in database.yml to by default deterine how many db connections we've got -- we want ActiveJob concurrency one less than that
