### PR TITLE
Admin for collection sort order

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -124,7 +124,7 @@ class Admin::CollectionsController < AdminController
     # This could be done in a form object or otherwise abstracted, but this is good
     # enough for now.
     def collection_params
-      permitted_attributes = [:title, :description, :department]
+      permitted_attributes = [:title, :description, :department, :default_sort_field]
       permitted_attributes << :published if can?(:publish, @collection || Kithe::Model)
 
       Kithe::Parameters.new(params).

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -17,7 +17,7 @@ class Collection < Kithe::Collection
 
   DEFAULT_SORT_FIELDS = ([
     ['Not specified', nil],
-    ['Ascending chronological by publication date', 'oldest_date']
+    ['Oldest date', 'oldest_date']
   ]).freeze
 
   # automatic Solr indexing on save

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -15,6 +15,11 @@ class Collection < Kithe::Collection
   DEPARTMENT_EXHIBITION_VALUE = "Exhibition"
   DEPARTMENTS = (Work::ControlledLists::DEPARTMENT + [DEPARTMENT_EXHIBITION_VALUE]).freeze
 
+  DEFAULT_SORT_FIELDS = ([
+    ['Not specified', nil],
+    ['Ascending chronological by publication date', 'oldest_date']
+  ]).freeze
+
   # automatic Solr indexing on save
   if ScihistDigicoll::Env.lookup(:solr_indexing) == 'true'
     self.kithe_indexable_mapper = CollectionIndexer.new
@@ -70,6 +75,9 @@ class Collection < Kithe::Collection
   #
   # Example value: 'oldest_date'.
   attr_json :default_sort_field, :string, default: -> { nil }
+  validates :default_sort_field, inclusion: { in: DEFAULT_SORT_FIELDS.to_h.values, allow_blank: true }
+
+
 
   # For ransack use, we need to list all attributes we want to use ransack to SEARCH or SORT by.
   #

--- a/app/views/admin/collections/_form.html.erb
+++ b/app/views/admin/collections/_form.html.erb
@@ -121,7 +121,7 @@
     <%= f.input :default_sort_field,
     collection: Collection::DEFAULT_SORT_FIELDS,
     include_blank: false,
-    hint: "Choose \"Not specified\" for most collections. (In a few special cases, we use a default sort order of \"oldest_date\". This allows us to display e.g. magazine issues in ascending chronological order by date of publication.)"
+    hint: "Choose \"Not specified\" for most collections. (In a few special cases, we use a default sort order of \"oldest_date\". This allows us to display things like magazine issues in the right order.)"
     %>
     <hr/>
 

--- a/app/views/admin/collections/_form.html.erb
+++ b/app/views/admin/collections/_form.html.erb
@@ -117,5 +117,13 @@
       <%= sub_form.input :image, collection: FundingCredit.image_collection_input  %>
     <% end %>
 
+    <hr/>
+    <%= f.input :default_sort_field,
+    collection: Collection::DEFAULT_SORT_FIELDS,
+    include_blank: false,
+    hint: "Choose \"Not specified\" for most collections. (In a few special cases, we use a default sort order of \"oldest_date\". This allows us to display e.g. magazine issues in ascending chronological order by date of publication.)"
+    %>
+    <hr/>
+
   </div>
 <% end %>

--- a/spec/controllers/collection_show_controller_spec.rb
+++ b/spec/controllers/collection_show_controller_spec.rb
@@ -90,7 +90,11 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
     end
 
     describe "default sort order refers to a nonexistent sort field" do
-      let(:default_sort_field) { 'goat' }
+      let(:default_sort_field)  { nil }
+      before do
+        collection.update(default_sort_field:'goat')
+        collection.save(validate:false)
+      end
       it "sorts by the default sort" do
         get :index, params: base_params
         expect(titles_as_displayed).to eq four_titles_in_arbitrary_order

--- a/spec/controllers/collection_show_controller_spec.rb
+++ b/spec/controllers/collection_show_controller_spec.rb
@@ -80,9 +80,10 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
     let(:parsed){ parsed = Nokogiri::HTML(response.body) }
     let(:titles_as_displayed) { parsed.css('.scihist-results-list-item-head a').map {|x| x.text} }
     let(:years_as_displayed) { parsed.css('span[itemprop="date_created"]').map {|x| x.text.strip } }
+    let(:default_sort_field)  { nil }
+
 
     describe "no default sort order for this collection" do
-      let(:default_sort_field)  { nil }
       it "no default sort order for this collection: sort by date_published_dtsi desc" do
         get :index, params: base_params
         expect(titles_as_displayed).to eq four_titles_in_arbitrary_order
@@ -90,7 +91,6 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
     end
 
     describe "default sort order refers to a nonexistent sort field" do
-      let(:default_sort_field)  { nil }
       before do
         collection.update(default_sort_field:'goat')
         collection.save(validate:false)
@@ -101,7 +101,7 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
       end
     end
 
-    describe "collection of serials with a default sort order: reverse chron by publication date" do
+    describe "collection of serials with a default sort order: chron by publication date" do
       let(:default_sort_field) { 'oldest_date' }
       it "sorts in chron order using the publication date" do
         get :index, params: base_params


### PR DESCRIPTION
This does not merge into `master`.
Issue: Ref https://github.com/sciencehistory/scihist_digicoll/issues/2494
This just adds admin functionality to  #2542.