### PR TITLE
Extract logic on whether to include a PDF to OUTSIDE ImageDownloadOptions

### DIFF
--- a/app/presenters/download_options/image_download_options.rb
+++ b/app/presenters/download_options/image_download_options.rb
@@ -12,16 +12,20 @@ module DownloadOptions
 
     attr_reader :asset
 
-    def initialize(asset)
+    def initialize(asset, show_pdf_link: false)
       @asset = asset
+      @show_pdf_link = show_pdf_link
+    end
+
+    def show_pdf_link?
+      !!@show_pdf_link
     end
 
     def options
       options = []
-      # Special case: an image asset is the *only* member of the work.
-      # We do allow a PDF download for this now, but we list it under "Download Selected Image".
-      # See https://github.com/sciencehistory/scihist_digicoll/issues/2278 .
-      if asset&.parent&.members&.count == 1
+      # Sometimes we want the PDF link in the individual-image download links,
+      # as per https://github.com/sciencehistory/scihist_digicoll/issues/2278 .
+      if show_pdf_link?
         options << DownloadOption.for_on_demand_derivative(
           label: "PDF", derivative_type: "pdf_file", work_friendlier_id: @asset&.parent&.friendlier_id
         )

--- a/app/serializers/viewer_member_info_serializer.rb
+++ b/app/serializers/viewer_member_info_serializer.rb
@@ -50,7 +50,9 @@ class ViewerMemberInfoSerializer
   end
 
   def download_options(asset)
-    DownloadOptions::ImageDownloadOptions.new(asset).options
+    # include the PDF link here if we only have one image, as there won't be a
+    # fixed whole-work download section, but we still want it.
+    DownloadOptions::ImageDownloadOptions.new(asset, show_pdf_link: work.member_count == 1).options
   end
 
   def thumb_src_attributes(asset)

--- a/spec/components/download_dropdown_component_spec.rb
+++ b/spec/components/download_dropdown_component_spec.rb
@@ -40,7 +40,7 @@ describe DownloadDropdownComponent, type: :component do
           download_large: build(:stored_uploaded_file),
           download_full: build(:stored_uploaded_file)
         },
-        parent: build(:work, friendlier_id: "faked#{rand(1000000).to_s(16)}", rights: "http://creativecommons.org/publicdomain/mark/1.0/")
+        parent: build(:public_work, members: [], friendlier_id: "faked#{rand(1000000).to_s(16)}", rights: "http://creativecommons.org/publicdomain/mark/1.0/")
       )
     end
 
@@ -51,6 +51,7 @@ describe DownloadDropdownComponent, type: :component do
 
       download_items = rendered.css("div.action-item.downloads a.dropdown-item").
         map {|a| a.text }
+
       expect(download_items.count).to eq 6
       expect(download_items[0]).to include "Public Domain"
       expect(download_items[1]).to include "PDF"


### PR DESCRIPTION
ImageDownloadOptions just gets a boolean whether to include pdf, the caller has to decide if it wants it or not.

Is this better? Hard to say. All this dropdown logic has become very convoluted. I have not been able to figure out how to make it incontrovertibly better, and am just resigning to this being good enough. What this does do is:

* Resolve the n-query problem in #2378. I still don't totally understand what was even going on there, but this resolve it.
* Set things up for #2372 to be easier, where in some cases the dropdown menu shouldn't include the whole-work-download options at all.

Separating this out from #2372 for easier review.

I am definitely not thrilled with how weird this has all become, but best I can do for now. If you have any other ideas though, let's talk.
