### PR TITLE
fix tests for new Rails 7.1 default action_dispatch.show_exceptions = :rescuable

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -30,9 +30,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 
-  # Raise exceptions instead of rendering exception templates.
-  # :rescueable is default in Rails 7.1, but we need to fix our tests
-  config.action_dispatch.show_exceptions = :none
+  config.action_dispatch.show_exceptions = :rescuable
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/spec/requests/bad_blacklight_requests_spec.rb
+++ b/spec/requests/bad_blacklight_requests_spec.rb
@@ -53,10 +53,9 @@ describe CatalogController do
   describe "missing facet id" do
     let(:collection) { create(:collection) }
     it "collections page search responds with 400" do
-      url = "/collections/#{collection.friendlier_id}/facet"
-      expect { get url }.
-        to raise_error(an_instance_of(ActionController::RoutingError).
-        and having_attributes(message: "Not Found"))
+
+      get "/collections/#{collection.friendlier_id}/facet"
+      expect(response).to have_http_status(404)
     end
     it "featured topic search responds with 400" do
       fake_definition =  {
@@ -70,10 +69,9 @@ describe CatalogController do
       }
       allow(FeaturedTopic).to receive(:definitions).and_return(fake_definition)
       expect(FeaturedTopic.from_slug(:test_featured_topic)).to be_a FeaturedTopic
-      url = "/focus/test_featured_topic/facet"
-      expect { get url}.
-        to raise_error(an_instance_of(ActionController::RoutingError).
-        and having_attributes(message: "Not Found"))
+
+      get "/focus/test_featured_topic/facet"
+      expect(response).to have_http_status(404)
     end
   end
 

--- a/spec/requests/download_redirects_spec.rb
+++ b/spec/requests/download_redirects_spec.rb
@@ -10,9 +10,8 @@ describe "legacy original download links redirect" do
   end
 
   it "404's for missing asset ID on original" do
-    expect {
-      get("/downloads/no_such_thing")
-    }.to raise_error(ActionController::RoutingError)
+    get("/downloads/no_such_thing")
+    expect(response).to have_http_status(404)
   end
 
   it "redirects derivative" do


### PR DESCRIPTION
We can (and must) actually test for 404's now instead of testing for the unrouteable exception -- actually much better.
