### PR TITLE
Re-organizing and documenting how dependencies are installed on MacOS dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ node_modules
 # https://vitejs.dev/guide/env-and-mode.html#env-files
 *.local
 
+# Brew bundle creates this pretty useless file, it's not a useful lock file like you think
+Brewfile.lock.json
+

--- a/Aptfile
+++ b/Aptfile
@@ -1,3 +1,10 @@
+# This file is used to install package dependencies on Heroku production,
+# using the heroku apt buildpack. It does NOT always (ever?) succesfully
+# install apt package dependencies, sometimes they need to be listed explicity.
+
+# For similar dependencies in other environments, see also: `Brewfile` MacOS development
+# machines; and `.github/workflows/ci.yml` for Github Actions CI.
+
 mediainfo
 imagemagick
 

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,26 @@
+# https://github.com/Homebrew/homebrew-bundle
+#
+# Install these with `brew bundle`
+
+# This file is used to install package dependencies on MacOS development;
+# See also `Aptfile` for heroku production; and `.github/workflows/ci.yml`
+# for Github Actions CI.
+
+# for managing JS dependencies, with `vite` or other tools
+brew "node"
+brew "yarn"
+
+# `mediainfo` installed for fallback contnet type detection
+brew 'mediainfo'
+
+# for more image, audio, video, and pdf characterization and manipulation
+brew 'vips'
+brew 'ffmpeg'
+brew 'qpdf'  # for combining tesseract textonly_pdf with graphical PDF in AssetPdfCreator
+
+
+# tesseract for OCR
+# Will not actually be the same version of tesseract as production. :(
+# See: https://sciencehistory.atlassian.net/l/cp/ucUvKjk3
+brew 'tesseract'
+brew 'tesseract-lang'

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ To set up a development instance on your workstation.
   * Python installer from https://www.python.org/downloads/macos/ gives you `pip3`, for `pip3 install -r requirements.txt`. Tends to leave lots of mismatched stuff around if you ever want to upgrade python.
 
 
+To ensure expected command-line utilities are present after install, you can run:
+
+    ./bin/rspec system_env_spec/
+
 
 ### Install and setup the app
 

--- a/README.md
+++ b/README.md
@@ -12,18 +12,18 @@ To set up a development instance on your workstation.
 
 ### Prerequisites
 
-* (MacOS) You're going to want homebrew, which will also take care of making sure you have a C compiler toolchain to install native C gems. https://brew.sh/
+* (MacOS) You will need homebrew, which will also take care of making sure you have a C compiler toolchain to install native C gems. https://brew.sh/
 * While not technically required just to run the app, you're going to want `git`. MacOS, `brew install git`.
 * ruby installed (I like using chruby and ruby-build to install/manage rubies, some like rvm)
 * Postgres version 14 or higher, installed and running -- on MacOS, I like https://postgresapp.com/
-* `yarn` and `node` installed for managing JS dependencies -- on MacOS, `brew install node yarn`.
-* `mediainfo` installed for fallback contnet type detection -- on MacOS, `brew install mediainfo`
-* vips installed --  on MacOS `brew install vips`
-* ffmpeg installed -- on MacOS `brew install ffmpeg`
-* tesseract for OCR -- `brew install tesseract tesseract-lang`. Will not be same version as
-  production, see https://sciencehistory.atlassian.net/l/cp/ucUvKjk3
-* 'qpdf' for pdf manipulation. On Mac `brew install qpdf`
 * You'll need Java installed to run Solr. If you don't already have it, on MacOS `brew install java`, then follow post-install instructions, such as `sudo ln -sfn /opt/homebrew/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk`
+
+* Various OS-package brew-installable packages are listed in the `Brewfile`, just run: `brew bundle` to install them from there.
+  * Note these packages in ubuntu apt variants generally have to be cross-listed in `Aptfile` for heroku, and in `.github/workflows/ci.yml` for test.
+
+* We now have some python dependencies. You need to install python on MacOS somehow, and then install from `requirements.txt`. We're not sure what the best way is.
+  * `brew install python` gives you a `pip` command, then `pip install -r requirements.txt`. You may have to re-install your requirements.txt if brew updates python underneath you?
+  * Python installer from https://www.python.org/downloads/macos/ gives you `pip3`, for `pip3 install -r requirements.txt`. Tends to leave lots of mismatched stuff around if you ever want to upgrade python.
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,9 @@
 #
 # due to lack of other lockfile, and to make caching work properly for example
 # https://github.com/actions/setup-python#caching-packages-dependencies
+#
+# On heroku, with python buildpack included, this file will be automatically
+# used for installs. https://www.codementor.io/@inanc/how-to-run-python-and-ruby-on-heroku-with-multiple-buildpacks-kgy6g3b1e
+
 
 img2pdf==0.4.4


### PR DESCRIPTION
We use a 'Brewfile' for 'brew bundle' installation of brew dependencies doc'd in repo, instead of relying on manual individual brew installs doc'd in README.

We try to doc using a requirements.txt for installing python dependencies, now that we unavoidably have at least one. The requirements.txt is also used for our heroku and Github Actions CI installs, to get python dependencies there.

This is becoming very convoluted, I defintiely understand why people like docker/container based setups instead. At some point we may want to consider figuring that out.
