### PR TITLE
rake task to save Assets with changed defaults

### DIFF
--- a/lib/tasks/data_fixes/update_asset_defaults.rake
+++ b/lib/tasks/data_fixes/update_asset_defaults.rake
@@ -1,0 +1,21 @@
+namespace :scihist do
+  namespace :data_fixes do
+
+    desc """
+      Save Assets that have changed defaults on load
+    """
+    task :update_assets_with_defaults => :environment do
+      progress_bar = ProgressBar.create(total: Asset.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+
+      Asset.find_each do |asset|
+        # If right after load the Asset has changed, that can happen due to changed embedded
+        # json defaults, let's just save it again to get those in DB.
+        if asset.changed?
+          asset.save!
+        end
+
+        progress_bar.increment
+      end
+    end
+  end
+end


### PR DESCRIPTION
Load assets, if they seemt o have changes right after loading -- probably means they have changed embedded json object defaults. Just save them to save those 'new' defaults.

Ref #2293

- [ ] Ran on production immediately after merge/release
