### PR TITLE
Remove barnes config from development puma

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -5,15 +5,6 @@
 # and maximum; this matches the default thread size of Active Record.
 #
 
-
-# Barnes reports Ruby runtime metrics to Heroku, where we can monitor them.
-# See https://devcenter.heroku.com/articles/language-runtime-metrics-ruby
-require 'barnes'
-before_fork do
-  # worker specific setup
-  Barnes.start # Must have enabled worker mode for this to block to be called
-end
-
 max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count


### PR DESCRIPTION
Barnes is used for Heroku statistics capturing, from #2446

But the config/puma.rb is onlu used in development, where this is irrelevant AND since we don't actually have cluster mode configured here, it doesn't do anything, and generates a warning:

> Warning: You specified code to run in a `before_fork` block, but Puma is not configured to run in cluster mode (worker count > 0 ), so your `before_fork` block did not run
> Puma starting in single mode...

Remove this non-functional code from config/puma.rb.  It's already also in config/heroku_puma.rb where it's actually used.
