### PR TITLE
oral history request access control was not always behaving properly.

### DIFF
--- a/app/controllers/oral_history_access_requests_controller.rb
+++ b/app/controllers/oral_history_access_requests_controller.rb
@@ -41,15 +41,10 @@ class OralHistoryAccessRequestsController < ApplicationController
   def show
     @access_request = Admin::OralHistoryAccessRequest.find(params[:id])
 
-    # oops, if it's not approved nobody can see it... not clear
-    # where to send someone with what message, but this shouldn't happen unless something weird
-    # is happening, so... 404 it? OK.
-    unless @access_request.delivery_status_approved?
+    # If they can't see it for any reason, just 404 as if it was not there.
+    unless current_oral_history_requester == @access_request.oral_history_requester_email &&
+          (@access_request.delivery_status_approved? || @access_request.delivery_status_automatic?)
       raise ActionController::RoutingError.new("Not found.")
-    end
-
-    unless current_oral_history_requester == @access_request.oral_history_requester_email
-      raise AccessDenied.new
     end
 
     # Calculate assets avail by request, broken up by type

--- a/spec/controllers/oral_history_access_requests_controller_spec.rb
+++ b/spec/controllers/oral_history_access_requests_controller_spec.rb
@@ -10,21 +10,62 @@ describe OralHistoryAccessRequestsController, type: :controller do
   end
 
   describe "#show" do
-    let(:oh_request) { create(:oral_history_access_request) }
+    let(:oh_request) { create(:oral_history_access_request, delivery_status: "approved") }
 
-    it "rejects if no auth" do
-      get :show, params: { id: oh_request.id }
-      expect(response).to redirect_to(new_oral_history_session_path)
-      expect(flash[:auto_link_message]).to eq "You must be authorized to access this page."
+    describe "no authorized user" do
+      it "404s" do
+        expect {
+          get :show, params: { id: oh_request.id }
+        }.to raise_error(ActionController::RoutingError)
+      end
     end
 
-    describe "unapproved request" do
-      let(:oh_request) { create(:oral_history_access_request, delivery_status: "pending") }
+    describe "wrong authorized user" do
+      before do
+        allow(session).to receive(:[]).and_call_original
+        allow(session).to receive(:[]).with(OralHistorySessionsController::SESSION_KEY).
+          and_return(Admin::OralHistoryRequesterEmail.create!(email: "example#{rand(999999)}@example.com").id)
+      end
 
       it "404s" do
         expect {
           get :show, params: { id: oh_request.id }
         }.to raise_error(ActionController::RoutingError)
+      end
+    end
+
+    describe "authorized user" do
+      before do
+        allow(session).to receive(:[]).and_call_original
+        allow(session).to receive(:[]).with(OralHistorySessionsController::SESSION_KEY).and_return(oh_request.oral_history_requester_email.id)
+      end
+
+      describe "unapproved request" do
+        let(:oh_request) { create(:oral_history_access_request, delivery_status: "pending") }
+
+        it "404s" do
+          expect {
+            get :show, params: { id: oh_request.id }
+          }.to raise_error(ActionController::RoutingError)
+        end
+      end
+
+      describe "automatic request" do
+        let(:oh_request) { create(:oral_history_access_request, delivery_status: "automatic") }
+
+        it "shows" do
+          get :show, params: { id: oh_request.id }
+          expect(response).to have_http_status(:success)
+        end
+      end
+
+      describe "approved request" do
+        let(:oh_request) { create(:oral_history_access_request, delivery_status: "approved") }
+
+        it "shows" do
+          get :show, params: { id: oh_request.id }
+          expect(response).to have_http_status(:success)
+        end
       end
     end
   end


### PR DESCRIPTION
Fixed, with more complete test coverage. 404 for all access denied, don't reveal whether the ID exists or not, no need fo rseparate behavior for logged in user vs not etc
