### PR TITLE
aggressively rate limit with rack attack to 30 requests per minute per IP

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -15,7 +15,7 @@ end
 # counted by rack-attack and this throttle may be activated too
 # quickly. If so, enable the condition to exclude them from tracking.
 
-# Throttle all requests by IP (60rpm)
+# Throttle all requests by IP
 #
 # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
 #
@@ -26,7 +26,10 @@ end
 #
 # But we're going to try a more generous 3 per second over
 # 1 minute instead.
-Rack::Attack.throttle('req/ip', limit: 180, period: 1.minutes) do |req|
+#
+# May 1 2024: Limiting much more extensively to 30 req per minute -- one per every two seconds
+# averaging over a minute -- after bot  attacks costing us money from s3.
+Rack::Attack.throttle('req/ip', limit: 30, period: 1.minutes) do |req|
   # On heroku, we may be delivering assets via rack, I think.
   # We also try to exempt our "api" responses from rate limit, although
   # we still include them in tracking logging below.
@@ -40,7 +43,7 @@ end
 
 # But we're also going to TRACK at half that limit, for ease
 # of understanding what's going on in our logs
-Rack::Attack.track("req/ip_track", limit: 90, period: 1.minute) do |req|
+Rack::Attack.track("req/ip_track", limit: 60, period: 1.minute) do |req|
   req.ip unless req.path.start_with?('/assets')
 end
 


### PR DESCRIPTION
one every other second, averaged over a minute. A human seems unlikely to get that? Googlebot might and we don’t want to harm our SEO, but what can you do.

Trying some things to deal with the apparent bot traffic we are getting which is running up our S3 costs -- although this only applies to our app not S3, the bots are getting the S3 urls from our app, and this is an easy thing we can try in an urgent situation.
