### PR TITLE
avoid gmail threading for magic link emails

### DIFF
--- a/app/mailers/oh_session_mailer.rb
+++ b/app/mailers/oh_session_mailer.rb
@@ -9,6 +9,11 @@ class OhSessionMailer < ApplicationMailer
   def link_email
     @requester_email = params[:requester_email] or raise ArgumentError.new("missing required params[:requester_email]")
 
+    # prevent gmail from threading multiple magic links in a thread, as gmail ends up hiding the more
+    # recent one, which is bad maybe. Set a unique "references" header to avoid this
+    # https://postmarkapp.com/blog/magic-links
+    headers["references"] = "Unique-#{SecureRandom.hex(20)}"
+
     mail to: @requester_email.email, subject: "Sign-in to Science History Insitute Oral Histories Requests"
   end
 

--- a/spec/mailers/oh_session_mailer_spec.rb
+++ b/spec/mailers/oh_session_mailer_spec.rb
@@ -22,4 +22,8 @@ RSpec.describe OhSessionMailer, :type => :mailer do
 
     expect(mail.body).to include("<a data-auto-login-link=\"true\" href=\"#{login_oral_history_session_url('TOKEN')}\">")
   end
+
+  it "includes a unique reference header to avoid threading with other magic link emails" do
+    expect(mail.header["references"]&.value).to match /Unique-[0-9a-f]+/
+  end
 end


### PR DESCRIPTION
Gmail threads them, and HIDES the more RECENT one.  Which is a bad UX, when the more recent one is more likely to work, older ones may have expired. We use a 'references' header in the mail to a unique value, to avoid threading per google docs

https://postmarkapp.com/blog/magic-links
