### PR TITLE
[WIP] Use webmock/spec in env_spec_helper.rb

### DIFF
--- a/system_env_spec/env_spec_helper.rb
+++ b/system_env_spec/env_spec_helper.rb
@@ -1,7 +1,7 @@
 require "rubygems"
 require "bundler/setup"
 
-require "rspec"
+require 'webmock/rspec'
 
 # We won't load all of rails, but activesupport is helpful
 require "active_support"


### PR DESCRIPTION
```
heroku run "rspec system_env_spec"
```
currently doesn't work in staging - failing with:

```
Running rspec system_env_spec on ⬢ scihist-digicoll-staging... up, run.5220 (Standard-1X)

An error occurred while loading ./system_env_spec/system_env_spec.rb.
Failure/Error: require "rspec"

LoadError:
  cannot load such file -- rspec
# ./system_env_spec/env_spec_helper.rb:4:in `<top (required)>'
# ./system_env_spec/system_env_spec.rb:1:in `require_relative'
# ./system_env_spec/system_env_spec.rb:1:in `<top (required)>'
No examples found.
```

So let's try and include `webmock/rspec` instead.