### PR TITLE
optional configuration to set non-default queue for OCR related jobs

### DIFF
--- a/app/jobs/create_asset_ocr_job.rb
+++ b/app/jobs/create_asset_ocr_job.rb
@@ -1,4 +1,8 @@
 class CreateAssetOcrJob < ApplicationJob
+  if ScihistDigicoll::Env.lookup("active_job_ocr_queue").present?
+    queue_as ScihistDigicoll::Env.lookup("active_job_ocr_queue")
+  end
+
   def perform(asset)
     AssetOcrCreator.new(asset).call
   end

--- a/app/jobs/work_ocr_creator_remover_job.rb
+++ b/app/jobs/work_ocr_creator_remover_job.rb
@@ -2,6 +2,10 @@
 # with the Work#ocr_requested_attribute
 #
 class WorkOcrCreatorRemoverJob < ApplicationJob
+  if ScihistDigicoll::Env.lookup("active_job_ocr_queue").present?
+    queue_as ScihistDigicoll::Env.lookup("active_job_ocr_queue")
+  end
+
   # if the work has already been deleted before the job is run, just discard
   # This is how ActiveJob docs suggest to do that (https://guides.rubyonrails.org/active_job_basics.html#deserialization),
   # although actually this eats lots of other errors too, but we'll take it I guess?

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -219,7 +219,7 @@ module ScihistDigicoll
     # can be obtained by running `terraform output`.
     define_key :s3_bucket_derivatives_host      # Cloudfront hostname for regular derivs bucket
     define_key :s3_bucket_derivatives_video_host # Ditto, for video derivs bucket
-    
+
     define_key :s3_bucket_uploads
     define_key :s3_bucket_on_demand_derivatives
     define_key :s3_bucket_dzi
@@ -544,6 +544,9 @@ module ScihistDigicoll
 
 
     define_key :honeybadger_api_key
+
+    # nil means use default, but we can define if we want to put all OCR work on, say, `special_jobs`.
+    define_key :active_job_ocr_queue
 
     # Used for sending mail, and if no queue is specified:
     define_key :regular_job_worker_count, default: 0


### PR DESCRIPTION
We will set to 'special_jobs' temporarily during a time period we want to bulk-enable OCR for a lot of already exisiting works

> heroku config:set ACTIVE_JOB_OCR_QUEUE=special_jobs
