### PR TITLE
DISABLE_DOWNLOADS flag

### DIFF
--- a/app/components/download_dropdown_component.rb
+++ b/app/components/download_dropdown_component.rb
@@ -224,10 +224,15 @@ class DownloadDropdownComponent < ApplicationComponent
       download_option.label, (content_tag("small", download_option.subhead) if download_option.subhead.present?)
     ])
 
-    content_tag("a", label,
-                      class: "dropdown-item",
-                      href: download_option.url,
-                      data: download_option.data_attrs)
+    if download_option.url.present?
+      content_tag("a", label,
+                        class: "dropdown-item",
+                        href: download_option.url,
+                        data: download_option.data_attrs)
+    else
+      # allow non-link label menu items. eg for disabled download notice
+      content_tag("span", label, class: "px-4 text-muted text-small")
+    end
   end
 
   def rights_statement_item

--- a/app/presenters/download_options/image_download_options.rb
+++ b/app/presenters/download_options/image_download_options.rb
@@ -37,7 +37,7 @@ module DownloadOptions
 
       # For historial reasons we have two download sizes MEDIUM and LARGE,
       # but we label the medium one as "small"
-      if dl_medium = asset.file_derivatives[:download_medium]
+      if !disabled_downloads && dl_medium = asset.file_derivatives[:download_medium]
         options << DownloadOption.with_formatted_subhead("Small JPG",
           work_friendlier_id: @asset.parent&.friendlier_id,
           url: download_derivative_path(asset, :download_medium),
@@ -48,7 +48,7 @@ module DownloadOptions
         )
       end
 
-      if dl_large = asset.file_derivatives[:download_large]
+      if !disabled_downloads && dl_large = asset.file_derivatives[:download_large]
         options << DownloadOption.with_formatted_subhead("Large JPG",
           work_friendlier_id: @asset.parent&.friendlier_id,
           url: download_derivative_path(asset, :download_large),
@@ -59,7 +59,7 @@ module DownloadOptions
         )
       end
 
-      if dl_full = asset.file_derivatives[:download_full]
+      if !disabled_downloads && dl_full = asset.file_derivatives[:download_full]
         options << DownloadOption.with_formatted_subhead("Full-sized JPG",
           url: download_derivative_path(asset, :download_full),
           work_friendlier_id: @asset.parent&.friendlier_id,
@@ -70,7 +70,7 @@ module DownloadOptions
         )
       end
 
-      if asset.stored?
+      if !disabled_downloads && asset.stored?
         options << DownloadOption.with_formatted_subhead("Original file",
           url: download_path(asset.file_category, asset),
           work_friendlier_id: @asset.parent&.friendlier_id,
@@ -82,7 +82,16 @@ module DownloadOptions
         )
       end
 
+      if disabled_downloads
+        options << DownloadOption.new("Downloads temporarily unavailable", url:nil, work_friendlier_id:nil)
+      end
+
       return options
+    end
+
+    def disabled_downloads
+      # wanted to allow for logged-in users, don't have access here.
+      ScihistDigicoll::Env.lookup(:disable_downloads)
     end
 
   end

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -622,5 +622,7 @@ module ScihistDigicoll
     # }, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM
 
     define_key "feature_search_inside_work", default: false, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM
+
+    define_key "disable_downloads", default: false, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM
   end
 end


### PR DESCRIPTION
Meant to temporarily halt the S3 asset accesses by bots that are costing us lots of money, until we can figure out a better solution.

Initial implementation removes ALL *image* download options (derivative and original) from download menu.

It does NOT actually disable the download controller, if someone already has a URL.

It also does not disable PDF or Audio downloads from OH-specific pages. (That is somewhat more confusing to do, since the links are kind of integrated all over the place).

This can be adjusted in either direction based on whether it works to stop our problematic access, and whehter it interferes with staff work too much, or what.

- [ ] heroku `heroku config:set DISABLE_DOWNLOADS=true -r production`
