### PR TITLE
Admin info on OCR status of works, move to a tab and enhance

### DIFF
--- a/app/components/work_show_ocr_component.html.erb
+++ b/app/components/work_show_ocr_component.html.erb
@@ -1,5 +1,4 @@
-<div class="alert alert-light mx-1">
-  <h2 class="h4 alert-heading">OCR</h2>
-  <p><small>OCR has <% unless @work.ocr_requested %> not <%end%> been requested for this work.</small></p>
-  <p><small><%= assets_with_ocr %> out of <%= total_assets %> assets currently have OCR.</small></p>
-</div>
+
+<p>OCR has <% unless @work.ocr_requested %> not <%end%> been requested for this work.</p>
+<p><%= assets_with_ocr %> out of <%= total_assets %> assets currently have OCR.</p>
+

--- a/app/components/work_show_ocr_component.html.erb
+++ b/app/components/work_show_ocr_component.html.erb
@@ -1,4 +1,28 @@
+<p>
+  OCR enabled:
+  <% if @work.ocr_requested %>
+    <span class="text-success font-weight-bold">
+      <i class="fa fa-check-circle" aria-hidden="true"></i> YES
+    </span>
+  <% else %>
+    <span class="text-danger font-weight-bold">
+      <i class="fa fa-minus-circle" aria-hidden="true"></i> NO
+    </span>
+  <% end %>
+</p>
 
-<p>OCR has <% unless @work.ocr_requested %> not <%end%> been requested for this work.</p>
-<p><%= assets_with_ocr %> out of <%= total_assets %> assets currently have OCR.</p>
+<% if work_language_warning? %>
+  <p>
+    <i class="fa fa-exclamation-triangle text-danger" aria-label="WARNING"></i> OCR enabled, but work does not include languages
+    compatible with OCR. <br>
+    Work languages: <code><%= @work.language.inspect %></code>. OCR-compatible languages: <code><%= AssetOcrCreator::TESS_LANGS.keys %></code>.
+  </p>
+<% end %>
+
+<p>
+  <% if asset_ocr_count_warning? %>
+    <i class="fa fa-exclamation-triangle text-danger" aria-label="WARNING"></i>
+  <% end %>
+  <b><%= assets_with_ocr %></b> out of <b><%= total_assets %></b> assets currently have OCR.
+</p>
 

--- a/app/components/work_show_ocr_component.html.erb
+++ b/app/components/work_show_ocr_component.html.erb
@@ -14,9 +14,12 @@
 <% if work_language_warning? %>
   <p>
     <i class="fa fa-exclamation-triangle text-danger" aria-label="WARNING"></i> OCR enabled, but work does not include languages
-    compatible with OCR. <br>
-    Work languages: <code><%= @work.language.inspect %></code>. OCR-compatible languages: <code><%= AssetOcrCreator::TESS_LANGS.keys %></code>.
+    compatible with OCR.
   </p>
+  <ul>
+    <li>Work languages: <code><%= @work.language.inspect %></code></li>
+    <li>OCR-compatible languages: <code><%= AssetOcrCreator::TESS_LANGS.keys %></code></li>
+  </ul>
 <% end %>
 
 <p>

--- a/app/components/work_show_ocr_component.rb
+++ b/app/components/work_show_ocr_component.rb
@@ -32,4 +32,8 @@ class WorkShowOcrComponent < ApplicationComponent
   def work_language_warning?
     @work.ocr_requested? && ! AssetOcrCreator.suitable_language?(work)
   end
+
+  def warnings?
+    asset_ocr_count_warning? || work_language_warning?
+  end
 end

--- a/app/components/work_show_ocr_component.rb
+++ b/app/components/work_show_ocr_component.rb
@@ -9,7 +9,7 @@ class WorkShowOcrComponent < ApplicationComponent
   def assets_with_ocr
     assets_with_and_without_ocr.count {|a| a['has_ocr']}
   end
-  
+
   def total_assets
     assets_with_and_without_ocr.length
   end
@@ -22,5 +22,14 @@ class WorkShowOcrComponent < ApplicationComponent
     AND parent_id = '#{@work.id}'"""
     @assets_with_and_without_ocr ||= ActiveRecord::Base.
       connection.exec_query(query).to_a
+  end
+
+  def asset_ocr_count_warning?
+    (work.ocr_requested? && assets_with_ocr != total_assets) ||
+    (! work.ocr_requested? && assets_with_ocr > 0)
+  end
+
+  def work_language_warning?
+    @work.ocr_requested? && ! AssetOcrCreator.suitable_language?(work)
   end
 end

--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -326,6 +326,11 @@ class Admin::WorksController < AdminController
   def show
     authorize! :read, @work
     @cart_presence = CartPresence.new([@work.friendlier_id], current_user: current_user)
+
+    # instantiate this in an iVar so we can use it in two different places in template,
+    # without double instantiation or double load of SQL query inside. A little bit hacky,
+    # but this works out.
+    @work_show_ocr_component = WorkShowOcrComponent.new(@work)
   end
 
   def reorder_members_form

--- a/app/views/admin/works/show.html.erb
+++ b/app/views/admin/works/show.html.erb
@@ -86,6 +86,8 @@
       <a class="nav-item nav-link" id="nav-oral-histories-tab" data-toggle="tab" href="#nav-oral-histories" role="tab" aria-controls="nav-profile" aria-selected="false">Oral History</a>
     <% end %>
 
+    <a class="nav-item nav-link" id="nav-ocr-tab" data-toggle="tab" href="#nav-ocr" role="tab" aria-controls="nav-profile" aria-selected="false">OCR</a>
+
   </div>
 </nav>
 
@@ -128,7 +130,6 @@
         <%= link_to "Manual", reorder_members_admin_work_path(@work), class: "btn btn-primary #{'disabled' unless can?(:update, @work)}" %>
         <%= link_to "Alphabetical", reorder_members_admin_work_path(@work), method: "put", class: "btn btn-primary #{'disabled' unless can?(:update, @work)}", data: { confirm: "Re-ordering members alphabetically by title can't be undone" } %>
       </div>
-      <%= render WorkShowOcrComponent.new(@work)%>
     </div>
 
     <p><%= @work.members.count  %> members</p>
@@ -155,4 +156,10 @@
       <%= render OralHistory::Admin::AvailableByRequestComponent.new(work: @work) %>
     </div>
   <% end %>
+
+  <div class="tab-pane" id="nav-ocr" role="tabpanel" aria-labelledby="nav-ocr-tab">
+    <%= render WorkShowOcrComponent.new(@work)%>
+  </div>
+
+
 </div>

--- a/app/views/admin/works/show.html.erb
+++ b/app/views/admin/works/show.html.erb
@@ -87,7 +87,7 @@
     <% end %>
 
     <a class="nav-item nav-link" id="nav-ocr-tab" data-toggle="tab" href="#nav-ocr" role="tab" aria-controls="nav-profile" aria-selected="false">
-      <% if WorkShowOcrComponent.new(@work).warnings? %>
+      <% if @work_show_ocr_component.warnings? %>
         <i class="fa fa-exclamation-triangle" aria-label="(WARNING)"></i>
       <% elsif @work.ocr_requested? %>
         <i class="fa fa-check-circle" aria-label="(ON)"></i>
@@ -167,7 +167,7 @@
   <% end %>
 
   <div class="tab-pane" id="nav-ocr" role="tabpanel" aria-labelledby="nav-ocr-tab">
-    <%= render WorkShowOcrComponent.new(@work)%>
+    <%= render @work_show_ocr_component %>
   </div>
 
 

--- a/app/views/admin/works/show.html.erb
+++ b/app/views/admin/works/show.html.erb
@@ -86,7 +86,16 @@
       <a class="nav-item nav-link" id="nav-oral-histories-tab" data-toggle="tab" href="#nav-oral-histories" role="tab" aria-controls="nav-profile" aria-selected="false">Oral History</a>
     <% end %>
 
-    <a class="nav-item nav-link" id="nav-ocr-tab" data-toggle="tab" href="#nav-ocr" role="tab" aria-controls="nav-profile" aria-selected="false">OCR</a>
+    <a class="nav-item nav-link" id="nav-ocr-tab" data-toggle="tab" href="#nav-ocr" role="tab" aria-controls="nav-profile" aria-selected="false">
+      <% if WorkShowOcrComponent.new(@work).warnings? %>
+        <i class="fa fa-exclamation-triangle" aria-label="(WARNING)"></i>
+      <% elsif @work.ocr_requested? %>
+        <i class="fa fa-check-circle" aria-label="(ON)"></i>
+      <% else %>
+        <i class="fa fa-minus-circle" aria-hidden="(OFF)"></i>
+      <% end %>
+      OCR
+    </a>
 
   </div>
 </nav>

--- a/spec/system/work/ocr_info_spec.rb
+++ b/spec/system/work/ocr_info_spec.rb
@@ -18,10 +18,12 @@ describe "Member list displays OCR info", logged_in_user: :editor do
   describe "Work with OCR requested" do
     it "Summarizes assets with OCR correctly; displays show OCR button" do
       visit admin_work_path(work)
-      click_on "Members"
-      expect(page).to have_text("OCR has been requested for this work.")
+
+      click_on "OCR"
+      expect(page).to have_text(/OCR enabled\:\s+YES/)
       expect(page).to have_text("1 out of 4 assets currently have OCR.")
 
+      click_on "Members"
       path_to_ocr = admin_asset_path(image_asset_with_hocr, anchor: "ocr")
       expect(page.find_all('table.member-list a.ocr-link').count).to eq 1
       expect(page).to have_link(:href=>path_to_ocr)


### PR DESCRIPTION
- move WorkShowOcrComponent to it's own tab
- better warnings on WorkShowOcrComponent
- OCR warning/status icons in tab title
