### PR TITLE
keep json_attributes out of #inspect output

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -3,6 +3,10 @@ class Asset < Kithe::Asset
 
   include RecordPublishedAt
 
+  # keep json_attributes out of string version of model shown in logs and console --
+  # because it's huge, and mostly duplicated by individual attributes that will be included!
+  self.filter_attributes = [:json_attributes]
+
   # We set an indexer to turn on Kithe Solr auto-indexing... but
   # we later override #update_index to index the PARENT WORK when
   # we ourselves change -- we don't index Assets, but we do include

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -8,6 +8,10 @@ class Collection < Kithe::Collection
 
   include RecordPublishedAt
 
+  # keep json_attributes out of string version of model shown in logs and console --
+  # because it's huge, and mostly duplicated by individual attributes that will be included!
+  self.filter_attributes = [:json_attributes]
+
   DEPARTMENT_EXHIBITION_VALUE = "Exhibition"
   DEPARTMENTS = (Work::ControlledLists::DEPARTMENT + [DEPARTMENT_EXHIBITION_VALUE]).freeze
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1,10 +1,14 @@
 class Work < Kithe::Work
   include AttrJson::Record::QueryScopes
 
-  # will trigger automatic solr indexing in callbacks
 
   include RecordPublishedAt
 
+  # keep json_attributes out of string version of model shown in logs and console --
+  # because it's huge, and mostly duplicated by individual attributes that will be included!
+  self.filter_attributes = [:json_attributes]
+
+  # will trigger automatic solr indexing in callbacks
   if ScihistDigicoll::Env.lookup(:solr_indexing) == 'true'
     self.kithe_indexable_mapper = WorkIndexer.new
   end


### PR DESCRIPTION
Mostly just because it's a LOT of text, that is inconvenient to see in console -- and most/all of it is going to be reported under specific attribute name that is serialized to json_attributes anyway.

https://api.rubyonrails.org/classes/ActiveRecord/Core/ClassMethods.html
