### PR TITLE
Store OH Request login in it's own cookie

### DIFF
--- a/app/controllers/oral_history_requests_controller.rb
+++ b/app/controllers/oral_history_requests_controller.rb
@@ -199,7 +199,7 @@ private
 
   def current_oral_history_requester
     unless defined?(@current_oral_history_requester)
-      @current_oral_history_requester = (OralHistoryRequester.find_by(id: session[OralHistorySessionsController::SESSION_KEY]) if session[OralHistorySessionsController::SESSION_KEY].present?)
+      @current_oral_history_requester = OralHistorySessionsController.fetch_oral_history_current_requester(request: request)
     end
     @current_oral_history_requester
   end

--- a/app/controllers/oral_history_requests_controller.rb
+++ b/app/controllers/oral_history_requests_controller.rb
@@ -199,7 +199,7 @@ private
 
   def current_oral_history_requester
     unless defined?(@current_oral_history_requester)
-      @current_oral_history_requester = OralHistorySessionsController.fetch_oral_history_current_requester(request: request)
+      @current_oral_history_requester = OralHistorySessionsController.fetch_oral_history_current_requester(request: request, reset_expiration_window: true)
     end
     @current_oral_history_requester
   end

--- a/app/controllers/oral_history_sessions_controller.rb
+++ b/app/controllers/oral_history_sessions_controller.rb
@@ -3,6 +3,23 @@
 class OralHistorySessionsController < ApplicationController
   SESSION_KEY = :oral_history_requester_id
 
+
+  # @param request [ActionDispatch::Request]
+  # @param oral_history_requester [OralHistoryRequester]
+  def self.store_oral_history_current_requester(request:, oral_history_requester:)
+     request.session[SESSION_KEY] = oral_history_requester.id
+  end
+
+  # @param request [ActionDispatch::Request]
+  # @return [OralHistoryRequester, nil]
+  def self.fetch_oral_history_current_requester(request:)
+    if request.session[SESSION_KEY].present?
+      OralHistoryRequester.find_by(id: request.session[OralHistorySessionsController::SESSION_KEY])
+    else
+      nil
+    end
+  end
+
   # GET /oral_history_session/login/$TOKEN
   #
   # Actually logs someone in
@@ -10,7 +27,7 @@ class OralHistorySessionsController < ApplicationController
     requester_email = OralHistoryRequester.find_by_token_for(:auto_login, params[:token])
 
     if requester_email.present?
-      session[SESSION_KEY] = requester_email.id
+      self.class.store_oral_history_current_requester(request: request, oral_history_requester: requester_email)
       redirect_to oral_history_requests_path
     else
       # invalid/expired/missing token

--- a/app/controllers/oral_history_sessions_controller.rb
+++ b/app/controllers/oral_history_sessions_controller.rb
@@ -17,10 +17,15 @@ class OralHistorySessionsController < ApplicationController
 
   # @param request [ActionDispatch::Request]
   # @return [OralHistoryRequester, nil]
-  def self.fetch_oral_history_current_requester(request:)
+  def self.fetch_oral_history_current_requester(request:, reset_expiration_window: true)
     if request.cookie_jar.encrypted[SESSION_COOKIE_NAME].present?
       id = JSON.parse(request.cookie_jar.encrypted[SESSION_COOKIE_NAME])[SESSION_KEY]
-      OralHistoryRequester.find_by(id: id)
+      OralHistoryRequester.find_by(id: id).tap do |requester|
+        if requester && reset_expiration_window
+          # push expiration to be further back
+          store_oral_history_current_requester(request: request, oral_history_requester: requester)
+        end
+      end
     else
       nil
     end

--- a/app/controllers/oral_history_sessions_controller.rb
+++ b/app/controllers/oral_history_sessions_controller.rb
@@ -17,7 +17,7 @@ class OralHistorySessionsController < ApplicationController
 
   # @param request [ActionDispatch::Request]
   # @return [OralHistoryRequester, nil]
-  def self.fetch_oral_history_current_requester(request:, reset_expiration_window: true)
+  def self.fetch_oral_history_current_requester(request:, reset_expiration_window: false)
     if request.cookie_jar.encrypted[SESSION_COOKIE_NAME].present?
       id = JSON.parse(request.cookie_jar.encrypted[SESSION_COOKIE_NAME])[SESSION_KEY]
       OralHistoryRequester.find_by(id: id).tap do |requester|

--- a/app/controllers/oral_history_sessions_controller.rb
+++ b/app/controllers/oral_history_sessions_controller.rb
@@ -3,12 +3,16 @@
 class OralHistorySessionsController < ApplicationController
   SESSION_COOKIE_NAME = "scihist_oh_user"
   SESSION_KEY = "oral_history_requester_id"
+  SESSION_EXPIRE_PERIOD = 30.days
 
 
   # @param request [ActionDispatch::Request]
   # @param oral_history_requester [OralHistoryRequester]
   def self.store_oral_history_current_requester(request:, oral_history_requester:)
-    request.cookie_jar.encrypted[SESSION_COOKIE_NAME] = JSON.generate({ SESSION_KEY => oral_history_requester.id })
+    request.cookie_jar.encrypted[SESSION_COOKIE_NAME] = {
+      value: JSON.generate({ SESSION_KEY => oral_history_requester.id }),
+      expires: SESSION_EXPIRE_PERIOD
+    }
   end
 
   # @param request [ActionDispatch::Request]

--- a/spec/controllers/oral_history_requests_controller_spec.rb
+++ b/spec/controllers/oral_history_requests_controller_spec.rb
@@ -36,8 +36,7 @@ describe OralHistoryRequestsController, type: :controller do
 
     describe "authorized user" do
       before do
-        allow(session).to receive(:[]).and_call_original
-        allow(session).to receive(:[]).with(OralHistorySessionsController::SESSION_KEY).and_return(oh_request.oral_history_requester.id)
+        allow(controller).to receive(:current_oral_history_requester).and_return(oh_request.oral_history_requester)
       end
 
       describe "unapproved request" do

--- a/spec/controllers/oral_history_sessions_controller_spec.rb
+++ b/spec/controllers/oral_history_sessions_controller_spec.rb
@@ -30,7 +30,7 @@ describe OralHistorySessionsController, type: :controller, queue_adapter: :inlin
     it "authenticates and stores login" do
       get :login, params: { token: auto_login_link}
 
-      expect(session[:oral_history_requester_id]).to eq requester_email.id
+      expect(OralHistorySessionsController.fetch_oral_history_current_requester(request: request)&.id).to eq requester_email.id
 
       expect(response).to redirect_to(oral_history_requests_path)
     end
@@ -65,7 +65,7 @@ describe OralHistorySessionsController, type: :controller, queue_adapter: :inlin
       session[:oral_history_requester_id] = requester_email.id
       delete :destroy
 
-      expect(session[:oral_history_requester_id]).to be nil
+      expect(OralHistorySessionsController.fetch_oral_history_current_requester(request: request)).to be nil
       expect(response).to have_http_status(:redirect)
       expect(flash[:notice]).to include("signed out")
     end


### PR DESCRIPTION
As one way to give it separately configurable expiration. Make sure cookie is encrypted and http-only. 

Set it with a 14-day expiration, and set it up logic so every time it's accessed the expiration date is reset, to give a sliding window where it will always stay good X days after last access. 

- extract OH current user session to be centralized
- switch OH requester session to it's own cookie
- add expiration to OH requester session
- push back OH requester session expiry window on every access
- fix spec to use standard API for checking OH requester session
- fetch_oral_history_current_requester by default will not reset expiry window, argument to opt in
