### PR TITLE
Make show PDF link logic match ZIP link for being smart about NO images at all

### DIFF
--- a/app/components/work_download_links_component.html.erb
+++ b/app/components/work_download_links_component.html.erb
@@ -1,34 +1,36 @@
 <div class="on-page-work-downloads">
 
-  <div class="on-page-work-downloads-item">
-    <div class="image">
-      <%= link_to(pdf_download_option.url, data: pdf_download_option.data_attrs, tabindex: -1, "aria-label": "Download PDF") do %>
-        <%= helpers.file_earmark_pdf_fill_svg %>
-      <% end %>
-    </div>
+  <% if has_any_pdf? %>
+    <div class="on-page-work-downloads-item">
+      <div class="image">
+        <%= link_to(pdf_download_option.url, data: pdf_download_option.data_attrs, tabindex: -1, "aria-label": "Download PDF") do %>
+          <%= helpers.file_earmark_pdf_fill_svg %>
+        <% end %>
+      </div>
 
-    <div class="text">
-        <%= link_to(pdf_download_option.url, data: pdf_download_option.data_attrs, tabindex: -1) do %>
-          <% if has_searchable_pdf? %>
-            Searchable PDF
-          <% else %>
-            PDF
+      <div class="text">
+          <%= link_to(pdf_download_option.url, data: pdf_download_option.data_attrs, tabindex: -1) do %>
+            <% if has_searchable_pdf? %>
+              Searchable PDF
+            <% else %>
+              PDF
+            <% end %>
           <% end %>
-        <% end %>
 
-        <% if has_searchable_pdf? %>
-          <div class="hint">
-            <small>may contain errors</small>
-          </div>
-        <% end %>
-    </div>
+          <% if has_searchable_pdf? %>
+            <div class="hint">
+              <small>may contain errors</small>
+            </div>
+          <% end %>
+      </div>
 
-    <div class="action">
-      <%= link_to(pdf_download_option.url, data: pdf_download_option.data_attrs, class: "btn btn-brand-main less-padding") do %>
-        Download PDF
-      <% end %>
+      <div class="action">
+        <%= link_to(pdf_download_option.url, data: pdf_download_option.data_attrs, class: "btn btn-brand-main less-padding") do %>
+          Download PDF
+        <% end %>
+      </div>
     </div>
-  </div>
+  <% end %>
 
   <% if has_downloadable_zip? %>
     <div class="on-page-work-downloads-item">

--- a/app/components/work_download_links_component.rb
+++ b/app/components/work_download_links_component.rb
@@ -15,7 +15,13 @@ class WorkDownloadLinksComponent < ApplicationComponent
     # but it's a bit slow, ends up being like 1ms per 10 pages. Instead, for now
     # we're just going to go based on the ocr_requested? flag, meaning sometimes we'll
     # show searchable PDF when OCR may be queued in progress...
-    @has_searchable_pdf = work.ocr_requested?  # && !WorkShowOcrComponent.new(work).asset_ocr_count_warning?
+    @has_searchable_pdf = work.ocr_requested? # && !WorkShowOcrComponent.new(work).asset_ocr_count_warning?
+  end
+
+  def has_any_pdf?
+    return @has_any_pdf if defined?(@has_any_pdf)
+
+    @has_any_pdf = DownloadDropdownComponent.work_has_multiple_published_images?(work)
   end
 
   def has_downloadable_zip?

--- a/spec/components/work_download_links_component_spec.rb
+++ b/spec/components/work_download_links_component_spec.rb
@@ -66,4 +66,13 @@ RSpec.describe WorkDownloadLinksComponent, type: :component do
       expect(page).not_to have_link("ZIP")
     end
   end
+
+  describe "zero item work with OCR requested" do
+    let(:work) { create(:work, :published, members: [], ocr_requested: true) }
+
+    it "still has no PDF or zip link" do
+      expect(page).not_to have_link("ZIP")
+      expect(page).not_to have_link("PDF")
+    end
+  end
 end


### PR DESCRIPTION
We decided to optimize it and not check for actual OCR status of each image, but it should still check for published images being present, same as ZIP already was.

Noticed mismatch at https://github.com/sciencehistory/scihist_digicoll/issues/2391#issuecomment-1745149886
