### PR TITLE
Refactor DownloadOption to DRY code

### DIFF
--- a/app/components/download_dropdown_component.rb
+++ b/app/components/download_dropdown_component.rb
@@ -246,20 +246,12 @@ class DownloadDropdownComponent < ApplicationComponent
     return [] unless has_work_download_options?
 
     [
-      DownloadOption.new("PDF", url: "#", analyticsAction: "download_pdf",
-        work_friendlier_id: @asset&.parent&.friendlier_id,
-        data_attrs: {
-          trigger: "on-demand-download",
-          derivative_type: "pdf_file",
-          work_id: display_parent_work.friendlier_id
-        }),
-      DownloadOption.new("ZIP", subhead: "of full-sized JPGs", url: "#", analyticsAction: "download_zip",
-        work_friendlier_id: @asset&.parent&.friendlier_id,
-        data_attrs: {
-          trigger: "on-demand-download",
-          derivative_type: "zip_file",
-          work_id: display_parent_work.friendlier_id
-        }),
+      DownloadOption.for_on_demand_derivative(
+        label: "PDF", derivative_type: "pdf_file", work_friendlier_id: @asset&.parent&.friendlier_id
+      ),
+      DownloadOption.for_on_demand_derivative(
+        label: "ZIP", derivative_type: "zip_file", work_friendlier_id: @asset&.parent&.friendlier_id
+      )
     ]
   end
 

--- a/app/components/download_dropdown_component.rb
+++ b/app/components/download_dropdown_component.rb
@@ -215,20 +215,10 @@ class DownloadDropdownComponent < ApplicationComponent
       download_option.label, (content_tag("small", download_option.subhead) if download_option.subhead.present?)
     ])
 
-    analytics_data_attr = if display_parent_work
-      {
-        analytics_category: "Work",
-        analytics_action: download_option.analyticsAction,
-        analytics_label: display_parent_work.friendlier_id
-      }
-    else
-      {}
-    end
-
     content_tag("a", label,
                       class: "dropdown-item",
                       href: download_option.url,
-                      data: download_option.data_attrs.merge(analytics_data_attr))
+                      data: download_option.data_attrs)
   end
 
   def rights_statement_item
@@ -257,12 +247,14 @@ class DownloadDropdownComponent < ApplicationComponent
 
     [
       DownloadOption.new("PDF", url: "#", analyticsAction: "download_pdf",
+        work_friendlier_id: @asset&.parent&.friendlier_id,
         data_attrs: {
           trigger: "on-demand-download",
           derivative_type: "pdf_file",
           work_id: display_parent_work.friendlier_id
         }),
       DownloadOption.new("ZIP", subhead: "of full-sized JPGs", url: "#", analyticsAction: "download_zip",
+        work_friendlier_id: @asset&.parent&.friendlier_id,
         data_attrs: {
           trigger: "on-demand-download",
           derivative_type: "zip_file",

--- a/app/models/download_option.rb
+++ b/app/models/download_option.rb
@@ -3,6 +3,37 @@
 class DownloadOption
   attr_reader :label, :subhead, :url, :analyticsAction, :data_attrs, :work_friendlier_id
 
+
+  # Create a DownloadOption for one of our on-demand derivatives, DRY it up here
+  # so we can re-use equivalently.
+  def self.for_on_demand_derivative(label:, derivative_type:, work_friendlier_id:)
+    derivative_type = derivative_type.to_s
+
+    unless derivative_type.in?(["pdf_file", "zip_file"])
+      raise ArgumentError.new("derivative_type `#{derivative_type}` must be one of pdf_file or zip_file")
+    end
+
+    analytics_action = {
+      "pdf_file" => "download_pdf",
+      "zip_file" => "download_zip"
+    }[derivative_type]
+
+    subhead = {
+     "pdf_file" => nil,
+      "zip_file" => "of full-sized JPGs"
+    }[derivative_type]
+
+    DownloadOption.new(label, url: "#", analyticsAction: analytics_action,
+      work_friendlier_id: work_friendlier_id,
+      subhead: subhead,
+      data_attrs: {
+        trigger: "on-demand-download",
+        derivative_type: derivative_type,
+        work_id: work_friendlier_id
+      }
+    )
+  end
+
   # Formats the sub-head for you, in a standard way, using info about the asset. If you don't
   # want this standard format, just use the ordinary new/initialize instead.
   #

--- a/app/models/download_option.rb
+++ b/app/models/download_option.rb
@@ -1,7 +1,7 @@
 # A simple value object representing a download option, used for constructing our download
 # menus
 class DownloadOption
-  attr_reader :label, :subhead, :url, :analyticsAction, :data_attrs
+  attr_reader :label, :subhead, :url, :analyticsAction, :data_attrs, :work_friendlier_id
 
   # Formats the sub-head for you, in a standard way, using info about the asset. If you don't
   # want this standard format, just use the ordinary new/initialize instead.
@@ -19,7 +19,8 @@ class DownloadOption
   # @param content_type[#to_s] mime/IANA media/content type like "image/jpeg"
   # @param data_attrs[Hash] hash compatible with rails content_tag `data:` argument, for additional data attributes
   #   to add to link.
-  def self.with_formatted_subhead(label, url:, analyticsAction:nil, width: nil, height: nil, size: nil, content_type: nil)
+  # @param work_friendlier_id [String] used for analytics data attributes
+  def self.with_formatted_subhead(label, url:, work_friendlier_id:, analyticsAction:nil, width: nil, height: nil, size: nil, content_type: nil)
     parts = []
     parts << ScihistDigicoll::Util.humanized_content_type(content_type) if content_type.present?
     parts << "#{width.to_s} x #{height.to_s}px" if width.present? && height.present?
@@ -29,20 +30,35 @@ class DownloadOption
 
     subhead = parts.join(" — ") # em-dash
 
-    new(label, url: url, analyticsAction: analyticsAction, subhead: subhead.presence)
+    new(label, url: url, work_friendlier_id: work_friendlier_id, analyticsAction: analyticsAction, subhead: subhead.presence)
   end
 
   # @param label [String] main label for the download link
-  # @param subhead [String] a subheading/hint/more info for the label for the download link
+  # @param work_friendlier_id [String] used for analytics data attributes
   # @param url [String] the url to link to
+  # @param subhead [String] a subheading/hint/more info for the label for the download link
   # @param analyticsAction [String] a key to record in our analytics logging, up to caller
   #   to decide what to do with it, but probably will turn into a data- attribute for JS.
-  def initialize(label, url:, subhead:nil, analyticsAction:nil, data_attrs: {})
+  def initialize(label, url:, work_friendlier_id:, subhead:nil, analyticsAction:nil, data_attrs: {})
     @label = label
     @subhead = subhead
     @url = url
     @analyticsAction = analyticsAction
     @data_attrs = data_attrs
+    @work_friendlier_id = work_friendlier_id
+
+    # Add in analytics data- attributes
+    @data_attrs.merge!(analytics_data_attributes)
+  end
+
+  # trigger analytics JS, eg Google Analytics prob
+  def analytics_data_attributes
+    return {} unless work_friendlier_id
+    {
+      analytics_category: "Work",
+      analytics_action: analyticsAction,
+      analytics_label: work_friendlier_id
+    }
   end
 
   # Rails architecture gives us #to_json for a string if we provide as_json

--- a/app/presenters/download_options/audio_download_options.rb
+++ b/app/presenters/download_options/audio_download_options.rb
@@ -17,6 +17,7 @@ module DownloadOptions
 
       if m4a_deriv = asset.file_derivatives[:m4a]
         options << DownloadOption.with_formatted_subhead("Smaller file",
+          work_friendlier_id: @asset.parent&.friendlier_id,
           url: download_derivative_path(asset, :m4a),
           analyticsAction: "download_m4a_derivative_of_flac_original",
           content_type: 'audio/mp4',
@@ -26,6 +27,7 @@ module DownloadOptions
 
       if asset.stored?
         options << DownloadOption.with_formatted_subhead("Original file",
+          work_friendlier_id: @asset.parent&.friendlier_id,
           url: download_path(asset.file_category, asset),
           analyticsAction: "download_original",
           content_type: asset.content_type,

--- a/app/presenters/download_options/image_download_options.rb
+++ b/app/presenters/download_options/image_download_options.rb
@@ -22,7 +22,7 @@ module DownloadOptions
       # We do allow a PDF download for this now, but we list it under "Download Selected Image".
       # See https://github.com/sciencehistory/scihist_digicoll/issues/2278 .
       if asset&.parent&.members&.count == 1
-        options << DownloadOption.new("PDF", url: "#", analyticsAction: "download_pdf",
+        options << DownloadOption.new("PDF", work_friendlier_id: @asset.parent&.friendlier_id, url: "#", analyticsAction: "download_pdf",
         data_attrs: {
           trigger: "on-demand-download",
           derivative_type: "pdf_file",
@@ -38,6 +38,7 @@ module DownloadOptions
       # but we label the medium one as "small"
       if dl_medium = asset.file_derivatives[:download_medium]
         options << DownloadOption.with_formatted_subhead("Small JPG",
+          work_friendlier_id: @asset.parent&.friendlier_id,
           url: download_derivative_path(asset, :download_medium),
           analyticsAction: "download_jpg_medium",
           width: dl_medium.width,
@@ -48,6 +49,7 @@ module DownloadOptions
 
       if dl_large = asset.file_derivatives[:download_large]
         options << DownloadOption.with_formatted_subhead("Large JPG",
+          work_friendlier_id: @asset.parent&.friendlier_id,
           url: download_derivative_path(asset, :download_large),
           analyticsAction: "download_jpg_large",
           width: dl_large.width,
@@ -59,6 +61,7 @@ module DownloadOptions
       if dl_full = asset.file_derivatives[:download_full]
         options << DownloadOption.with_formatted_subhead("Full-sized JPG",
           url: download_derivative_path(asset, :download_full),
+          work_friendlier_id: @asset.parent&.friendlier_id,
           analyticsAction: "download_jpg_full",
           width: dl_full.width,
           height: dl_full.height,
@@ -69,6 +72,7 @@ module DownloadOptions
       if asset.stored?
         options << DownloadOption.with_formatted_subhead("Original file",
           url: download_path(asset.file_category, asset),
+          work_friendlier_id: @asset.parent&.friendlier_id,
           analyticsAction: "download_original",
           content_type: asset.content_type,
           width: asset.width,

--- a/app/presenters/download_options/image_download_options.rb
+++ b/app/presenters/download_options/image_download_options.rb
@@ -22,12 +22,9 @@ module DownloadOptions
       # We do allow a PDF download for this now, but we list it under "Download Selected Image".
       # See https://github.com/sciencehistory/scihist_digicoll/issues/2278 .
       if asset&.parent&.members&.count == 1
-        options << DownloadOption.new("PDF", work_friendlier_id: @asset.parent&.friendlier_id, url: "#", analyticsAction: "download_pdf",
-        data_attrs: {
-          trigger: "on-demand-download",
-          derivative_type: "pdf_file",
-          work_id: @asset.parent.friendlier_id
-        })
+        options << DownloadOption.for_on_demand_derivative(
+          label: "PDF", derivative_type: "pdf_file", work_friendlier_id: @asset&.parent&.friendlier_id
+        )
       end
 
       # We don't use content_type in derivative option subheads,

--- a/spec/components/download_dropdown_component_spec.rb
+++ b/spec/components/download_dropdown_component_spec.rb
@@ -8,7 +8,7 @@ describe DownloadDropdownComponent, type: :component do
     let(:asset) do
       create(:asset_with_faked_file,
             faked_derivatives: {},
-            parent: build(:work, rights: "http://creativecommons.org/publicdomain/mark/1.0/")
+            parent: build(:work, friendlier_id: "faked#{rand(1000000).to_s(16)}", rights: "http://creativecommons.org/publicdomain/mark/1.0/")
       )
     end
 
@@ -40,7 +40,7 @@ describe DownloadDropdownComponent, type: :component do
           download_large: build(:stored_uploaded_file),
           download_full: build(:stored_uploaded_file)
         },
-        parent: build(:work, rights: "http://creativecommons.org/publicdomain/mark/1.0/")
+        parent: build(:work, friendlier_id: "faked#{rand(1000000).to_s(16)}", rights: "http://creativecommons.org/publicdomain/mark/1.0/")
       )
     end
 
@@ -69,7 +69,7 @@ describe DownloadDropdownComponent, type: :component do
 
   describe "work with two image files and derivatives" do
     let(:work) do
-      build(:work, rights: "http://creativecommons.org/publicdomain/mark/1.0/",
+      build(:work, friendlier_id: "faked#{rand(1000000).to_s(16)}", rights: "http://creativecommons.org/publicdomain/mark/1.0/",
         members:
         [
           create(:asset_with_faked_file,

--- a/spec/models/download_option_spec.rb
+++ b/spec/models/download_option_spec.rb
@@ -5,6 +5,7 @@ describe DownloadOption do
     it "formats with everything" do
       expect(DownloadOption.with_formatted_subhead(
         "something",
+        work_friendlier_id: "work_id",
         url: "http://example.org",
         content_type: "image/jpeg",
         width: 100,
@@ -15,6 +16,7 @@ describe DownloadOption do
     it "formats with no content-type" do
       expect(DownloadOption.with_formatted_subhead(
         "something",
+        work_friendlier_id: "work_id",
         url: "http://example.org",
         width: 100,
         height: 200,
@@ -24,6 +26,7 @@ describe DownloadOption do
     it "formats with no dimensions" do
       expect(DownloadOption.with_formatted_subhead(
         "something",
+        work_friendlier_id: "work_id",
         url: "http://example.org",
         height: nil,
         width: nil,
@@ -37,7 +40,8 @@ describe DownloadOption do
     let(:subhead) { "This is a <small>subhead</small>" }
     let(:label) { "This is a label" }
     let(:analyticsAction) { "click-on-something" }
-    let(:download_option) { DownloadOption.new(label, url: url, subhead: subhead, analyticsAction: analyticsAction) }
+    let(:work_friendlier_id) { "work-id" }
+    let(:download_option) { DownloadOption.new(label, work_friendlier_id: work_friendlier_id, url: url, subhead: subhead, analyticsAction: analyticsAction) }
 
     it "produces hash" do
       expect(download_option.as_json).to match({
@@ -55,6 +59,21 @@ describe DownloadOption do
         "label" => label,
         "analyticsAction" => analyticsAction
       })
+    end
+  end
+
+  describe "analytics data- attributes" do
+    let(:analyticsAction) { "click-on-something" }
+    let(:work_friendlier_id) { "work-id" }
+
+    let(:download_option) {
+      DownloadOption.new("some label", work_friendlier_id: work_friendlier_id, analyticsAction: analyticsAction, url: "#")
+    }
+
+    it "are included in data_attrs" do
+      expect(download_option.data_attrs[:analytics_category]).to eq "Work"
+      expect(download_option.data_attrs[:analytics_action]).to eq analyticsAction
+      expect(download_option.data_attrs[:analytics_label]).to eq work_friendlier_id
     end
   end
 


### PR DESCRIPTION
For intended re-use at #2372

- move analytics data attributes inside DownloadOption, requires passing work-id to DownloadOption
- extract creation of on-demand-deriv DownloadOption to DRY

This code is definitely kind of squirrely, and remains so... not sure if we made it easier to understand or harder with this refactor, but we do DRY it for re-use. 
