### PR TITLE
 attempt at more RAM-efficient find_each for batch jobs

### DIFF
--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -47,11 +47,11 @@ SitemapGenerator::Sitemap.create(
     add featured_topic_path(slug), changefreq: 'weekly'
   end
 
-  Collection.where(published: true).find_each do |c|
+  ScihistDigicoll::Util.find_each(Collection.where(published: true)) do |c|
     add collection_path(c), changefreq: 'weekly', lastmod: nil
   end
 
-  Work.where(published: true).includes(:members => :leaf_representative).order("updated_at desc").find_each do |w|
+  ScihistDigicoll::Util.find_each(Work.where(published: true).includes(:members => :leaf_representative).order("updated_at desc")) do |w|
 
     # spec says we can add at most 1000 image URLs for each page. Let's add large thumbs
     # of all members, trying to use same URLs we'll use for src in page.

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -51,7 +51,7 @@ SitemapGenerator::Sitemap.create(
     add collection_path(c), changefreq: 'weekly', lastmod: nil
   end
 
-  ScihistDigicoll::Util.find_each(Work.where(published: true).includes(:members => :leaf_representative).order("updated_at desc")) do |w|
+  ScihistDigicoll::Util.find_each(Work.where(published: true).includes(:members => :leaf_representative)) do |w|
 
     # spec says we can add at most 1000 image URLs for each page. Let's add large thumbs
     # of all members, trying to use same URLs we'll use for src in page.

--- a/lib/tasks/active_encode_status.rake
+++ b/lib/tasks/active_encode_status.rake
@@ -10,7 +10,7 @@ namespace :scihist do
     You want a scheduled job to run this periodically, maybe once an hour.
     """
     task :update => :environment do
-      ActiveEncodeStatus.running.find_each do |job_status|
+      ScihistDigicoll::Util.find_each(ActiveEncodeStatus.running) do |job_status|
         RefreshActiveEncodeStatusJob.perform_later(job_status)
       end
 


### PR DESCRIPTION
Ref #2383

We make a utility method that applies a few tricks we're hoping will reduce RAM consumption for batch jobs. Let's deploy and see if it helps?

- attempt at more RAM-efficient find_each for batch jobs
- .order is ignored for find_each, always
