### PR TITLE
Don't send  null byte errors to honeybadger

### DIFF
--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -23,7 +23,11 @@ Honeybadger.configure do |config|
   }.delete_if { |_k, v| v.blank? }
 
   config.before_notify do |notice|
-    notice.halt! if notice.error_message =~ /string contains null byte/
+    
+    # see https://github.com/sciencehistory/scihist_digicoll/issues/2352
+    if notice.error_message =~ /string contains null byte/ && notice.backtrace[0] =~ /postgresql_adapter\.rb/
+      notice.halt!
+    end
 
     secrets.each do |secret_name, secret_value|
       notice.error_message.gsub!(secret_value, "[:#{secret_name}]") unless secret_value.blank?

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -23,6 +23,8 @@ Honeybadger.configure do |config|
   }.delete_if { |_k, v| v.blank? }
 
   config.before_notify do |notice|
+    notice.halt! if notice.error_message =~ /string contains null byte/
+
     secrets.each do |secret_name, secret_value|
       notice.error_message.gsub!(secret_value, "[:#{secret_name}]") unless secret_value.blank?
     end


### PR DESCRIPTION
#2352
This works great. We can and should reuse this pattern for similar errors:
- not affecting any particular controller
- not caused by human users
- thus not visible to human users
