### PR TITLE
Memoize fetch of WorkFileListShowComponent#all_members

### DIFF
--- a/app/components/work_file_list_show_component.rb
+++ b/app/components/work_file_list_show_component.rb
@@ -81,7 +81,7 @@ class WorkFileListShowComponent < ApplicationComponent
   # We need to slice and dice the members in a couple ways, so just load them all in,
   # but we should never show this to the public
   def all_members
-    @all_members = work.members.includes(:leaf_representative).order(:position).strict_loading.to_a
+    @all_members ||= work.members.includes(:leaf_representative).order(:position).strict_loading.to_a
   end
 
 


### PR DESCRIPTION
This really should have been memoized, as @bensheldon noticed in investigating #2449 -- or actually, should it be passed in from a caller that may already have this list, isntead of being fetched again in the component anyway?  (The biggest challenge we have with components!).  Not sure how to do that, but we can memoize it, and do so here.

Probably NOT responsible for any huge memory problems of #2449, or of any major performance problems even -- this component is only currentlu used in restricted oral histories which generally don't have too many members. But still good to tidy up. 
