### PR TITLE
Configure lockbox to allow key rotation

### DIFF
--- a/config/initializers/lockbox.rb
+++ b/config/initializers/lockbox.rb
@@ -19,3 +19,12 @@ unless lockbox_master_key.present?
 end
 
 Lockbox.master_key = lockbox_master_key
+
+# If we are rotating, just use ENV
+if ENV["LOCKBOX_MASTER_KEY_PREVIOUS"].present?
+    Lockbox.default_options[:previous_versions] = [{master_key: ENV["LOCKBOX_MASTER_KEY_PREVIOUS"]}]
+end
+# To rotate, run eg
+#     Lockbox.rotate(SomeModel, attributes: [:email])
+#
+#


### PR DESCRIPTION
Lockbox used to do app-level per-attribute enccryption of model attributes. 

(We could actually use new Rails 7.1 feature for that if we wanted to, in future). 

Sometimes we need to rotate lockbox keys. This adds some configuration to lockbox to allow key rotation.  

## Rotation procedure

0. Deploy this code
1. Get OLD key from herkou config, or our password storage.
2. Generate NEW key with `Lockbox.generate_key` in any console (save in password storage)
3. `heroku config:set LOCKBOX_MASTER_KEY_PREVIOUS=[OLD] LOCKBOX_MASTER_KEY=[NEW]`
4. In a console, run:  
  * `Lockbox.rotate(Admin::OralHistoryAccessRequest, attributes: [:patron_name, :patron_email, :patron_institution, :intended_use])`
  * Note those are model/attributes currently encrpted, found by grep'ing for `has_encrypted`, just those at present
5. Verify you can still see protected info on `https://digital.sciencehistory.org/admin/oral_history_access_requests` (or stging version)
6. Good, now `heroku config:remove LOCKBOX_MASTER_KEY_PREVIOUS`
7. Verify you can still see protected info again!
