### PR TITLE
Update to view_component 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,9 @@ gem 'scout_apm'
 # version may require an update with yarn to `blacklight-frontend`, has to be
 # checked manually.
 gem "blacklight", "~> 7.34.0"
-gem "blacklight_range_limit", "~> 8.3.0" # version no longer sync'd with blacklight, not sure how we tell what version works with what version of BL
+
+# Temporarily need to use blacklight_range_limit master for view_component 3.x support.
+gem "blacklight_range_limit", github: "projectblacklight/blacklight_range_limit" #"~> 8.3.0" # version no longer sync'd with blacklight, not sure how we tell what version works with what version of BL
 
 # for some code to deal with transcoding video, via AWS MediaConvert
 # Lower than 1.2.1 had far too big gem builds! https://github.com/samvera-labs/active_encode/issues/126

--- a/Gemfile
+++ b/Gemfile
@@ -44,9 +44,7 @@ gem 'scout_apm'
 # version may require an update with yarn to `blacklight-frontend`, has to be
 # checked manually.
 gem "blacklight", "~> 7.34.0"
-
-# Temporarily need to use blacklight_range_limit master for view_component 3.x support.
-gem "blacklight_range_limit", github: "projectblacklight/blacklight_range_limit" #"~> 8.3.0" # version no longer sync'd with blacklight, not sure how we tell what version works with what version of BL
+gem "blacklight_range_limit", "~> 8.4.0" # version no longer sync'd with blacklight, not sure how we tell what version works with what version of BL
 
 # for some code to deal with transcoding video, via AWS MediaConvert
 # Lower than 1.2.1 had far too big gem builds! https://github.com/samvera-labs/active_encode/issues/126

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem "mail", ">= 2.8.0.rc1", "< 3"
 #
 gem "net-protocol", "!= 0.2.0"
 
-gem "view_component", "~> 2.49"
+gem "view_component", "~> 3.6"
 gem "alba", "~> 2.0" # for JSON serialization of models
 
 #  Scout is a monitoring tool we are experimenting with

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/projectblacklight/blacklight_range_limit.git
+  revision: 6cffb2e6ca649527046251654a59d2d44f354700
+  specs:
+    blacklight_range_limit (8.3.0)
+      blacklight (>= 7.25.2, < 9)
+      deprecation
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -136,9 +144,6 @@ GEM
       ostruct (>= 0.3.2)
       rails (>= 5.1, < 7.1)
       view_component (>= 2.66, < 4)
-    blacklight_range_limit (8.3.0)
-      blacklight (>= 7.25.2, < 9)
-      deprecation
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     bootstrap (4.6.2)
@@ -721,7 +726,7 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1.0)
   axe-core-rspec (~> 4.3)
   blacklight (~> 7.34.0)
-  blacklight_range_limit (~> 8.3.0)
+  blacklight_range_limit!
   bootsnap (>= 1.4.4)
   bootstrap (~> 4.6, >= 4.6.2)
   bootstrap4-kaminari-views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -669,7 +669,7 @@ GEM
       aws-sdk-s3 (~> 1.0)
       content_disposition (~> 1.0)
       roda (>= 2.27, < 4)
-    view_component (2.82.0)
+    view_component (3.6.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
@@ -789,7 +789,7 @@ DEPENDENCIES
   terser (~> 1.1)
   traject (>= 3.5)
   uppy-s3_multipart
-  view_component (~> 2.49)
+  view_component (~> 3.6)
   vite_rails (~> 3.0)
   warning (~> 1.2)
   web-console (>= 4.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/projectblacklight/blacklight_range_limit.git
-  revision: 6cffb2e6ca649527046251654a59d2d44f354700
-  specs:
-    blacklight_range_limit (8.3.0)
-      blacklight (>= 7.25.2, < 9)
-      deprecation
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -144,6 +136,10 @@ GEM
       ostruct (>= 0.3.2)
       rails (>= 5.1, < 7.1)
       view_component (>= 2.66, < 4)
+    blacklight_range_limit (8.4.0)
+      blacklight (>= 7.25.2, < 9)
+      deprecation
+      view_component (>= 2.54, < 4)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     bootstrap (4.6.2)
@@ -726,7 +722,7 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1.0)
   axe-core-rspec (~> 4.3)
   blacklight (~> 7.34.0)
-  blacklight_range_limit!
+  blacklight_range_limit (~> 8.4.0)
   bootsnap (>= 1.4.4)
   bootstrap (~> 4.6, >= 4.6.2)
   bootstrap4-kaminari-views

--- a/spec/components/search_result/work_component_spec.rb
+++ b/spec/components/search_result/work_component_spec.rb
@@ -9,7 +9,7 @@ describe SearchResult::WorkComponent, type: :component do
           (element = noko.children[0]) &&
           element.name == "a" &&
           element.text == value &&
-          element['href'] == controller.view_context.search_on_facet_path(facet_param, value)
+          element['href'] == vc_test_controller.view_context.search_on_facet_path(facet_param, value)
       end
     end
 

--- a/spec/components/social_share_component_spec.rb
+++ b/spec/components/social_share_component_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe SocialShareComponent, type: :component do
   def work_url(work)
-    controller.work_url(work)
+    vc_test_controller.work_url(work)
   end
 
   let(:work) { create(:work, :with_complete_metadata, representative: create(:asset_with_faked_file))}

--- a/spec/presenters/work_social_share_attributes_spec.rb
+++ b/spec/presenters/work_social_share_attributes_spec.rb
@@ -12,7 +12,7 @@ describe WorkSocialShareAttributes, type: :component do
   let(:title) { "some work" }
   let(:description) { "This is a thing" }
   let(:work) { build(:work, title: title, description: description) }
-  let(:attributes) { WorkSocialShareAttributes.new(work, view_context: controller.view_context) }
+  let(:attributes) { WorkSocialShareAttributes.new(work, view_context: vc_test_controller.view_context) }
 
   describe "#page_title" do
     it "is correct" do
@@ -78,7 +78,7 @@ describe WorkSocialShareAttributes, type: :component do
         let(:work) { build(:oral_history_work) }
 
         it "has generic oral history icon" do
-          expect(attributes.share_media_url).to eq(controller.view_context.asset_url("scihist_oral_histories_thumb.jpg"))
+          expect(attributes.share_media_url).to eq(vc_test_controller.view_context.asset_url("scihist_oral_histories_thumb.jpg"))
           # we were just too lazy to implement this for this edge case, and social
           # media sites don't really NEED it.
           expect(attributes.share_media_height).to be_nil

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,7 +75,8 @@ RSpec.configure do |config|
   config.include Rails.application.routes.url_helpers, type: :component
   config.before(:each, type: :component) do
     # for devise support according to ViewComponent docs.
-    @request = controller.request
+    # https://viewcomponent.org/guide/testing.html#rspec-configuration
+    @request = vc_test_controller.request
   end
 
   # and this applies to wrapped Rails 'system' tests, which rspec recommends


### PR DESCRIPTION
We finally have a version of Blacklight 7.x that supports view_component 3.x. And will soon have a version of blacklight_range_limit that does. 

So we can actually get on board with recent view_component -- without needing to update to Blacklight 8 yet, which we still have some blockers for. 

Some of our tests made reference to the view_component test controller at `controller`; it's now changed to `vc_test_controller`, and is maybe meant to be internal API.. but there's some test setup we don't know how to do without it, and it still works as long as we use the new name (and view_component docs even _recommend_ it for devise test integration, https://viewcomponent.org/guide/testing.html#rspec-configuration), so it's good enough for now. 

- update view_component to 3.x, now that we're on a version of Blacklight that allows it
- view_component 3.x uses 'vc_test_controller' instead of 'controller' for it's test controller.
- ~temporarily need to use blacklight_range_limit from main git, waiting release supporting view_component 3.x~ (update to blacklight_range_limit 8.4.0)
