### PR TITLE
Omit display of exiftool validation warnings

### DIFF
--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -340,17 +340,6 @@
           <%= @exiftool_result.camera_iso %>
         </dd>
       <% end %>
-
-      <% if @exiftool_result.exiftool_validation_warnings.present? %>
-        <dt class="col-sm-4">Exiftool Validation Warnings</dt>
-        <dd class="col-sm-8">
-          <ul>
-            <% @exiftool_result.exiftool_validation_warnings.each do |warning| %>
-              <li><%= warning %> </li>
-            <% end %>
-          </ul>
-        </dd>
-      <% end %>
     </dl>
 
     <h2 class="mt-4">Derivatives</h2>


### PR DESCRIPTION
While they will still be included in the exiftool output JSON stored in the DB, for now we won't display them on admin page. Annabel found them unhelpful, in #2271.

If developer staff discovers later that WE really could use them, we could see about displaying them in a more filtered/less disruptive way.
