### PR TITLE
avoid double adding OCR highlight boxes

### DIFF
--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -750,8 +750,12 @@ ScihistImageViewer.prototype.getSearchResults = async function(query) {
       searchResultsContainer.append(resultHtml)
     }
 
-    // show highlights on current page
-    this.highlightSearchResults();
+    // show highlights on current page if it's already open. otherwise
+    // highlights will be triggered in our open callback, and we don't want to
+    // double render.
+    if (this.viewer.isOpen()) {
+      this.highlightSearchResults();
+    }
   } catch (error) {
     console.log("scihist_viewer, error fetching search results: " + error.message);
     searchResultsContainer.innerHTML = "<p class='alert alert-danger' role='alert'>\


### PR DESCRIPTION
This was triggered in certain cases where highlights were added by BOTH an openseadragon 'open' event handler, AND in getSearchResults(). Specifically, when opening a bookmarked URL to specific search results and a page with hits.

The effect was two highlight divs on one on top of the other, both semi-transparent, but effectively less transparent than intended since there were two of them.

This is all getting a bit tricky
