### PR TITLE
WorkOcrCreatorRemover should skip works with incompatible language metadata

### DIFF
--- a/app/services/asset_ocr_creator.rb
+++ b/app/services/asset_ocr_creator.rb
@@ -29,6 +29,11 @@ class AssetOcrCreator
 
   attr_accessor :asset
 
+  def self.suitable_language?(work)
+    ((work.language || []) &  TESS_LANGS.keys).present?
+  end
+
+
   def initialize(asset)
     unless asset&.content_type&.start_with?("image/")
       raise ArgumentError, "Can only use with content type begining `image/`, not #{asset.content_type}"

--- a/app/services/work_ocr_creator_remover.rb
+++ b/app/services/work_ocr_creator_remover.rb
@@ -26,7 +26,11 @@ class WorkOcrCreatorRemover
 
   def process
     if @work.ocr_requested
-      image_assets.each { |a| maybe_add(a) }
+      if AssetOcrCreator.suitable_language?(work)
+        image_assets.each { |a| maybe_add(a) }
+      else
+        Rails.logger.warn("#{self.class}: OCR enabled for work #{work.friendlier_id}, but it does not have suitable languages: #{work.language.inspect}")
+      end
     else
       image_assets.each { |a| maybe_remove(a) }
     end


### PR DESCRIPTION
If the OCR box were checked for such a work, previously we get errors when we try to actually OCR it -- which can happen again and again, as the nightly checker checks it!

Instead, just notice early it's incompatible, and don't enqueue jobs. Do print out a warning to logs.

We will also do more on admin UX to make this situation apparent.
