### PR TITLE
Remember Oral History request form entries to re-use

### DIFF
--- a/app/controllers/oral_history_access_requests_controller.rb
+++ b/app/controllers/oral_history_access_requests_controller.rb
@@ -1,6 +1,8 @@
 # PUBLIC FACING
 # Staff-facing actions are in app/controllers/admin/oral_history_access_requests_controller.rb
 class OralHistoryAccessRequestsController < ApplicationController
+  include OralHistoryRequestFormMemoryHelper
+
   # GET /works/4j03d09fr7t/request_oral_history_access
   def new
     @work = load_work(params['work_friendlier_id'])
@@ -33,6 +35,10 @@ class OralHistoryAccessRequestsController < ApplicationController
     else
      render :new
     end
+
+    # write entries to a cookie to pre-fill form next time; every time we write
+    # it will bump the TTL expiration too, so they get another day until it expires.
+    oral_history_request_form_entry_write(oral_history_access_request_params.to_h)
   end
 
 private

--- a/app/helpers/oral_history_request_form_memory_helper.rb
+++ b/app/helpers/oral_history_request_form_memory_helper.rb
@@ -1,0 +1,34 @@
+# This stores Oral History request form entries so we can pre-fill form on subsequent
+# requests.
+#
+# THIS IS SENSITIVE PATRON INFO.  But we do want to remember it to pre-fill.
+# We store it ENCRYPTED so only the back-end app can decrypt it; and also
+# set it to be http-only (not accessible by JS).
+#
+# We set a 1 day expiration, although every time they fill out a form the cookie
+# will get re-written and bumped.
+#
+# it is important we remember this info is for pre-filling form only -- it is of course
+# not auth, just cause a user says they have an email address doens't mean they should
+# get access to ANY personal info of past requests in our system from that email addr!
+module OralHistoryRequestFormMemoryHelper
+  COOKIE_KEY = "_scihist_digicoll_oh_request_entries"
+  TTL = 1.day
+  ALLOWED_KEYS = %w{patron_name patron_email patron_institution intended_use}
+
+  def oral_history_request_form_entry_read
+    JSON.parse( cookies.signed[COOKIE_KEY] || "{}").slice(*ALLOWED_KEYS)
+  rescue JSON::ParserError
+    {}
+  end
+
+  def oral_history_request_form_entry_write(json_hash)
+    cookies.signed[COOKIE_KEY] = {
+      value: JSON.generate(json_hash.slice(*ALLOWED_KEYS)),
+      expires: TTL,
+      httponly: true,
+      # for tests to work, have to have non-https cookies in test and dev!
+      secure: Rails.env.production?
+    }
+  end
+end

--- a/app/views/oral_history_access_requests/_form.html.erb
+++ b/app/views/oral_history_access_requests/_form.html.erb
@@ -1,5 +1,7 @@
 <%= simple_form_for @oral_history_access_request,  :url => :request_oral_history_access  do |f| %>
 
+  <% remembered_form_values = oral_history_request_form_entry_read %>
+
   <div class="mb-5 mt-4">
     <p>
       To receive files for "<%= @work.title %>" by email, please fill out the form below.
@@ -31,7 +33,8 @@
     <div class="row">
       <div class="col">
         <%= f.input :patron_name,
-          label: "Your name" %>
+          label: "Your name",
+          input_html: { value: remembered_form_values["patron_name"] } %>
       </div>
     </div>
 
@@ -39,6 +42,7 @@
       <div class="col">
         <%= f.input :patron_email,
           hint: "Links to files will be emailed to this address",
+          input_html: { value: remembered_form_values["patron_email"] },
           label: "Your email address" %>
       </div>
     </div>
@@ -46,6 +50,7 @@
     <div class="row">
       <div class="col">
         <%= f.input :patron_institution,
+          input_html: { value: remembered_form_values["patron_institution"] },
           label: "Your institution", hint: "Optional" %>
       </div>
     </div>
@@ -56,6 +61,7 @@
           as: :text,
           label: "Intended use",
           hint: (@work.oral_history_content.available_by_request_automatic? ? "So that we can better understand our audience, please tell us how you plan to use the oral history you have requested." : "Please tell us how you intend to use this oral history interview to help us inform you about any relevant interviewee restrictions."),
+          input_html: { value: remembered_form_values["intended_use"] },
           required: @oral_history_access_request.work&.oral_history_content&.available_by_request_manual_review?
         %>
       </div>

--- a/spec/system/oral_history_by_request_spec.rb
+++ b/spec/system/oral_history_by_request_spec.rb
@@ -135,4 +135,37 @@ describe "Oral History with by-request delivery", type: :system, js: true, queue
     end
   end
 
+  describe "for multiple requests", js: false do
+    let(:work1) { create(:oral_history_work, :available_by_request, published: true) }
+    let(:work2) { create(:oral_history_work, :available_by_request, published: true) }
+
+    let(:patron_name) { "My Name" }
+    let(:patron_email) { "me@example.com" }
+    let(:patron_institution) { "University of wherever"}
+    let(:intended_use) { "for fun" }
+
+    it "remembers form entry" do
+      visit request_oral_history_access_form_path(work1.friendlier_id)
+
+      pr = '#admin_oral_history_access_request_'
+
+      find("#{pr}patron_name").fill_in  with: patron_name
+      find("#{pr}patron_email").fill_in with: patron_email
+      find("#{pr}patron_institution").fill_in with: patron_institution
+      find("#{pr}intended_use").fill_in with: intended_use
+
+
+      click_on 'Submit request'
+      expect(page).to have_text "Thank you for your interest"
+
+      # by saving and restoring from cookie, the form should be pre-filled
+      visit request_oral_history_access_form_path(work2.friendlier_id)
+      expect(find("#{pr}patron_name").value).to eq patron_name
+      expect(find("#{pr}patron_email").value).to eq patron_email
+      expect(find("#{pr}patron_institution").value).to eq patron_institution
+      expect(find("#{pr}intended_use").value).to eq intended_use
+    end
+
+  end
+
 end


### PR DESCRIPTION
In a cookie, when same browser is used.  cookie lasts a day, but TTL is refreshed on each succesful form submission, so a day past last time you used.

With an actual system test demonstrating the user really does get a pre-filled form, since this is important behavior, that we ourselves might not use so might not notice if working or not.

Ref #2426
