### PR TITLE
Remove #q={query} from work page URL even if the work does not support search-inside

### DIFF
--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -807,19 +807,21 @@ jQuery(document).ready(function($) {
 
     // Do we have a viewer search form on a work page, and a preserved
     // main query in the current URL anchor to pre-fill it?
-    const searchInput = document.querySelector("#search-inside-q");
-    if (searchInput) {
-      const currentUrl = new URL(location.href);
-      const hashKeys = new URLSearchParams(
-        currentUrl.hash.replace(/^\#/, "")
-      );
-      const queryFromUrl = hashKeys.get("prevq");
+    const currentUrl = new URL(location.href);
+    const hashKeys = new URLSearchParams(
+      currentUrl.hash.replace(/^\#/, "")
+    );
+    const queryFromUrl = hashKeys.get("prevq");
 
-      if (queryFromUrl && searchInput.value == "") {
-        searchInput.value = queryFromUrl;
+    if(queryFromUrl) {
+      const searchInput = document.querySelector("#search-inside-q");
+      if (searchInput) {
+        if (searchInput.value == "") {
+          searchInput.value = queryFromUrl;
+        }
       }
 
-      // AND remove it to avoid it sticking around for viewer, and just generally being confusing
+      // AND remove it to provide a clean URL
       hashKeys.delete("prevq");
       currentUrl.hash = hashKeys.toString();
       history.replaceState({}, "", currentUrl.href);
@@ -832,7 +834,6 @@ jQuery(document).ready(function($) {
     }
 
     // If we have a query in the URL, load it
-    const queryFromUrl = chf_image_viewer().getQueryInUrl();
     if (queryFromUrl) {
       chf_image_viewer().showSearchDrawer();
       chf_image_viewer().modal.find("#q").val(queryFromUrl); // set in search box in viewer


### PR DESCRIPTION
That anchor is used to pre-fill the search-inside box on the work page. When we have a search-inside box, we pre-fill from there, then remove it from the page URL to have a clean URL in address bar.

But even if we don't have a search-inside box, but the anchor is still there, we still want to clean it up and remove it.
