### PR TITLE
    When migrating to new OH request schema, erase email addr in old location

### DIFF
--- a/lib/tasks/data_fixes/migrate_oh_request_email.rake
+++ b/lib/tasks/data_fixes/migrate_oh_request_email.rake
@@ -15,6 +15,7 @@ namespace :scihist do
 
         if request.patron_email.present?
           original_email = request.patron_email
+          original_email_normalized = OralHistoryRequester.normalize_value_for(:email, original_email)
 
           request.oral_history_requester = OralHistoryRequester.find_or_create_by(email: request.patron_email)
           request.patron_email = nil
@@ -22,7 +23,7 @@ namespace :scihist do
 
           # double-check before we remove data
           request.reload
-          unless original_email == request.oral_history_requester.email
+          unless original_email_normalized == request.oral_history_requester.email
             raise "expected email (#{original_email}) missing for OralHistoryRequest #{request.id}, #{request.patron_email}"
           end
 

--- a/lib/tasks/data_fixes/migrate_oh_request_email.rake
+++ b/lib/tasks/data_fixes/migrate_oh_request_email.rake
@@ -14,13 +14,16 @@ namespace :scihist do
         next if request.oral_history_requester.present?
 
         if request.patron_email.present?
+          original_email = request.patron_email
+
           request.oral_history_requester = OralHistoryRequester.find_or_create_by(email: request.patron_email)
+          request.patron_email = nil
           request.save!
 
           # double-check before we remove data
           request.reload
-          unless request.patron_email == request.oral_history_requester.email
-            raise "data missing for OralHistoryRequest #{request.id}, #{request.patron_email}"
+          unless original_email == request.oral_history_requester.email
+            raise "expected email (#{original_email}) missing for OralHistoryRequest #{request.id}, #{request.patron_email}"
           end
 
           request.save!


### PR DESCRIPTION
We had tried to leave it in both for safety, but our validation rules don't actually allow that! Which is good, our validation rules make sure it's in the right place.

- handle normalization when ensuring we migrated properly
