### PR TITLE
Dashboard observability/alert of promotion/ingest failed

### DIFF
--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -14,6 +14,10 @@ class Admin::AssetsController < AdminController
       )
     end
 
+    if params[:promotion_failed] == "true"
+      scope = scope.promotion_failed
+    end
+
     scope = scope.page(params[:page]).per(20).order(created_at: :desc)
     scope = scope.includes(:parent)
 

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -62,6 +62,15 @@
               <% if ScihistDigicoll::Env.lookup(:service_level) %>
                 <%= content_tag "li", ScihistDigicoll::Env.lookup(:service_level).upcase, class: ["text-center p-1 mb-2 font-weight-bold", ("bg-warning" if ScihistDigicoll::Env.staging?)] %>
               <% end %>
+
+              <% if Rails.cache.fetch("Asset.promotion_failed", expires_in: 5.minutes) { Asset.promotion_failed.count > 0 } %>
+                <li>
+                  <%= link_to admin_assets_path(promotion_failed: true), class: "text-danger" do %>
+                    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Asset ingest failed
+                  <% end %>
+                </li>
+              <% end %>
+
               <li><%= link_to  "Works", admin_works_path %></li>
               <li><%= link_to  "Assets", admin_assets_path %></li>
               <li><%= link_to "Collections", admin_collections_path %></li>


### PR DESCRIPTION
Some easy simple hacky dashboard observabiilty of asets that have had promotion failed. (This is an unfortuante case of using different internal shrine language "promotion" than staff-user-facing language ("ingest"), so be it.

Yes, we potentially do a query on every single admin sidebar display to see if there are any ingest-failed. But it should be a fairly quick query -- we did ensure it's backed by an index. And actually we'll add some Rails cache -- but we haven't actually set up Rails cache, so it won't actually be used yet, but will if we ever set up a cache in production!

There is a filter for promotoin-failed assets on the admin asset list, but no UI to trigger it except clicking on the alert in sidebar.

All pretty hacky but simple enough that it doesn't seem like a big deal, and just a last resort to make sure admins notice if an asset has failed ingest, if they miss other ways to notice.
