### PR TITLE
remove unused db column OralHistoryAccessRequest#status and #notes

### DIFF
--- a/db/migrate/20231218201400_remove_oral_history_access_request_status.rb
+++ b/db/migrate/20231218201400_remove_oral_history_access_request_status.rb
@@ -1,0 +1,6 @@
+class RemoveOralHistoryAccessRequestStatus < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :oral_history_access_requests, :status, :string
+  remove_column :oral_history_access_requests, :notes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_03_183838) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_18_201400) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -204,8 +204,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_03_183838) do
     t.text "patron_email_ciphertext"
     t.text "patron_institution_ciphertext"
     t.text "intended_use_ciphertext"
-    t.string "status"
-    t.text "notes"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "delivery_status", default: "pending"


### PR DESCRIPTION
We have a used column 'delivery_status'. Perhaps initially we were considering calling it 'status', and they both wound up in there? 'status' is not used in code, all rows in prod db have nil value for it. We can remove it to avoid confusion.

We never got around to using #notes, I guess either? All nil in db.  We are going to give it a more specific name now that we're about to use it in OH request dashboard redesign