### PR TITLE
A PDF asset should not display download option for whole-work-pdf derivative

### DIFF
--- a/app/components/download_dropdown_component.rb
+++ b/app/components/download_dropdown_component.rb
@@ -119,7 +119,8 @@ class DownloadDropdownComponent < ApplicationComponent
       # a published work, cause PDF assets are not individually access-controlled!), we still
       # want it in individual image download options, as per
       # https://github.com/sciencehistory/scihist_digicoll/issues/2278
-      DownloadOptions::ImageDownloadOptions.new(asset, show_pdf_link: (!has_work_download_options? && display_parent_work&.published?)).options
+      #
+      DownloadOptions::ImageDownloadOptions.new(asset, show_pdf_link: (!has_work_download_options? && display_parent_work&.published? && asset.content_type.start_with?("image/"))).options
    end
   end
 

--- a/spec/components/download_dropdown_component_spec.rb
+++ b/spec/components/download_dropdown_component_spec.rb
@@ -142,7 +142,7 @@ describe DownloadDropdownComponent, type: :component do
     let(:asset) do
       create(:asset_with_faked_file, :pdf,
         faked_derivatives: {},
-        parent: build(:work, rights: "http://creativecommons.org/publicdomain/mark/1.0/")
+        parent: build(:work, :published, rights: "http://creativecommons.org/publicdomain/mark/1.0/")
       )
     end
 
@@ -156,6 +156,9 @@ describe DownloadDropdownComponent, type: :component do
       expect(div).not_to have_selector("a.dropdown-item", text: /Medium JPG/)
       expect(div).not_to have_selector("a.dropdown-item", text: /Large JPG/)
       expect(div).not_to have_selector("a.dropdown-item", text: /Full-sized JPG/)
+      expect(div).not_to have_selector("a.dropdown-item", text: /\APDF/)
+
+      expect(div.css("a.dropdown-item").count).to be 2
     end
   end
 


### PR DESCRIPTION
This is a band-aid on a mess -- actually worse than a band-aid, it's making the mess worse, with a quick fix. But we fix #2401 with this at least.

Long-term we need to refactor how this works. Having multiple different points that are responsible for deciding what download links to include, based on characteristics of the asset and it's parent itself -- is not working, not viable.  Left a ticket for a refactor here: #2416

This is a quick fix to our current bug, even though it makes the underlying issue of convoluted logic built of exceptions-to-exceptions in non-local places temporarily worse.
