### PR TITLE
Add `barnes` gem (needed to report ruby runtime metrics to heroku)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -249,3 +249,8 @@ end
 # to configure Blacklight, for automatic retry
  gem "faraday", "~> 2.0"
  gem "faraday-retry", "~> 2.0"
+
+
+# Barnes reports Ruby runtime metrics to Heroku, where we can monitor them.
+# See https://devcenter.heroku.com/articles/language-runtime-metrics-ruby
+gem "barnes"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,9 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
+    barnes (0.0.9)
+      multi_json (~> 1)
+      statsd-ruby (~> 1.1)
     base64 (0.2.0)
     bcp47_spec (0.2.1)
     bcrypt (3.1.19)
@@ -383,6 +386,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.5)
     minitar (0.9)
     minitest (5.20.0)
     mono_logger (1.1.2)
@@ -404,6 +408,9 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.4)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.4-x86_64-linux)
@@ -648,6 +655,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    statsd-ruby (1.5.0)
     stringio (3.0.9)
     terser (1.1.19)
       execjs (>= 0.3.0, < 3)
@@ -722,6 +730,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
   x86_64-linux
 
 DEPENDENCIES
@@ -735,6 +744,7 @@ DEPENDENCIES
   aws-sdk-mediaconvert (~> 1.0)
   aws-sdk-s3 (~> 1.0)
   axe-core-rspec (~> 4.3)
+  barnes
   blacklight (~> 7.35.0)
   blacklight_range_limit (~> 8.4.0)
   bootsnap (>= 1.4.4)

--- a/config/heroku_puma.rb
+++ b/config/heroku_puma.rb
@@ -5,6 +5,15 @@
 # worker is all that fits for our app in a small heroku dyno?)
 # Setting heroku config vars can tune these.
 
+# Barnes reports Ruby runtime metrics to Heroku, where we can monitor them.
+# See https://devcenter.heroku.com/articles/language-runtime-metrics-ruby
+require 'barnes'
+before_fork do
+  # worker specific setup
+  Barnes.start # Must have enabled worker mode for this to block to be called
+end
+
+
 workers Integer(ENV['WEB_CONCURRENCY'] || 1)
 threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
 threads threads_count, threads_count

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,6 +4,16 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
+
+
+# Barnes reports Ruby runtime metrics to Heroku, where we can monitor them.
+# See https://devcenter.heroku.com/articles/language-runtime-metrics-ruby
+require 'barnes'
+before_fork do
+  # worker specific setup
+  Barnes.start # Must have enabled worker mode for this to block to be called
+end
+
 max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count


### PR DESCRIPTION
Ref #2449

This PR adds the `barnes` gem, which reports Ruby runtime metrics to Heroku, where we can monitor them at e.g.

Note: to turn on ruby runtime metrics:
```
heroku labs:enable "runtime-heroku-metrics"
heroku buildpacks:add -i 1 heroku/metrics
```
After these are run and this PR is merged and deployed, you will see three more time series graphs on the `Metrics` tab for the app in Heroku's admin interface. (e.g. https://dashboard.heroku.com/apps/scihist-digicoll-staging/metrics/web), namely
- Ruby: Heap Objects
- Ruby: Puma Pool Usage
- Ruby: Free Memory Slots

https://devcenter.heroku.com/articles/language-runtime-metrics-ruby



