### PR TITLE
Update redis configuration finding to allow stackhero and more flexibility as to where config is found

### DIFF
--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -222,8 +222,10 @@ module ScihistDigicoll
       end
 
       error_message = "No redis url could be found, cannot provide!\n\n" +
-       "REDIS_PROVIDER_ENV=='#{ENV['REDIS_PROVIDER_ENV']}' ;\n" +
-       "ENV[ ENV['REDIS_PROVIDER_ENV'] ]=='#{ENV[ ENV['REDIS_PROVIDER_ENV'] ]}'\n"
+       "REDIS_PROVIDER_ENV=='#{ENV['REDIS_PROVIDER_ENV']}' ;\n"
+      if ENV['REDIS_PROVIDER_ENV']
+        error_message += "ENV[ ENV['REDIS_PROVIDER_ENV'] ]=='#{ENV[ ENV['REDIS_PROVIDER_ENV'] ]}'\n"
+      end
 
       raise RuntimeError(error_message)
     end

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -212,11 +212,17 @@ module ScihistDigicoll
         # TODO: stop disabling verify if we are not using Heroku redis!
         #
         # If it was a cleartext `redis:` connection, the ssl_params will just be ignored.
-        Redis.new(url: redis_url, ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE })
-      else
+        return Redis.new(url: redis_url, ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE })
+      elsif !Rails.env.production?
         # Still didn't find one? Probably in dev, just use default redis location.
-        Redis.new(url: "redis://localhost:6379")
+        return Redis.new(url: "redis://localhost:6379")
       end
+
+      error_message = "No redis url could be found, cannot provide!\n\n" +
+       "REDIS_PROVIDER_ENV=='#{ENV['REDIS_PROVIDER_ENV']}' ;\n" +
+       "ENV[ ENV['REDIS_PROVIDER_ENV'] ]=='#{ENV[ ENV['REDIS_PROVIDER_ENV'] ]}'\n"
+
+      raise RuntimeError(error_message)
     end
 
     define_key :s3_bucket_originals

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -227,7 +227,7 @@ module ScihistDigicoll
         error_message += "ENV[ ENV['REDIS_PROVIDER_ENV'] ]=='#{ENV[ ENV['REDIS_PROVIDER_ENV'] ]}'\n"
       end
 
-      raise RuntimeError(error_message)
+      raise RuntimeError.new(error_message)
     end
 
     define_key :s3_bucket_originals

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -216,7 +216,7 @@ module ScihistDigicoll
         end
 
         return Redis.new(url: redis_url, ssl_params: ssl_params)
-      elsif !Rails.env.production?
+      elsif false && !Rails.env.production?
         # Still didn't find one? Probably in dev, just use default redis location.
         return Redis.new(url: "redis://localhost:6379")
       end
@@ -226,8 +226,9 @@ module ScihistDigicoll
       if ENV['REDIS_PROVIDER_ENV']
         error_message += "ENV[ ENV['REDIS_PROVIDER_ENV'] ]=='#{ENV[ ENV['REDIS_PROVIDER_ENV'] ]}'\n"
       end
+      Rails.logger.fatal("#{self.name}#persistent_redis_connection! => #{error_message}")
 
-      raise RuntimeError.new(error_message)
+      return nil
     end
 
     define_key :s3_bucket_originals


### PR DESCRIPTION
Ref #2296 

Temporary testing on staging of this caused some disaster, see https://github.com/sciencehistory/scihist_digicoll/issues/2296#issuecomment-1915149051

- [x] More careful testing, including test failure conditions
- [x] TODO: stop disabling verify if we are not using Heroku redis!

---

- remove old unused persistent_redis_host config
- change how redis URL is found to use REDIS_PROVIDER_ENV redirection, and also default to looking for stackhero provider
- Refuse to use localhost redsi default in production, refuse to boot if no redis
