### PR TITLE
Remove workaround from Rails 7 migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,6 @@ We preferentially use Vite.js (an ES6-style JS bundler, https://vite-ruby.netlif
   * image is in `./app/frontend/images/*`
   * reference using standard CSS `url(@/images/*)`, vite will properly serve/build and translate url. Note the `@/` at the beginning that vite will use to look it up in vite entrypoint directories, which are configured by vite-ruby to include ./app/frontend/images.
 
-* vite-ruby tries to install yarn deps using `npx`, but heroku ruby buildpack doesn't offer `npx` we have a workaround to run `yarn install` with `assets:precompile` in local `./Rakefile`.
-
 #### Individual asset dependency special handling notes
 
 * blacklight JS and CSS now comes from the [blacklight-frontend npm package](https://www.npmjs.com/package/blacklight-frontend). If you update the blacklight rubygem, you will have to manually make sure to remember to check if a new `blacklight_frontend` npm package is available and update with yarn too! Letting these get out of sync could be disastrous, and is a somewhat confusing manual process.

--- a/Rakefile
+++ b/Rakefile
@@ -4,17 +4,3 @@
 require_relative 'config/application'
 
 Rails.application.load_tasks
-
-
-# Vite tries to install yarn/npm dependencies with `npx ci`, but heroku
-# ruby buildpack doesn't have `npx` available, so it will fail.
-#
-# So we wire up assets:precompile to run `yarn install`, like it did pre-Rails 7,
-# as `yarn` is available on heroku ruby buidpack.  At worst, this might mean
-# yarn install gets run twice, which should be pretty cheap.
-#
-# See: https://github.com/ElMassimo/vite_ruby/discussions/316
-#
-if Rake::Task.task_defined?("assets:precompile") && File.exist?(Rails.root.join("yarn.lock"))
-  Rake::Task["assets:precompile"].enhance [ "yarn:install" ]
-end


### PR DESCRIPTION
Ref #2563

Rails 7 stopped automatically running `yarn install` at app startup, which led to the problem discussed [here](https://github.com/ElMassimo/vite_ruby/discussions/316).
@jrochkind  introduced a [workaround](https://github.com/sciencehistory/scihist_digicoll/commit/6c5672ce53f1dc1c4c4d38496460b55d1dfb5a78) for this problem.

I was [messing around with vite and node](https://github.com/sciencehistory/scihist_digicoll/issues/2498) this week and I believe this workaround is no longer needed, so I'd like to remove it.

With this PR applied, Vite still works fine in dev, and assets still compile on Heroku.
