### PR TITLE
Take `ocr suppressed` into account when creating derivatives

### DIFF
--- a/spec/services/work_ocr_creator_remover_spec.rb
+++ b/spec/services/work_ocr_creator_remover_spec.rb
@@ -2,6 +2,15 @@ require 'rails_helper'
 
 describe WorkOcrCreatorRemover, queue_adapter: :test do
   let(:image_asset_without_hocr) { create(:asset_with_faked_file) }
+  let(:image_asset_with_ocr_suppressed) { create(:asset_with_faked_file, :suppress_ocr, title: "Asset with OCR suppressed") }
+  let(:image_asset_with_ocr_suppressed_but_with_derivs) do
+    create(:asset_with_faked_file,
+      :suppress_ocr, title: "Asset with OCR suppressed BUT with derivs", hocr:'remove this hocr', faked_derivatives: {
+        textonly_pdf: create(:stored_uploaded_file, content_type: "application/pdf")
+      }
+    )
+  end
+
   let(:image_asset_with_hocr) do
     create(:asset_with_faked_file,
       hocr: "goat",
@@ -10,6 +19,15 @@ describe WorkOcrCreatorRemover, queue_adapter: :test do
       }
     )
   end
+  let(:image_asset_with_hocr) do
+    create(:asset_with_faked_file,
+      hocr: "goat",
+      faked_derivatives: {
+        textonly_pdf: create(:stored_uploaded_file, content_type: "application/pdf")
+      }
+    )
+  end
+
   let(:sound_asset) { create(:asset_with_faked_file, :m4a) }
   let(:child_work)  { create(:public_work, representative: create(:asset_with_faked_file)) }
 
@@ -19,6 +37,8 @@ describe WorkOcrCreatorRemover, queue_adapter: :test do
       ocr_requested: ocr_requested,
       members: [
         image_asset_without_hocr,
+        image_asset_with_ocr_suppressed,
+        image_asset_with_ocr_suppressed_but_with_derivs,
         image_asset_with_hocr,
         sound_asset,
         child_work
@@ -29,12 +49,17 @@ describe WorkOcrCreatorRemover, queue_adapter: :test do
   context "work needs OCR" do
     let(:ocr_requested) { true }
 
-    it "enqueues an ocr creation job for assets that need it" do
+    it "enqueues an ocr creation job for assets that need it; removes OCR and textonly_pdf from works that don't" do
       WorkOcrCreatorRemover.new(work).process
       expect(CreateAssetOcrJob).to have_been_enqueued.with(image_asset_without_hocr)
       expect(CreateAssetOcrJob).not_to have_been_enqueued.with(image_asset_with_hocr)
       expect(CreateAssetOcrJob).not_to have_been_enqueued.with(sound_asset)
       expect(CreateAssetOcrJob).not_to have_been_enqueued.with(child_work)
+      expect(CreateAssetOcrJob).not_to have_been_enqueued.with(image_asset_with_ocr_suppressed)
+      expect(CreateAssetOcrJob).not_to have_been_enqueued.with(image_asset_with_ocr_suppressed_but_with_derivs)
+      image_asset_with_ocr_suppressed_but_with_derivs.reload
+      expect(image_asset_with_ocr_suppressed_but_with_derivs.file_derivatives.keys).to eq []
+      expect(image_asset_with_ocr_suppressed_but_with_derivs.hocr).to be_nil
     end
 
     context "but does not have suitable language metadata" do


### PR DESCRIPTION
Ref #2311

When we process a work's OCR in `WorkOcrCreatorRemover`:
- when one of the assets has `ocr_suppressed` flag set:
  - if `hocr` and `textonly_pdf` exist:
    - remove them;
  - if `hocr` and `textonly_pdf` do not exist:
    - don't try to create them.