### PR TITLE
viewer, escape key should close modal even when input is focused

### DIFF
--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -113,8 +113,6 @@ ScihistImageViewer.prototype.show = function(id) {
     // make sure selected thumb in thumb list is in view
     _self.scrollSelectedIntoView();
 
-
-
     // Catch keyboard controls
     $("body").on("keydown.chf_image_viewer", function(event) {
       _self.onKeyDown(event);
@@ -304,7 +302,8 @@ ScihistImageViewer.prototype.locationWithNewPath = function(newPath) {
 
 ScihistImageViewer.prototype.onKeyDown = function(event) {
   // If we're in a text input, nevermind, just do the normal thing
-  if (event.target.tagName == "INPUT") {
+  // if it's escape key though, keep going, to let escape key still close dialog
+  if (event.target.tagName == "INPUT" && event.which != 27) {
     return;
   }
 


### PR DESCRIPTION
Without this, there was a weird bug where the escape key for some reason caused the whole modal to increase in size briefly then return to size. I have NO idea what's going on there... but we'll just return to desired behavior where escape key is caught and triggers close of viewer modal.

This is all getting a bit rickety.
