### PR TITLE
Enhancmenets to FileListComponent for use in OH request delivery

### DIFF
--- a/app/components/file_list_item_component.html.erb
+++ b/app/components/file_list_item_component.html.erb
@@ -11,7 +11,7 @@
       <%= maybe_view_link_to(member) do %>
         <%= member_label %>
       <% end %>
-      <% unless member.published? %>
+      <% if show_private_badge && !member.published?  %>
           <span title="Private" class="badge badge-warning">Private</span>
       <% end %>
     </div>

--- a/app/components/file_list_item_component.html.erb
+++ b/app/components/file_list_item_component.html.erb
@@ -16,7 +16,7 @@
       <% end %>
     </div>
     <% if member.kind_of?(Asset) %>
-      <div>
+      <div class="details">
         <small><%= asset_details(member) %></small>
       </div>
     <% end %>

--- a/app/components/file_list_item_component.rb
+++ b/app/components/file_list_item_component.rb
@@ -86,8 +86,18 @@ class FileListItemComponent < ApplicationComponent
     if asset.content_type.present?
       details << ScihistDigicoll::Util.humanized_content_type(asset.content_type)
     end
-    if asset.size.present?
-      details << ScihistDigicoll::Util.simple_bytes_to_human_string(asset.size)
+
+    # For A/V include duration, else include original file size
+    # Note that in some cases there may be alternate derivatives -- FLAC size may be
+    # huge, but maybe m4a is what you'll download.
+    if asset.content_type&.start_with?("audio/") || asset.content_type&.start_with?("video/")
+      if asset.file_metadata["duration_seconds"].present?
+        details << helpers.format_ohms_timestamp(asset.file_metadata["duration_seconds"])
+      end
+    else
+      if asset.size.present?
+        details << ScihistDigicoll::Util.simple_bytes_to_human_string(asset.size)
+      end
     end
 
     str = details.join(" — ")

--- a/app/components/file_list_item_component.rb
+++ b/app/components/file_list_item_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class FileListItemComponent < ApplicationComponent
-  attr_reader :member, :index, :view_link_attributes, :download_original_only
+  attr_reader :member, :index, :view_link_attributes, :download_original_only, :show_private_badge
 
   # @param index [integer] Need index so we know whether to lazy-load
   #
@@ -12,11 +12,17 @@ class FileListItemComponent < ApplicationComponent
   # @param download_original_only [Boolean] default false. If true, instead of the
   #   download menu component in the action column, there will be a single download
   #   button to download original.
-  def initialize(member, index:, view_link_attributes: {}, download_original_only: false)
+  #
+  # @param show_private_badge [Boolean] default true. If true, when a private item is
+  # visible to the user, it will be marked with a 'Private' badge, to warn (usually admin)
+  # they are seeing something the public wouldn't see. Main use case for 'false' is
+  # when we we are showing OH by-request items to authorized users.
+  def initialize(member, index:, view_link_attributes: {}, download_original_only: false, show_private_badge: true)
     @member = member
     @index = index
     @view_link_attributes = view_link_attributes
     @download_original_only = download_original_only
+    @show_private_badge = show_private_badge
 
     unless member.association(:parent).loaded?
       raise ArgumentError.new("parent must be pre-loaded to avoid n+1 queries please, on: #{member}")

--- a/app/components/file_list_item_component.rb
+++ b/app/components/file_list_item_component.rb
@@ -62,10 +62,20 @@ class FileListItemComponent < ApplicationComponent
       # image thumb is in a link, but right next to filename with same link.
       # Suppress image thumb from assistive technology to avoid un-useful double
       # link. https://www.sarasoueidan.com/blog/keyboard-friendlier-article-listings/
-      link_to(download_path(member.leaf_representative.file_category, member.leaf_representative, disposition: :inline),
+      link_to(view_link,
               view_link_attributes.merge("aria-hidden" => "true", "tabindex" => -1, "target" => "_blank")) do
         yield
       end
+    end
+  end
+
+  def view_link
+    if member.leaf_representative.content_type == "audio/flac" && member.leaf_representative.file_derivatives.keys.include?(:m4a)
+      # inline link to m4a derivative, we don't want to give the browser flac
+      download_derivative_path(member.leaf_representative, :m4a, disposition: :inline)
+    else
+      # inline link to original, perhaps a PDF
+      download_path(member.leaf_representative.file_category, member.leaf_representative, disposition: :inline)
     end
   end
 

--- a/app/components/thumb_component.rb
+++ b/app/components/thumb_component.rb
@@ -95,7 +95,14 @@ class ThumbComponent < ApplicationComponent
   end
 
   def placeholder_image_tag
-    tag "img", alt: "", src: placeholder_img_url, width: "100%";
+    if asset&.content_type&.start_with?("audio/")
+      # use a Audio File icon in SVG. This does mean we'll have repeated svg
+      # on a page, some technique to use svg `use`, but not clear how to handle it
+      # well while just letting people call ThumbComponent from different places
+      helpers.fa_file_audio_class_solid
+    else
+      tag "img", alt: "", src: placeholder_img_url, width: "100%";
+    end
   end
 
 

--- a/app/frontend/stylesheets/local/show-layout.scss
+++ b/app/frontend/stylesheets/local/show-layout.scss
@@ -157,7 +157,9 @@
   }
 }
 
-// Yeah, this has no parent selector, it's used on audio page too.
+// This has no parent selector, this component is now used in several
+// places, including OH public downloads and proteted request downloads.
+// Extract to own file?
 .show-member-file-list-item {
   display: flex;
 
@@ -178,6 +180,9 @@
     width: 100%;
     word-break: break-word;
   }
+
+  // keep more compact, to fit three lines next to thumb, looks fine
+  line-height: 1.3;
 }
 
 .by-request-file-list {

--- a/app/helpers/bootstrap_file_icon_svg_helper.rb
+++ b/app/helpers/bootstrap_file_icon_svg_helper.rb
@@ -10,6 +10,8 @@
 #
 # BUT then also edited to remove right/left padding, cause work better for us
 # like that.
+#
+# OPTIMIZATION IDEAS at https://github.com/sciencehistory/scihist_digicoll/issues/2482
 module BootstrapFileIconSvgHelper
   def file_earmark_pdf_fill_svg
     <<-EOS.strip_heredoc.html_safe
@@ -27,5 +29,31 @@ module BootstrapFileIconSvgHelper
         <path d="M 7.293,0 H 2 A 2,2 0 0 0 0,2 v 12 a 2,2 0 0 0 2,2 h 8 a 2,2 0 0 0 2,-2 V 4.707 A 1,1 0 0 0 11.707,4 L 8,0.293 A 1,1 0 0 0 7.293,0 Z M 7.5,3.5 v -2 l 3,3 h -2 a 1,1 0 0 1 -1,-1 z M 3.5,3 V 2 h -1 V 1 H 4 V 2 H 5 V 3 H 4 V 4 H 5 V 5 H 4 V 6 H 5 V 7 H 3.5 V 6 h -1 V 5 h 1 V 4 h -1 V 3 Z m 0,4.5 h 1 a 1,1 0 0 1 1,1 v 0.938 l 0.4,1.599 a 1,1 0 0 1 -0.416,1.074 l -0.93,0.62 a 1,1 0 0 1 -1.109,0 l -0.93,-0.62 A 1,1 0 0 1 2.1,11.037 L 2.5,9.438 V 8.5 a 1,1 0 0 1 1,-1 z" id="path118" />
       </svg>
     EOS
+  end
+
+  # okay, actually from fontawesome.
+  # https://fontawesome.com/icons/file-audio?f=classic&s=solid
+  #
+  # We don't LOVE this icon, but bootstrap doesn't have a file-audio icon! Only file-music
+  # with a music note, not what we want.
+  #
+  # 4 Jan 2023.  Free font awesome svg are licensed  CC-BY, with attribution
+  # in the svg sufficient. https://fontawesome.com/license/free
+  #
+  # Removed height and width, and removed fill from internal path, replaced with fill="currentColor"
+  # Added class fa-custom-svg for testing identification etc.
+  #
+  # Experimented with referencing a symbol from an external svg, so it can be cached and not included
+  # multiple times on a page. we DO need to repeat the viewBox here to
+  def fa_file_audio_class_solid
+    <<-EOS.strip_heredoc.html_safe
+      <svg xmlns="http://www.w3.org/2000/svg" class="fa-custom-svg" fill="currentColor" viewBox="0 0 384 512">
+        <!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->
+        <path opacity="1" d="M64 0C28.7 0 0 28.7 0 64V448c0 35.3 28.7 64 64 64H320c35.3 0 64-28.7 64-64V160H256c-17.7 0-32-14.3-32-32V0H64zM256 0V128H384L256 0zm2 226.3c37.1 22.4 62 63.1 62 109.7s-24.9 87.3-62 109.7c-7.6 4.6-17.4 2.1-22-5.4s-2.1-17.4 5.4-22C269.4 401.5 288 370.9 288 336s-18.6-65.5-46.5-82.3c-7.6-4.6-10-14.4-5.4-22s14.4-10 22-5.4zm-91.9 30.9c6 2.5 9.9 8.3 9.9 14.8V400c0 6.5-3.9 12.3-9.9 14.8s-12.9 1.1-17.4-3.5L113.4 376H80c-8.8 0-16-7.2-16-16V312c0-8.8 7.2-16 16-16h33.4l35.3-35.3c4.6-4.6 11.5-5.9 17.4-3.5zm51 34.9c6.6-5.9 16.7-5.3 22.6 1.3C249.8 304.6 256 319.6 256 336s-6.2 31.4-16.3 42.7c-5.9 6.6-16 7.1-22.6 1.3s-7.1-16-1.3-22.6c5.1-5.7 8.1-13.1 8.1-21.3s-3.1-15.7-8.1-21.3c-5.9-6.6-5.3-16.7 1.3-22.6z"/>
+      </svg>
+    EOS
+
+    # notes toward another approach involving external file
+    # "<svg viewBox='0 0 384 512'><use xlink:href='#{asset_path("svg_symbols/fa-file-audio-solid-def.svg#fa-file-audio-solid")}'></svg>".html_safe
   end
 end

--- a/spec/components/file_list_item_component_spec.rb
+++ b/spec/components/file_list_item_component_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe FileListItemComponent, type: :component do
+  let(:rendered) { render_inline(FileListItemComponent.new(asset, index: 0)) }
+
+  describe "PDF transcript" do
+    let(:asset) { create(:asset_with_faked_file, :pdf, role: "transcript", parent: create(:work)) }
+
+    it "renders" do
+      img = rendered.at_css(".image img")
+      expect(img).to be_present
+      expect(img['src']).to eq asset.file_url("thumb_mini")
+
+      title_link = rendered.at_css(".title a")
+      expect(title_link.text.strip).to eq "Transcript (Published Version)"
+      expect(title_link["href"]).to eq download_path(asset.file_category, asset, disposition: :inline)
+
+      details = rendered.at_css(".details")
+      expect(details.text).to include("PDF — #{ScihistDigicoll::Util.simple_bytes_to_human_string(asset.size)}")
+    end
+  end
+end

--- a/spec/components/file_list_item_component_spec.rb
+++ b/spec/components/file_list_item_component_spec.rb
@@ -35,4 +35,20 @@ describe FileListItemComponent, type: :component do
       expect(details.text).to include("FLAC — 00:00:05")
     end
   end
+
+  describe "private item" do
+    let(:asset) { create(:asset_with_faked_file, :pdf, published: false, parent: create(:work)) }
+
+    it "has private badge" do
+      expect(rendered).to have_selector("span.badge:contains('Private')")
+    end
+
+    describe "without show_private_badge" do
+      let(:rendered) { render_inline(FileListItemComponent.new(asset, index: 0, show_private_badge: false)) }
+
+      it "does not have private badge" do
+        expect(rendered).not_to have_selector("span.badge:contains('Private')")
+      end
+    end
+  end
 end

--- a/spec/components/file_list_item_component_spec.rb
+++ b/spec/components/file_list_item_component_spec.rb
@@ -19,4 +19,15 @@ describe FileListItemComponent, type: :component do
       expect(details.text).to include("PDF — #{ScihistDigicoll::Util.simple_bytes_to_human_string(asset.size)}")
     end
   end
+
+  describe "FLAC audio" do
+    let(:asset) { create(:asset_with_faked_file, :flac, parent: create(:work)) }
+
+    it "links to m4a derivative download" do
+      title_link = rendered.at_css(".title a")
+
+      expect(title_link.text.strip).to eq asset.title
+      expect(title_link["href"]).to eq download_derivative_path(asset, :m4a, disposition: :inline)
+    end
+  end
 end

--- a/spec/components/file_list_item_component_spec.rb
+++ b/spec/components/file_list_item_component_spec.rb
@@ -29,5 +29,10 @@ describe FileListItemComponent, type: :component do
       expect(title_link.text.strip).to eq asset.title
       expect(title_link["href"]).to eq download_derivative_path(asset, :m4a, disposition: :inline)
     end
+
+    it "includes duration not size in details" do
+      details = rendered.at_css(".details")
+      expect(details.text).to include("FLAC — 00:00:05")
+    end
   end
 end

--- a/spec/components/thumb_component_spec.rb
+++ b/spec/components/thumb_component_spec.rb
@@ -23,10 +23,21 @@ describe ThumbComponent, type: :component do
     end
   end
 
-  describe "non-handlable type" do
+  describe "audio type" do
     let(:argument) do
       build(:asset).tap do |asset|
         allow(asset).to receive(:content_type).and_return("audio/mpeg")
+      end
+    end
+    it "renders audio file svg" do
+      expect(rendered).to have_selector("svg.fa-custom-svg")
+    end
+  end
+
+  describe "non-handlable type" do
+    let(:argument) do
+      build(:asset).tap do |asset|
+        allow(asset).to receive(:content_type).and_return("video/mpeg")
       end
     end
     it "renders placeholder" do

--- a/spec/factories/asset_factory.rb
+++ b/spec/factories/asset_factory.rb
@@ -160,7 +160,7 @@ FactoryBot.define do
       trait :mp3 do
         faked_file { File.open((Rails.root + "spec/test_support/audio/5-seconds-of-silence.mp3")) }
         faked_content_type { "audio/mpeg" }
-        faked_duration_seconds { "00:00:05" }
+        faked_duration_seconds { 5.02 }
         faked_bitrate { 8002 }
         faked_audio_bitrate { 8000 }
         faked_audio_sample_rate { 44100 }
@@ -172,7 +172,7 @@ FactoryBot.define do
       trait :m4a do
         faked_file { File.open((Rails.root + "spec/test_support/audio/5-seconds-of-silence.m4a")) }
         faked_content_type { "audio/mp4" }
-        faked_duration_seconds { "00:00:05" }
+        faked_duration_seconds { 5.02 }
         faked_bitrate { 8002 }
         faked_audio_bitrate { 8000 }
         faked_audio_sample_rate { 44100 }
@@ -184,7 +184,7 @@ FactoryBot.define do
       trait :flac do
         faked_file { File.open((Rails.root + "spec/test_support/audio/5-seconds-of-silence.flac")) }
         faked_content_type { "audio/flac" }
-        faked_duration_seconds { "00:00:05" }
+        faked_duration_seconds { 5.02 }
         faked_bitrate { 8002 }
         faked_audio_bitrate { 8000 }
         faked_audio_sample_rate { 44100 }


### PR DESCRIPTION
The FileListItemComponent shows an individual file in a list of files. It was formerly mostly only used on the public work pages for _restricted_ Oral Histories, where the public would see any public files -- basically only the "Front Matter" PDF!

So it was _really_ only polished for this use case.  Although admins could see other files there, marked with "Private", we hadn't really polished how these files displayed or worked. 

_________________
![Screen Shot 2024-01-04 at 4 58 54 PM](https://github.com/sciencehistory/scihist_digicoll/assets/149304/5adaa16e-5d8b-4541-92dd-1bb3d441d251)
_________________

It was also used on the "Downloads" tab for public Oral Histories -- again only for a PDF file, the public transcript. 

We are going to re-use this component in the re-designed Oral History in-browser request delivery, for delivering both PDFs and Audio files. 

We had to add/polish some functions/features to it, to make it work how we wanted for audio files. 

Notably, we want a generic File Icon used for a thumbnail, instead of just a cross-box. (The latest FontAwesome "free" package had one that was okay -- not perfect, but the best we found that was licensed for free re-use and modification. We deliver it as an inline SVG). 

For FLACs, we also want clicking on the title to load the M4A version directly in the browser (at least for first pass) -- not the FLAC original as previous, it's too big!

And with that in mind, while the component displays original file size ordinarily, which works great for PDFs -- for FLACs, the huge original file size is disconcerting, and they have their choice of FLAC or much smaller M4A -- it's a bit confusing how to display all this information and options, this is just first pass. But for audio and video we now show _duration_ and _not_ file size on initial line. 

_________________
![Screen Shot 2024-01-04 at 5 04 07 PM](https://github.com/sciencehistory/scihist_digicoll/assets/149304/dda9cda3-f349-4f82-a9e6-41576b2e5618)
_________________

Or, without "private" badge, and with full download menu with both derivative options, as we'll use it on OH request page:

_________________
![Screen Shot 2024-01-04 at 5 05 41 PM](https://github.com/sciencehistory/scihist_digicoll/assets/149304/2904a7fb-8547-4366-ad1a-0dfbfabb552a)
_________________

## All commits/changes


- make lines in file listing shorter, to fit three next ti thumb icon
- audio assets get default audio file icon thumbnail
- initial basic FileListItemComponent spec
- FileListItemComponent for FLAC should link inline to M4A derivative
- fix  Asset audio factories to have duration_seconds as float, matching actual app behavior
- FileListItemComponent for A/V includes duration instead of file size
- FileListItemComponent has new ability to turn off show_private_badge
