### PR TITLE
Asset Admin UI should be able to handle assets without parents

### DIFF
--- a/app/views/admin/assets/index.html.erb
+++ b/app/views/admin/assets/index.html.erb
@@ -38,7 +38,11 @@
           <%= link_to asset.title, admin_asset_path(asset) %>
         </td>
         <td>
-          <%= link_to asset.parent.title, parent_path(asset) %>
+          <% if asset.parent %>
+            <%= link_to asset.parent.title, parent_path(asset) %>
+          <% else %>
+            <span class="text-danger">NO PARENT</span>
+          <% end %>
         </td>
         <td class="datestamp"><%=  l asset.created_at.to_date, format: :admin %> </td>
       </tr>

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -7,6 +7,8 @@
   <% else %>
     <p>In work: <%= link_to @asset.parent.title, [:admin, @asset.parent] %> </p>
   <% end %>
+<% else %>
+    <p class="text-danger">NO PARENT</p>
 <% end %>
 
 

--- a/spec/system/admin/asset_list_spec.rb
+++ b/spec/system/admin/asset_list_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+RSpec.describe "Oral History Access Interviewee bio", :logged_in_user, type: :system, queue_adapter: :test  do
+  let!(:normal_asset) { create(:asset, title: "normal asset", parent: create(:work, title: "Parent work")) }
+  let!(:orphaned_asset) { create(:asset, title: "orphaned asset", parent: nil) }
+
+  it "can display assets, including orphaned" do
+    visit admin_assets_path
+
+    expect(page).to have_text("Assets")
+
+    expect(page).to have_link(normal_asset.title, href: admin_asset_path(normal_asset))
+    expect(page).to have_link(normal_asset.parent.title, href: admin_work_path(normal_asset.parent))
+
+    expect(page).to have_link(orphaned_asset.title, href: admin_asset_path(orphaned_asset))
+    expect(page).to have_text("NO PARENT")
+  end
+end


### PR DESCRIPTION
We add a spec for this too.

While ordinarily this shoudln't happen, it technically can, and working admin UI is very helpful for diagnosing it.

Ref #2290 
