### PR TITLE
Fixes to task set_legacy_ocr_requested"

### DIFF
--- a/lib/tasks/data_fixes/set_legacy_ocr_requested.rake
+++ b/lib/tasks/data_fixes/set_legacy_ocr_requested.rake
@@ -24,7 +24,7 @@ namespace :scihist do
           work.ocr_requested = true
           work.save!
 
-          WorkOcrCreatorRemoverJob.set(queue: "special_jobs").perform_later
+          WorkOcrCreatorRemoverJob.set(queue: "special_jobs").perform_later(work)
 
           ocr_enabled_count += 1
         end


### PR DESCRIPTION
This time I DID run on staging, seems to actually work. 

Although not clear if Solr index batching is really working, not going to worry about that right now. 

Also this reminded me that config ACTIVE_JOB_OCR_QUEUE DOES need to be set to "special_jobs" if we want OCR work to actually be on special_jobs queue. It is set thus on production! 

- proper call of WorkOcrCreatorRemoverJob
- batch Solr indexing
