### PR TITLE
Few more things missed in OH class rename

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -24,7 +24,7 @@ class Work < Kithe::Work
   belongs_to :digitization_queue_item, optional: true, class_name: "Admin::DigitizationQueueItem"
 
   has_many :on_demand_derivatives, inverse_of: :work, dependent: :destroy
-  has_many :oral_history_access_requests, inverse_of: :work, dependent: :destroy, class_name: "OralHistoryRequest"
+  has_many :oral_history_requests, inverse_of: :work, dependent: :destroy
 
 
   has_many :cart_items, dependent: :delete_all

--- a/app/views/oral_history_request_notification_mailer/notification_email.html.erb
+++ b/app/views/oral_history_request_notification_mailer/notification_email.html.erb
@@ -2,4 +2,4 @@
   (<%= ScihistDigicoll::Env.lookup(:service_level) %>),
   at <%= I18n.l(@oral_history_request.created_at, format: :long) %></p>
 
-<p><%= link_to "Review Request", admin_oral_history_access_request_url(@oral_history_request)%></p>
+<p><%= link_to "Review Request", admin_oral_history_request_url(@oral_history_request)%></p>

--- a/app/views/oral_history_requests/new.html.erb
+++ b/app/views/oral_history_requests/new.html.erb
@@ -5,4 +5,4 @@
     Get Oral History Access
   <% end %>
 </h1>
-<%= render 'form', oral_history_access_request: @oral_history_request %>
+<%= render 'form', oral_history_request: @oral_history_request %>


### PR DESCRIPTION
Including some that created actual errors not caught by existing tests. :( 

- fix bad old method name to renamed route helper admin_oral_history_request_url
- rename association to new name #oral_history_requests
- use correct new param name oral_history_request to preserve existing values on invalid redisplay
