### PR TITLE
Remove puma on_worker_boot that heroku docs say is no longer needed in current Rails

### DIFF
--- a/config/heroku_puma.rb
+++ b/config/heroku_puma.rb
@@ -18,8 +18,4 @@ rackup      DefaultRackup if defined?(DefaultRackup)
 port        ENV['PORT']     || 3000
 environment ENV['RACK_ENV'] || 'development'
 
-on_worker_boot do
-  # Worker specific setup for Rails 4.1+
-  # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
-  ActiveRecord::Base.establish_connection
-end
+


### PR DESCRIPTION
We added this because of heroku docs, but heroku docs now say not needed. Clean things up by removing unnecessary code that could be having weird side effects.

> Using on_worker_boot is no longer needed for Rails 5.2+ apps as forked connections will automatically re-connect.

https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#preload-app
