### PR TITLE
Stop using deprecated Rails 7.1 fixture_path

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -50,7 +50,9 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  # config.fixture_paths = [
+  #   Rails.root.join('spec/fixtures')
+  # ]
 
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your


### PR DESCRIPTION
Was getting deprecation warning (from rspec?):

> Rails 7.1 has deprecated the singular fixture_path in favour of an array

We change the source to the new Rails 7.1 way to avoid the deprecation warning, but ALSO comment it out, cause we're not using it -- leave it commented out in case someone needs fixtures in the future.
