### PR TITLE
Viewer, highlight CURRENT selected result on OCR page

### DIFF
--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -739,7 +739,7 @@ ScihistImageViewer.prototype.getSearchResults = async function(query) {
 
     // For each search result, we need to render it in results
     for (const result of this.searchResults.jsonResults()) {
-      const id = result['id'];
+      const id = result['member_id'];
 
       const resultHtml = document.createElement('a');
       resultHtml["href"] = "#";
@@ -769,7 +769,7 @@ ScihistImageViewer.prototype.selectSearchResult = function(resultElement) {
   this.currentSearchResult = resultData;
   document.getElementById("searchNavLabel").textContent = `${ searchResultIndex + 1 } / ${ this.searchResults.resultsCount()}`
 
-  const memberId = resultData['id'];
+  const memberId = resultData['member_id'];
 
   if (memberId != this.selectedThumbData.memberId) {
     const thumbElement = this.findThumbElement(memberId);

--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -664,6 +664,7 @@ ScihistImageViewer.prototype.highlightSearchResults = function() {
     for (let result of resultOverlaysForPage) {
       let elt = document.createElement("div");
       elt.className = "viewer-search-highlight";
+      elt.id = result.result_id;
 
       // the bounding box is EXACTLY where OCR thinks letters stop/start. Making
       // the highlight a bit bigger looks better. let's say 1/6th of (line) height padding

--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -679,6 +679,18 @@ ScihistImageViewer.prototype.highlightSearchResults = function() {
           location: new OpenSeadragon.Rect(left, top, width, height)
       });
     }
+
+    this.setSelectedHighlight();
+  }
+}
+
+// The .viewer-search-highlight OCR highlight div for the current result
+// gets a custom class which also has an initial animation
+ScihistImageViewer.prototype.setSelectedHighlight = function() {
+  $(".viewer-search-highlight").removeClass("selected-search-highlight");
+
+  if (this.currentSearchResult) {
+    $("#" + this.currentSearchResult.result_id).addClass("selected-search-highlight");
   }
 }
 
@@ -776,6 +788,8 @@ ScihistImageViewer.prototype.selectSearchResult = function(resultElement) {
     const thumbElement = this.findThumbElement(memberId);
     this.selectThumb(thumbElement, { resetCurrentSearchResult: false });
     this.scrollSelectedIntoView();
+  } else {
+    this.setSelectedHighlight();
   }
 }
 

--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -658,7 +658,7 @@ ScihistImageViewer.prototype.initOpenSeadragon = function() {
 ScihistImageViewer.prototype.highlightSearchResults = function() {
   const currentMemberId = this.selectedThumbData?.memberId;
 
-  const resultOverlaysForPage = this.searchResults?.highlightsByPageId( currentMemberId );
+  const resultOverlaysForPage = this.searchResults?.resultsByPageId( currentMemberId );
 
   if (resultOverlaysForPage) {
     for (let result of resultOverlaysForPage) {
@@ -667,11 +667,11 @@ ScihistImageViewer.prototype.highlightSearchResults = function() {
 
       // the bounding box is EXACTLY where OCR thinks letters stop/start. Making
       // the highlight a bit bigger looks better. let's say 1/6th of (line) height padding
-      const padding = result.height / 6;
-      const left = result.left - padding;
-      const top = result.top - padding;
-      const width = result.width + (padding * 2);
-      const height = result.height + (padding * 2);
+      const padding = result.osd_rect.height / 6;
+      const left = result.osd_rect.left - padding;
+      const top = result.osd_rect.top - padding;
+      const width = result.osd_rect.width + (padding * 2);
+      const height = result.osd_rect.height + (padding * 2);
 
       this.viewer.addOverlay({
           element: elt,

--- a/app/frontend/javascript/scihist_viewer/viewer_search_results.js
+++ b/app/frontend/javascript/scihist_viewer/viewer_search_results.js
@@ -39,7 +39,7 @@ export default class ViewerSearchResults {
     //
 
     let i = 0;
-    this._highlightsByPageId = {};
+    this._resultsByPageId = {};
     for (const result of this._jsonResults) {
       // Add index number (0..n) to each result for convenience
       result['resultIndex'] = i;
@@ -51,13 +51,13 @@ export default class ViewerSearchResults {
       result['pageIndex'] = pageInfo.getIndexByMemberId(memberID);
 
       // Index each OSD highlight dimensions in a hash by member Id
-      this._highlightsByPageId[memberID] = (this._highlightsByPageId[memberID] || []);
-      this._highlightsByPageId[memberID].push(result.osd_rect);
+      this._resultsByPageId[memberID] = (this._resultsByPageId[memberID] || []);
+      this._resultsByPageId[memberID].push(result);
     }
   }
 
-  highlightsByPageId(pageId) {
-    return this._highlightsByPageId[pageId] || []
+  resultsByPageId(pageId) {
+    return this._resultsByPageId[pageId] || []
   }
 
   // straight json results from server, but with resultIndex too

--- a/app/frontend/javascript/scihist_viewer/viewer_search_results.js
+++ b/app/frontend/javascript/scihist_viewer/viewer_search_results.js
@@ -7,7 +7,7 @@ export default class ViewerSearchResults {
   constructor(jsonResults, pageInfo) {
     // Results stored, enhanced with index, they should look like an array of
     // {
-    //    id: memberId,
+    //    member_id: memberId,
     //    text: snippetText,
     //    resultIndex: {0..length-1},
     //    pageIndex: {0..totalPages-1},
@@ -45,7 +45,7 @@ export default class ViewerSearchResults {
       result['resultIndex'] = i;
       i++;
 
-      const memberID = result['id'];
+      const memberID = result['member_id'];
 
       // Add the PAGE index into total page results, need for looking up results
       result['pageIndex'] = pageInfo.getIndexByMemberId(memberID);

--- a/app/frontend/stylesheets/local/scihist_viewer.scss
+++ b/app/frontend/stylesheets/local/scihist_viewer.scss
@@ -223,6 +223,21 @@ $scihist_image_viewer_thumb_width: 54px; // Needs to match ImageServiceHelper::T
     opacity: 0.35;
   }
 
+  // the single actually selected one gets an outline and an initial blink animation
+  .selected-search-highlight {
+    outline: solid 4px $shi-green-4;
+    outline-offset: 3px;
+    animation: highlight-flash 0.8s ease-in-out;
+  }
+
+  @keyframes highlight-flash {
+    0% { opacity: 0.35; }
+    40% { opacity: 0; }
+    70% { opacity: .5; }
+    85% { opacity: 0; }
+    100% { opacity: .35; }
+  }
+
   .viewer-image-and-navbar {
     position: relative;
 

--- a/app/frontend/stylesheets/local/scihist_viewer.scss
+++ b/app/frontend/stylesheets/local/scihist_viewer.scss
@@ -231,9 +231,9 @@ $scihist_image_viewer_thumb_width: 54px; // Needs to match ImageServiceHelper::T
   }
 
   @keyframes highlight-flash {
-    0% { opacity: 0.35; }
+    0% { opacity: 0.35; outline-style: none; }
     40% { opacity: 0; }
-    70% { opacity: .5; }
+    70% { opacity: .5; outline-style: solid; }
     85% { opacity: 0; }
     100% { opacity: .35; }
   }

--- a/app/frontend/stylesheets/local/scihist_viewer.scss
+++ b/app/frontend/stylesheets/local/scihist_viewer.scss
@@ -227,7 +227,7 @@ $scihist_image_viewer_thumb_width: 54px; // Needs to match ImageServiceHelper::T
   .selected-search-highlight {
     outline: solid 4px $shi-green-4;
     outline-offset: 3px;
-    animation: highlight-flash 0.8s ease-in-out;
+    animation: highlight-flash 0.7s ease-in-out;
   }
 
   @keyframes highlight-flash {

--- a/app/services/hocr_searcher.rb
+++ b/app/services/hocr_searcher.rb
@@ -52,6 +52,7 @@ class HocrSearcher
   #       [{
   #         "text"=>"All {{{units}}} must be connected as above",
   #         "member_id" => "adf8a7dfa",
+  #         "result_id" => {unique id for result},
   #         "osd_rect"=>{
   #           "left"=>0.38815,
   #           "top"=>0.18576,
@@ -68,9 +69,10 @@ class HocrSearcher
       parsed_hocr = Nokogiri::XML(asset.hocr) { |config| config.strict }
       next unless parsed_hocr.css(".ocr_page").length >= 1
 
-      matching_ocrx_words_for(parsed_hocr).collect do |ocrx_word|
+      matching_ocrx_words_for(parsed_hocr).collect.with_index do |ocrx_word, index|
         {
           "member_id"  => member.friendlier_id, # for child works, viewer uses the direct member id
+          "result_id"  => "r_#{member.friendlier_id}_#{index}", # unique id for the result hit
           "text" => extract_context(ocrx_word),
           "osd_rect" => extract_osd_rect(ocrx_word: ocrx_word, asset: asset)
         }

--- a/app/services/hocr_searcher.rb
+++ b/app/services/hocr_searcher.rb
@@ -51,7 +51,7 @@ class HocrSearcher
   #
   #       [{
   #         "text"=>"All {{{units}}} must be connected as above",
-  #         "id" => "adf8a7dfa",
+  #         "member_id" => "adf8a7dfa",
   #         "osd_rect"=>{
   #           "left"=>0.38815,
   #           "top"=>0.18576,
@@ -70,7 +70,7 @@ class HocrSearcher
 
       matching_ocrx_words_for(parsed_hocr).collect do |ocrx_word|
         {
-          "id"  => member.friendlier_id, # for child works, viewer uses the direct member id
+          "member_id"  => member.friendlier_id, # for child works, viewer uses the direct member id
           "text" => extract_context(ocrx_word),
           "osd_rect" => extract_osd_rect(ocrx_word: ocrx_word, asset: asset)
         }

--- a/spec/services/hocr_searcher_spec.rb
+++ b/spec/services/hocr_searcher_spec.rb
@@ -14,7 +14,7 @@ describe HocrSearcher do
 
     result = results.first
     expect(result).to be_kind_of(Hash)
-    expect(result["id"]).to eq asset.friendlier_id
+    expect(result["member_id"]).to eq asset.friendlier_id
     expect(result['text']).to be_kind_of(String)
     expect(result['text']).to match "<mark>units</mark>"
     expect(result['osd_rect']).to be_kind_of(Hash)
@@ -90,7 +90,7 @@ describe HocrSearcher do
       expect(results).to be_kind_of(Array)
       expect(results.length).to be 1
 
-      expect(results.first["id"]).to eq work.friendlier_id
+      expect(results.first["member_id"]).to eq work.friendlier_id
     end
   end
 
@@ -99,14 +99,14 @@ describe HocrSearcher do
 
     it "does not include unpublished asset" do
       searcher = HocrSearcher.new(work, query: "units")
-      expect(searcher.results_for_osd_viewer).not_to include(an_object_satisfying { |h| h["id"] == asset.friendlier_id })
+      expect(searcher.results_for_osd_viewer).not_to include(an_object_satisfying { |h| h["member_id"] == asset.friendlier_id })
     end
 
     context "when including unpublished" do
       it "includes unpublished asset" do
         searcher = HocrSearcher.new(work, show_unpublished: true, query: "units")
 
-        expect(searcher.results_for_osd_viewer).to include(an_object_satisfying { |h| h["id"] == asset.friendlier_id })
+        expect(searcher.results_for_osd_viewer).to include(an_object_satisfying { |h| h["member_id"] == asset.friendlier_id })
       end
     end
   end

--- a/spec/services/hocr_searcher_spec.rb
+++ b/spec/services/hocr_searcher_spec.rb
@@ -19,6 +19,9 @@ describe HocrSearcher do
     expect(result['text']).to match "<mark>units</mark>"
     expect(result['osd_rect']).to be_kind_of(Hash)
 
+    # unique ids
+    expect(results.collect { |h| h["result_id"]}.uniq.length).to eq results.length
+
     # sanity check
     %w{left top height width}.each do |key|
       expect(result['osd_rect'][key]).to be_kind_of(Float)
@@ -46,6 +49,9 @@ describe HocrSearcher do
       results = searcher.results_for_osd_viewer
       expect(results).to be_kind_of(Array)
       expect(results.length).to be 2
+
+      # unique ids
+      expect(results.collect { |h| h["result_id"]}.uniq.length).to eq results.length
     end
   end
 


### PR DESCRIPTION
All matches on a page get highlighted. But the currently selected one gets a border around it, and a little initial animation, so when you are going between multiple results on the same page, your eye is drawn to the next/current one

To do so, we need to give each overlay for each highlight a unique HTML `id` so we can target it; and we need to record that id in the data in the JS, so for a given result we can find the overlay and add a new class to it for the currently selected overlay. 

- change name in HocrSearcher result data dictionary from 'id' to 'member_id' to avoid confusion
- add unique result_id to HocrSearcher results
- JS Viewer, change .highlightsByPageId to return full .resultsByPageId
- give each OCR highlight box it's own unique DOM id so it can get targetted
- viewer, special style for currently selected search result OCR highlight
