### PR TITLE
let DownloadController give access to authorized OH requesters for their originals

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -77,7 +77,9 @@ class DownloadsController < ApplicationController
   def set_asset
     @asset = Asset.find_by_friendlier_id!(params[:asset_id])
 
-    authorize! :read, @asset
+    if cannot?(:read, @asset)
+      raise AccessGranted::AccessDenied.new(:read, @asset, 'Access Denied')
+    end
 
     unless @asset.stored?
       raise ActiveRecord::RecordNotFound.new("No downloads allowed for non-promoted Asset '#{@asset.id}' or its derivatives",

--- a/app/models/oral_history_requester.rb
+++ b/app/models/oral_history_requester.rb
@@ -29,4 +29,9 @@ class OralHistoryRequester < ApplicationRecord
     # constant for token to be good.
     email
   end
+
+  # @param [Asset]
+  def has_approved_request_for_asset?(asset)
+    OralHistoryRequest.where(work: asset.parent, oral_history_requester: self, delivery_status: "approved").exists?
+  end
 end

--- a/app/models/oral_history_requester.rb
+++ b/app/models/oral_history_requester.rb
@@ -32,6 +32,6 @@ class OralHistoryRequester < ApplicationRecord
 
   # @param [Asset]
   def has_approved_request_for_asset?(asset)
-    OralHistoryRequest.where(work: asset.parent, oral_history_requester: self, delivery_status: "approved").exists?
+    OralHistoryRequest.where(work: asset.parent, oral_history_requester: self, delivery_status: ["approved", "automatic"]).exists?
   end
 end

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe DownloadsController do
-
+  let(:faked_download_url) { "http://test.host/faked_download_url" }
   # We're not actually using S3 in test, but we want to make sure
   # we're sending the right params to S3 url generation.
   # So we mock it out.
@@ -14,7 +14,7 @@ describe DownloadsController do
 
     allow_any_instance_of(Shrine::UploadedFile).to receive(:url) do |**args|
       @received_s3_url_args << args
-      "http://test.host/faked_download_url"
+      faked_download_url
     end
   end
 
@@ -35,6 +35,40 @@ describe DownloadsController do
       it "redirects to login page" do
         get :original, params: { asset_id: asset, file_category: file_category }
         expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    describe "by-request only asset" do
+      let(:work) { create(:oral_history_work, :available_by_request) }
+      let(:asset) { work.members.find { |m| m.oh_available_by_request? } }
+
+      describe "with permission, when logged in" do
+        let!(:approved_request) { create(:oral_history_request, work: work, delivery_status: "approved") }
+
+        before do
+          # mock signed-in OH requester
+          OralHistorySessionsController.store_oral_history_current_requester(request: request, oral_history_requester: approved_request.oral_history_requester)
+        end
+
+        it "returns redirect to file" do
+          get :original, params: { asset_id: asset, file_category: file_category }
+          expect(response.status).to eq 302
+          expect(response).not_to redirect_to(new_user_session_path)
+          expect(response.location).to eq faked_download_url
+        end
+      end
+
+      describe "logged in, but no request" do
+        let(:oral_history_requester) { OralHistoryRequester.new(email: "example#{rand(999999)}@example.com") }
+        before do
+          # mock signed-in OH requester
+          OralHistorySessionsController.store_oral_history_current_requester(request: request, oral_history_requester: oral_history_requester)
+        end
+
+        it "redirects to login page" do
+          get :original, params: { asset_id: asset, file_category: file_category }
+          expect(response).to redirect_to(new_user_session_path)
+        end
       end
     end
 

--- a/spec/models/oral_history_requester_spec.rb
+++ b/spec/models/oral_history_requester_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe OralHistoryRequester, type: :model do
+  let(:oral_history_requester) { OralHistoryRequester.new(email: "example#{rand(999999)}@example.com") }
+  describe "#has_approved_request?" do
+    describe "with no request" do
+      let(:asset) { create(:asset) }
+
+      it "is false" do
+        expect(oral_history_requester.has_approved_request_for_asset?(asset)).to be false
+      end
+    end
+
+    describe "with pending request" do
+      let!(:oral_history_request) { create(:oral_history_request, oral_history_requester: oral_history_requester, delivery_status: "pending") }
+      let(:asset) { oral_history_request.work.members.find { |m| m.oh_available_by_request? } }
+
+      it "is false" do
+        expect(oral_history_requester.has_approved_request_for_asset?(asset)).to be false
+      end
+    end
+
+    describe "with approved request" do
+      let!(:oral_history_request) { create(:oral_history_request, oral_history_requester: oral_history_requester, delivery_status: "approved") }
+      let(:asset) { oral_history_request.work.members.find { |m| m.oh_available_by_request? } }
+
+      it "is true" do
+        expect(oral_history_requester.has_approved_request_for_asset?(asset)).to be true
+      end
+    end
+  end
+end

--- a/spec/models/oral_history_requester_spec.rb
+++ b/spec/models/oral_history_requester_spec.rb
@@ -28,5 +28,14 @@ describe OralHistoryRequester, type: :model do
         expect(oral_history_requester.has_approved_request_for_asset?(asset)).to be true
       end
     end
+
+    describe "with automatic request" do
+      let!(:oral_history_request) { create(:oral_history_request, oral_history_requester: oral_history_requester, delivery_status: "automatic") }
+      let(:asset) { oral_history_request.work.members.find { |m| m.oh_available_by_request? } }
+
+      it "is true" do
+        expect(oral_history_requester.has_approved_request_for_asset?(asset)).to be true
+      end
+    end
   end
 end


### PR DESCRIPTION
Ref #2536 
- unroll access-granted logic, so we can customize it with the stuff for our by-request assets
- OralHistoryRequester#has_approved_request_for_asset?
- let DownloadController give access to authorized OH requesters for their originals
- copy specs to ensure OH requester access to download derivatives too
