### PR TITLE
store selected exiftool characterization in normalized metadata location

### DIFF
--- a/lib/tasks/data_fixes/extract_normalized_exiftool.rake
+++ b/lib/tasks/data_fixes/extract_normalized_exiftool.rake
@@ -1,0 +1,29 @@
+namespace :scihist do
+  namespace :data_fixes do
+
+    desc """
+      Extract selected exiftool as normalized metadata, via `special_job` bg jobs
+
+      Or in foreground with FOREGROUND=true
+    """
+    task :extract_normalized_exiftool => :environment do
+      scope = Asset.where("derived_metadata_jsonb ->> 'exiftool_result' is not null")
+
+      progress_bar = ProgressBar.create(total: scope.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+
+      scope.find_in_batches(batch_size: 100) do |batch|
+        Asset.transaction do
+          Kithe::Indexable.index_with(batching: true) do
+            batch.each do |asset|
+              asset.set_selected_normalized_exiftool
+              asset.save!
+              progress_bar.increment
+            rescue Shrine::FileNotFound => e
+              # meh, we dont' worry about the file not existing, skip it.
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/asset/asset_exiftool_on_ingest_spec.rb
+++ b/spec/models/asset/asset_exiftool_on_ingest_spec.rb
@@ -43,6 +43,11 @@ describe "Asset exiftool characterization on ingest" do
       expect(asset.exiftool_result["EXIF:ISO"]).to eq 50
       expect(asset.exiftool_result["ICC_Profile:ProfileDescription"]).to eq "Adobe RGB (1998)"
     end
+
+    it "includes selected values in normalized metadata" do
+      expect(asset.file_metadata["dpi"]).to be_present
+      expect(asset.file_metadata["dpi"]).to eq asset.exiftool_result["EXIF:XResolution"]
+    end
   end
 
   describe "file that causes exiftool error" do


### PR DESCRIPTION
We store complete exiftool characterization result in native json format, so we can always refer to it later, if we want more from it or there were bugs in using it. This is good archival practice.

But future exiftool versions may change their results. For anything we want to use computationally, we also want to extract and store in a standardized normalized metadata location. For now, we defintely need dpi for giving to InternetArchive BookReader ref #2463. 

For now only that!

With rake task to extract from existing objects -- quick enough that no bg jobs are needed, just do it foreground. 

**Don't merge until you are ready to deploy and:**

- [ ] `heroku run rake scihist:data_fixes:extract_normalized_exiftool`