### PR TITLE
Ingest/Promotion Validation

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -25,6 +25,12 @@ class Asset < Kithe::Asset
 
   set_shrine_uploader(AssetUploader)
 
+  scope :promotion_failed, ->{
+    # jsonb in file_data column, metadata.promotion_validation_errors exists as array,
+    # we consider that promotion failed.
+    where(%Q{file_data @> '{ "metadata": { "promotion_validation_errors": []}}'})
+  }
+
   # We are doing a weird thing with shrine making it use an attr_json attribute instead
   # of a db column. We 1) create the `attr_json`, then 2) in the shrine attachment we tell it
   # column_serializer:nil tells shrine not to serialize the JSON, let

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -335,12 +335,12 @@ class Asset < Kithe::Asset
     end
   end
 
-  def ingest_validation_errors
-    self.file_metadata["ingest_validation_errors"]
+  def promotion_validation_errors
+    self.file_metadata["promotion_validation_errors"]
   end
 
-  def ingest_validation_failed?
-    ingest_validation_errors.present?
+  def promotion_failed?
+    file_attacher.cached? && promotion_validation_errors.present?
   end
 
   def invalidate_corrupt_tiff
@@ -367,7 +367,7 @@ class Asset < Kithe::Asset
       original_promote = self.promotion_directives[:promote]
       self.set_promotion_directives(promote: false)
 
-      self.file_attacher.add_metadata("ingest_validation_errors" => fatal_errors)
+      self.file_attacher.add_metadata("promotion_validation_errors" => fatal_errors)
 
       self.set_promotion_directives(promote: original_promote)
 

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -43,8 +43,11 @@ class Asset < Kithe::Asset
   include VideoHlsUploader::Attachment(:hls_playlist_file, store: :video_derivatives, column_serializer: nil)
 
   before_promotion :store_exiftool
-
   before_promotion :invalidate_corrupt_tiff, if: ->(asset) { asset.content_type == "image/tiff" }
+
+  after_commit if: ->(asset) { asset.file_data_previously_changed? && asset.promotion_failed? } do
+    Rails.logger.error("AssetPromotionValidation: Asset `#{friendlier_id}` failed ingest: #{promotion_validation_errors.inspect}")
+  end
 
 
   THUMB_WIDTHS = AssetUploader::THUMB_WIDTHS

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -335,6 +335,14 @@ class Asset < Kithe::Asset
     end
   end
 
+  def ingest_validation_errors
+    self.file_metadata["ingest_validation_errors"]
+  end
+
+  def ingest_validation_failed?
+    ingest_validation_errors.present?
+  end
+
   def invalidate_corrupt_tiff
     exif = Kithe::ExiftoolCharacterization.presenter_for(self.exiftool_result)
 

--- a/app/views/admin/assets/index.html.erb
+++ b/app/views/admin/assets/index.html.erb
@@ -36,6 +36,9 @@
         <td><%= asset.friendlier_id %></td>
         <td>
           <%= link_to asset.title, admin_asset_path(asset) %>
+          <% if asset.promotion_failed? %>
+            <span class="badge badge-danger">Ingest Failed</span>
+          <% end %>
         </td>
         <td>
           <% if asset.parent %>

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -23,7 +23,16 @@
   <div class="col-sm-6">
     <% if @asset.file_derivatives[:thumb_large] && @asset.file_derivatives[:thumb_large_2X] %>
       <%= thumb_image_tag @asset, size: :large, style: "max-width: 100%" %>
-    <% elsif ! @asset.stored? %>
+    <% elsif !@asset.stored? && @asset.promotion_failed? %>
+      <h2 class="text-white bg-danger">
+        Ingest Failed
+      </h2>
+      <ul>
+        <% @asset.promotion_validation_errors.each do |err_msg| %>
+          <li><%= err_msg %></li>
+        <% end %>
+      </ul>
+    <%elsif !@asset.stored? %>
       <p class="text-white bg-danger">
         Waiting on ingest...
       </p>

--- a/app/views/admin/works/_member_list_table.html.erb
+++ b/app/views/admin/works/_member_list_table.html.erb
@@ -44,7 +44,14 @@
 
           </td>
           <td>
-            <%= link_to member.title, [:admin, member] %> <%= publication_badge(member) %>
+            <%= link_to member.title, [:admin, member] %>
+
+            <% if member.kind_of?(Asset) && member.promotion_failed? %>
+              <span class="badge badge-danger">Ingest Failed</span>
+            <% end %>
+
+            <%= publication_badge(member) %>
+
             <% if member.kind_of?(Asset) && member.derivative_storage_type == "restricted" %>
               <span class="badge badge-warning">Restricted derivatives storage</span>
             <% end %>

--- a/db/migrate/20231003183838_add_file_data_gin.rb
+++ b/db/migrate/20231003183838_add_file_data_gin.rb
@@ -1,0 +1,5 @@
+class AddFileDataGin < ActiveRecord::Migration[7.0]
+  def change
+    add_index :kithe_models, :file_data, using: "gin"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_07_141354) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_03_183838) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -177,6 +177,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_07_141354) do
     t.string "role"
     t.datetime "published_at", precision: nil
     t.jsonb "derived_metadata_jsonb"
+    t.index ["file_data"], name: "index_kithe_models_on_file_data", using: :gin
     t.index ["friendlier_id"], name: "index_kithe_models_on_friendlier_id", unique: true
     t.index ["leaf_representative_id"], name: "index_kithe_models_on_leaf_representative_id"
     t.index ["parent_id"], name: "index_kithe_models_on_parent_id"

--- a/spec/models/asset/asset_ingest_validation_spec.rb
+++ b/spec/models/asset/asset_ingest_validation_spec.rb
@@ -8,13 +8,13 @@ describe "Asset ingest validation" do
       it "does not ingest" do
         asset = create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))
 
-        expect(asset.ingest_validation_failed?).to be true
+        expect(asset.promotion_failed?).to be true
 
         expect(asset.file_attacher.cached?).to be true
         expect(asset.stored?).to be false
 
         # and has validation errors
-        expect(asset.reload.ingest_validation_errors).to include(
+        expect(asset.reload.promotion_validation_errors).to include(
           "Missing required TIFF IFD0 tag 0x0111 StripOffsets",
           "Missing required TIFF IFD0 tag 0x0116 RowsPerStrip",
           "Missing required TIFF IFD0 tag 0x0117 StripByteCounts",
@@ -36,8 +36,8 @@ describe "Asset ingest validation" do
 
         asset.reload
 
-        expect(asset.ingest_validation_failed?).to be true
-        expect(asset.reload.ingest_validation_errors).to be_present
+        expect(asset.promotion_failed?).to be true
+        expect(asset.reload.promotion_validation_errors).to be_present
 
         expect(asset.file_attacher.cached?).to be true
         expect(asset.stored?).to be false

--- a/spec/models/asset/asset_ingest_validation_spec.rb
+++ b/spec/models/asset/asset_ingest_validation_spec.rb
@@ -44,4 +44,18 @@ describe "Asset ingest validation" do
       end
     end
   end
+
+  describe ".promotion_failed scope" do
+    let(:corrupt_tiff_path) { Rails.root + "spec/test_support/images/corrupt_bad.tiff" }
+    let!(:good_asset) { create(:asset_with_faked_file)}
+    let!(:bad_asset) { create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))}
+
+    it "includes only failed assets" do
+      failed = Asset.promotion_failed.to_a
+
+      expect(failed.size).to be 1
+      expect(failed.map(&:friendlier_id)).to include(bad_asset.friendlier_id)
+      expect(failed.map(&:friendlier_id)).not_to include(good_asset.friendlier_id)
+    end
+  end
 end

--- a/spec/models/asset/asset_ingest_validation_spec.rb
+++ b/spec/models/asset/asset_ingest_validation_spec.rb
@@ -8,11 +8,13 @@ describe "Asset ingest validation" do
       it "does not ingest" do
         asset = create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))
 
+        expect(asset.ingest_validation_failed?).to be true
+
         expect(asset.file_attacher.cached?).to be true
         expect(asset.stored?).to be false
 
         # and has validation errors
-        expect(asset.reload.file_metadata["ingest_validation_errors"]).to include(
+        expect(asset.reload.ingest_validation_errors).to include(
           "Missing required TIFF IFD0 tag 0x0111 StripOffsets",
           "Missing required TIFF IFD0 tag 0x0116 RowsPerStrip",
           "Missing required TIFF IFD0 tag 0x0117 StripByteCounts",
@@ -34,7 +36,8 @@ describe "Asset ingest validation" do
 
         asset.reload
 
-        expect(asset.reload.file_metadata["ingest_validation_errors"]).to be_present
+        expect(asset.ingest_validation_failed?).to be true
+        expect(asset.reload.ingest_validation_errors).to be_present
 
         expect(asset.file_attacher.cached?).to be true
         expect(asset.stored?).to be false

--- a/spec/models/asset/asset_ingest_validation_spec.rb
+++ b/spec/models/asset/asset_ingest_validation_spec.rb
@@ -4,6 +4,10 @@ describe "Asset ingest validation" do
   describe "corrupt TIFF" do
     let(:corrupt_tiff_path) { Rails.root + "spec/test_support/images/corrupt_bad.tiff" }
 
+    before do
+      allow(Rails.logger).to receive(:error)
+    end
+
     describe "inline promotion" do
       it "does not ingest" do
         asset = create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))
@@ -22,6 +26,8 @@ describe "Asset ingest validation" do
           "Missing required TIFF IFD0 tag 0x0100 ImageWidth",
           "Missing required TIFF IFD0 tag 0x0101 ImageHeight"
         )
+
+        expect(Rails.logger).to have_received(:error).with(/\AAssetPromotionValidation\: Asset `#{asset.friendlier_id}` failed ingest/)
       end
     end
 
@@ -41,6 +47,8 @@ describe "Asset ingest validation" do
 
         expect(asset.file_attacher.cached?).to be true
         expect(asset.stored?).to be false
+
+        expect(Rails.logger).to have_received(:error).with(/\AAssetPromotionValidation\: Asset `#{asset.friendlier_id}` failed ingest/)
       end
     end
   end

--- a/spec/models/asset/asset_ingest_validation_spec.rb
+++ b/spec/models/asset/asset_ingest_validation_spec.rb
@@ -9,6 +9,16 @@ describe "Asset ingest validation" do
 
       expect(asset.file_attacher.cached?).to be true
       expect(asset.stored?).to be false
+
+      # and has validation errors
+      expect(asset.reload.file_metadata["ingest_validation_errors"]).to include(
+        "Missing required TIFF IFD0 tag 0x0111 StripOffsets",
+        "Missing required TIFF IFD0 tag 0x0116 RowsPerStrip",
+        "Missing required TIFF IFD0 tag 0x0117 StripByteCounts",
+        "Missing required TIFF IFD0 tag 0x0106 PhotometricInterpretation",
+        "Missing required TIFF IFD0 tag 0x0100 ImageWidth",
+        "Missing required TIFF IFD0 tag 0x0101 ImageHeight"
+      )
     end
   end
 end

--- a/spec/models/asset/asset_ingest_validation_spec.rb
+++ b/spec/models/asset/asset_ingest_validation_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe "Asset ingest validation" do
+  describe "corrupt TIFF" do
+    let(:corrupt_tiff_path) { Rails.root + "spec/test_support/images/corrupt_bad.tiff" }
+
+    it "does not ingest" do
+      asset = create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))
+
+      expect(asset.file_attacher.cached?).to be true
+      expect(asset.stored?).to be false
+    end
+  end
+end

--- a/spec/models/asset/asset_ingest_validation_spec.rb
+++ b/spec/models/asset/asset_ingest_validation_spec.rb
@@ -4,21 +4,41 @@ describe "Asset ingest validation" do
   describe "corrupt TIFF" do
     let(:corrupt_tiff_path) { Rails.root + "spec/test_support/images/corrupt_bad.tiff" }
 
-    it "does not ingest" do
-      asset = create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))
+    describe "inline promotion" do
+      it "does not ingest" do
+        asset = create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))
 
-      expect(asset.file_attacher.cached?).to be true
-      expect(asset.stored?).to be false
+        expect(asset.file_attacher.cached?).to be true
+        expect(asset.stored?).to be false
 
-      # and has validation errors
-      expect(asset.reload.file_metadata["ingest_validation_errors"]).to include(
-        "Missing required TIFF IFD0 tag 0x0111 StripOffsets",
-        "Missing required TIFF IFD0 tag 0x0116 RowsPerStrip",
-        "Missing required TIFF IFD0 tag 0x0117 StripByteCounts",
-        "Missing required TIFF IFD0 tag 0x0106 PhotometricInterpretation",
-        "Missing required TIFF IFD0 tag 0x0100 ImageWidth",
-        "Missing required TIFF IFD0 tag 0x0101 ImageHeight"
-      )
+        # and has validation errors
+        expect(asset.reload.file_metadata["ingest_validation_errors"]).to include(
+          "Missing required TIFF IFD0 tag 0x0111 StripOffsets",
+          "Missing required TIFF IFD0 tag 0x0116 RowsPerStrip",
+          "Missing required TIFF IFD0 tag 0x0117 StripByteCounts",
+          "Missing required TIFF IFD0 tag 0x0106 PhotometricInterpretation",
+          "Missing required TIFF IFD0 tag 0x0100 ImageWidth",
+          "Missing required TIFF IFD0 tag 0x0101 ImageHeight"
+        )
+      end
+    end
+
+    describe "async promotion", queue_adapter: :async do
+      include ActiveJob::TestHelper
+
+      it "does not ingest" do
+        asset = nil
+        perform_enqueued_jobs do
+          asset = create(:asset, file: File.open(corrupt_tiff_path))
+        end
+
+        asset.reload
+
+        expect(asset.reload.file_metadata["ingest_validation_errors"]).to be_present
+
+        expect(asset.file_attacher.cached?).to be true
+        expect(asset.stored?).to be false
+      end
     end
   end
 end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -224,4 +224,16 @@ describe Asset do
       end
     end
   end
+
+  describe "corrupt TIFF" do
+    let(:corrupt_tiff_path) { Rails.root + "spec/test_support/images/corrupt_bad.tiff" }
+
+    it "does not ingest" do
+      asset = create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))
+
+      expect(asset.file_attacher.cached?).to be true
+      expect(asset.stored?).to be false
+    end
+  end
+
 end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -224,16 +224,4 @@ describe Asset do
       end
     end
   end
-
-  describe "corrupt TIFF" do
-    let(:corrupt_tiff_path) { Rails.root + "spec/test_support/images/corrupt_bad.tiff" }
-
-    it "does not ingest" do
-      asset = create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))
-
-      expect(asset.file_attacher.cached?).to be true
-      expect(asset.stored?).to be false
-    end
-  end
-
 end


### PR DESCRIPTION
During the shrine "promotion" step, we want the ability use logic to cancel promotion based on validation, and leave validation errors stored somewehre. 

Ref #1652

Then we want to catch certain corrupt files by looking at exiftool validation errors. And in some cases unexpected content_types. 

We do this by using the kithe `before_promotion` hooks, and `throw :abort` (a standard convention for ActiveSupport callback chains, which `before_promotion` is). But then we have to store the validation errors too. We store them in shrine metadata under `promotion_validation_errors` key -- just as plain strings for now. 

This was all a bit tricky to do becuase we have to _save_ the asset to store the validation errors, but _without_ triggering another promotion (which would be an infinite loop as it gets aborted again).  Just a bit weird to figure out, fighting a bit with our perhaps over-complex use of shrine via kithe. 

We should consider making this a feature in `kithe` that doesn't have to be implemented app-level, since it's a bit tricky, but for now we'll maybe link to this PR in kithe, and see how it works out. 

We also provide some cover methods and scopes for accessing the errors, and finding and identifying assets with errors.

Then we will need some UI for showing them in our admin screens, and possibly alerts.   

