### PR TITLE
Change [Missing] text to Undated

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -255,7 +255,7 @@ class CatalogController < ApplicationController
 
     # The "show: :current_user" arg lets us limit facets to only showing up if someone is logged in
 
-    config.add_facet_field "year_facet_isim", label: "Date", range: true
+    config.add_facet_field "year_facet_isim", label: "Date", range: true, item_presenter: DateFacetItemPresenter
     config.add_facet_field "subject_facet", label: "Subject", limit: 5
     config.add_facet_field "creator_facet", label: "Creator", limit: 5
     config.add_facet_field "genre_facet", label: "Genre", limit: 5

--- a/app/presenters/date_facet_item_presenter.rb
+++ b/app/presenters/date_facet_item_presenter.rb
@@ -1,0 +1,15 @@
+# Allows us to customize various aspects of the date field (year_facet_isim) facet.
+class DateFacetItemPresenter < BlacklightRangeLimit::FacetItemPresenter
+
+  # Look up the label for the facet for items missing a date in blacklight.en.yml .
+  def label
+    if value == {:missing=>true}
+      # The path to the label is taken from
+      #   https://github.com/projectblacklight/blacklight/blob/457f89f3dba758c0e642e881724cd818c1cc5f9e/lib/blacklight/solr/response/facets.rb#L199
+      I18n.t(:"blacklight.search.fields.facet.missing.#{@facet_config.field}", default: super)
+    else
+      super
+    end
+  end
+
+end

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -19,3 +19,8 @@ en:
         #
         # no_items_found: "No entries found"
         no_items_found: ""
+      fields:
+          facet:
+              missing:
+                  year_facet_isim:
+                    "Undated" # See DateFacetItemPresenter

--- a/spec/system/catalog_search_spec.rb
+++ b/spec/system/catalog_search_spec.rb
@@ -47,6 +47,13 @@ describe CatalogController, solr: true, indexable_callbacks: true do
         #expect(page).to have_link(text: collection.title, href: collection_path(work1))
       end
 
+      # Make sure the date facet labels missing dates as "Undated".
+      # See https://github.com/sciencehistory/scihist_digicoll/issues/2282
+      click_on "Date"
+      within "div.blacklight-year_facet_isim" do
+         expect(page).to have_content "Undated"
+      end
+
       # no fulltext search highlights here
       expect(page).not_to have_selector(".scihist-results-list-item-highlights")
 


### PR DESCRIPTION
Ref: #2282
Subclass BlacklightRangeLimit::FacetItemPresenter so we can have more control over labels.
Unlike a previous attempt, this does not "cheat" by taking advantage of the fact that facets.missing is turned off for all facets *except* the date range facet.