### PR TITLE
Rails 7.1 config and deprecation -- step 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
 
         - name: Set up app
           run: |
-            RAILS_ENV=test bundle exec rails db:prepare
+            RAILS_ENV=test bundle exec rails db:test:prepare
             yarn install
 
         # This cache probably doesn't actually save us any time, but it hopes to save

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
 
         - name: Set up app
           run: |
-            RAILS_ENV=test bundle exec rails db:create
+            RAILS_ENV=test bundle exec rails db:prepare
             yarn install
 
         # This cache probably doesn't actually save us any time, but it hopes to save

--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,7 @@ gem "device_detector", "~> 1.0" # user-agent parsing we use for logging
 
 gem "attr_json", "~> 2.0"
 
-gem 'kithe', "~> 2.11"
+gem 'kithe', "~> 2.13"
 
 gem "traject", ">= 3.5" # to include support for HTTP basic auth in Solr url
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,7 +330,7 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    kithe (2.12.0)
+    kithe (2.13.0)
       attr_json (~> 2.0)
       fastimage (~> 2.0)
       fx (>= 0.6.0, < 1)
@@ -763,7 +763,7 @@ DEPENDENCIES
   irb (>= 1.3.1)
   jbuilder (~> 2.5)
   kaminari (~> 1.2)
-  kithe (~> 2.11)
+  kithe (~> 2.13)
   listen (~> 3.3)
   lockbox
   lograge (< 2)

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -52,7 +52,7 @@ class DownloadsController < ApplicationController
         disposition: content_disposition_mode,
         filename: DownloadFilenameHelper.filename_for_asset(@asset)
       )
-    ), status: 302
+    ), status: 302, allow_other_host: true
   end
 
   #GET /downloads/:asset_id/:derivative_key
@@ -68,7 +68,7 @@ class DownloadsController < ApplicationController
         disposition: content_disposition_mode,
         filename: DownloadFilenameHelper.filename_for_asset(@asset, derivative_key: params[:derivative_key].to_sym)
       )
-    ), status: 302
+    ), status: 302, allow_other_host: true
   end
 
   private

--- a/bin/setup
+++ b/bin/setup
@@ -5,7 +5,7 @@ require "fileutils"
 APP_ROOT = File.expand_path('..', __dir__)
 
 def system!(*args)
-  system(*args) || abort("\n== Command #{args} failed ==")
+  system(*args, exception: true)
 end
 
 FileUtils.chdir APP_ROOT do

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,11 @@ module ScihistDigicoll
     # or Rails version we have upgraded to and verified for new defaults.
     config.load_defaults 7.0
 
+    # Before we have 7.1 defaults, we want to opt into this, for some reason
+    # doing it in the standard new_framework_defaults_7_1.rb doesn't work it's too late,
+    # need it here.
+    config.active_record.run_after_transaction_callbacks_in_order_defined = true
+
     config.time_zone = "US/Eastern"
 
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,7 +36,7 @@ module ScihistDigicoll
 
     # Initialize configuration defaults for originally generated Rails version,
     # or Rails version we have upgraded to and verified for new defaults.
-    config.load_defaults 6.1
+    config.load_defaults 7.0
 
     config.time_zone = "US/Eastern"
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,7 +6,7 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  config.enable_reloading = true
 
   # Do not eager load code on boot.
   config.eager_load = false
@@ -76,6 +76,9 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  # Highlight code that enqueued background job in logs.
+  config.active_job.verbose_enqueue_logs = true
+
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
@@ -86,6 +89,9 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.i18n.raise_on_missing_translations = true
+
+  # Raise error when a before_action's only/except options reference missing actions
+  config.action_controller.raise_on_missing_callback_actions = true
 
   # Annotate rendered view with file names.
   config.action_view.annotate_rendered_view_with_filenames = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,7 +4,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
-  config.cache_classes = true
+  config.enable_reloading = false
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
@@ -193,10 +193,11 @@ Rails.application.configure do
   # for our output.
   if ENV["RAILS_DISABLE_LOGGING"].present?
     config.logger    = ActiveSupport::Logger.new("/dev/null")
-  elsif ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  else
+    # Log to STDOUT by default
+    config.logger = ActiveSupport::Logger.new(STDOUT)
+      .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
+      .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
   end
 
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -6,6 +6,9 @@ Rails.application.configure do
   # Code is not reloaded between requests.
   config.enable_reloading = false
 
+  # in production we set secret_key_base from an env variable, to keep it out of source
+  config.secret_key_base = ScihistDigicoll::Env.lookup!("secret_key_base")
+
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,12 +7,13 @@ Rails.application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  config.enable_reloading = false
 
-  # Do not eager load code on boot. This avoids loading your whole application
-  # just for the purpose of running a single test. If you are using a tool that
-  # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+   # Eager loading loads your entire application. When running a single test locally,
+   # this is usually not necessary, and can slow down your test suite. However, it's
+   # recommended that you enable it in continuous integration systems to ensure eager
+   # loading is working properly before deploying your code.
+   config.eager_load = ENV["CI"].present?
 
   # Use :test ActiveJob adapter which does not really run jobs, as default.
   # We can change on an example-by-example basis if needed.
@@ -30,7 +31,8 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  # :rescueable is default in Rails 7.1, but we need to fix our tests
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
@@ -60,4 +62,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Raise error when a before_action's only/except options reference missing actions
+  config.action_controller.raise_on_missing_callback_actions = true
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -3,12 +3,19 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
+
+
+
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
   # config.secret_key = '5c21c4628df5c96817e6bffdf1d697d5ee4272bebde637b44f8139a18a476bcce540dc16447a6f78353756d7201671347289a949e2c1a4916bc98366bcc891e7'
+
+  # Tell devise where to get secret_key_base to avoid Rails 7.1 deprecation warning
+  # when it tries deprecated places. https://github.com/heartcombo/devise/issues/5644
+  config.secret_key = Rails.application.secret_key_base
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -34,7 +34,7 @@ Rails.application.config.action_dispatch.default_headers = {
 # Do not treat an `ActionController::Parameters` instance
 # as equal to an equivalent `Hash` by default.
 #++
-# Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
+Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
 
 ###
 # Active Record Encryption now uses SHA-256 as its hash digest algorithm.
@@ -80,7 +80,7 @@ Rails.application.config.active_record.sqlite3_adapter_strict_strings_by_default
 ###
 # Disable deprecated singular associations names.
 #++
-# Rails.application.config.active_record.allow_deprecated_singular_associations_name = false
+Rails.application.config.active_record.allow_deprecated_singular_associations_name = false
 
 ###
 # Enable the Active Job `BigDecimal` argument serializer, which guarantees
@@ -92,7 +92,7 @@ Rails.application.config.active_record.sqlite3_adapter_strict_strings_by_default
 # serializer. Therefore, this setting should only be enabled after all replicas
 # have been successfully upgraded to Rails 7.1.
 #++
-# Rails.application.config.active_job.use_big_decimal_serializer = true
+Rails.application.config.active_job.use_big_decimal_serializer = true
 
 ###
 # Specify if an `ArgumentError` should be raised if `Rails.cache` `fetch` or
@@ -195,7 +195,7 @@ Rails.application.config.precompile_filter_parameters = true
 # recommended to explicitly define the serialization method for each column
 # rather than to rely on a global default.
 #++
-# Rails.application.config.active_record.default_column_serializer = nil
+Rails.application.config.active_record.default_column_serializer = nil
 
 ###
 # Enable a performance optimization that serializes Active Record models
@@ -262,7 +262,11 @@ Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.b
 #
 # In previous versions of Rails, Action Text always used `Rails::HTML4::Sanitizer` as its vendor.
 #++
-# Rails.application.config.action_text.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
+#
+#scihist : we're not using actiontext currently, so this one does not apply, and in fact raises:
+# "undefined method `action_text' for #<Rails::Application::Configuration:0x0000000000c418>"??
+#
+#Rails.application.config.action_text.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
 
 
 ###
@@ -280,4 +284,4 @@ Rails.application.config.action_dispatch.debug_exception_log_level = :error
 #
 # In previous versions of Rails, these test helpers always used an HTML4 parser.
 #++
-# Rails.application.config.dom_testing_default_html_version = :html5
+Rails.application.config.dom_testing_default_html_version = :html5

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -1,0 +1,283 @@
+# Be sure to restart your server when you modify this file.
+#
+# This file eases your Rails 7.1 framework defaults upgrade.
+#
+# Uncomment each configuration one by one to switch to the new default.
+# Once your application is ready to run with all new defaults, you can remove
+# this file and set the `config.load_defaults` to `7.1`.
+#
+# Read the Guide for Upgrading Ruby on Rails for more info on each option.
+# https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
+
+###
+# No longer add autoloaded paths into `$LOAD_PATH`. This means that you won't be able
+# to manually require files that are managed by the autoloader, which you shouldn't do anyway.
+#
+# This will reduce the size of the load path, making `require` faster if you don't use bootsnap, or reduce the size
+# of the bootsnap cache if you use it.
+#++
+# Rails.application.config.add_autoload_paths_to_load_path = false
+
+###
+# Remove the default X-Download-Options headers since it is used only by Internet Explorer.
+# If you need to support Internet Explorer, add back `"X-Download-Options" => "noopen"`.
+#++
+# Rails.application.config.action_dispatch.default_headers = {
+#   "X-Frame-Options" => "SAMEORIGIN",
+#   "X-XSS-Protection" => "0",
+#   "X-Content-Type-Options" => "nosniff",
+#   "X-Permitted-Cross-Domain-Policies" => "none",
+#   "Referrer-Policy" => "strict-origin-when-cross-origin"
+# }
+
+###
+# Do not treat an `ActionController::Parameters` instance
+# as equal to an equivalent `Hash` by default.
+#++
+# Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
+
+###
+# Active Record Encryption now uses SHA-256 as its hash digest algorithm.
+#
+# There are 3 scenarios to consider.
+#
+# 1. If you have data encrypted with previous Rails versions, and you have
+# +config.active_support.key_generator_hash_digest_class+ configured as SHA1 (the default
+# before Rails 7.0), you need to configure SHA-1 for Active Record Encryption too:
+#++
+# Rails.application.config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA1
+#
+# 2. If you have +config.active_support.key_generator_hash_digest_class+ configured as SHA256 (the new default
+# in 7.0), then you need to configure SHA-256 for Active Record Encryption:
+#++
+# Rails.application.config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256
+#
+# 3. If you don't currently have data encrypted with Active Record encryption, you can disable this setting to
+# configure the default behavior starting 7.1+:
+#++
+# Rails.application.config.active_record.encryption.support_sha1_for_non_deterministic_encryption = false
+
+###
+# No longer run after_commit callbacks on the first of multiple Active Record
+# instances to save changes to the same database row within a transaction.
+# Instead, run these callbacks on the instance most likely to have internal
+# state which matches what was committed to the database, typically the last
+# instance to save.
+#++
+# Rails.application.config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction = false
+
+###
+# Configures SQLite with a strict strings mode, which disables double-quoted string literals.
+#
+# SQLite has some quirks around double-quoted string literals.
+# It first tries to consider double-quoted strings as identifier names, but if they don't exist
+# it then considers them as string literals. Because of this, typos can silently go unnoticed.
+# For example, it is possible to create an index for a non existing column.
+# See https://www.sqlite.org/quirks.html#double_quoted_string_literals_are_accepted for more details.
+#++
+# Rails.application.config.active_record.sqlite3_adapter_strict_strings_by_default = true
+
+###
+# Disable deprecated singular associations names.
+#++
+# Rails.application.config.active_record.allow_deprecated_singular_associations_name = false
+
+###
+# Enable the Active Job `BigDecimal` argument serializer, which guarantees
+# roundtripping. Without this serializer, some queue adapters may serialize
+# `BigDecimal` arguments as simple (non-roundtrippable) strings.
+#
+# When deploying an application with multiple replicas, old (pre-Rails 7.1)
+# replicas will not be able to deserialize `BigDecimal` arguments from this
+# serializer. Therefore, this setting should only be enabled after all replicas
+# have been successfully upgraded to Rails 7.1.
+#++
+# Rails.application.config.active_job.use_big_decimal_serializer = true
+
+###
+# Specify if an `ArgumentError` should be raised if `Rails.cache` `fetch` or
+# `write` are given an invalid `expires_at` or `expires_in` time.
+# Options are `true`, and `false`. If `false`, the exception will be reported
+# as `handled` and logged instead.
+#++
+# Rails.application.config.active_support.raise_on_invalid_cache_expiration_time = true
+
+###
+# Specify whether Query Logs will format tags using the SQLCommenter format
+# (https://open-telemetry.github.io/opentelemetry-sqlcommenter/), or using the legacy format.
+# Options are `:legacy` and `:sqlcommenter`.
+#++
+# Rails.application.config.active_record.query_log_tags_format = :sqlcommenter
+
+###
+# Specify the default serializer used by `MessageEncryptor` and `MessageVerifier`
+# instances.
+#
+# The legacy default is `:marshal`, which is a potential vector for
+# deserialization attacks in cases where a message signing secret has been
+# leaked.
+#
+# In Rails 7.1, the new default is `:json_allow_marshal` which serializes and
+# deserializes with `ActiveSupport::JSON`, but can fall back to deserializing
+# with `Marshal` so that legacy messages can still be read.
+#
+# In Rails 7.2, the default will become `:json` which serializes and
+# deserializes with `ActiveSupport::JSON` only.
+#
+# Alternatively, you can choose `:message_pack` or `:message_pack_allow_marshal`,
+# which serialize with `ActiveSupport::MessagePack`. `ActiveSupport::MessagePack`
+# can roundtrip some Ruby types that are not supported by JSON, and may provide
+# improved performance, but it requires the `msgpack` gem.
+#
+# For more information, see
+# https://guides.rubyonrails.org/v7.1/configuring.html#config-active-support-message-serializer
+#
+# If you are performing a rolling deploy of a Rails 7.1 upgrade, wherein servers
+# that have not yet been upgraded must be able to read messages from upgraded
+# servers, first deploy without changing the serializer, then set the serializer
+# in a subsequent deploy.
+#++
+# Rails.application.config.active_support.message_serializer = :json_allow_marshal
+
+###
+# Enable a performance optimization that serializes message data and metadata
+# together. This changes the message format, so messages serialized this way
+# cannot be read by older versions of Rails. However, messages that use the old
+# format can still be read, regardless of whether this optimization is enabled.
+#
+# To perform a rolling deploy of a Rails 7.1 upgrade, wherein servers that have
+# not yet been upgraded must be able to read messages from upgraded servers,
+# leave this optimization off on the first deploy, then enable it on a
+# subsequent deploy.
+#++
+# Rails.application.config.active_support.use_message_serializer_for_metadata = true
+
+###
+# Set the maximum size for Rails log files.
+#
+# `config.load_defaults 7.1` does not set this value for environments other than
+# development and test.
+#++
+# if Rails.env.local?
+#   Rails.application.config.log_file_size = 100 * 1024 * 1024
+# end
+
+###
+# Enable raising on assignment to attr_readonly attributes. The previous
+# behavior would allow assignment but silently not persist changes to the
+# database.
+#++
+# Rails.application.config.active_record.raise_on_assign_to_attr_readonly = true
+
+###
+# Enable validating only parent-related columns for presence when the parent is mandatory.
+# The previous behavior was to validate the presence of the parent record, which performed an extra query
+# to get the parent every time the child record was updated, even when parent has not changed.
+#++
+# Rails.application.config.active_record.belongs_to_required_validates_foreign_key = false
+
+###
+# Enable precompilation of `config.filter_parameters`. Precompilation can
+# improve filtering performance, depending on the quantity and types of filters.
+#++
+# Rails.application.config.precompile_filter_parameters = true
+
+###
+# Enable before_committed! callbacks on all enrolled records in a transaction.
+# The previous behavior was to only run the callbacks on the first copy of a record
+# if there were multiple copies of the same record enrolled in the transaction.
+#++
+# Rails.application.config.active_record.before_committed_on_all_records = true
+
+###
+# Disable automatic column serialization into YAML.
+# To keep the historic behavior, you can set it to `YAML`, however it is
+# recommended to explicitly define the serialization method for each column
+# rather than to rely on a global default.
+#++
+# Rails.application.config.active_record.default_column_serializer = nil
+
+###
+# Enable a performance optimization that serializes Active Record models
+# in a faster and more compact way.
+#
+# To perform a rolling deploy of a Rails 7.1 upgrade, wherein servers that have
+# not yet been upgraded must be able to read caches from upgraded servers,
+# leave this optimization off on the first deploy, then enable it on a
+# subsequent deploy.
+#++
+# Rails.application.config.active_record.marshalling_format_version = 7.1
+
+###
+# Run `after_commit` and `after_*_commit` callbacks in the order they are defined in a model.
+# This matches the behaviour of all other callbacks.
+# In previous versions of Rails, they ran in the inverse order.
+#++
+# Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true
+
+###
+# Whether a `transaction` block is committed or rolled back when exited via `return`, `break` or `throw`.
+#++
+# Rails.application.config.active_record.commit_transaction_on_non_local_return = true
+
+###
+# Controls when to generate a value for <tt>has_secure_token</tt> declarations.
+#++
+# Rails.application.config.active_record.generate_secure_token_on = :initialize
+
+###
+# ** Please read carefully, this must be configured in config/application.rb **
+#
+# Change the format of the cache entry.
+#
+# Changing this default means that all new cache entries added to the cache
+# will have a different format that is not supported by Rails 7.0
+# applications.
+#
+# Only change this value after your application is fully deployed to Rails 7.1
+# and you have no plans to rollback.
+# When you're ready to change format, add this to `config/application.rb` (NOT
+# this file):
+#   config.active_support.cache_format_version = 7.1
+
+
+###
+# Configure Action View to use HTML5 standards-compliant sanitizers when they are supported on your
+# platform.
+#
+# `Rails::HTML::Sanitizer.best_supported_vendor` will cause Action View to use HTML5-compliant
+# sanitizers if they are supported, else fall back to HTML4 sanitizers.
+#
+# In previous versions of Rails, Action View always used `Rails::HTML4::Sanitizer` as its vendor.
+#++
+# Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
+
+
+###
+# Configure Action Text to use an HTML5 standards-compliant sanitizer when it is supported on your
+# platform.
+#
+# `Rails::HTML::Sanitizer.best_supported_vendor` will cause Action Text to use HTML5-compliant
+# sanitizers if they are supported, else fall back to HTML4 sanitizers.
+#
+# In previous versions of Rails, Action Text always used `Rails::HTML4::Sanitizer` as its vendor.
+#++
+# Rails.application.config.action_text.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
+
+
+###
+# Configure the log level used by the DebugExceptions middleware when logging
+# uncaught exceptions during requests.
+#++
+# Rails.application.config.action_dispatch.debug_exception_log_level = :error
+
+
+###
+# Configure the test helpers in Action View, Action Dispatch, and rails-dom-testing to use HTML5
+# parsers.
+#
+# Nokogiri::HTML5 isn't supported on JRuby, so JRuby applications must set this to :html4.
+#
+# In previous versions of Rails, these test helpers always used an HTML4 parser.
+#++
+# Rails.application.config.dom_testing_default_html_version = :html5

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -64,7 +64,7 @@ Rails.application.config.action_controller.allow_deprecated_parameters_hash_equa
 # state which matches what was committed to the database, typically the last
 # instance to save.
 #++
-# Rails.application.config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction = false
+Rails.application.config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction = false
 
 ###
 # Configures SQLite with a strict strings mode, which disables double-quoted string literals.
@@ -187,7 +187,7 @@ Rails.application.config.precompile_filter_parameters = true
 # The previous behavior was to only run the callbacks on the first copy of a record
 # if there were multiple copies of the same record enrolled in the transaction.
 #++
-# Rails.application.config.active_record.before_committed_on_all_records = true
+Rails.application.config.active_record.before_committed_on_all_records = true
 
 ###
 # Disable automatic column serialization into YAML.
@@ -213,7 +213,7 @@ Rails.application.config.active_record.default_column_serializer = nil
 # This matches the behaviour of all other callbacks.
 # In previous versions of Rails, they ran in the inverse order.
 #++
-# Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true
+Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true
 
 ###
 # Whether a `transaction` block is committed or rolled back when exited via `return`, `break` or `throw`.

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -16,19 +16,19 @@
 # This will reduce the size of the load path, making `require` faster if you don't use bootsnap, or reduce the size
 # of the bootsnap cache if you use it.
 #++
-# Rails.application.config.add_autoload_paths_to_load_path = false
+Rails.application.config.add_autoload_paths_to_load_path = false
 
 ###
 # Remove the default X-Download-Options headers since it is used only by Internet Explorer.
 # If you need to support Internet Explorer, add back `"X-Download-Options" => "noopen"`.
 #++
-# Rails.application.config.action_dispatch.default_headers = {
-#   "X-Frame-Options" => "SAMEORIGIN",
-#   "X-XSS-Protection" => "0",
-#   "X-Content-Type-Options" => "nosniff",
-#   "X-Permitted-Cross-Domain-Policies" => "none",
-#   "Referrer-Policy" => "strict-origin-when-cross-origin"
-# }
+Rails.application.config.action_dispatch.default_headers = {
+  "X-Frame-Options" => "SAMEORIGIN",
+  "X-XSS-Protection" => "0",
+  "X-Content-Type-Options" => "nosniff",
+  "X-Permitted-Cross-Domain-Policies" => "none",
+  "Referrer-Policy" => "strict-origin-when-cross-origin"
+}
 
 ###
 # Do not treat an `ActionController::Parameters` instance
@@ -75,7 +75,7 @@
 # For example, it is possible to create an index for a non existing column.
 # See https://www.sqlite.org/quirks.html#double_quoted_string_literals_are_accepted for more details.
 #++
-# Rails.application.config.active_record.sqlite3_adapter_strict_strings_by_default = true
+Rails.application.config.active_record.sqlite3_adapter_strict_strings_by_default = true
 
 ###
 # Disable deprecated singular associations names.
@@ -100,14 +100,14 @@
 # Options are `true`, and `false`. If `false`, the exception will be reported
 # as `handled` and logged instead.
 #++
-# Rails.application.config.active_support.raise_on_invalid_cache_expiration_time = true
+Rails.application.config.active_support.raise_on_invalid_cache_expiration_time = true
 
 ###
 # Specify whether Query Logs will format tags using the SQLCommenter format
 # (https://open-telemetry.github.io/opentelemetry-sqlcommenter/), or using the legacy format.
 # Options are `:legacy` and `:sqlcommenter`.
 #++
-# Rails.application.config.active_record.query_log_tags_format = :sqlcommenter
+Rails.application.config.active_record.query_log_tags_format = :sqlcommenter
 
 ###
 # Specify the default serializer used by `MessageEncryptor` and `MessageVerifier`
@@ -158,29 +158,29 @@
 # `config.load_defaults 7.1` does not set this value for environments other than
 # development and test.
 #++
-# if Rails.env.local?
-#   Rails.application.config.log_file_size = 100 * 1024 * 1024
-# end
+if Rails.env.local?
+  Rails.application.config.log_file_size = 100 * 1024 * 1024
+end
 
 ###
 # Enable raising on assignment to attr_readonly attributes. The previous
 # behavior would allow assignment but silently not persist changes to the
 # database.
 #++
-# Rails.application.config.active_record.raise_on_assign_to_attr_readonly = true
+Rails.application.config.active_record.raise_on_assign_to_attr_readonly = true
 
 ###
 # Enable validating only parent-related columns for presence when the parent is mandatory.
 # The previous behavior was to validate the presence of the parent record, which performed an extra query
 # to get the parent every time the child record was updated, even when parent has not changed.
 #++
-# Rails.application.config.active_record.belongs_to_required_validates_foreign_key = false
+Rails.application.config.active_record.belongs_to_required_validates_foreign_key = false
 
 ###
 # Enable precompilation of `config.filter_parameters`. Precompilation can
 # improve filtering performance, depending on the quantity and types of filters.
 #++
-# Rails.application.config.precompile_filter_parameters = true
+Rails.application.config.precompile_filter_parameters = true
 
 ###
 # Enable before_committed! callbacks on all enrolled records in a transaction.
@@ -218,12 +218,12 @@
 ###
 # Whether a `transaction` block is committed or rolled back when exited via `return`, `break` or `throw`.
 #++
-# Rails.application.config.active_record.commit_transaction_on_non_local_return = true
+Rails.application.config.active_record.commit_transaction_on_non_local_return = true
 
 ###
 # Controls when to generate a value for <tt>has_secure_token</tt> declarations.
 #++
-# Rails.application.config.active_record.generate_secure_token_on = :initialize
+Rails.application.config.active_record.generate_secure_token_on = :initialize
 
 ###
 # ** Please read carefully, this must be configured in config/application.rb **
@@ -250,7 +250,7 @@
 #
 # In previous versions of Rails, Action View always used `Rails::HTML4::Sanitizer` as its vendor.
 #++
-# Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
+Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
 
 
 ###
@@ -269,7 +269,7 @@
 # Configure the log level used by the DebugExceptions middleware when logging
 # uncaught exceptions during requests.
 #++
-# Rails.application.config.action_dispatch.debug_exception_log_level = :error
+Rails.application.config.action_dispatch.debug_exception_log_level = :error
 
 
 ###

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,4 +1,0 @@
-<% if Rails.env.production? %>
-production:
-  secret_key_base: <%= ScihistDigicoll::Env.lookup!("secret_key_base") %>
-<% end %>


### PR DESCRIPTION
While #2431 upgraded to Rails 7.1, and was green in CI -- it did not update any configuration defaults to match Rails 7.1 yet, and still produced some Rails 7.1 deprecation warnings. 

This PR is separated for ease of review, but it should be merged and deployed simultaneous with #2431.  

It eliminates any deprecation warnings when run under Rails 7.1, and also updates much configuration to match Rails 7.1 defaults. 

## How we found what to update

First we checked railsdiff.com, to reivew how a _newly generated app_ under Rails 7.1 might differ from Rails 7.0.  We manually reviewed, and updated some local files to match. See for instance https://railsdiff.org/7.0.8/7.1.2

THEN we used the `new_framework_defaults_7_1.rb` file generated by Rails to opt into new defaults one by one, and see which ones if any broke our tests. https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#configure-framework-defaults. You can see this file in this PR. 

We did NOT opt into any defaults that would keep our app from _going back_ to 7.0 -- mainly ones that change serialization formats to ones that are not backwards compat and could not be readalbe by a 7.0 app. 

At some LATER point, when we've been running 7.1 several weeks and know we won't need to go back -- we'll have another PR to fully take all 7.1 defaults, with `load_defaults` in application.rb instead of the `new_framework_defaults...` file. 

## Actual problem with run_after_transaction_callbacks_in_order_defined

So... ONE piece of config, `run_after_transaction_callbacks_in_order_defined`, actually did cause our tests to fail -- and it was catching real problem. 

To make things more confusing -- at FIRST we didn't catch this, becuase it turned out enabling this in `new_framework_defaults_7_1.rb` didn't actually enable it in time to effect our `Asset` class. I _noticed_ the problem when trying out the future branc that would have `load_defaults 7.1` -- THAT one triggered the problem. 

I realized that for reasons I won't go into here, we load our Asset classes _during_ initialization, so we had to opt into this config _before_ the initializer -- in `application.rb`. I did so to demonstrate the problem, then set about solving it. 

It turned out to be pretty confusing -- we had some `after_commit` hooks in Asset, that need to run _before_ shrine promotion, so they can look at `file_data_previously_changed` and see the delta that _caused_ the shrine promotion, rather than the delta _of_ the promotion. 

Rails 7.1 defaults _changed the order of after_commit hooks_ so they were broken... and Rails 7.1 didn't actually give us any tools to alter this!  I was pretty stymied, but figured out using other Rails public API (I think!), I could easily implement a method that _did_ let us insert `after_commit` hooks where we needed. That is implemented in kithe at https://github.com/sciencehistory/kithe/pull/178

Then this PR right here upgrades to a version of kithe with the new function, and uses the new function to register the after_commit hooks so they will run _before_ shrine promotion, and have access to the right previously changed deltas. 

Phew! 