### PR TITLE
oh ux improvements

### DIFF
--- a/app/components/work_file_list_show_component.html.erb
+++ b/app/components/work_file_list_show_component.html.erb
@@ -54,7 +54,7 @@
             %>
           </div>
 
-          <p class="alert alert-primary mt-4 mb-4">
+          <p>
             If you have any questions about transcripts, recordings, or usage permissions, contact the Center for Oral History at
             <%= link_to ScihistDigicoll::Env.lookup!(:oral_history_email_address), "mailto:#{ScihistDigicoll::Env.lookup!(:oral_history_email_address)}", class: "alert-link" %>.
           </p>

--- a/app/components/work_file_list_show_component.html.erb
+++ b/app/components/work_file_list_show_component.html.erb
@@ -31,36 +31,17 @@
       <div class="show-sub-head-body request-section">
         <div class="pr-2 mt-3">
 
-            <% if @work.oral_history_content.available_by_request_automatic? %>
-              <p>
-                Fill out a brief form to <span class="text-danger">receive immediate access</span> to these files.
-              </p>
-            <% else %>
-              <p>Fill out a brief form and a staff member will review your request for these files.
-                 <span class="text-danger">You should receive an email within 3 business days</span>.
-              </p>
-            <% end %>
-          </p>
+          <p><span class="by-request-items-label">By request</span> <%= available_by_request_sentence %></p>
 
-          <ul class="list-unstyled by-request-file-list">
-            <% if available_by_request_pdf_count.nonzero? %>
-              <li>
-                <i class="fa fa-file-pdf-o" aria-hidden="true"></i>
-                <%= available_by_request_pdf_count %> PDF Transcript <%= "File".pluralize(available_by_request_pdf_count) %>
-              </li>
-            <% end %>
-
-            <% if available_by_request_audio_count.nonzero? %>
-              <li>
-                <i class="fa fa-file-audio-o" aria-hidden="true"></i>
-                <%= available_by_request_audio_count %> Audio Recording <%= "File".pluralize(available_by_request_audio_count) %>
-              </li>
-            <% end %>
-
-            <% if available_by_request_pdf_count.zero? && available_by_request_audio_count.zero? %>
-              <li><span class="text-danger">No files available? Something has gone wrong with our system!</span>/li>
-            <% end %>
-          </ul>
+          <% if @work.oral_history_content.available_by_request_automatic? %>
+            <p>
+              Fill out a brief form to <span class="text-danger">receive immediate access</span> to these files.
+            </p>
+          <% else %>
+            <p>Fill out a brief form and a staff member will review your request for these files.
+               <span class="text-danger">You should receive an email within 3 business days</span>.
+            </p>
+          <% end %>
 
           <% unless @work.oral_history_content.available_by_request_automatic? %>
             <p>Usage is subject to restrictions set by the interviewee.</p>

--- a/app/components/work_file_list_show_component.rb
+++ b/app/components/work_file_list_show_component.rb
@@ -56,6 +56,26 @@ class WorkFileListShowComponent < ApplicationComponent
     @available_by_request_audio_count ||= available_by_request_assets.find_all { |asset| asset.content_type&.start_with?("audio/") }.count
   end
 
+  def available_by_request_sentence
+    @available_by_request_sentance ||= begin
+      components = []
+
+      if available_by_request_pdf_count.nonzero?
+        components << "#{ available_by_request_pdf_count } PDF Transcript #{ "File".pluralize(available_by_request_pdf_count) }"
+      end
+
+      if available_by_request_audio_count.nonzero?
+        components << "#{ available_by_request_audio_count } Audio Recording #{ "File".pluralize(available_by_request_audio_count) }"
+      end
+
+      if components.empty?
+        components << '<li><span class="text-danger">No files available? Something has gone wrong with our system!</span>'
+      end
+
+      components.to_sentence
+    end
+  end
+
   def request_button_name
     if @work.oral_history_content.available_by_request_automatic?
       "Get Access"

--- a/app/controllers/oral_history_requests_controller.rb
+++ b/app/controllers/oral_history_requests_controller.rb
@@ -72,7 +72,7 @@ class OralHistoryRequestsController < ApplicationController
     if ScihistDigicoll::Env.lookup("feature_new_oh_request_emails") && current_oral_history_requester &&
           OralHistoryRequest.where(work: @work, oral_history_requester: current_oral_history_requester).exists?
 
-        redirect_to oral_history_requests_path, notice: "You have already requested this Oral History: #{@work.title}"
+        redirect_to oral_history_requests_path, flash: { success: "You have already requested this Oral History: #{@work.title}" }
 
         return # abort further processing
     end
@@ -130,7 +130,7 @@ class OralHistoryRequestsController < ApplicationController
             oral_history_delivery_email.
             deliver_later
 
-          redirect_to work_path(@work.friendlier_id), notice: "Check your email! We are sending you links to the files you requested, to #{@oral_history_request.requester_email}."
+          redirect_to work_path(@work.friendlier_id), flash: { success: "Check your email! We are sending you links to the files you requested, to #{@oral_history_request.requester_email}." }
         end
       else # manual review
         OralHistoryRequestNotificationMailer.
@@ -138,7 +138,7 @@ class OralHistoryRequestsController < ApplicationController
           notification_email.
           deliver_later
 
-        redirect_to work_path(@work.friendlier_id), notice: "Thank you for your interest. Your request will be reviewed, usually within 3 business days, and we'll email you at #{@oral_history_request.requester_email}"
+        redirect_to work_path(@work.friendlier_id), flash: { success: "Thank you for your interest. Your request will be reviewed, usually within 3 business days, and we'll email you at #{@oral_history_request.requester_email}" }
       end
     else
      render :new
@@ -171,7 +171,7 @@ private
       redirect_to oral_history_requests_path, notice: immediate_notice
     else
       mailer_proc.call
-      redirect_to work_path(work.friendlier_id), notice: emailed_notice
+      redirect_to work_path(work.friendlier_id), flash: { success: emailed_notice }
     end
   end
 

--- a/app/controllers/oral_history_requests_controller.rb
+++ b/app/controllers/oral_history_requests_controller.rb
@@ -168,7 +168,7 @@ private
   def want_request_dashboard_response(work:, requester_email:, emailed_notice:, immediate_notice:, mailer_proc:)
     # new style, if they are already logged in they have immediate access, else an email
     if current_oral_history_requester.present? && current_oral_history_requester.email == requester_email.email
-      redirect_to oral_history_requests_path, notice: immediate_notice
+      redirect_to oral_history_requests_path, flash: { success: immediate_notice }
     else
       mailer_proc.call
       redirect_to work_path(work.friendlier_id), flash: { success: emailed_notice }

--- a/app/frontend/stylesheets/local/oral_history_request_dashboard.scss
+++ b/app/frontend/stylesheets/local/oral_history_request_dashboard.scss
@@ -64,14 +64,24 @@
   padding: 2rem 3rem 1rem 3rem;
   background-color: $shi-maroon;
 
-  @include media-breakpoint-up(sm) {
+  .title-and-button {
     display: flex;
     align-items: flex-start;
     gap: 1rem;
-  }
+    flex-direction: column;
 
-  .signout {
-    flex-shrink: 0;
+    @include media-breakpoint-up(sm) {
+      flex-direction: row;
+    }
+
+    margin-bottom: $paragraph-spacer;
+
+    .text {
+      flex-grow: 1;
+    }
+    .signout {
+      flex-shrink: 0;
+    }
   }
 
   p {

--- a/app/frontend/stylesheets/local/show-layout.scss
+++ b/app/frontend/stylesheets/local/show-layout.scss
@@ -185,15 +185,9 @@
   line-height: 1.3;
 }
 
-.by-request-file-list {
-  padding-left: $spacer * 1.5;
-  li {
-    display: flex;
-    vertical-align: middle;
-    margin-bottom: 0.66rem;
-    i {
-      font-size: 1.4em;
-      margin-right: 0.66rem;
-    }
-  }
+.by-request-items-label {
+  @extend %special-label;
+  margin-right: 0.66em;
+  color: $shi-alt-muted-text;
 }
+

--- a/app/frontend/stylesheets/local/site_wide.scss
+++ b/app/frontend/stylesheets/local/site_wide.scss
@@ -279,3 +279,25 @@ hr.brand {
     transform: translateY(-0.04em);
   }
 }
+
+// A custom class we use for top-of-page success alerts
+.alert-scihist-success {
+  border: black 1px solid;
+  background-color: $shi-green-4;
+  color: white;
+
+  // there's an SVG icon, we use flex to position it next to text
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+
+  svg.bi-check-circle-fill {
+    width: 2.5rem;
+    height: 2.5rem;
+  }
+
+  .close {
+    opacity: 1;
+    color: white;
+  }
+}

--- a/app/helpers/bootstrap_file_icon_svg_helper.rb
+++ b/app/helpers/bootstrap_file_icon_svg_helper.rb
@@ -31,6 +31,14 @@ module BootstrapFileIconSvgHelper
     EOS
   end
 
+  def bi_check_circle_fill_svg
+    <<-EOS.strip_heredoc.html_safe
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check-circle-fill" viewBox="0 0 16 16">
+        <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z"/>
+      </svg>
+    EOS
+  end
+
   # okay, actually from fontawesome.
   # https://fontawesome.com/icons/file-audio?f=classic&s=solid
   #

--- a/app/views/application/_flash_message_display.html.erb
+++ b/app/views/application/_flash_message_display.html.erb
@@ -1,10 +1,15 @@
 <% {  notice: 'alert-info',
       error: 'alert-danger',
       alert: 'alert-warning',
-      success: 'alert-success'
+      success: 'alert-scihist-success'
     }.each do |type, css_class| %>
   <% if flash[type] %>
     <div class="notice alert <%= css_class %> alert-dismissible fade show" role="alert">
+      <% if type == :success %>
+        <%# use a graphic! no width/height let CSS style it %>
+        <%= bi_check_circle_fill_svg %>
+      <% end %>
+
       <%= flash[type] %>
       <button type="button" class="close" data-dismiss="alert" aria-label="Close">
         <span aria-hidden="true">&times;</span>

--- a/app/views/oral_history_requests/index.html.erb
+++ b/app/views/oral_history_requests/index.html.erb
@@ -1,16 +1,18 @@
 <div class="oral-history-request-dashboard">
   <div class="oral-history-request-dashboard-header-block">
-    <div>
-      <h2 class="brand-alt-h2">
-        <%= link_to "Oral History Requests", oral_history_requests_path %>
-      </h2>
-      <p class="requester-email">
-        <%= current_oral_history_requester.email %>
-      </p>
-      <p>Below you can view the status of your oral history requests and download materials from approved requests. Please note that some oral histories are available by request only and are not available on the public web.</p>
+    <div class="title-and-button">
+      <div class="text">
+        <h2 class="brand-alt-h2">
+          <%= link_to "Oral History Requests", oral_history_requests_path %>
+        </h2>
+        <div class="requester-email">
+          <%= current_oral_history_requester.email %>
+        </div>
+      </div>
+      <%= link_to "Sign out", oral_history_session_path, method: :delete, class: "btn btn-brand-main signout" %>
     </div>
 
-    <%= link_to "Sign out", oral_history_session_path, method: :delete, class: "btn btn-brand-main signout" %>
+    <p>Below you can view the status of your oral history requests and download materials from approved requests. Please note that some oral histories are available by request only and are not available on the public web.</p>
   </div>
 
   <p class="alert alert-primary mt-4 mb-4">

--- a/app/views/oral_history_requests/show.html.erb
+++ b/app/views/oral_history_requests/show.html.erb
@@ -37,18 +37,10 @@
     </div>
   </div>
 
-
-  <div class="rights-and-terms">
-    <%= render(RightsIconComponent.new(rights_id: @access_request.work.rights, work: @access_request.work)) %>
-
-    <div class="small">Your receipt of an electronic copy of this oral history indicates your agreement to abide by U.S. copyright law and terms of licensing. Please credit the "Science History Institute."</div>
-  </div>
-
   <% if @access_request.notes_from_staff.present? %>
     <h4 class="h3 brand-alt-h3 notes-from-staff-header">Notes from staff</h4>
     <%= simple_format @access_request.notes_from_staff %>
   <% end %>
-
 
   <% if @transcript_assets.present? %>
     <h4 class="attribute-sub-head">Transcript</h4>
@@ -85,6 +77,13 @@
       <% end %>
     </ul>
   <% end %>
+
+  <div class="rights-and-terms mt-5">
+    <%= render(RightsIconComponent.new(rights_id: @access_request.work.rights, work: @access_request.work)) %>
+
+    <div class="small">Your receipt of an electronic copy of this oral history indicates your agreement to abide by U.S. copyright law and terms of licensing. Please credit the "Science History Institute."</div>
+  </div>
+
 
   <p class="alert alert-primary bottom-alert">
     If you have any questions about transcripts, recordings, or usage permissions, contact the Center for Oral History at

--- a/spec/controllers/oral_history_requests_controller_spec.rb
+++ b/spec/controllers/oral_history_requests_controller_spec.rb
@@ -100,7 +100,7 @@ describe OralHistoryRequestsController, type: :controller do
           get :new, params: { work_friendlier_id: work.friendlier_id }
 
           expect(response).to redirect_to(oral_history_requests_path)
-          expect(flash[:notice]).to match /You have already requested this Oral History/
+          expect(flash[:success]).to match /You have already requested this Oral History/
         end
       end
     end
@@ -132,7 +132,7 @@ describe OralHistoryRequestsController, type: :controller do
           }
 
           expect(response).to redirect_to(work_path(work.friendlier_id))
-          expect(flash[:notice]).to match /We are sending you links to the files you requested/
+          expect(flash[:success]).to match /We are sending you links to the files you requested/
         end
       end
 
@@ -148,7 +148,7 @@ describe OralHistoryRequestsController, type: :controller do
           }
 
           expect(response).to redirect_to(work_path(work.friendlier_id))
-          expect(flash[:notice]).to match /Your request will be reviewed/
+          expect(flash[:success]).to match /Your request will be reviewed/
         end
       end
     end
@@ -176,7 +176,7 @@ describe OralHistoryRequestsController, type: :controller do
             }.not_to have_enqueued_job
 
             expect(response).to redirect_to(oral_history_requests_path)
-            expect(flash[:notice]).to match /The files you requested are immediately available, from: #{Regexp.escape work.title}/
+            expect(flash[:success]).to match /The files you requested are immediately available, from: #{Regexp.escape work.title}/
           end
         end
 
@@ -190,7 +190,7 @@ describe OralHistoryRequestsController, type: :controller do
             }
 
             expect(response).to redirect_to(work_path(work.friendlier_id))
-            expect(flash[:notice]).to match /The files you have requested are immediately available. We've sent an email to #{Regexp.escape full_create_params[:patron_email]} with a sign-in link/
+            expect(flash[:success]).to match /The files you have requested are immediately available. We've sent an email to #{Regexp.escape full_create_params[:patron_email]} with a sign-in link/
           end
         end
       end
@@ -208,7 +208,7 @@ describe OralHistoryRequestsController, type: :controller do
           }
 
           expect(response).to redirect_to(work_path(work.friendlier_id))
-          expect(flash[:notice]).to match /Your request will be reviewed/
+          expect(flash[:success]).to match /Your request will be reviewed/
         end
       end
 
@@ -232,7 +232,7 @@ describe OralHistoryRequestsController, type: :controller do
             }
 
             expect(response).to redirect_to(work_path(work.friendlier_id))
-            expect(flash[:notice]).to match /We've sent another email to #{Regexp.escape full_create_params[:patron_email]}/
+            expect(flash[:success]).to match /We've sent another email to #{Regexp.escape full_create_params[:patron_email]}/
           end
         end
         describe "already logged in" do
@@ -246,7 +246,7 @@ describe OralHistoryRequestsController, type: :controller do
             }.not_to have_enqueued_job
 
             expect(response).to redirect_to(oral_history_requests_path)
-            expect(flash[:notice]).to match /You have already requested this Oral History/
+            expect(flash[:success]).to match /You have already requested this Oral History/
           end
         end
       end


### PR DESCRIPTION
- make by-request list of items NOT look like links
- oral history dashboard index text extends full width of container
- make OH request notices use 'success' style instead of 'notice' style
- customize flash success notice
- remove shading around contact box, this page is too busy
- move rights statement to bottom of OH request show page
