### PR TITLE
Pre-fill search-inside form on work with previous query you came from

### DIFF
--- a/app/components/search_result/work_component.rb
+++ b/app/components/search_result/work_component.rb
@@ -36,14 +36,7 @@ module SearchResult
     end
 
     def link_to_href
-      # include the current search query if any in a URL anchor/fragment
-      # that can be picked up by receiving page.
-      #
-      # While not ideal practice, we can access #params directly
-      #
-      # We use a different name than 'q' to avoid conflicting with actual viewer
-      current_query = params&.fetch("q", nil)&.truncate_words(6, omission: '')
-      work_path(model, anchor: ("prevq=#{current_query}" if current_query.present?))
+      url_to_work(model)
     end
 
     # Returns a hash of lables and values for display on the tabular metadata field, for
@@ -83,7 +76,7 @@ module SearchResult
     # (Used to handle more possibilities is why this is written abstractly like this)
     def part_of_elements
       if model.parent.present?
-        [link_to(model.parent.title, work_path(model.parent))]
+        [link_to(model.parent.title, url_to_work(model.parent))]
       else
         []
       end
@@ -91,6 +84,19 @@ module SearchResult
 
     def show_cart_control?
       can? :access_staff_functions
+    end
+
+    private
+
+    # include the current search query if any in a URL anchor/fragment
+    # that can be picked up by receiving page.
+    #
+    # While not ideal practice, we can access #params directly
+    #
+    # We use a different name than 'q' to avoid conflicting with actual viewer
+    def url_to_work(work)
+      current_query = params&.fetch("q", nil)&.truncate_words(6, omission: '')
+      work_path(work, anchor: ("prevq=#{current_query}" if current_query.present?))
     end
   end
 end

--- a/app/components/search_result/work_component.rb
+++ b/app/components/search_result/work_component.rb
@@ -36,7 +36,14 @@ module SearchResult
     end
 
     def link_to_href
-      work_path(model)
+      # include the current search query if any in a URL anchor/fragment
+      # that can be picked up by receiving page.
+      #
+      # While not ideal practice, we can access #params directly
+      #
+      # We use a different name than 'q' to avoid conflicting with actual viewer
+      current_query = params&.fetch("q", nil)&.truncate_words(6, omission: '')
+      work_path(model, anchor: ("prevq=#{current_query}" if current_query.present?))
     end
 
     # Returns a hash of lables and values for display on the tabular metadata field, for

--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -719,6 +719,27 @@ jQuery(document).ready(function($) {
       return _chf_image_viewer;
     };
 
+
+    // Do we have a viewer search form on a work page, and a preserved
+    // main query in the current URL anchor to pre-fill it?
+    const searchInput = document.querySelector("#search-inside-q");
+    if (searchInput) {
+      const currentUrl = new URL(location.href);
+      const hashKeys = new URLSearchParams(
+        currentUrl.hash.replace(/^\#/, "")
+      );
+      const queryFromUrl = hashKeys.get("prevq");
+
+      if (queryFromUrl) {
+        searchInput.value = queryFromUrl;
+      }
+
+      // AND remove it to avoid it sticking around for viewer, and just generally being confusing
+      hashKeys.delete("prevq");
+      currentUrl.hash = hashKeys.toString();
+      history.replaceState({}, "", currentUrl.href);
+    }
+
     var viewerUrlMatch = ScihistImageViewer.prototype.viewerPathComponentRe.exec(location.pathname);
     if (viewerUrlMatch != null) {
       // we have a viewer thumb in URL, let's load the viewer on page load!

--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -730,7 +730,7 @@ jQuery(document).ready(function($) {
       );
       const queryFromUrl = hashKeys.get("prevq");
 
-      if (queryFromUrl) {
+      if (queryFromUrl && searchInput.value == "") {
         searchInput.value = queryFromUrl;
       }
 

--- a/spec/components/search_result/work_component_spec.rb
+++ b/spec/components/search_result/work_component_spec.rb
@@ -62,6 +62,24 @@ describe SearchResult::WorkComponent, type: :component do
     expect(rendered).not_to have_content("do_not_show")
   end
 
+  describe "on a search page with a query in params" do
+    let(:query) { "some search" }
+
+    around do |example|
+      with_request_url search_catalog_path(q: query) do
+        example.run
+      end
+    end
+
+    it "includes query as URL anchor fragment" do
+      link_to_work = rendered.at_css("a[itemprop='url']")
+      anchor_fragment = URI(link_to_work['href']).fragment
+
+      # eg #q=some%20search
+      expect(anchor_fragment).to eq "prevq=#{CGI.escapeURIComponent query}"
+    end
+  end
+
   describe "one child" do
     let(:work) { create(:work, members: [create(:asset)])}
 


### PR DESCRIPTION
Implemented clever-hackily by:

* links from search results have a hash/fragment added to them, #q={query}
* work page has javascript that notices this, uses it to pre-fill query, then REMOVES it to keep url tidy

Confirmed that google indexing seems to ignore #fragmentIdentifiers in URLs, it won't think it's a different page. https://searchengineland.com/the-right-way-to-apply-javascript-to-your-links-for-seo-333888

Code for adding/removing things from fragmentIdentifier avoids stepping on other key=value pairs that may be in there should we want to use this more in future.
