### PR TITLE
derived_metadata _jsonb column, move hocr to it

### DIFF
--- a/app/components/work_show_ocr_component.rb
+++ b/app/components/work_show_ocr_component.rb
@@ -26,7 +26,7 @@ class WorkShowOcrComponent < ApplicationComponent
 
         SELECT
           (
-            json_attributes ->> 'hocr' IS NOT NULL
+            derived_metadata_jsonb ->> 'hocr' IS NOT NULL
             and
             coalesce(json_attributes ->> 'suppress_ocr', 'false') != 'true'
           ) has_ocr,

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -64,15 +64,16 @@ class Asset < Kithe::Asset
   attr_json :transcription, :text
   attr_json :english_translation, :text
 
-  # OCR data in hOCR format, for the image asset
-  attr_json :hocr, :text
-
   # If this is set, do not create OCR for this asset,
   # regardless of the parent work's settings.
   attr_json :suppress_ocr, :boolean, default: false
 
   # A place for staff to enter any internal notes about OCR for this asset.
   attr_json :ocr_admin_note, :text
+
+  # OCR data in hOCR format, for the image asset
+  attr_json :hocr, :text, container_attribute: :derived_metadata_jsonb
+
 
   validates :ocr_admin_note,
     presence: { message: ": Please specify why OCR is suppressed." },

--- a/db/migrate/20230907141354_add_derived_metadata_jsonb_to_kithe_models.rb
+++ b/db/migrate/20230907141354_add_derived_metadata_jsonb_to_kithe_models.rb
@@ -1,0 +1,5 @@
+class AddDerivedMetadataJsonbToKitheModels < ActiveRecord::Migration[7.0]
+  def change
+    add_column :kithe_models, :derived_metadata_jsonb, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_16_205620) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_07_141354) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -176,6 +176,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_16_205620) do
     t.integer "kithe_model_type", null: false
     t.string "role"
     t.datetime "published_at", precision: nil
+    t.jsonb "derived_metadata_jsonb"
     t.index ["friendlier_id"], name: "index_kithe_models_on_friendlier_id", unique: true
     t.index ["leaf_representative_id"], name: "index_kithe_models_on_leaf_representative_id"
     t.index ["parent_id"], name: "index_kithe_models_on_parent_id"

--- a/lib/tasks/data_fixes/migrate_hocr_to_derived_metadata_jsonb.rake
+++ b/lib/tasks/data_fixes/migrate_hocr_to_derived_metadata_jsonb.rake
@@ -1,0 +1,18 @@
+namespace :scihist do
+  namespace :data_fixes do
+    desc "Migrate attr-json Asset#hocr to new separate derived_metadata_jsonb column"
+    task :migrate_hocr_to_derived_metadata_jsonb => :environment do
+      scope = Asset.where("json_attributes ->> 'hocr' is not null")
+
+      progress_bar = ProgressBar.create(total: scope.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+
+      scope.find_each do |asset|
+        asset.hocr = asset.json_attributes["hocr"]
+        asset.json_attributes.delete("hocr")
+        asset.save!
+
+        progress_bar.increment
+      end
+    end
+  end
+end


### PR DESCRIPTION
Create new column `derived_metadata_jsonb` on kithe_models, and move Asset#hocr attr_json to it. 

Since the `hocr` data is not currently actually used by anything, we don't need to worry about race conditions in the migration, it's fine that it deploys with new location, then we migrate the data, etc. 

Prep for #2271

- [ ] run rake task to migrate existing data: `rake scihist:data_fixes:migrate_hocr_to_derived_metadata_jsonb`

- add derived_metadata_jsonb column
- move Asset#hocr to be defined on derived_metadata_jsonb
- rake task to move Asset#hocr to new location
