### PR TITLE
Viewer, highlight current search result in results list

### DIFF
--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -136,15 +136,19 @@ ScihistImageViewer.prototype.show = function(id) {
   });
 };
 
+// Scroll given element into view only if it's not already in full view. Unlike built-into
+// browser function which always scrolls so it's at the top, even if it already was in view.
+//
 // position can be 'start', 'end'
-ScihistImageViewer.prototype.scrollSelectedIntoView = function(position) {
+ScihistImageViewer.prototype.scrollElementIntoView = function(elem, position = "start", container) {
   // only if the selected thing is not currently in scroll view, scroll
   // it to be so.
   // https://stackoverflow.com/a/16309126/307106
 
-  var elem = this.selectedThumb;
-
-  var container = $(".viewer-thumbs");
+  if (container == undefined) {
+    container = elem.parentNode;
+  }
+  container = $(container);
 
   var contHeight = container.height();
   var contTop = container.scrollTop();
@@ -164,11 +168,16 @@ ScihistImageViewer.prototype.scrollSelectedIntoView = function(position) {
 
   if (! isTotal) {
     if (position == "end") {
-      this.selectedThumb.scrollIntoView(false);
+      elem.scrollIntoView(false);
     } else {
-      this.selectedThumb.scrollIntoView();
+      elem.scrollIntoView();
     }
   }
+}
+
+// position can be 'start', 'end'
+ScihistImageViewer.prototype.scrollSelectedIntoView = function(position = "start") {
+  this.scrollElementIntoView(this.selectedThumb, position)
 }
 
 ScihistImageViewer.prototype.hide = function() {

--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -771,6 +771,7 @@ ScihistImageViewer.prototype.selectSearchResult = function(resultElement) {
   // Add class for highlighting search result, removing from any others
   $(".result.current-viewer-result").removeClass("current-viewer-result")
   $(resultElement).addClass("current-viewer-result");
+  this.scrollElementIntoView(resultElement);
 
   const searchResultIndex = parseInt( resultElement.getAttribute('data-search-result-index') );
   const resultData = this.searchResults.resultByIndex(searchResultIndex)

--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -139,8 +139,7 @@ ScihistImageViewer.prototype.show = function(id) {
 // Scroll given element into view only if it's not already in full view. Unlike built-into
 // browser function which always scrolls so it's at the top, even if it already was in view.
 //
-// position can be 'start', 'end'
-ScihistImageViewer.prototype.scrollElementIntoView = function(elem, position = "start", container) {
+ScihistImageViewer.prototype.scrollElementIntoView = function(elem, container) {
   // only if the selected thing is not currently in scroll view, scroll
   // it to be so.
   // https://stackoverflow.com/a/16309126/307106
@@ -167,17 +166,21 @@ ScihistImageViewer.prototype.scrollElementIntoView = function(elem, position = "
   var isTotal = (elemTop >= 0 && elemBottom <= contHeight && elemLeft >= 0 && elemRight <= contWidth);
 
   if (! isTotal) {
-    if (position == "end") {
-      elem.scrollIntoView(false);
-    } else {
-      elem.scrollIntoView();
-    }
+    // We'd love to use smooth scroll, but bug in Chrome where it can't do two
+    // smooth scrolls at once, and we sometimes have both page thumb list and
+    // search result list.
+    // https://stackoverflow.com/questions/49318497/google-chrome-simultaneously-smooth-scrollintoview-with-more-elements-doesn
+
+    elem.scrollIntoView({
+        //behavior: 'smooth',
+        block: 'center',
+        inline: 'center'
+    });
   }
 }
 
-// position can be 'start', 'end'
-ScihistImageViewer.prototype.scrollSelectedIntoView = function(position = "start") {
-  this.scrollElementIntoView(this.selectedThumb, position)
+ScihistImageViewer.prototype.scrollSelectedIntoView = function() {
+  this.scrollElementIntoView(this.selectedThumb)
 }
 
 ScihistImageViewer.prototype.hide = function() {
@@ -300,7 +303,7 @@ ScihistImageViewer.prototype.next = function() {
   var nextElement = $(this.selectedThumb).next().get(0);
   if (nextElement) {
     this.selectThumb(nextElement);
-    this.scrollSelectedIntoView("start");
+    this.scrollSelectedIntoView();
   }
 };
 
@@ -308,7 +311,7 @@ ScihistImageViewer.prototype.prev = function() {
   var prevElement = $(this.selectedThumb).prev().get(0);
   if (prevElement) {
     this.selectThumb(prevElement);
-    this.scrollSelectedIntoView("end");
+    this.scrollSelectedIntoView();
   }
 };
 

--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -235,6 +235,7 @@ ScihistImageViewer.prototype.selectThumb = function(thumbElement , { resetCurren
   // Normally we reset any current search result on page change, unless this was being
   // done to go to a search result!
   if (this.searchResults && this.currentSearchResult && resetCurrentSearchResult) {
+    $(".result.current-viewer-result").removeClass("current-viewer-result");
     document.getElementById("searchNavLabel").textContent = this.searchResults.resultsCountMessage();
     this.currentSearchResult = undefined;
   }
@@ -758,6 +759,10 @@ ScihistImageViewer.prototype.getSearchResults = async function(query) {
 };
 
 ScihistImageViewer.prototype.selectSearchResult = function(resultElement) {
+  // Add class for highlighting search result, removing from any others
+  $(".result.current-viewer-result").removeClass("current-viewer-result")
+  $(resultElement).addClass("current-viewer-result");
+
   const searchResultIndex = parseInt( resultElement.getAttribute('data-search-result-index') );
   const resultData = this.searchResults.resultByIndex(searchResultIndex)
 

--- a/app/frontend/stylesheets/local/scihist_viewer.scss
+++ b/app/frontend/stylesheets/local/scihist_viewer.scss
@@ -194,7 +194,7 @@ $scihist_image_viewer_thumb_width: 54px; // Needs to match ImageServiceHelper::T
     }
 
     .search-results-container {
-      padding: 0 ($paragraph-spacer / 2) $paragraph-spacer ($paragraph-spacer / 2);
+      padding: 0 ($paragraph-spacer * 0.5) $paragraph-spacer ($paragraph-spacer * 0.5);
       flex-grow: 1;
       overflow-y: scroll;
       overflow-x: hidden;
@@ -211,7 +211,7 @@ $scihist_image_viewer_thumb_width: 54px; // Needs to match ImageServiceHelper::T
       color: $body-color;
       display: block;
       // padding so highlighted background will include it
-      padding: $paragraph-spacer ($paragraph-spacer / 2);
+      padding: $paragraph-spacer ($paragraph-spacer * 0.5);
       // invisible border so adding a border for current doens't change size
       border: 1px solid transparent;
 

--- a/app/frontend/stylesheets/local/scihist_viewer.scss
+++ b/app/frontend/stylesheets/local/scihist_viewer.scss
@@ -194,7 +194,7 @@ $scihist_image_viewer_thumb_width: 54px; // Needs to match ImageServiceHelper::T
     }
 
     .search-results-container {
-      padding: 0 $paragraph-spacer $paragraph-spacer $paragraph-spacer;
+      padding: 0 ($paragraph-spacer / 2) $paragraph-spacer ($paragraph-spacer / 2);
       flex-grow: 1;
       overflow-y: scroll;
       overflow-x: hidden;
@@ -210,10 +210,18 @@ $scihist_image_viewer_thumb_width: 54px; // Needs to match ImageServiceHelper::T
     .result {
       color: $body-color;
       display: block;
-      margin-bottom: $paragraph-spacer * 2;
+      // padding so highlighted background will include it
+      padding: $paragraph-spacer ($paragraph-spacer / 2);
+      // invisible border so adding a border for current doens't change size
+      border: 1px solid transparent;
 
       mark {
         background-color: $shi-red-1;
+      }
+
+      &.current-viewer-result {
+        border: 1px solid $body-color;
+        background-color: $shi-chartreuse-2;
       }
     }
   }


### PR DESCRIPTION
And scroll it into view if it wasn't already. 

Also change method we use to scroll things into view -- to scroll to CENTER of list, instead of top or bottom. We can do this with new browser API that wasn't widely avail when we first wrote it. Simplifies need to track if we're going next or prev for top/bottom, also I think center is prob better UI anyhow. 

- viewer, highlight currently selected search result in results list
- viewer, factor out generic scrollElementIntoView for re-use
- viewer, scroll selected search result item into view
- viewer scroll into viewer always scrolls so element is centered now
