### PR TITLE
rack-attack throttle limit to 80 per minute

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -29,7 +29,7 @@ end
 #
 # May 1 2024: Limiting much more extensively to 30 req per minute -- one per every two seconds
 # averaging over a minute -- after bot  attacks costing us money from s3.
-Rack::Attack.throttle('req/ip', limit: 30, period: 1.minutes) do |req|
+Rack::Attack.throttle('req/ip', limit: 80, period: 1.minutes) do |req|
   # On heroku, we may be delivering assets via rack, I think.
   # We also try to exempt our "api" responses from rate limit, although
   # we still include them in tracking logging below.


### PR DESCRIPTION
~1.3 per second over a minute

PRIOR to bot troubles, this was at 180 per minute (~3 per second), with a informational-only log warning at 90 per minute.

After we redued this in response to bot troubles, it had been 30 per minute (~1 per 2 seconds~), with accidentally misconfigured informational warning that didn't trigger.

Now we limit to a more reaosnable 80 per minute, with an informational log warning at 60 per minute (~1 per second). `
