### PR TITLE
Removing stray reference to `FEATURE_NEW_OH_REQUEST_EMAILS`

### DIFF
--- a/spec/controllers/admin/oral_history_requests_controller_spec.rb
+++ b/spec/controllers/admin/oral_history_requests_controller_spec.rb
@@ -69,7 +69,6 @@ RSpec.describe Admin::OralHistoryRequestsController, :logged_in_user, type: :con
      let(:oral_history_access_request) { create(:oral_history_request, delivery_status: "pending") }
       before do
         allow(ScihistDigicoll::Env).to receive(:lookup).and_call_original
-        allow(ScihistDigicoll::Env).to receive(:lookup).with("feature_new_oh_request_emails").and_return(true)
       end
 
       it "can approve" do


### PR DESCRIPTION
Apparently I forgot to remove a single reference to the old feature flag. Let's get rid of it before it causes confusion.
Ref https://github.com/sciencehistory/scihist_digicoll/issues/2569