### PR TITLE
Metadata to suppress OCR at the metadata level

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -67,6 +67,12 @@ class Asset < Kithe::Asset
   # OCR data in hOCR format, for the image asset
   attr_json :hocr, :text
 
+  # If this is set, do not create OCR for this asset,
+  # regardless of the parent work's settings.
+  attr_json :suppress_ocr, :boolean, default: false
+
+  # A place for staff to enter any internal notes about OCR for this asset.
+  attr_json :ocr_admin_note, :text
 
   validates :derivative_storage_type, inclusion: { in: ["public", "restricted"] }
 


### PR DESCRIPTION
Metadata to suppress OCR at the metadata level, and to store comments about any decisions.
This PR doesn't do anything with the metadata yet.
Ref #2311 
