### PR TITLE
update rspec-rails to 6.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -583,7 +583,7 @@ GEM
     rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-rails (6.0.3)
+    rspec-rails (6.1.0)
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       railties (>= 6.1)


### PR DESCRIPTION
Was having weird error output in my rspec tests that this seems to have solved. Eg

```
     1.2) Failure/Error:
            raise WrongScopeError,
                  "`#{name}` is not available from within an example (e.g. an " \
                  "`it` block) or from constructs that run in the scope of an " \
                  "example (e.g. `before`, `let`, etc). It is only available " \
                  "on an example group (e.g. a `describe` or `context` block)."
```
