### PR TITLE
Redirect requests with a null byte to /422 error page

### DIFF
--- a/spec/requests/null_byte_requests_spec.rb
+++ b/spec/requests/null_byte_requests_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe "url contains a null byte" do
+  it "responds with 422" do
+    get "/works/bla%00bla"
+    expect(response.code).to eq("302")
+    expect(response).to redirect_to("/422")
+  end
+end


### PR DESCRIPTION
Ref #2352
This feels clumsy, but I'm not really sure what else to do.
Adding middleware to catch this problem lower in the stack seems like overkill at first glance.
Other ideas welcome!