### PR TITLE
make ocr_requested filter consistent  with the other filters on the admin work page

### DIFF
--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -76,9 +76,9 @@ class Admin::WorksController < AdminController
     authorize! :update, @work
     respond_to do |format|
       if @work.update(work_params)
-        # If this update also just switched ocr_requested, queue up a job to update it's OCR
+        # If this update also just switched ocr_requested, queue up a job to update its OCR
         # data accordingly. If for some reason this is missed, we still have a nightly rake
-        # task to restore consistent state, but let's try to do it sooner?
+        # task to restore consistent state, but let's try to do it sooner.
         if @work.ocr_requested_previously_changed?
           WorkOcrCreatorRemoverJob.perform_later(@work)
         end
@@ -628,13 +628,9 @@ class Admin::WorksController < AdminController
         end
       end
 
-      # Note from Eddie:
-      # Could not get Ransack's ransackable_attributes to allow this,
-      # so I'm bypassing Ransack and
-      # putting :ocr_requested in params instead of in params[:q].
-      if params[:ocr_requested] == 'true'
+      if params[:q][:ocr_requested] == 'true'
         scope = scope.jsonb_contains(ocr_requested: true)
-      elsif params[:ocr_requested] == 'false'
+      elsif params[:q][:ocr_requested] == 'false'
         scope = scope.not_jsonb_contains(ocr_requested: true)
       end
 

--- a/app/views/admin/works/index.html.erb
+++ b/app/views/admin/works/index.html.erb
@@ -61,15 +61,12 @@
     </div>
 
     <div class="admin-filter">
-      <label for="ocr_requested">OCR</label>
-
-      <%= select_tag "ocr_requested",
-        options_for_select({"Any" => "", "Yes" => "true", "No" => "false"}, params[:ocr_requested]),
+      <label for="q_ocr_requested">OCR</label>
+      <%= select_tag "q[ocr_requested]",
+        options_for_select({"Any" => "", "Requested" => true, "Not requested" => false}, params[:q][:ocr_requested]),
         class: "custom-select"
       %>
     </div>
-
-
 
     <div class="admin-filter">
       <label for="q_review_requested">Review requested</label>


### PR DESCRIPTION
This PR is equivalent to[ #2330](https://github.com/sciencehistory/scihist_digicoll/pull/2330)
but we still need to merge it to master.

Ref https://github.com/sciencehistory/scihist_digicoll/issues/2286 (the initial issue)
Ref https://github.com/sciencehistory/scihist_digicoll/issues/2315 (a sub-issue - to solve the problem better, which this PR takes care of.)
Also changes "yes" and "no" to "Requested" and "not requested", which may avoid some confusion later on.
This was already merged into suppress_ocr_feature.
