### PR TITLE
Ability for the OnDemandDerivative system to deliver inline links

### DIFF
--- a/app/frontend/javascript/scihist_on_demand_downloader.js
+++ b/app/frontend/javascript/scihist_on_demand_downloader.js
@@ -44,6 +44,8 @@ $( document ).ready(function() {
   ScihistOnDemandDownloader.prototype.fetchForStatus = function() {
     var _self = this;
 
+
+
     var fetchUrl = "/works/" + this.work_id + "/" + _self.deriv_type;
 
     if (this.disposition) {
@@ -55,10 +57,21 @@ $( document ).ready(function() {
     }).then(function(json) {
       if (json.status == "success") {
         var existing;
-        if (existing = _self.getModal(true)) {
-          existing.modal("hide");
+
+        if (_self.disposition == "inline") {
+          // We want to open in new tab,
+          // I guess we need to provide a button that says "open here", since
+          // popup blocker won't let us actually open a new tab at this point,
+          // after a fetch instead of immediately on click... more code needed
+          TO BE DONE
+        } else {
+          // close model and load PDF for download
+
+          if (existing = _self.getModal(true)) {
+            existing.modal("hide");
+          }
+          window.location = json.file_url;
         }
-        window.location = json.file_url;
       } else if (json.status == "in_progress") {
         _self.updateProgress(json);
         _self.getModal().modal("show");

--- a/app/models/download_option.rb
+++ b/app/models/download_option.rb
@@ -6,11 +6,15 @@ class DownloadOption
 
   # Create a DownloadOption for one of our on-demand derivatives, DRY it up here
   # so we can re-use equivalently.
-  def self.for_on_demand_derivative(label:, derivative_type:, work_friendlier_id:)
+  def self.for_on_demand_derivative(label:, derivative_type:, work_friendlier_id:, disposition: nil)
     derivative_type = derivative_type.to_s
 
     unless derivative_type.in?(["pdf_file", "zip_file"])
       raise ArgumentError.new("derivative_type `#{derivative_type}` must be one of pdf_file or zip_file")
+    end
+
+    unless disposition.in?([nil, :inline, :attachment])
+      raise ArgumentError.new("disposition `#{disposition}` must be nil or one of :inline or :attachment")
     end
 
     analytics_action = {
@@ -29,8 +33,9 @@ class DownloadOption
       data_attrs: {
         trigger: "on-demand-download",
         derivative_type: derivative_type,
-        work_id: work_friendlier_id
-      }
+        work_id: work_friendlier_id,
+        :"download-content-disposition" => disposition
+      }.compact
     )
   end
 

--- a/app/models/on_demand_derivative.rb
+++ b/app/models/on_demand_derivative.rb
@@ -59,12 +59,19 @@ class OnDemandDerivative < ApplicationRecord
     uploaded_file.exists?
   end
 
-  def file_url
+  # @param disposition [String,Symbol] if :inline we'll return inline content-diposition, otherwise attachment default
+  def file_url(disposition: :attachment)
+    content_disposition = if disposition.to_s == "inline"
+        ContentDisposition.inline(desired_filename)
+      else
+        ContentDisposition.attachment(desired_filename)
+      end
+
     uploaded_file.url(
       public: false,
       expires_in: PRESIGNED_URL_EXPIRES_IN,
       response_content_type: uploaded_file.metadata["mime_type"],
-      response_content_disposition: ContentDisposition.attachment(desired_filename)
+      response_content_disposition: content_disposition
     )
   end
 


### PR DESCRIPTION
For use in #2372, extracted to separate PR

Ackowledging the lack of tests. This stuff wasn't well tested to begin with. It is difficult to test because we aren't great at testing Javascript; and because content-disposition headeres on download links aren't even currently available in test where we use shrine local file adapter instead of S3 adapter in production.

Regrettable, but I coudln't figure out a reasonable way to improve things. I did test manually. I also improved the docs at top of JS code.
