### PR TITLE
remove distrating link to work from OH approval email

### DIFF
--- a/app/views/oral_history_delivery_mailer/approved_with_session_link_email.html.erb
+++ b/app/views/oral_history_delivery_mailer/approved_with_session_link_email.html.erb
@@ -1,6 +1,6 @@
 <p>Dear <%= mailer.patron_name %>,</p>
 
-<p>Thank you for your recent visit to the <%= link_to "Science History Institute’s Digital Collections", mailer.hostname %>. Your request for files from <%= link_to mailer.work.title, work_url(mailer.work.friendlier_id) %> has been approved.
+<p>Thank you for your recent visit to the <%= link_to "Science History Institute’s Digital Collections", mailer.hostname %>. Your request for files from <i><%= mailer.work.title %></i> has been approved.
 
 <% if mailer.custom_message.present? %>
   <%= simple_format mailer.custom_message %>


### PR DESCRIPTION
Link to log-in is the one they need, they WILL click on that link they don't actually want if it's there
