### PR TITLE
Remove webdrivers gem -- may no longer be necessary, and currently causing problems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -197,7 +197,7 @@ group :test do
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
   # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'webdrivers'
+  #gem 'webdrivers'
   gem 'capybara-screenshot'
   gem 'factory_bot_rails'
   gem "database_cleaner", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -683,10 +683,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -788,7 +784,6 @@ DEPENDENCIES
   vite_rails (~> 3.0)
   warning (~> 1.2)
   web-console (>= 4.1.0)
-  webdrivers
   webmock (~> 3.5)
 
 RUBY VERSION


### PR DESCRIPTION
It may no longer be neccessary, selenium-webdrivers can handle webdriver install itself? And webdrivers may now be causing a problem?  Very unclear what is going on, trying this.

https://github.com/titusfortner/webdrivers/issues/247

@eddierubeiz You may need to `brew remove webdriver` on your Mac, to remove a very old unnecessary webdriver package that was being ignored before this PR, but for me caused problems after this PR. 
