### PR TITLE
Rake task to add missing graphiconly_pdf assets

### DIFF
--- a/lib/tasks/data_fixes/add_missing_graphiconly_pdf.rake
+++ b/lib/tasks/data_fixes/add_missing_graphiconly_pdf.rake
@@ -1,0 +1,30 @@
+namespace :scihist do
+  namespace :data_fixes do
+    desc """
+      Enqueues a jobs to special_workers for any image assets missing graphiconly_pdf
+      derivative
+    """
+
+    task :add_missing_graphiconly_pdf => :environment do
+      scope = Asset.where("file_data -> 'metadata' ->> 'mime_type' = 'image/tiff'")
+
+      progress_bar = ProgressBar.create(total: scope.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+
+      jobs_enqueued = 0;
+
+      Kithe::Indexable.index_with(batching: true) do
+        scope.find_each do |asset|
+          if asset.file_derivatives[:graphiconly_pdf].blank?
+            Kithe::CreateDerivativesJob.set(queue: 'special_jobs').perform_later(asset, only: :graphiconly_pdf, lazy: true)
+            jobs_enqueued += 1
+          end
+
+          progress_bar.increment
+        end
+      end
+
+      puts "Enqueued #{jobs_enqueued} jobs for missing graphiconly_derivaties, to special_jobs queue"
+
+    end
+  end
+end


### PR DESCRIPTION
We thought we already did this, but somehow a bunch are still missing on production.  Not sure why, but let's go through again.

When new assets are ingested, they are supposed to get this derivative automatically. (Is that not working?) https://github.com/sciencehistory/scihist_digicoll/blob/master/app/uploaders/asset_uploader.rb#L93-L95

The rake task will enqueue derivative creation jobs, for those missing the deriv, on the `special_jobs` queue. So you'll have to run some special workers to process them.

    rake scihist:data_fixes:add_missing_graphiconly_pdf

- [ ] Ran in production
- [ ] Jobs completed in production
