### PR TITLE
Rake task to promote the child works of four specific works.

### DIFF
--- a/lib/tasks/data_fixes/publish_child_works.rake
+++ b/lib/tasks/data_fixes/publish_child_works.rake
@@ -1,0 +1,31 @@
+namespace :scihist do
+  namespace :data_fixes do
+    desc """
+      bundle exec rake scihist:data_fixes:publish_child_works
+      See https://github.com/sciencehistory/scihist_digicoll/issues/2477
+    """
+
+    task :publish_child_works => :environment do
+      Kithe::Indexable.index_with(batching: true) do        
+        work_ids=['e172xgb', 'ulbrb9w', 'xoe9glc', 'vx7n5ou']
+
+        work_ids.each do |parent_id|
+          parent = Work.find_by_friendlier_id(parent_id)
+
+          # PROMOTE CHILD WORKS:
+          parent.members.each do |member|
+            member.update( {parent_id: nil } )
+            puts "Promoted child work #{member.friendlier_id}"
+          end
+          
+          # UNPUBLISH:
+          parent.update({published: false})
+          parent.admin_note << 'Unpublished per: https://github.com/sciencehistory/scihist_digicoll/issues/2477'
+          puts "Unpublished parent work #{parent.friendlier_id}"
+          parent.save!
+        end
+
+      end
+    end
+  end
+end

--- a/lib/tasks/data_fixes/publish_child_works.rake
+++ b/lib/tasks/data_fixes/publish_child_works.rake
@@ -6,25 +6,27 @@ namespace :scihist do
     """
 
     task :publish_child_works => :environment do
-      Kithe::Indexable.index_with(batching: true) do        
-        work_ids=['e172xgb', 'ulbrb9w', 'xoe9glc', 'vx7n5ou']
+      Work.transaction do
+        Kithe::Indexable.index_with(batching: true) do        
+          work_ids=['e172xgb', 'ulbrb9w', 'xoe9glc', 'vx7n5ou']
 
-        work_ids.each do |parent_id|
-          parent = Work.find_by_friendlier_id(parent_id)
+          work_ids.each do |parent_id|
+            parent = Work.find_by_friendlier_id(parent_id)
 
-          # PROMOTE CHILD WORKS:
-          parent.members.each do |member|
-            member.update( {parent_id: nil } )
-            puts "Promoted child work #{member.friendlier_id}"
+            # PROMOTE CHILD WORKS:
+            parent.members.each do |member|
+              member.update( {parent_id: nil } )
+              puts "Promoted child work #{member.friendlier_id}"
+            end
+            
+            # UNPUBLISH:
+            parent.update({published: false})
+            parent.admin_note << 'Unpublished per: https://github.com/sciencehistory/scihist_digicoll/issues/2477'
+            puts "Unpublished parent work #{parent.friendlier_id}"
+            parent.save!
           end
-          
-          # UNPUBLISH:
-          parent.update({published: false})
-          parent.admin_note << 'Unpublished per: https://github.com/sciencehistory/scihist_digicoll/issues/2477'
-          puts "Unpublished parent work #{parent.friendlier_id}"
-          parent.save!
-        end
 
+        end
       end
     end
   end


### PR DESCRIPTION
Ref #2477 .
This unpublishes the parent works rather than delete them. I'll do that manually after I run this.
Tested in staging.
- [ ] run in production
- [ ] delete the 4 parents manually