### PR TITLE
Attempt to fix flaky test

### DIFF
--- a/spec/system/oral_history_with_audio_spec.rb
+++ b/spec/system/oral_history_with_audio_spec.rb
@@ -414,6 +414,7 @@ describe "Oral history with audio display", type: :system, js: true do
       expect(page).to have_selector("*[data-ohms-hitcount='transcript']", text: "43")
 
       click_on "Description"
+      expect(page).to have_css("#ohDescriptionTab[aria-selected='true']")
       expect(page).to have_selector("h2", text: "About the Interviewer")
       expect(page).to have_text("This has some html")
     end


### PR DESCRIPTION
This adds an extra `expect` right after changing tab to OH description.
Technically this shouldn't be necessary, but fixing these flaky systems test is more of an art than a science.
Ref #2437 
I'll run CI tests a bunch of times on this and see if I can get it to fail.