### PR TITLE
    When already logged-in OH user requests automatic-approval, they should STILL get a sign-in email

### DIFF
--- a/app/controllers/oral_history_requests_controller.rb
+++ b/app/controllers/oral_history_requests_controller.rb
@@ -80,20 +80,35 @@ class OralHistoryRequestsController < ApplicationController
     @oral_history_request = OralHistoryRequest.new(work: @work)
   end
 
-  # POST "/request_oral_history_access"
+  before_action :setup_create_request, only: :create
+
+  # POST "/request_oral_history"
   #
   # Action to create request from form
   def create
+    if ScihistDigicoll::Env.lookup("feature_new_oh_request_emails")
+      new_style_create
+    else
+      old_style_create
+    end
+  end
+
+private
+
+  # load @work, and create a new @oral_history_request
+  #
+  # Depending on config, we may abort if request already exists. As a before_action,
+  # redirecting or rendering will abort further processing.
+  def setup_create_request
     @work = load_work(params['oral_history_request'].delete('work_friendlier_id'))
 
     # note `create_or_find_by` is the version with fewer race conditions, to make
     # this record if it doesn't already exist.
     requester_email = (OralHistoryRequester.create_or_find_by!(email: patron_email_param) if patron_email_param.present?)
 
-    # In new mode, check to see if request already exists,
-    if ScihistDigicoll::Env.lookup("feature_new_oh_request_emails") && requester_email &&
-        OralHistoryRequest.where(work: @work, oral_history_requester: requester_email).exists?
 
+    # Check to see if request already exists,
+    if ScihistDigicoll::Env.lookup("feature_new_oh_request_emails") && requester_email && OralHistoryRequest.where(work: @work, oral_history_requester: requester_email).exists?
       # If they are already authenticated, we can just direct them there,
       # otherwise we send them a sign-in link
       if current_oral_history_requester.present? && current_oral_history_requester.email == requester_email.email
@@ -103,8 +118,9 @@ class OralHistoryRequestsController < ApplicationController
         redirect_to work_path(@work.friendlier_id), flash: { success: "You have already requested this Oral History. We've sent another email to #{patron_email_param} with a sign-in link, which you can use to view your requests.", }
       end
 
-      return # abort further processing
+      return false # abort further processing
     end
+
 
     @oral_history_request = OralHistoryRequest.new(
       oral_history_request_params.merge(
@@ -113,51 +129,81 @@ class OralHistoryRequestsController < ApplicationController
       )
     )
 
-    if @oral_history_request.save
-      if @work.oral_history_content.available_by_request_automatic?
-        @oral_history_request.update!(delivery_status: "automatic")
+    return true
+  end
 
-        if ScihistDigicoll::Env.lookup("feature_new_oh_request_emails")
-
-          # If they are already logged in, they can just be directed to see this
-          # automatically-approved request. Either way they should get an email,
-          # per specs from OH team.
-          OralHistoryDeliveryMailer.with(request: @oral_history_request).approved_with_session_link_email.deliver_later
-          if current_oral_history_requester.present? && current_oral_history_requester.email == requester_email.email
-            redirect_to oral_history_requests_path, flash: { success: "The files you requested are immediately available, from: #{@work.title}" }
-          else
-            redirect_to work_path(@work.friendlier_id), flash: { success: "The files you have requested are immediately available. We've sent an email to #{patron_email_param} with a sign-in link." }
-          end
-
-        else
-          OralHistoryDeliveryMailer.
-            with(request: @oral_history_request).
-            oral_history_delivery_email.
-            deliver_later
-
-          redirect_to work_path(@work.friendlier_id), flash: { success: "Check your email! We are sending you links to the files you requested, to #{@oral_history_request.requester_email}." }
-        end
-      else # manual review
-        OralHistoryRequestNotificationMailer.
-          with(request: @oral_history_request).
-          notification_email.
-          deliver_later
-
-        redirect_to work_path(@work.friendlier_id), flash: { success: "Thank you for your interest. Your request will be reviewed, usually within 3 business days, and we'll email you at #{@oral_history_request.requester_email}" }
-      end
-    else
-     render :new
-    end
-
+  def old_style_create
     # write entries to a cookie to pre-fill form next time; every time we write
     # it will bump the TTL expiration too, so they get another day until it expires.
     # Make sure to include the separate patron_eamil
     oral_history_request_form_entry_write(
       oral_history_request_params.merge(patron_email: patron_email_param).to_h
     )
+
+    saved_valid = @oral_history_request.save
+
+    unless saved_valid
+      render :new
+      return
+    end
+
+    if @work.oral_history_content.available_by_request_automatic?
+      @oral_history_request.update!(delivery_status: "automatic")
+
+      OralHistoryDeliveryMailer.
+        with(request: @oral_history_request).
+        oral_history_delivery_email.
+        deliver_later
+
+      redirect_to work_path(@work.friendlier_id), flash: { success: "Check your email! We are sending you links to the files you requested, to #{@oral_history_request.requester_email}." }
+    else # manual review
+      OralHistoryRequestNotificationMailer.
+        with(request: @oral_history_request).
+        notification_email.
+        deliver_later
+
+      redirect_to work_path(@work.friendlier_id), flash: { success: "Thank you for your interest. Your request will be reviewed, usually within 3 business days, and we'll email you at #{@oral_history_request.requester_email}" }
+    end
   end
 
-private
+
+  def new_style_create
+    # write entries to a cookie to pre-fill form next time; every time we write
+    # it will bump the TTL expiration too, so they get another day until it expires.
+    # Make sure to include the separate patron_eamil
+    oral_history_request_form_entry_write(
+      oral_history_request_params.merge(patron_email: patron_email_param).to_h
+    )
+
+    saved_valid = @oral_history_request.save
+
+    unless saved_valid
+      render :new
+      return
+    end
+
+    if @work.oral_history_content.available_by_request_automatic?
+      @oral_history_request.update!(delivery_status: "automatic")
+
+      # If they are already logged in, they can just be directed to see this
+      # automatically-approved request. Either way they should get an email,
+      # per specs from OH team.
+      OralHistoryDeliveryMailer.with(request: @oral_history_request).approved_with_session_link_email.deliver_later
+
+      if current_oral_history_requester.present? && current_oral_history_requester.email == @oral_history_request.requester_email
+        redirect_to oral_history_requests_path, flash: { success: "The files you requested are immediately available, from: #{@work.title}" }
+      else
+        redirect_to work_path(@work.friendlier_id), flash: { success: "The files you have requested are immediately available. We've sent an email to #{patron_email_param} with a sign-in link." }
+      end
+    else # manual review
+      OralHistoryRequestNotificationMailer.
+        with(request: @oral_history_request).
+        notification_email.
+        deliver_later
+
+      redirect_to work_path(@work.friendlier_id), flash: { success: "Thank you for your interest. Your request will be reviewed, usually within 3 business days, and we'll email you at #{@oral_history_request.requester_email}" }
+    end
+  end
 
   def oral_history_request_params
     params.require(:oral_history_request).permit(

--- a/app/controllers/oral_history_requests_controller.rb
+++ b/app/controllers/oral_history_requests_controller.rb
@@ -120,11 +120,12 @@ class OralHistoryRequestsController < ApplicationController
         if ScihistDigicoll::Env.lookup("feature_new_oh_request_emails")
 
           # If they are already logged in, they can just be directed to see this
-          # automatically-approved request. Otherwise they need a sign-in link emailed.
+          # automatically-approved request. Either way they should get an email,
+          # per specs from OH team.
+          OralHistoryDeliveryMailer.with(request: @oral_history_request).approved_with_session_link_email.deliver_later
           if current_oral_history_requester.present? && current_oral_history_requester.email == requester_email.email
             redirect_to oral_history_requests_path, flash: { success: "The files you requested are immediately available, from: #{@work.title}" }
           else
-            OralHistoryDeliveryMailer.with(request: @oral_history_request).approved_with_session_link_email.deliver_later
             redirect_to work_path(@work.friendlier_id), flash: { success: "The files you have requested are immediately available. We've sent an email to #{patron_email_param} with a sign-in link." }
           end
 

--- a/spec/controllers/oral_history_requests_controller_spec.rb
+++ b/spec/controllers/oral_history_requests_controller_spec.rb
@@ -173,7 +173,10 @@ describe OralHistoryRequestsController, type: :controller do
           it "redirects to dashboard" do
             expect {
               post :create, params: full_create_params
-            }.not_to have_enqueued_job
+            }.to have_enqueued_job(ActionMailer::MailDeliveryJob).with { |class_name, action|
+                expect(class_name).to eq "OralHistoryDeliveryMailer"
+                expect(action).to eq "approved_with_session_link_email"
+            }
 
             expect(response).to redirect_to(oral_history_requests_path)
             expect(flash[:success]).to match /The files you requested are immediately available, from: #{Regexp.escape work.title}/


### PR DESCRIPTION
Per specs from OH team.  They can be redirected directly to the OH since they are already signed in, but they should get the email with sign-in link anyway in addition.

Also, that started making the #create method far too complex and long, so:

- Refactor OH request controller methods to be more legible, separate new and old logic in separate methods
