### PR TITLE
kick off a work ocr update when you change suppress_ocr on an asset

### DIFF
--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -44,7 +44,7 @@ class Admin::AssetsController < AdminController
 
     respond_to do |format|
       if @asset.update(asset_params)
-        # If this update changed, enqueue a job to update
+        # If this update changed suppress_ocr, enqueue a job to update
         # the entire parent work's OCR.
         # Reprocessing the entire work based on changes to a single asset
         # seems like overkill.

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -44,6 +44,14 @@ class Admin::AssetsController < AdminController
 
     respond_to do |format|
       if @asset.update(asset_params)
+        # If this update changed, enqueue a job to update
+        # the entire parent work's OCR.
+        # Reprocessing the entire work based on changes to a single asset
+        # seems like overkill.
+        # In practice, this operation is cheap and keeps the code DRY.
+        if @asset.suppress_ocr_previously_changed?
+          WorkOcrCreatorRemoverJob.perform_later(@asset.parent)
+        end
         format.html { redirect_to admin_asset_url(@asset), notice: 'Asset was successfully updated.' }
         format.json { render :show, status: :ok, location: @asset }
       else

--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -76,9 +76,9 @@ class Admin::WorksController < AdminController
     authorize! :update, @work
     respond_to do |format|
       if @work.update(work_params)
-        # If this update also just switched ocr_requested, queue up a job to update it's OCR
+        # If this update also just switched ocr_requested, queue up a job to update its OCR
         # data accordingly. If for some reason this is missed, we still have a nightly rake
-        # task to restore consistent state, but let's try to do it sooner?
+        # task to restore consistent state, but let's try to do it sooner.
         if @work.ocr_requested_previously_changed?
           WorkOcrCreatorRemoverJob.perform_later(@work)
         end

--- a/app/services/work_ocr_creator_remover.rb
+++ b/app/services/work_ocr_creator_remover.rb
@@ -59,9 +59,8 @@ class WorkOcrCreatorRemover
   def maybe_remove(asset)
     # don't need it if we already don't have hocr or textonly_pdf
     return if !asset.hocr && !asset.file_derivatives[:textonly_pdf]
-
     asset.hocr = nil
-    # this kithe command will save record to, persisting the hocr=nil,
+    # this next kithe command will save record too, persisting the hocr=nil,
     # atomically concurrently safely making the change.
     asset.remove_derivatives(:textonly_pdf, allow_other_changes: true)
   end


### PR DESCRIPTION
Ref https://github.com/sciencehistory/scihist_digicoll/issues/2311

When you update an asset, if the update changed `suppress_ocr`, go ahead and kick off a job to update the entire work's OCR.
Yes, reprocessing the entire work based on changes to a single asset seems like overkill. In practice, this operation is cheap and doing things this way is DRYer.