### PR TITLE
Optimizations to decrease memory allocations

### DIFF
--- a/app/components/download_dropdown_component.rb
+++ b/app/components/download_dropdown_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Renders the download button with a dropdown menu of options.
 #
 # The standard menu also includes "rights" information, to put that next to

--- a/app/components/download_dropdown_component.rb
+++ b/app/components/download_dropdown_component.rb
@@ -193,24 +193,24 @@ class DownloadDropdownComponent < ApplicationComponent
     elements = []
 
     if display_parent_work && display_parent_work.rights.present?
-      elements << "<h3 class='dropdown-header'>Rights</h3>".html_safe
+      elements << content_tag("h3", 'Rights', class: 'dropdown-header')
       elements << rights_statement_item
-      elements << "<div class='dropdown-divider'></div>".html_safe
+      elements << content_tag("div", nil,  class:'dropdown-divider')
     end
 
     if include_whole_work_options && has_work_download_options?
-      elements << "<h3 class='dropdown-header'>Download all #{display_parent_work.member_count} images</h3>".html_safe
+      elements << content_tag("h3", "Download all #{display_parent_work.member_count} images", class:'dropdown-header')
       whole_work_download_options.each do |download_option|
         elements << format_download_option(download_option)
       end
-      elements << "<div class='dropdown-divider'></div>".html_safe
+      elements << content_tag("div", nil,  class:'dropdown-divider')
     end
 
     if viewer_template_mode?
-      elements << "<h3 class='dropdown-header'>Download selected image</h3>".html_safe
-      elements << '<div data-slot="selected-downloads"></div>'.html_safe
+      elements << content_tag("h3", "Download selected image", class: 'dropdown-header')
+      elements << content_tag("div", nil,  "data-slot" =>"selected-downloads")
     elsif asset_download_options
-      elements << "<h3 class='dropdown-header'>Download selected #{thing_name}</h3>".html_safe
+      elements << content_tag("h3", "Download selected #{thing_name}", class: 'dropdown-header')
       asset_download_options.each do |download_option|
         elements << format_download_option(download_option)
       end

--- a/app/components/file_list_item_component.rb
+++ b/app/components/file_list_item_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class FileListItemComponent < ApplicationComponent
   attr_reader :member, :index, :view_link_attributes, :download_original_only
 

--- a/app/components/member_image_component.rb
+++ b/app/components/member_image_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A thumb, usually with 'view' and 'download' buttons below it. We call that the "member image" presentation.
 # Naming is hard!
 #

--- a/app/components/social_share_component.rb
+++ b/app/components/social_share_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Displays our social media share buttons for a work
 #
 # http://sharingbuttons.io/ is a good place to get URL template formats for new plain static

--- a/app/components/thumb_component.rb
+++ b/app/components/thumb_component.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+
 # A component that displays an image tag, for a thumbnail derivative for a given Kithe::Asset.
 #
 # The Kithe::Asset provided as an arg will usually be a leaf_representative of a Work or Collection.

--- a/app/components/work_image_show_component.rb
+++ b/app/components/work_image_show_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The standard image-centered work show page, used for works by default, when
 # we don't have a special purpose work show page.
 

--- a/app/components/work_show_info_component.rb
+++ b/app/components/work_show_info_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Display the right column of a work show page including, metadata attributes,
 # physical location, 'related items'.
 #

--- a/app/lib/scihist_digicoll/util.rb
+++ b/app/lib/scihist_digicoll/util.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ScihistDigicoll
   module Util
     # inspired by code at

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Asset < Kithe::Asset
   include AttrJson::Record::QueryScopes
 

--- a/app/models/compact_user_agent.rb
+++ b/app/models/compact_user_agent.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+
 # Tries to parse the user-agent to make a much more compact representation of what we'd
 # eally want to know from it, to keep our logs shorter
 #

--- a/app/models/download_option.rb
+++ b/app/models/download_option.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A simple value object representing a download option, used for constructing our download
 # menus
 class DownloadOption

--- a/app/presenters/date_display_formatter.rb
+++ b/app/presenters/date_display_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Takes an array of `Work::Date` objects (generally from `some_work.date_of_work`),
 # and formats them for display to the user.
 #
@@ -71,11 +73,7 @@ class DateDisplayFormatter
   end
 
   def qualified_date(date, qualifier)
-    begin
-      int_date_value = Integer(date)
-    rescue
-      int_date_value = nil
-    end
+    int_date_value = Integer(date, exception: false)
 
     date = humanize_date_str(date)
 


### PR DESCRIPTION
Some attempts to reduce the number of memory allocations our app makes, which could theoretically increase performance and possibly reduce RAM usage -- although most of these allocations should be GC'able and aren't _supposed_ to effect long-term RAM usage...  

This was an attempt to respond to #2449 although I think it might have been a red herring. But shouldn't hurt. 

- add frozen string pragma in a lot of places, that are implicated by 'derailed' benchmarks as creating a lot of objects
- using content-tag instead of frozen string with interpolation may e more optimized
- more frozen string literal pragmas
- parsing date with new exception:false option instead of rescue may be more efficient of cpu and memory
