### PR TITLE
Change list of dig. queue item statuses

### DIFF
--- a/app/controllers/admin/digitization_queue_items_controller.rb
+++ b/app/controllers/admin/digitization_queue_items_controller.rb
@@ -165,13 +165,6 @@ class Admin::DigitizationQueueItemsController < AdminController
         },
         params.dig(:query, :status) || ""
       )
-
-      # helpers.options_for_select(
-      #   Admin::DigitizationQueueItem::STATUSES.
-      #     find_all {|s| s != "closed" }.
-      #     collect {|s| [s.humanize, s]},
-      #   params.dig(:query, :status)
-      # )
     end
     helper_method :status_filter_options
 

--- a/app/models/admin/digitization_queue_item.rb
+++ b/app/models/admin/digitization_queue_item.rb
@@ -25,8 +25,12 @@ class Admin::DigitizationQueueItem < ApplicationRecord
   validates :collecting_area, inclusion: { in: COLLECTING_AREAS }
 
   STATUSES = %w{
-    awaiting_dig_on_cart imaging_in_process post_production_completed
-    batch_metadata_completed individual_metadata_completed closed hold re_pull_object
+    awaiting_digitization
+    imaging_in_process
+    image_export_completed
+    metadata_in_progress
+    hold
+    closed
    }
   validates :status, inclusion: { in: STATUSES }
 

--- a/db/migrate/20240125204926_change_default_status_on_digitization_queue_items.rb
+++ b/db/migrate/20240125204926_change_default_status_on_digitization_queue_items.rb
@@ -1,0 +1,9 @@
+class ChangeDefaultStatusOnDigitizationQueueItems < ActiveRecord::Migration[7.1]
+  def up
+    change_column_default :digitization_queue_items, :status, from: 'awaiting_dig_on_cart', to: 'awaiting_digitization'
+  end
+
+  def down
+    change_column_default :digitization_queue_items, :status, from: 'awaiting_digitization', to: 'awaiting_dig_on_cart'
+  end
+end

--- a/db/migrate/20240125204926_change_default_status_on_digitization_queue_items.rb
+++ b/db/migrate/20240125204926_change_default_status_on_digitization_queue_items.rb
@@ -1,9 +1,5 @@
 class ChangeDefaultStatusOnDigitizationQueueItems < ActiveRecord::Migration[7.1]
-  def up
+  def change
     change_column_default :digitization_queue_items, :status, from: 'awaiting_dig_on_cart', to: 'awaiting_digitization'
-  end
-
-  def down
-    change_column_default :digitization_queue_items, :status, from: 'awaiting_digitization', to: 'awaiting_dig_on_cart'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.1].define(version: 2024_01_25_204926) do
-  create_schema "heroku_ext"
-
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_enum :available_by_request_mode_type, [
@@ -210,10 +207,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_25_204926) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "delivery_status", default: "pending"
-    t.bigint "oral_history_requester_email_id"
-    t.datetime "delivery_status_changed_at"
-    t.text "notes_from_staff"
-    t.index ["oral_history_requester_email_id"], name: "idx_on_oral_history_requester_email_id_ff2cc727ac"
     t.index ["work_id"], name: "index_oral_history_access_requests_on_work_id"
   end
 
@@ -231,13 +224,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_25_204926) do
     t.jsonb "json_attributes", default: {}
     t.jsonb "combined_audio_m4a_data"
     t.index ["work_id"], name: "index_oral_history_content_on_work_id", unique: true
-  end
-
-  create_table "oral_history_requester_emails", force: :cascade do |t|
-    t.string "email", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["email"], name: "index_oral_history_requester_emails_on_email", unique: true
   end
 
   create_table "orphan_reports", force: :cascade do |t|
@@ -299,7 +285,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_25_204926) do
   add_foreign_key "kithe_models", "kithe_models", column: "representative_id"
   add_foreign_key "on_demand_derivatives", "kithe_models", column: "work_id"
   add_foreign_key "oral_history_access_requests", "kithe_models", column: "work_id"
-  add_foreign_key "oral_history_access_requests", "oral_history_requester_emails"
   add_foreign_key "oral_history_content", "kithe_models", column: "work_id"
   add_foreign_key "queue_item_comments", "digitization_queue_items"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_18_201400) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_25_204926) do
+  create_schema "heroku_ext"
+
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_enum :available_by_request_mode_type, [
@@ -103,7 +106,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_18_201400) do
     t.text "scope"
     t.text "additional_notes"
     t.string "copyright_status"
-    t.string "status", default: "awaiting_dig_on_cart"
+    t.string "status", default: "awaiting_digitization"
     t.datetime "status_changed_at", precision: nil
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
@@ -207,6 +210,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_18_201400) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "delivery_status", default: "pending"
+    t.bigint "oral_history_requester_email_id"
+    t.datetime "delivery_status_changed_at"
+    t.text "notes_from_staff"
+    t.index ["oral_history_requester_email_id"], name: "idx_on_oral_history_requester_email_id_ff2cc727ac"
     t.index ["work_id"], name: "index_oral_history_access_requests_on_work_id"
   end
 
@@ -224,6 +231,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_18_201400) do
     t.jsonb "json_attributes", default: {}
     t.jsonb "combined_audio_m4a_data"
     t.index ["work_id"], name: "index_oral_history_content_on_work_id", unique: true
+  end
+
+  create_table "oral_history_requester_emails", force: :cascade do |t|
+    t.string "email", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_oral_history_requester_emails_on_email", unique: true
   end
 
   create_table "orphan_reports", force: :cascade do |t|
@@ -285,6 +299,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_18_201400) do
   add_foreign_key "kithe_models", "kithe_models", column: "representative_id"
   add_foreign_key "on_demand_derivatives", "kithe_models", column: "work_id"
   add_foreign_key "oral_history_access_requests", "kithe_models", column: "work_id"
+  add_foreign_key "oral_history_access_requests", "oral_history_requester_emails"
   add_foreign_key "oral_history_content", "kithe_models", column: "work_id"
   add_foreign_key "queue_item_comments", "digitization_queue_items"
 end

--- a/lib/tasks/data_fixes/edit_digitization_queue_item_statuses.rake
+++ b/lib/tasks/data_fixes/edit_digitization_queue_item_statuses.rake
@@ -1,0 +1,28 @@
+namespace :scihist do
+  namespace :data_fixes do
+    desc """
+    Migrate dig queue item statuses. See
+    bundle exec rake scihist:data_fixes:edit_digitization_queue_item_statuses
+    """
+    task :edit_digitization_queue_item_statuses => :environment do
+      mapping = {
+        post_production_completed:     'image_export_completed',
+        batch_metadata_completed:      'metadata_in_progress',
+        individual_metadata_completed: 'metadata_in_progress',
+        awaiting_dig_on_cart:          'awaiting_digitization',
+        re_pull_object:                nil,
+      }
+      Admin::DigitizationQueueItem.transaction do
+        Admin::DigitizationQueueItem.find_each do |item|
+          if mapping.keys.include? item.status.to_sym
+            new_status = mapping[item.status.to_sym]
+            abort "ERROR: don't know how to migrate this status.\n" if new_status.nil?
+            pp "Changing ##{item.id} from #{item.status} to #{new_status}"
+            item.update!({status: new_status})
+          end
+          abort "ERROR: item #{item.id} isn't valid.\n" unless item.valid?
+        end
+      end
+    end
+  end
+end

--- a/spec/system/digitization_queue_spec.rb
+++ b/spec/system/digitization_queue_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Digitization Queue", logged_in_user: :editor, type: :system, js:
     # START STATUS CHANGE AJAX TEST:
 
     # Change the status of the DQ item via the dropdown:
-    expect(dq.status).to eq("awaiting_dig_on_cart")
+    expect(dq.status).to eq("awaiting_digitization")
     expect(page).not_to have_selector :css, '.fa-spinner'
     select 'Imaging in process', from: 'admin_digitization_queue_item_status'
     click_button('Save')
@@ -64,7 +64,7 @@ RSpec.describe "Digitization Queue", logged_in_user: :editor, type: :system, js:
     # This block will throw a Selenium::WebDriver::Error::TimeOutError
     # unless the JS alert that we expect occurs.
     accept_alert do
-      select 'Batch metadata completed', from: 'admin_digitization_queue_item_status'
+      select 'Metadata in progress', from: 'admin_digitization_queue_item_status'
       click_button('Save')
     end
 


### PR DESCRIPTION
Ref #2476
- Changes the status values in the model
- Adds a migration to change the default status (I would love to remove that default status altogether, but I also don't want to modify more code than I have to.)
- Fixes tests
- Adds rake task to do the crosswalk

Note: I didn't bother trying to get the migration to change the actual statuses in the table. None of this code faces the public, and this controller is not in heavy use at the moment. So if a staff member visits that page between deploy and when the rake task is run, they'll see an error.

Steps:
- [ ] Deploy
- [ ] Run rake task

