### PR TITLE
Asset promotion validation for no content-type detected

### DIFF
--- a/spec/models/asset/asset_ingest_validation_spec.rb
+++ b/spec/models/asset/asset_ingest_validation_spec.rb
@@ -66,4 +66,16 @@ describe "Asset ingest validation" do
       expect(failed.map(&:friendlier_id)).not_to include(good_asset.friendlier_id)
     end
   end
+
+  describe "Unknown file type" do
+    it "does not ingest" do
+      asset = create(:asset, :inline_promoted_file, file: StringIO.new("not a recognized file type with binary data \xF0\xA4\xAD"))
+
+      expect(asset.promotion_failed?).to be true
+      expect(asset.file_attacher.cached?).to be true
+      expect(asset.stored?).to be false
+
+      expect(asset.reload.promotion_validation_errors).to include "Unknown/undetected content-type"
+    end
+  end
 end

--- a/spec/services/work_combined_audio_creator_spec.rb
+++ b/spec/services/work_combined_audio_creator_spec.rb
@@ -158,7 +158,8 @@ describe "Combined Audio" do
     end
 
     it "fails quickly", queue_adapter: :inline do
-      expect(work.members.map(&:stored?)).to match([true, true])
+      # the first one actually fails ingestion validation
+      expect(work.members.map(&:stored?)).to match([false, true])
       creator = CombinedAudioDerivativeCreator.new(work)
       combined_audio_info = creator.generate
       # This file should not even be counted as an available audio member:


### PR DESCRIPTION
application/octet-stream is the generic "binary" content type which effectively means no content type detected.

This will also catch 0-byte files, as they can't have a content-type detected.

If it ends up catching files we want -- we'll have to fix our content-type detection, cause even if we want them, we don't want them without being labelled properly with content type!
