### PR TITLE
OH Request UX text changes by request

### DIFF
--- a/app/mailers/oh_session_mailer.rb
+++ b/app/mailers/oh_session_mailer.rb
@@ -14,7 +14,7 @@ class OhSessionMailer < ApplicationMailer
     # https://postmarkapp.com/blog/magic-links
     headers["references"] = "Unique-#{SecureRandom.hex(20)}"
 
-    mail to: @requester_email.email, subject: "Sign-in to Science History Insitute Oral Histories Requests"
+    mail to: @requester_email.email, subject: "Access Science History Insitute Requests"
   end
 
   def login_magic_link

--- a/app/mailers/oral_history_delivery_mailer.rb
+++ b/app/mailers/oral_history_delivery_mailer.rb
@@ -20,7 +20,7 @@ class OralHistoryDeliveryMailer < ApplicationMailer
     raise ArgumentError.new("Required request.oral_history_requester missing") unless request.oral_history_requester.present?
     raise ArgumentError.new("params[:request] must be approved but was #{request.delivery_status}") unless request.delivery_status_approved?
 
-    mail(to: to_address, subject: "Science History Institute: Access files for #{work.title}", content_type: "text/html")
+    mail(to: to_address, subject: "Science History Institute Oral History Request: Approved: #{work.title}", content_type: "text/html")
   end
 
   def rejected_with_session_link_email
@@ -28,7 +28,7 @@ class OralHistoryDeliveryMailer < ApplicationMailer
     raise ArgumentError.new("Required request.oral_history_requester missing") unless request.oral_history_requester.present?
     raise ArgumentError.new("params[:request] must be rejected but was #{request.delivery_status}") unless request.delivery_status_rejected?
 
-    mail(to: to_address, subject: "Science History Institute: Your request for #{work.title}", content_type: "text/html")
+    mail(to: to_address, subject: "Science History Institute Oral History Request: #{work.title}", content_type: "text/html")
   end
 
   def request

--- a/app/views/oh_session_mailer/link_email.html.erb
+++ b/app/views/oh_session_mailer/link_email.html.erb
@@ -1,12 +1,12 @@
-<b>Science History Institute Oral Histories Collection</b>
+<p><b>Science History Institute Oral History Requests</b></p>
 
 <p>
-  Someone, hopefully you, has requested Science History Institute oral histories to this email address.
+  Thank you for requesting oral history interviews via the Science History Institute’s Digital Collections.
 </p>
 
 <p><%= I18n.t("oral_history.sign_in_prompt") %>
     <%= link_to I18n.t("oral_history.sign_in_link_label"), login_magic_link, data: { auto_login_link: true}  %></p>
 
-<p>Please keep this email around, so you can use this link to access your requests in the future.</p>
+<p>Please do not share this link with anyone without the permission of Science History Institute staff and please save this e-mail so that you can access your requests in the future.</p>
 
-<p>If you have any questions, you can reply to this email, or write <%= link_to ScihistDigicoll::Env.lookup!(:oral_history_email_address), "mailto:#{ScihistDigicoll::Env.lookup!(:oral_history_email_address)}" %>.<p>
+<p>If you have any questions, please reply to this email, or write to <%= link_to ScihistDigicoll::Env.lookup!(:oral_history_email_address), "mailto:#{ScihistDigicoll::Env.lookup!(:oral_history_email_address)}" %>.<p>

--- a/app/views/oral_history_delivery_mailer/approved_with_session_link_email.html.erb
+++ b/app/views/oral_history_delivery_mailer/approved_with_session_link_email.html.erb
@@ -1,6 +1,8 @@
+<p><b>Science History Institute Oral History Requests</b></p>
+
 <p>Dear <%= mailer.patron_name %>,</p>
 
-<p>Thank you for your recent visit to the <%= link_to "Science History Institute’s Digital Collections", mailer.hostname %>. Your request for files from <i><%= mailer.work.title %></i> has been approved.
+<p>Thank you for requesting <i><%= mailer.work.title %></i> via the Science History Institute's Digital Collections. Your request has been approved.</p>
 
 <% if mailer.custom_message.present? %>
   <%= simple_format mailer.custom_message %>
@@ -9,4 +11,7 @@
 <p><%= I18n.t("oral_history.sign_in_prompt") %>
     <%= link_to I18n.t("oral_history.sign_in_link_label"), login_magic_link, data: { auto_login_link: true}  %></p>
 
-<p>If you have any questions, you can reply to this email, or write <%= link_to ScihistDigicoll::Env.lookup!(:oral_history_email_address), "mailto:#{ScihistDigicoll::Env.lookup!(:oral_history_email_address)}" %>.<p>
+<p>Please do not share this link with anyone without the permission of Science History Institute
+staff and please save this e-mail so that you can access your requests in the future.</p>
+
+<p>If you have any questions, please reply to this email, or write to <%= link_to ScihistDigicoll::Env.lookup!(:oral_history_email_address), "mailto:#{ScihistDigicoll::Env.lookup!(:oral_history_email_address)}" %>.<p>

--- a/app/views/oral_history_delivery_mailer/rejected_with_session_link_email.html.erb
+++ b/app/views/oral_history_delivery_mailer/rejected_with_session_link_email.html.erb
@@ -1,8 +1,8 @@
 <p>Dear <%= mailer.patron_name %>,</p>
 
-<p>Thank you for your recent visit to the <%= link_to "Science History Institute’s Digital Collections", mailer.hostname %>.</p>
+<p>Thank you for your recent visit to the Science History Institute’s Digital Collections.</p>
 
-<p>Unfortunately we could <b>not</b> approve your request for files from <%= link_to mailer.work.title, work_url(mailer.work.friendlier_id) %> at this time.
+<p>Unfortunately we could <b>not</b> approve your request for <%= link_to mailer.work.title, work_url(mailer.work.friendlier_id) %> at this time.
 
 <% if mailer.custom_message.present? %>
   <%= simple_format mailer.custom_message %>
@@ -11,4 +11,4 @@
 <p><%= I18n.t("oral_history.sign_in_prompt") %>
     <%= link_to I18n.t("oral_history.sign_in_link_label"), login_magic_link, data: { auto_login_link: true}  %></p>
 
-<p>If you have any questions, you can reply to this email, or write <%= link_to ScihistDigicoll::Env.lookup!(:oral_history_email_address), "mailto:#{ScihistDigicoll::Env.lookup!(:oral_history_email_address)}" %>.<p>
+<p>If you have any questions, please reply to this email or write to <%= link_to ScihistDigicoll::Env.lookup!(:oral_history_email_address), "mailto:#{ScihistDigicoll::Env.lookup!(:oral_history_email_address)}" %>.<p>

--- a/app/views/oral_history_requests/index.html.erb
+++ b/app/views/oral_history_requests/index.html.erb
@@ -7,7 +7,7 @@
       <p class="requester-email">
         <%= current_oral_history_requester.email %>
       </p>
-      <p>Some Oral Histories are available by request only, and are not on the public web. You can find your requests here.</p>
+      <p>Below you can view the status of your oral history requests and download materials from approved requests. Please note that some oral histories are available by request only and are not available on the public web.</p>
     </div>
 
     <%= link_to "Sign out", oral_history_session_path, method: :delete, class: "btn btn-brand-main signout" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,8 +83,8 @@ en:
     front_matter: "Front Matter and Index"
 
   oral_history:
-    sign_in_prompt: "You can access your Oral History requests using this special sign-in link:"
-    sign_in_link_label: "Sign In to Science History Institute Requests"
+    sign_in_prompt: "You can view the status of all of your oral history requests and download materials from approved requests using this special sign-in link:"
+    sign_in_link_label: "Access Science History Institute Requests"
 
 
 

--- a/spec/controllers/admin/oral_history_requests_controller_spec.rb
+++ b/spec/controllers/admin/oral_history_requests_controller_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Admin::OralHistoryRequestsController, :logged_in_user, type: :con
           expect(oral_history_access_request.delivery_status).to eq "approved"
 
           last_email = ActionMailer::Base.deliveries.last
-          expect(last_email.subject).to eq "Science History Institute: Access files for #{oral_history_access_request.work.title}"
+          expect(last_email.subject).to eq "Science History Institute Oral History Request: Approved: #{oral_history_access_request.work.title}"
           expect(last_email.from).to eq [ScihistDigicoll::Env.lookup(:oral_history_email_address)]
           expect(last_email.body).to match /You can view the status of all of your oral history requests and download materials from approved requests using this special sign-in link/
         end
@@ -147,7 +147,7 @@ RSpec.describe Admin::OralHistoryRequestsController, :logged_in_user, type: :con
           expect(oral_history_access_request.delivery_status).to eq "rejected"
 
           last_email = ActionMailer::Base.deliveries.last
-          expect(last_email.subject).to eq "Science History Institute: Your request for #{oral_history_access_request.work.title}"
+          expect(last_email.subject).to eq "Science History Institute Oral History Request: #{oral_history_access_request.work.title}"
           expect(last_email.from).to eq [ScihistDigicoll::Env.lookup(:oral_history_email_address)]
           expect(last_email.body).to match /Unfortunately we could <b>not<\/b> approve your request/
           expect(last_email.body).to include(message)

--- a/spec/controllers/admin/oral_history_requests_controller_spec.rb
+++ b/spec/controllers/admin/oral_history_requests_controller_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Admin::OralHistoryRequestsController, :logged_in_user, type: :con
           last_email = ActionMailer::Base.deliveries.last
           expect(last_email.subject).to eq "Science History Institute: Access files for #{oral_history_access_request.work.title}"
           expect(last_email.from).to eq [ScihistDigicoll::Env.lookup(:oral_history_email_address)]
-          expect(last_email.body).to match /You can access your Oral History requests using this special sign-in link/
+          expect(last_email.body).to match /You can view the status of all of your oral history requests and download materials from approved requests using this special sign-in link/
         end
 
         it "can reject" do

--- a/spec/controllers/oral_history_requests_controller_spec.rb
+++ b/spec/controllers/oral_history_requests_controller_spec.rb
@@ -185,8 +185,8 @@ describe OralHistoryRequestsController, type: :controller do
             expect {
               post :create, params: full_create_params
             }.to have_enqueued_job(ActionMailer::MailDeliveryJob).with { |class_name, action|
-                expect(class_name).to eq "OhSessionMailer"
-                expect(action).to eq "link_email"
+                expect(class_name).to eq "OralHistoryDeliveryMailer"
+                expect(action).to eq "approved_with_session_link_email"
             }
 
             expect(response).to redirect_to(work_path(work.friendlier_id))

--- a/spec/mailers/oh_session_mailer_spec.rb
+++ b/spec/mailers/oh_session_mailer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe OhSessionMailer, :type => :mailer do
   it "it has good metadata" do
     expect(mail.to).to eq ([requester_email.email])
     expect(mail.from).to eq(["oralhistory@sciencehistory.org"])
-    expect(mail.subject).to eq "Sign-in to Science History Insitute Oral Histories Requests"
+    expect(mail.subject).to eq "Access Science History Insitute Requests"
   end
 
   it "includes an auto-login-link" do

--- a/spec/mailers/oral_history_delivery_mailer_spec.rb
+++ b/spec/mailers/oral_history_delivery_mailer_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe OralHistoryDeliveryMailer, :type => :mailer do
       expect(mail.body.raw_source).to include("<a data-auto-login-link=\"true\" href=\"#{login_oral_history_session_url('TOKEN')}\">")
 
       mail_body_html = Nokogiri::HTML(mail.body.raw_source)
-      expect(mail_body_html).to have_text("Your request for files from #{access_request.work.title} has been approved.")
+      expect(mail_body_html).to have_text(/Thank you for requesting #{Regexp.escape access_request.work.title}.*has been approved/)
     end
   end
 

--- a/spec/mailers/oral_history_delivery_mailer_spec.rb
+++ b/spec/mailers/oral_history_delivery_mailer_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe OralHistoryDeliveryMailer, :type => :mailer do
       expect(mail.body.raw_source).to include("<a data-auto-login-link=\"true\" href=\"#{login_oral_history_session_url('TOKEN')}\">")
 
       mail_body_html = Nokogiri::HTML(mail.body.raw_source)
-      expect(mail_body_html).to have_text("Unfortunately we could not approve your request for files from #{access_request.work.title} at this time.")
+      expect(mail_body_html).to have_text("Unfortunately we could not approve your request for #{access_request.work.title} at this time.")
     end
 
     it "includes the custom message" do

--- a/spec/mailers/oral_history_delivery_mailer_spec.rb
+++ b/spec/mailers/oral_history_delivery_mailer_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe OralHistoryDeliveryMailer, :type => :mailer do
     it "it has good metadata" do
       expect(mail.to).to eq ([access_request.requester_email])
       expect(mail.from).to eq(["oralhistory@sciencehistory.org"])
-      expect(mail.subject).to eq "Science History Institute: Access files for #{access_request.work.title}"
+      expect(mail.subject).to eq "Science History Institute Oral History Request: Approved: #{access_request.work.title}"
     end
 
     it "includes an auto-login-link and body" do
@@ -45,7 +45,7 @@ RSpec.describe OralHistoryDeliveryMailer, :type => :mailer do
     it "it has good metadata" do
       expect(mail.to).to eq ([access_request.requester_email])
       expect(mail.from).to eq(["oralhistory@sciencehistory.org"])
-      expect(mail.subject).to eq "Science History Institute: Your request for #{access_request.work.title}"
+      expect(mail.subject).to eq "Science History Institute Oral History Request: #{access_request.work.title}"
     end
 
     it "includes an auto-login-link and body" do


### PR DESCRIPTION
- reword text in OhSessionMailer#link_email
- new text for OralHistoryDeliveryMailer#approved_with_session_link_email
- new text for OralHistoryDeliveryMailer#rejected_with_session_link_email
- revise text in OH request list header
- new subject lines for OralHistoryDeliveryMailer emails
- change subject on OhSessionMailer email
- fix specs for new subject lines
- automatic delivery OH request should get same email as manual approval delivery
