### PR TITLE
update kithe to 2.10.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,7 +110,7 @@ gem "lograge", "< 2"
 gem "device_detector", "~> 1.0" # user-agent parsing we use for logging
 
 gem "attr_json", "~> 2.0"
-gem 'kithe', "~> 2.8"
+gem 'kithe', "~> 2.10"
 
 gem "traject", ">= 3.5" # to include support for HTTP basic auth in Solr url
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,7 +315,7 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    kithe (2.9.1)
+    kithe (2.10.0)
       attr_json (< 3.0.0)
       fastimage (~> 2.0)
       fx (>= 0.6.0, < 1)
@@ -739,7 +739,7 @@ DEPENDENCIES
   irb (>= 1.3.1)
   jbuilder (~> 2.5)
   kaminari (~> 1.2)
-  kithe (~> 2.8)
+  kithe (~> 2.10)
   listen (~> 3.3)
   lockbox
   lograge (< 2)


### PR DESCRIPTION
To get a feature that will give us a rake task making it easy to queue up bg jobs to create new graphiconly_pdf for every existing suitable asset

https://github.com/sciencehistory/kithe/pull/166

> heroku run -r production "rake kithe:create_derivatives -- --derivatives=graphiconly_pdf --lazy --bg=special_jobs"


