### PR TITLE
Don't inherit graphiconly_pdf on collection thumbs

### DIFF
--- a/app/uploaders/collection_thumb_asset_uploader.rb
+++ b/app/uploaders/collection_thumb_asset_uploader.rb
@@ -4,8 +4,11 @@ class CollectionThumbAssetUploader < AssetUploader
   # remove inherited derivatives we don't need for collections. Kind of bad OO
   # design maybe we should have an abstract asset superclass with ordinary and collection
   # asset both as sub-classes we don't need to do this, but it works for now.
+  #
+  # Should we actually be removing ALL derivatives defined in parent, so we don't forget
+  # to add here when we add new ones to parent we don't want here? Do we want ANY of them?
   Attacher.remove_derivative_definition!(*Attacher.defined_derivative_keys.find_all { |key| key.start_with?("download_")})
-  Attacher.remove_derivative_definition!(:thumb_large, :thumb_large_2X)
+  Attacher.remove_derivative_definition!(:thumb_large, :thumb_large_2X, :graphiconly_pdf)
 
   Attacher.define_derivative("thumb_collection_page", content_type: "image") do |original_file|
     Kithe::VipsCliImageToJpeg.new(max_width: COLLECTION_PAGE_THUMB_SIZE, thumbnail_mode: true).call(original_file)


### PR DESCRIPTION
We realized we were trying to create graphiconly_pdf derivatives on collection thumbs, when some of them failed at #2288

but that's not actually useful to do. Oh right, current architeccture requires us to "disable" any derivatives on main uploader that we don't want on collection tumb uploader, because they are all inherited. 

That's not a great design. We may want to either break the inheritance hieararchy, or remove ALL inherited derivatives before adding the ones we want. 

But for now, we'll just do this. 

