### PR TITLE
Further tweaks and bugfixes to disable-downloads env option

### DIFF
--- a/app/components/download_dropdown_component.rb
+++ b/app/components/download_dropdown_component.rb
@@ -231,7 +231,7 @@ class DownloadDropdownComponent < ApplicationComponent
                         data: download_option.data_attrs)
     else
       # allow non-link label menu items. eg for disabled download notice
-      content_tag("span", label, class: "px-4 text-muted text-small")
+      content_tag("div", label, class: "px-4 text-muted text-small")
     end
   end
 

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -41,6 +41,14 @@ class DownloadsController < ApplicationController
 
   #GET /downloads/:asset_id
   def original
+    # for IMAGES only, when we have downloads disable, simply refuse to redirect IF the user
+    # is not logged in. PHEW lots of exceptions, trying to avoid breaking LOTS of our app.
+    if ScihistDigicoll::Env.lookup(:disable_downloads) && !current_user && @asset.content_type.start_with?("image/")
+      render status: 503, plain: "Sorry, this download is currently unavailable"
+
+      return
+    end
+
     # Tell shrine url method `public:false` to make sure we get a signed URL
     # that lets us set content-disposition and content-type, even if
     # it's public in S3.

--- a/app/presenters/download_options/image_download_options.rb
+++ b/app/presenters/download_options/image_download_options.rb
@@ -25,7 +25,7 @@ module DownloadOptions
       options = []
       # Sometimes we want the PDF link in the individual-image download links,
       # as per https://github.com/sciencehistory/scihist_digicoll/issues/2278 .
-      if show_pdf_link?
+      if !disabled_downloads && show_pdf_link?
         options << DownloadOption.for_on_demand_derivative(
           label: "PDF", derivative_type: "pdf_file", work_friendlier_id: @asset&.parent&.friendlier_id
         )
@@ -70,7 +70,7 @@ module DownloadOptions
         )
       end
 
-      if !disabled_downloads && asset.stored?
+      if asset.stored? && !(disabled_downloads && asset.content_type.start_with?("image/"))
         options << DownloadOption.with_formatted_subhead("Original file",
           url: download_path(asset.file_category, asset),
           work_friendlier_id: @asset.parent&.friendlier_id,
@@ -82,7 +82,7 @@ module DownloadOptions
         )
       end
 
-      if disabled_downloads
+      if disabled_downloads && options.empty?
         options << DownloadOption.new("Downloads temporarily unavailable", url:nil, work_friendlier_id:nil)
       end
 


### PR DESCRIPTION
We DO let OH PDFs through.  We stop *originals* downloads *at the point of redirect* (since some are still being logged even though we're not providing the option?) -- but only for IMAGEs and non-logged-inusers, cause we're trying to stop errors and buggy UI from happening all over our complex app!



- for download disabled menu item, div instead of span wraps better
- Gate DISABLE_DOWNLOADS *at* redirect controller -- for IMAGES and NON-LOGGED-IN users
- more care with when 'downloads disabled' message is shown to user, dont' show when we really have options
