### PR TITLE
keep very lengthy attributes out of Asset#inspect

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -5,7 +5,9 @@ class Asset < Kithe::Asset
 
   # keep json_attributes out of string version of model shown in logs and console --
   # because it's huge, and mostly duplicated by individual attributes that will be included!
-  self.filter_attributes = [:json_attributes]
+  #
+  # But we'll also keep out some enormous individual attributes, like :hocr
+  self.filter_attributes = [:json_attributes, :derived_metadata_jsonb, :hocr]
 
   # We set an indexer to turn on Kithe Solr auto-indexing... but
   # we later override #update_index to index the PARENT WORK when


### PR DESCRIPTION
To keep displays of Asset in logs and console from being so unmananageable
