### PR TITLE
Fix padding on cookie banner for narrow screens

### DIFF
--- a/app/frontend/stylesheets/local/accept_cookies_banner.scss
+++ b/app/frontend/stylesheets/local/accept_cookies_banner.scss
@@ -15,7 +15,6 @@ nav.accept-cookies-banner-nav {
 
   .i-accept-copy {
     flex-basis: 25rem;
-    flex-shrink: 0;
     flex-grow: 1;
   }
 


### PR DESCRIPTION
Ref #2388.
Removed the `flex-shrink` css property.
Fixes the problem on phone, and doesn't seem to make a difference on other platforms I've been able to test on.