### PR TITLE
Allow per-collection default sort

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -124,7 +124,7 @@ class Admin::CollectionsController < AdminController
     # This could be done in a form object or otherwise abstracted, but this is good
     # enough for now.
     def collection_params
-      permitted_attributes = [:title, :description, :department]
+      permitted_attributes = [:title, :description, :department, :default_sort_field]
       permitted_attributes << :published if can?(:publish, @collection || Kithe::Model)
 
       Kithe::Parameters.new(params).

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -400,12 +400,12 @@ class CatalogController < ApplicationController
 
     config.add_sort_field("newest_date") do |field|
       field.label = "newest date"
-      field.sort = "latest_date desc"
+      field.sort = "latest_date desc, title desc"
     end
 
     config.add_sort_field("oldest_date") do |field|
       field.label = "oldest date"
-      field.sort = "earliest_date asc"
+      field.sort = "earliest_date asc, title asc"
     end
 
     config.add_sort_field("recently_added") do |field|

--- a/app/controllers/collection_show_controller.rb
+++ b/app/controllers/collection_show_controller.rb
@@ -69,9 +69,16 @@ class CollectionShowController < CatalogController
 
   private
 
-  # Our custom SearchBuilder needs to know collection id (UUID)
+  # Our custom SearchBuilder needs to know:
+  #   collection id (UUID)
+  #   the default sort order for this collection, if specified.
   def search_service_context
-    super.merge!(collection_id: collection.id)
+    super.merge!(collection_id: collection.id, collection_default_sort_order: collection_default_sort_order)
+  end
+
+  # Some collections define a default sort field. Look up its sort order in blacklight_config and use that.
+  def collection_default_sort_order
+    blacklight_config.sort_fields.dig(collection&.default_sort_field)&.sort
   end
 
   def check_auth

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -76,6 +76,14 @@ class WorkIndexer < Kithe::Indexer
     end
 
 
+    # We use this a sort key when the work's title is
+    # a proxy for its order in a series,
+    # e.g. 'Chemical Heritage, Volume 15 Number 2'.
+    # See https://github.com/sciencehistory/scihist_digicoll/issues/2494
+    to_field "title" do |record, acc|
+      acc << record.title
+    end
+
     # We need to know what collection(s) this work is in, to support search-within-a-collection.
     #
     # NOTE: This will do an SQL query to fetch collection ids, if are you indexing a bunch

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -15,6 +15,11 @@ class Collection < Kithe::Collection
   DEPARTMENT_EXHIBITION_VALUE = "Exhibition"
   DEPARTMENTS = (Work::ControlledLists::DEPARTMENT + [DEPARTMENT_EXHIBITION_VALUE]).freeze
 
+  DEFAULT_SORT_FIELDS = ([
+    ['Not specified', nil],
+    ['Oldest date', 'oldest_date']
+  ]).freeze
+
   # automatic Solr indexing on save
   if ScihistDigicoll::Env.lookup(:solr_indexing) == 'true'
     self.kithe_indexable_mapper = CollectionIndexer.new
@@ -70,6 +75,9 @@ class Collection < Kithe::Collection
   #
   # Example value: 'oldest_date'.
   attr_json :default_sort_field, :string, default: -> { nil }
+  validates :default_sort_field, inclusion: { in: DEFAULT_SORT_FIELDS.to_h.values, allow_blank: true }
+
+
 
   # For ransack use, we need to list all attributes we want to use ransack to SEARCH or SORT by.
   #

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -64,6 +64,13 @@ class Collection < Kithe::Collection
     self.representative = CollectionThumbAsset.new(title: "collection-thumbnail-placeholder", parent: self)
   end
 
+  # Some collections define an arbitrary default sort field.
+  # We use this for the inital presentation when you first visit the collection page,
+  # before the user searches inside the collection or alter the sort order.
+  #
+  # Example value: 'oldest_date'.
+  attr_json :default_sort_field, :string, default: -> { nil }
+
   # For ransack use, we need to list all attributes we want to use ransack to SEARCH or SORT by.
   #
   # We really probably oughta stop using ransack, I hate having this in the model.

--- a/app/models/search_builder/custom_sort_logic.rb
+++ b/app/models/search_builder/custom_sort_logic.rb
@@ -4,13 +4,24 @@ class SearchBuilder
 
     # OVERRIDE this method from:
     # https://github.com/projectblacklight/blacklight/blob/v6.7.2/lib/blacklight/search_builder.rb#L224
-    # To make relevance only default if there is a query parameter, otherwise it makes no sense.
     def sort
+      # if no sort is specified by the user, and there's no search phrase
       if blacklight_params[:sort].blank? && blacklight_params[:q].blank?
-        @default_blank_query_sort ||= (blacklight_config.sort_fields.values.find { |f| f.blank_query_default == true }.try(:sort)  || blacklight_config.default_sort_field )
+        # use the default sort order from catalog controller
+        @default_blank_query_sort ||= default_sort_order
       else
         super
       end
+    end
+
+    private
+
+    # see also WithinCollectionBuilder#default_sort_order, which overrides this method
+    def default_sort_order
+      # look up the blank_query_default sort order in the catalog controller
+      blacklight_config.sort_fields.values.find { |f| f.blank_query_default == true }.try(:sort) ||
+        # or just use relevance
+        blacklight_config.default_sort_field
     end
 
   end

--- a/app/models/search_builder/within_collection_builder.rb
+++ b/app/models/search_builder/within_collection_builder.rb
@@ -17,6 +17,10 @@ class SearchBuilder
     end
 
     private
+    # Overrides CustomSortLogic#default_sort_order
+    def default_sort_order
+      scope.context.dig(:collection_default_sort_order) || super
+    end
 
     def collection_id
       scope.context.fetch(:collection_id)

--- a/app/views/admin/collections/_form.html.erb
+++ b/app/views/admin/collections/_form.html.erb
@@ -117,5 +117,13 @@
       <%= sub_form.input :image, collection: FundingCredit.image_collection_input  %>
     <% end %>
 
+    <hr/>
+    <%= f.input :default_sort_field,
+    collection: Collection::DEFAULT_SORT_FIELDS,
+    include_blank: false,
+    hint: "Choose \"Not specified\" for most collections. (In a few special cases, we use a default sort order of \"oldest_date\". This allows us to display things like magazine issues in the right order.)"
+    %>
+    <hr/>
+
   </div>
 <% end %>

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -251,11 +251,17 @@
     <field name="lat" type="pdouble" stored="true" indexed="true" multiValued="false"/>
     <field name="lng" type="pdouble" stored="true" indexed="true" multiValued="false"/>
 
-    <!-- added by CHF, our year sort fields -->
+    <!-- Our year sort fields. Added by Science History Institute. -->
     <field name="latest_year" type="int_sortmissinglast" stored="true" indexed="true" multiValued="false"/>
     <field name="earliest_year" type="int_sortmissinglast" stored="true" indexed="true" multiValued="false"/>
     <field name="latest_date" type="date_sortmissinglast" stored="true" indexed="true" multiValued="false"/>
     <field name="earliest_date" type="date_sortmissinglast" stored="true" indexed="true" multiValued="false"/>
+
+    <!-- Single-value title sort field. Used to sort collections of serials by title.
+    See https://github.com/sciencehistory/scihist_digicoll/issues/2494
+    If we can use the first value of (multivalued) text1_tesim instead, let's consider doing that.
+    -->
+    <field name="title"  type="string" stored="true" indexed="true" multiValued="false"/>
 
     <!-- Three full text fields (containing oral history transcripts, transcriptions, translations, OCR text, and the like).
 

--- a/spec/controllers/collection_show_controller_spec.rb
+++ b/spec/controllers/collection_show_controller_spec.rb
@@ -80,9 +80,10 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
     let(:parsed){ parsed = Nokogiri::HTML(response.body) }
     let(:titles_as_displayed) { parsed.css('.scihist-results-list-item-head a').map {|x| x.text} }
     let(:years_as_displayed) { parsed.css('span[itemprop="date_created"]').map {|x| x.text.strip } }
+    let(:default_sort_field)  { nil }
+
 
     describe "no default sort order for this collection" do
-      let(:default_sort_field)  { nil }
       it "no default sort order for this collection: sort by date_published_dtsi desc" do
         get :index, params: base_params
         expect(titles_as_displayed).to eq four_titles_in_arbitrary_order
@@ -90,14 +91,17 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
     end
 
     describe "default sort order refers to a nonexistent sort field" do
-      let(:default_sort_field) { 'goat' }
+      before do
+        collection.update(default_sort_field:'goat')
+        collection.save(validate:false)
+      end
       it "sorts by the default sort" do
         get :index, params: base_params
         expect(titles_as_displayed).to eq four_titles_in_arbitrary_order
       end
     end
 
-    describe "collection of serials with a default sort order: reverse chron by publication date" do
+    describe "collection of serials with a default sort order: chron by publication date" do
       let(:default_sort_field) { 'oldest_date' }
       it "sorts in chron order using the publication date" do
         get :index, params: base_params

--- a/spec/controllers/collection_show_controller_spec.rb
+++ b/spec/controllers/collection_show_controller_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
     render_views
     let(:requested_sort_order) { nil }
     let(:four_dates_in_desc_order) { (1..4).to_a.map { |i| i.days.ago } }
+    let(:four_years_in_arbitrary_order) { [1992, 1990, 1991, 1993] }
     let(:four_titles_in_arbitrary_order) { ['4', '1', '3', '2'] }
 
     let!(:collection) { create(:collection, title: "The Collection", default_sort_field: default_sort_field) }
@@ -70,74 +71,48 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
         create(:work,
           title:          four_titles_in_arbitrary_order[i],
           published_at:   four_dates_in_desc_order[i],
-          updated_at:     four_dates_in_desc_order[i],
+          date_of_work:   [Work::DateOfWork.new(start: four_years_in_arbitrary_order[i])],
           contained_by:   [collection]
         )
       end
     }
     let(:base_params) { { collection_id: collection.friendlier_id, sort: requested_sort_order } }
     let(:parsed){ parsed = Nokogiri::HTML(response.body) }
-    let(:titles_in_order) { parsed.css('.scihist-results-list-item-head a').map {|x| x.text} }
+    let(:titles_as_displayed) { parsed.css('.scihist-results-list-item-head a').map {|x| x.text} }
+    let(:years_as_displayed) { parsed.css('span[itemprop="date_created"]').map {|x| x.text.strip } }
 
     describe "no default sort order for this collection" do
       let(:default_sort_field)  { nil }
       it "no default sort order for this collection: sort by date_published_dtsi desc" do
         get :index, params: base_params
-        expect(titles_in_order).to eq four_titles_in_arbitrary_order
+        expect(titles_as_displayed).to eq four_titles_in_arbitrary_order
       end
     end
 
-
-    describe "collection of serials with a default sort order: reverse chron by date modified" do
-      let(:default_sort_field) { 'date_modified_desc' }
-      it "sorts in reverse updated_at order" do
+    describe "collection of serials with a default sort order: reverse chron by publication date" do
+      let(:default_sort_field) { 'oldest_date' }
+      it "sorts in chron order using the publication date" do
         get :index, params: base_params
-        expect(titles_in_order).to eq four_titles_in_arbitrary_order
+        expect(years_as_displayed).to eq ["1990", "1991", "1992", "1993"]
       end
     end
 
     describe "default order overridden from the front-end sort order menu" do
-      let(:default_sort_field) { 'date_modified_desc' }      
-      let(:requested_sort_order) { 'date_modified_asc'}
+      let(:default_sort_field) { 'oldest_date' }      
+      let(:requested_sort_order) { 'newest_date'}
       it "uses the order requested by the user" do
         get :index, params: base_params
-        expect(titles_in_order).to eq  four_titles_in_arbitrary_order.reverse
+        expect(years_as_displayed).to eq ["1993", "1992", "1991", "1990"]
       end
     end
 
-    # "it would be ideal for the Distillations and Chemical Heritage collections chronologically sorted by default, from oldest to newest."
-    describe "collection of serials with a default sort order of earliest_date desc, title asc" do
-      let(:default_sort_field) { 'oldest_date' }
-      let(:works) { [
-        create(:work,
-          date_of_work:   [Work::DateOfWork.new(start: '1990')],
-          title:          "Distillations, Volume 3 Number 1",
-          contained_by:   [collection]
-        ),
-        create(:work,
-          date_of_work:   [Work::DateOfWork.new(start: '1991')],
-          title:          "Distillations, Volume 3 Number 2",
-          contained_by:   [collection]
-        ),
-        create(:work,
-          date_of_work:   [Work::DateOfWork.new(start: '1991')],
-          title:          "Distillations, Volume 3 Number 3",
-          contained_by:   [collection]
-        ),
-        create(:work,
-          date_of_work:   [Work::DateOfWork.new(start: '1991')],
-          title:          "Distillations, Volume 3 Number 4",
-          contained_by:   [collection]
-        )
-      ] }
-      it "sorts by date, with the title acting as tiebreaker" do
+    describe "identical dates" do
+      let(:default_sort_field) { 'oldest_date' } 
+      let(:four_years_in_arbitrary_order) { [1990, 1991, 1991, 1991] }   
+      it "uses title as tiebreaker sort field" do
         get :index, params: base_params
-        expect(titles_in_order).to eq [
-          "Distillations, Volume 3 Number 1",
-          "Distillations, Volume 3 Number 2",
-          "Distillations, Volume 3 Number 3",
-          "Distillations, Volume 3 Number 4"
-        ]
+        expect(years_as_displayed).to eq  ["1990", "1991", "1991", "1991"]
+        expect(titles_as_displayed).to eq ["4", "1", "2", "3"]
       end
     end
   end

--- a/spec/controllers/collection_show_controller_spec.rb
+++ b/spec/controllers/collection_show_controller_spec.rb
@@ -89,6 +89,14 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
       end
     end
 
+    describe "default sort order refers to a nonexistent sort field" do
+      let(:default_sort_field) { 'goat' }
+      it "sorts by the default sort" do
+        get :index, params: base_params
+        expect(titles_as_displayed).to eq four_titles_in_arbitrary_order
+      end
+    end
+
     describe "collection of serials with a default sort order: reverse chron by publication date" do
       let(:default_sort_field) { 'oldest_date' }
       it "sorts in chron order using the publication date" do

--- a/spec/controllers/collection_show_controller_spec.rb
+++ b/spec/controllers/collection_show_controller_spec.rb
@@ -57,4 +57,88 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
       expect(response).to have_http_status(:unprocessable_entity)
     end
   end
+
+  describe "sort", indexable_callbacks: true do
+    render_views
+    let(:requested_sort_order) { nil }
+    let(:four_dates_in_desc_order) { (1..4).to_a.map { |i| i.days.ago } }
+    let(:four_titles_in_arbitrary_order) { ['4', '1', '3', '2'] }
+
+    let!(:collection) { create(:collection, title: "The Collection", default_sort_field: default_sort_field) }
+    let!(:works) {
+      (0..3).to_a.map do |i|
+        create(:work,
+          title:          four_titles_in_arbitrary_order[i],
+          published_at:   four_dates_in_desc_order[i],
+          updated_at:     four_dates_in_desc_order[i],
+          contained_by:   [collection]
+        )
+      end
+    }
+    let(:base_params) { { collection_id: collection.friendlier_id, sort: requested_sort_order } }
+    let(:parsed){ parsed = Nokogiri::HTML(response.body) }
+    let(:titles_in_order) { parsed.css('.scihist-results-list-item-head a').map {|x| x.text} }
+
+    describe "no default sort order for this collection" do
+      let(:default_sort_field)  { nil }
+      it "no default sort order for this collection: sort by date_published_dtsi desc" do
+        get :index, params: base_params
+        expect(titles_in_order).to eq four_titles_in_arbitrary_order
+      end
+    end
+
+
+    describe "collection of serials with a default sort order: reverse chron by date modified" do
+      let(:default_sort_field) { 'date_modified_desc' }
+      it "sorts in reverse updated_at order" do
+        get :index, params: base_params
+        expect(titles_in_order).to eq four_titles_in_arbitrary_order
+      end
+    end
+
+    describe "default order overridden from the front-end sort order menu" do
+      let(:default_sort_field) { 'date_modified_desc' }      
+      let(:requested_sort_order) { 'date_modified_asc'}
+      it "uses the order requested by the user" do
+        get :index, params: base_params
+        expect(titles_in_order).to eq  four_titles_in_arbitrary_order.reverse
+      end
+    end
+
+    # "it would be ideal for the Distillations and Chemical Heritage collections chronologically sorted by default, from oldest to newest."
+    describe "collection of serials with a default sort order of earliest_date desc, title asc" do
+      let(:default_sort_field) { 'oldest_date' }
+      let(:works) { [
+        create(:work,
+          date_of_work:   [Work::DateOfWork.new(start: '1990')],
+          title:          "Distillations, Volume 3 Number 1",
+          contained_by:   [collection]
+        ),
+        create(:work,
+          date_of_work:   [Work::DateOfWork.new(start: '1991')],
+          title:          "Distillations, Volume 3 Number 2",
+          contained_by:   [collection]
+        ),
+        create(:work,
+          date_of_work:   [Work::DateOfWork.new(start: '1991')],
+          title:          "Distillations, Volume 3 Number 3",
+          contained_by:   [collection]
+        ),
+        create(:work,
+          date_of_work:   [Work::DateOfWork.new(start: '1991')],
+          title:          "Distillations, Volume 3 Number 4",
+          contained_by:   [collection]
+        )
+      ] }
+      it "sorts by date, with the title acting as tiebreaker" do
+        get :index, params: base_params
+        expect(titles_in_order).to eq [
+          "Distillations, Volume 3 Number 1",
+          "Distillations, Volume 3 Number 2",
+          "Distillations, Volume 3 Number 3",
+          "Distillations, Volume 3 Number 4"
+        ]
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ref #2494
Allows you to specify a default sort field. No changes to the admin interface in this PR (that is #2546 ).
TODO:
- [ ] Reindex after deploy