### PR TITLE
Better screening for range limit params

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -678,8 +678,8 @@ class CatalogController < ApplicationController
   # range_start and range_end parameter and ensures they are in the correct order,
   # then makes a second request to #range_limit .
   def screen_params_for_range_limit
-    if (params['range_end'].nil?) ||
-      (params['range_start'].nil?) ||
+    if (params['range_end'].class != String) ||
+      (params['range_start'].class != String) ||
       (params['range_start'].to_i > params['range_end'].to_i)
         render plain: "Calls to range_limit should have a range_start " +
           "and a range_end parameter, and range_start " +

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -127,6 +127,14 @@ RSpec.describe CatalogController, solr: true, type: :controller do
         "range_end"=>"1930"
       }
     end
+    let(:not_strings) do
+      {
+        "range_field"=>"year_facet_isim",
+        "range_start"=>"1931",
+        "range_end"=>["1940"]
+      }
+    end
+
     it "throws 406 unless start param is present" do
       get :range_limit, params: no_start_params
       expect(response.status).to eq(406)
@@ -137,6 +145,10 @@ RSpec.describe CatalogController, solr: true, type: :controller do
     end
     it "throws 406 if params out of order" do
       get :range_limit, params: end_before_start_params
+      expect(response.status).to eq(406)
+    end
+    it "throws 406 if one of the params is an array" do
+      get :range_limit, params: not_strings
       expect(response.status).to eq(406)
     end
   end


### PR DESCRIPTION
Ref #2355 

We were already screening for nil values, but we should actually be testing that both values are strings.