### PR TITLE
large collection thumbs, oops 2x size has to be really 2x

### DIFF
--- a/app/uploaders/collection_thumb_asset_uploader.rb
+++ b/app/uploaders/collection_thumb_asset_uploader.rb
@@ -24,7 +24,7 @@ class CollectionThumbAssetUploader < AssetUploader
   end
 
   Attacher.define_derivative("thumb_collection_show_page_2X", content_type: "image") do |original_file|
-    Kithe::VipsCliImageToJpeg.new(max_width: COLLECTION_SHOW_PAGE_THUMB_SIZE, thumbnail_mode: true).call(original_file)
+    Kithe::VipsCliImageToJpeg.new(max_width: COLLECTION_SHOW_PAGE_THUMB_SIZE * 2, thumbnail_mode: true).call(original_file)
   end
 
 end


### PR DESCRIPTION
Didn't have the sizes expressed right in #2342

After deploying, need to re-create derivatives:

    CollectionThumbAsset.find_each {|a| Kithe::CreateDerivativesJob.perform_later(a, only: :thumb_collection_show_page_2X) }

- [ ] re-created derivs in production
