### PR TITLE
Search inside on work page should be type=search

### DIFF
--- a/app/components/work_image_show_component.html.erb
+++ b/app/components/work_image_show_component.html.erb
@@ -39,9 +39,8 @@
                 </label>
               </div>
 
-              <%= text_field_tag :q, '', class: "q form-control",
-                  id: "search-inside-q",
-                  autocomplete: "off"
+              <%= search_field_tag :q, '', class: "q form-control",
+                  id: "search-inside-q"
               %>
 
               <div class="input-group-append">


### PR DESCRIPTION
Most browsers provide a convenient 'clear entry' button that some people find convenient, I was reaching for it myself. So why not.

![Screen Shot 2024-04-18 at 9 55 16 AM](https://github.com/sciencehistory/scihist_digicoll/assets/149304/1a660fab-5db1-4899-bf3f-f8535cc1fbaa)


Also remove the code that disabled browser auto-complete, no reason not to allow browser-autocomplete here. (In other places it messes with our own UI, but not here)
