### PR TITLE
Redirects to s3 for downloads now expire in 15 minutes

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -33,7 +33,7 @@
 #
 class DownloadsController < ApplicationController
   # Will be sent to S3 as expires_in, seconds, max 1 week.
-  URL_EXPIRES_IN = 2.days.to_i
+  URL_EXPIRES_IN = 15.minutes.to_i # reduced to try to slow down bots. was 2.days.to_i
 
   before_action :set_asset
   before_action :set_derivative, only: :derivative


### PR DESCRIPTION
This is an attempt to see if it helps with the bots who are pounding us on S3 and causing elevated costs. 15 minutes is actuall the default S3 signed url expiration, we go down to that here instead of allowing a larger window just in case.
