### PR TITLE
Remove and stop using download_small derivatives

### DIFF
--- a/app/presenters/download_options/image_download_options.rb
+++ b/app/presenters/download_options/image_download_options.rb
@@ -33,18 +33,11 @@ module DownloadOptions
       # We don't use content_type in derivative option subheads,
       # cause it's in the main label. But do use it for original.
 
-      if dl_small = asset.file_derivatives[:download_small]
-        options << DownloadOption.with_formatted_subhead("Small JPG",
-          url: download_derivative_path(asset, :download_small),
-          analyticsAction: "download_jpg_small",
-          width: dl_small.width,
-          height: dl_small.height,
-          size: dl_small.size
-        )
-      end
 
+      # For historial reasons we have two download sizes MEDIUM and LARGE,
+      # but we label the medium one as "small"
       if dl_medium = asset.file_derivatives[:download_medium]
-        options << DownloadOption.with_formatted_subhead("Medium JPG",
+        options << DownloadOption.with_formatted_subhead("Small JPG",
           url: download_derivative_path(asset, :download_medium),
           analyticsAction: "download_jpg_medium",
           width: dl_medium.width,

--- a/app/uploaders/asset_uploader.rb
+++ b/app/uploaders/asset_uploader.rb
@@ -43,8 +43,7 @@ class AssetUploader < Kithe::AssetUploader
 
   IMAGE_DOWNLOAD_WIDTHS = {
     large: 2880,
-    medium: 1200,
-    small: 800
+    medium: 1200
   }
 
 

--- a/lib/tasks/data_fixes/remove_download_small_derivative.rake
+++ b/lib/tasks/data_fixes/remove_download_small_derivative.rake
@@ -7,6 +7,10 @@ namespace :scihist do
       progress_bar = ProgressBar.create(total: Asset.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
 
       # https://shrinerb.com/docs/changing-derivatives#removing-derivatives
+      #
+      # Has a recipe for concurrency-safe derivative changes... but it also slows down
+      # things a LOT as it involves a reload. We will do it less safely, it's fine for
+      # our needs.
       Asset.find_in_batches(batch_size: 200) do |batch|
         batch.each do |asset|
           # transaction around batches of 200 could make faster?
@@ -19,11 +23,13 @@ namespace :scihist do
 
             attacher.remove_derivative(:download_small, delete: true)
 
-            begin
-              attacher.atomic_persist            # persist changes if attachment has not changed in the meantime
-            rescue Shrine::AttachmentChanged,    # attachment has changed
-                   ActiveRecord::RecordNotFound  # record has been deleted
-            end
+            asset.save(validate: false)
+
+            # begin
+            #   attacher.atomic_persist            # persist changes if attachment has not changed in the meantime
+            # rescue Shrine::AttachmentChanged,    # attachment has changed
+            #        ActiveRecord::RecordNotFound  # record has been deleted
+            # end
           end
         end
       end

--- a/lib/tasks/data_fixes/remove_download_small_derivative.rake
+++ b/lib/tasks/data_fixes/remove_download_small_derivative.rake
@@ -1,0 +1,27 @@
+namespace :scihist do
+  namespace :data_fixes do
+    desc """
+      Remove download_small derivative from all assets, remove from S3
+    """
+    task :remove_download_small_derivatives => :environment do
+      progress_bar = ProgressBar.create(total: Asset.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+
+      # https://shrinerb.com/docs/changing-derivatives#removing-derivatives
+      Asset.find_each do |asset|
+        attacher = asset.file_attacher
+
+        progress_bar.increment
+
+        next unless attacher.derivatives.key?(:download_small)
+
+        attacher.remove_derivative(:download_small, delete: true)
+
+        begin
+          attacher.atomic_persist            # persist changes if attachment has not changed in the meantime
+        rescue Shrine::AttachmentChanged,    # attachment has changed
+               ActiveRecord::RecordNotFound  # record has been deleted
+        end
+      end
+    end
+  end
+end

--- a/spec/components/download_dropdown_component_spec.rb
+++ b/spec/components/download_dropdown_component_spec.rb
@@ -51,14 +51,13 @@ describe DownloadDropdownComponent, type: :component do
 
       download_items = rendered.css("div.action-item.downloads a.dropdown-item").
         map {|a| a.text }
-      expect(download_items.count).to eq 7
+      expect(download_items.count).to eq 6
       expect(download_items[0]).to include "Public Domain"
       expect(download_items[1]).to include "PDF"
       expect(download_items[2]).to include "Small JPG"
-      expect(download_items[3]).to include "Medium JPG"
-      expect(download_items[4]).to include "Large JPG"
-      expect(download_items[5]).to include "Full-sized JPG"
-      expect(download_items[6]).to include "Original file"
+      expect(download_items[3]).to include "Large JPG"
+      expect(download_items[4]).to include "Full-sized JPG"
+      expect(download_items[5]).to include "Original file"
 
       sample_download_option = div.at_css("a.dropdown-item:contains('Large JPG')")
       expect(sample_download_option["href"]).to be_present
@@ -102,13 +101,12 @@ describe DownloadDropdownComponent, type: :component do
       download_items = rendered.css("div.action-item.downloads a.dropdown-item").
         map {|a| a.text }
 
-      expect(download_items.count).to eq 6
+      expect(download_items.count).to eq 5
       expect(download_items[0]).to include "Public Domain"
       expect(download_items[1]).to include "Small JPG"
-      expect(download_items[2]).to include "Medium JPG"
-      expect(download_items[3]).to include "Large JPG"
-      expect(download_items[4]).to include "Full-sized JPG"
-      expect(download_items[5]).to include "Original file"
+      expect(download_items[2]).to include "Large JPG"
+      expect(download_items[3]).to include "Full-sized JPG"
+      expect(download_items[4]).to include "Original file"
 
       sample_download_option = div.at_css("a.dropdown-item:contains('Large JPG')")
       expect(sample_download_option["href"]).to be_present

--- a/spec/models/asset_factory_spec.rb
+++ b/spec/models/asset_factory_spec.rb
@@ -38,7 +38,7 @@ describe "FactoryBot Asset factory" do
         expect(asset.file_derivatives).to be_present
 
         [ "thumb_mini", "thumb_mini_2X", "thumb_large", "thumb_large_2X", "thumb_standard",
-          "thumb_standard_2X", "download_large", "download_medium", "download_small",
+          "thumb_standard_2X", "download_large", "download_medium",
           "download_full"].each do |key|
             deriv = asset.file_derivatives[key.to_sym]
 


### PR DESCRIPTION
In public UI, call the download_medium `small` -- if there are two options to users, it should be `small` and `large`, not `medium` and `larger`.

But it's harder to rename derivative internally, the name `download_medium` is actually part of its' path on S3. So we'll leave it "medium" internally everywhere, just change it to be labelled `small` in the single part of codebase responsible for presenting to user.

Also a rake task to remove all existing `download_small` derivatives, from S3 and from metadata on each asset. 

    rake scihist:data_fixes:remove_download_small_derivatives

Ref #2276

After deploying, the app will no longer CREATE or USE the `download_small` derivative. But we need to run rake task to remove existing. 

(It's okay if you run rake task when new version isn't fully deployed on heroku -- existing app checks for download_small derivative being present before presenting link to it, so it's okay if it's getting deleted!)

- [ ] Run rake task on production