### PR TITLE
AssetGraphicOnlyPdfCreator: if original DPI appears LESS than target dpi, don't scale it UP, just leave it the same size

### DIFF
--- a/app/services/asset_graphic_only_pdf_creator.rb
+++ b/app/services/asset_graphic_only_pdf_creator.rb
@@ -73,8 +73,13 @@ class AssetGraphicOnlyPdfCreator
     orig_width = asset.width
     orig_dpi   = get_tiff_dpi(temp_orig.path)
 
-    # what to resize x width to get from original dpi to target dpi?
-    target_width = (orig_width.to_f * (target_dpi.to_f / orig_dpi.to_f)).round
+    if orig_dpi > target_dpi
+      # what to resize x width to get from original dpi to target dpi?
+      target_width = (orig_width.to_f * (target_dpi.to_f / orig_dpi.to_f)).round
+    else
+      # don't scale it UP to meet target!
+      target_width = orig_width
+    end
 
     output_jp2_tempfile = Tempfile.new(["scihist_digicoll_asset_graphic_only_pdf_creator", ".jp2"])
 


### PR DESCRIPTION
Ref #2300

- [ ] After deploying, manually create GraphicOnlyPDF for assets mentioned in #2300

They'll still be REALLY BIG since they have incorrect metadata saying they are 72 dpi so they won't be scaled down -- but at least the won't be SCALED UP, triggering `img2pdf` pixel limit error
