### PR TITLE
Report for clir august 2023

### DIFF
--- a/lib/tasks/reports/clir_report_august_2023.rake
+++ b/lib/tasks/reports/clir_report_august_2023.rake
@@ -67,7 +67,7 @@ namespace :scihist do
 
         i = 0
         Kithe::Indexable.index_with(batching: true) do
-          bredig_collection.contains.each do |work|
+          bredig_collection.contains.shuffle.each do |work|
 
             # Only include the 2019 accession for this report:
             next unless work.external_id.any? { |a| a.value = '2019.011' && a.category = 'accn'}

--- a/lib/tasks/reports/clir_report_august_2023.rake
+++ b/lib/tasks/reports/clir_report_august_2023.rake
@@ -1,0 +1,56 @@
+namespace :scihist do
+  namespace :reports do
+    desc """Export metadata to stdout for some data visualizations work.
+      See https://github.com/sciencehistory/scihist_digicoll/issues/1927 .
+      bundle exec rake scihist:reports:clir_report_august_2023
+    """
+    task :clir_report_august_2023 => :environment do
+      include Rails.application.routes.url_helpers
+
+      bredig_collection =  Collection.find_by_friendlier_id('qfih5hl')
+      base_url = ScihistDigicoll::Env.lookup!(:app_url_base)
+
+      def sample_size = 600
+        
+      csv_string = CSV.generate do |csv|
+        csv << [
+          'Admin URL',
+          'Download URL',
+          'Internal filename',
+          'Filename as downloaded',
+          'SHA 512 checksum',
+          'Date file verified',
+        ]
+        i = 0
+        Kithe::Indexable.index_with(batching: true) do
+          bredig_collection.contains.find_each do |work|
+            asset = work.members.sample
+            break if (i = i + 1) > sample_size
+            
+            csv << ([
+              # 'admin_url',
+              "#{base_url}/admin/asset_files/#{asset.friendlier_id}",
+
+              # 'download_url',
+              "#{base_url}#{download_path(asset.file_category, asset)}",
+
+              # 'filename_1',
+              asset.file.metadata['filename'],
+
+              # 'filename_2',
+              DownloadFilenameHelper.filename_for_asset(asset),
+
+              # 'checksum',
+              asset.file.metadata['sha512'],
+
+              #Fixity check date
+              check = asset.fixity_checks.last.created_at,
+
+            ])
+          end
+        end
+      end
+      puts csv_string
+    end
+  end
+end

--- a/lib/tasks/reports/clir_report_august_2023.rake
+++ b/lib/tasks/reports/clir_report_august_2023.rake
@@ -1,8 +1,47 @@
 namespace :scihist do
   namespace :reports do
-    desc """Export metadata to stdout for some data visualizations work.
-      See https://github.com/sciencehistory/scihist_digicoll/issues/1927 .
+    desc """Export metadata to stdout for the final CLIR Report (summer 2023).
+      See https://github.com/sciencehistory/scihist_digicoll/issues/2299 .
       bundle exec rake scihist:reports:clir_report_august_2023
+
+      SPEC: The filenames of a representative sampling of access files created
+      through your project. (600 files for a 24-month project). Include the
+      file extensions (.jpg, .jpeg, .tiff, .mp3, .mp4, etc.) as part of the
+      filenames.
+          NOTES:
+            Filenames: I'm providing both the friendly filename saved on
+              your computer when you download it, *and* the internal
+              filename here (which is the filename as ingested).
+              I would argue for using the latter since we're looking
+              at this from a preservation context.
+            Representative sample: I picked one image at random from the
+              first 600 works that came up in the Bredig collection.
+              We could of course change this recipe, but it seems
+              'representative' enough.
+
+      SPEC: The full URL/URI (including http:// or https://) for the location of
+      the listed files on your main access system. Note this should be the
+      URL/URI for the file itself and not for the metadata record
+      associated with the file.
+          NOTE: I'm using the download URL for this. This is, after a manner
+            of speaking, the URL for the file itself: if you visit that URL,
+            your browser will download the file.
+
+      SPEC: If you have generated a checksum to monitor the integrity of the
+      files, enter the checksum value into the column labeled 'CHECKSUM'.
+          NOTE: I'm using the SHA512 checksum. We keep several, but that's
+            the one we check.
+
+      SPEC: Enter the date you last verified the availability of each file on your
+      main access system.
+          NOTE: I'm using the date of the latest checksum. Why?
+            In the process of calculating a checksum, we download the
+              entire contents of the file from storage.
+            If a file can be downloaded from s3 in this manner,
+              we consider it 'available';
+            If a file passed its fixity check, the file was
+              a fortiori 'available' at the time of the check.
+
     """
     task :clir_report_august_2023 => :environment do
       include Rails.application.routes.url_helpers
@@ -26,26 +65,19 @@ namespace :scihist do
           bredig_collection.contains.find_each do |work|
             asset = work.members.sample
             break if (i = i + 1) > sample_size
-            
             csv << ([
-              # 'admin_url',
+              # 'Admin URL',
               "#{base_url}/admin/asset_files/#{asset.friendlier_id}",
-
-              # 'download_url',
+              # 'Download URL',
               "#{base_url}#{download_path(asset.file_category, asset)}",
-
-              # 'filename_1',
+              # 'Internal filename',
               asset.file.metadata['filename'],
-
-              # 'filename_2',
+              # 'Filename as downloaded',
               DownloadFilenameHelper.filename_for_asset(asset),
-
-              # 'checksum',
+              # 'SHA 512 checksum',
               asset.file.metadata['sha512'],
-
-              #Fixity check date
+              # 'Date file verified',
               check = asset.fixity_checks.last.created_at,
-
             ])
           end
         end

--- a/lib/tasks/reports/clir_report_august_2023.rake
+++ b/lib/tasks/reports/clir_report_august_2023.rake
@@ -50,7 +50,7 @@ namespace :scihist do
       bredig_collection =  Collection.find_by_friendlier_id('qfih5hl')
       base_url = ScihistDigicoll::Env.lookup!(:app_url_base)
 
-      def sample_size = 600
+      def sample_size = 1000
 
       csv_string = CSV.generate do |csv|
         csv << [


### PR DESCRIPTION
Ref #2299
# Sample
The filenames of a representative sampling of access files created through your project. (600 files for a 24-month project). Include the file extensions (.jpg, .jpeg, .tiff, .mp3, .mp4, etc.) as part of the filenames.
- **Representative sample**: A random image from each of 600 members of the Bredig collection, each of which was also picked at random.

# Column notes
**ACCESS FILENAME** No instructions for this column.
 - I'm using the 'friendly' filename saved on your computer when you download the file. (e.g. `letter_from_max_lndkiyg_1_bamf3ku.tiff`)

**DIRECT URL TO FILE:** The full URL/URI for the location of the listed files on your main access system. Note this should be the URL/URI for the file itself and not for the metadata record associated with the file.
 - I'm using the download URL for this (e.g. `https://digital.sciencehistory.org/downloads/orig/image/r0lb9il`). Presumably they want to be able to download the file at this URL and make sure that its checksum is what we say it is. 

**CHECKSUM**: If you have generated a checksum to monitor the integrity of the files, enter the checksum value into the column labeled 'CHECKSUM'.
 - I'm using the SHA512 checksum.

**DATE LAST CHECKED**: Enter the date you last verified the availability of each file on your main access system.
 - I'm using the date of the latest checksum. Why?
      * In the process of calculating a checksum, we download the entire contents of the file from storage.
      * If a file can be downloaded from s3 in this manner, we consider it 'available';
      * If a file passed its fixity check, the file was _a fortiori_ 'available' at the time of the check.

**RESTRICTED (Y/N)** `N` if published, `Y` otherwise.

**COMMENTS ABOUT RESTRICTIONS**
 - Blank most of the time. If the item is unpublished I just say "Not yet published".

**PRESERVATION FILENAME** Enter the relevant filename for the preservation copy of the file [...]
 - I'm using the filename as ingested from the mounted ingest drive (e.g. `2019.011.B2F41.001.001.tif` )

**PRESERVATION FILE LOCATION** Provide information about where the preservation file is kept.
 - I'm using a garden-variety S3 URL for this, e.g. `https://s3.console.aws.amazon.com/s3/buckets/scihist-digicoll-originals?region=us-east-1&prefix=asset/09326b64-c5c3-4f72-bb91-c505869d234d/&prefixSearch=bda9bf2d0eafe5f9ef1129adec6b2de7.tif`

























































