### PR TITLE
viewer alert z-index needs to be higher than next/previous edges

### DIFF
--- a/app/frontend/stylesheets/local/scihist_viewer.scss
+++ b/app/frontend/stylesheets/local/scihist_viewer.scss
@@ -92,7 +92,7 @@ $scihist_image_viewer_thumb_width: 54px; // Needs to match ImageServiceHelper::T
 
   .viewer-alert {
     position: absolute;
-    z-index: 1;
+    z-index: 10;
     right: 0.5rem;
     top: 0.5rem;
   }


### PR DESCRIPTION
After we repositioned viewer alert, attempts to click on it's close button were winding up as a click on the large invisible "next" bar area, when both absolutely positioned items had the same z-index.
