### PR TITLE
    Viewer, add search result count overlays to thumb list

### DIFF
--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -836,6 +836,12 @@ ScihistImageViewer.prototype.getSearchResults = async function(query) {
     if (this.viewer.isOpen()) {
       this.highlightSearchResults();
     }
+
+    // Highlight thumbs in thumblist with result count. Add data attribute,
+    // CSS will take care of rest.
+    for (const [memberId, results] of Object.entries(this.searchResults.allResultsByPageId())) {
+      document.querySelector(".viewer-thumb[data-member-id='" + memberId + "']").setAttribute("data-search-result-count", results.length);
+    }
   } catch (error) {
     console.log("scihist_viewer, error fetching search results: " + error.message);
     searchResultsContainer.innerHTML = "<p class='alert alert-danger' role='alert'>\
@@ -877,6 +883,8 @@ ScihistImageViewer.prototype.clearSearchResults = function() {
   const searchResultsContainer = document.querySelector(".viewer-search-area .search-results-container");
 
   document.getElementById("searchNav").style.display = "none";
+
+  $(".viewer-thumb[data-search-result-count]").removeAttr("data-search-result-count");
 
   this.viewer.clearOverlays();
   this.removeQueryInUrl();

--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -568,7 +568,8 @@ ScihistImageViewer.prototype.makeThumbnails = function(json) {
         ' data-index="' + index + '"' +
       '>' +
         '<img class="lazyload"' +
-              ' alt="Image ' + (index + 1) +
+              ' alt="Image ' + (index + 1) + '"' +
+              ' data-base-alt="Image ' + (index + 1) + '"' +
               ' data-src="' + config.thumbSrc + '"' +
               ' data-srcset="' +  (config.thumbSrcset || '') + '"' +
               // not totally sure if this forced height is really necessary currently, maybe for lazyload?
@@ -840,7 +841,11 @@ ScihistImageViewer.prototype.getSearchResults = async function(query) {
     // Highlight thumbs in thumblist with result count. Add data attribute,
     // CSS will take care of rest.
     for (const [memberId, results] of Object.entries(this.searchResults.allResultsByPageId())) {
-      document.querySelector(".viewer-thumb[data-member-id='" + memberId + "']").setAttribute("data-search-result-count", results.length);
+      const elt = document.querySelector(".viewer-thumb[data-member-id='" + memberId + "']");
+      const imgElt = elt.querySelector("img");
+
+      elt.setAttribute("data-search-result-count", results.length);
+      imgElt.setAttribute("alt", imgElt.getAttribute("data-base-alt") + " (" + results.length + " results)");
     }
   } catch (error) {
     console.log("scihist_viewer, error fetching search results: " + error.message);
@@ -884,7 +889,12 @@ ScihistImageViewer.prototype.clearSearchResults = function() {
 
   document.getElementById("searchNav").style.display = "none";
 
-  $(".viewer-thumb[data-search-result-count]").removeAttr("data-search-result-count");
+  document.querySelectorAll(".viewer-thumb[data-search-result-count]").forEach(function(el) {
+    el.removeAttribute("data-search-result-count");
+
+    const imgElt = el.querySelector("img");
+    imgElt.setAttribute("alt", imgElt.getAttribute("data-base-alt"));
+  });
 
   this.viewer.clearOverlays();
   this.removeQueryInUrl();

--- a/app/frontend/javascript/scihist_viewer/viewer_search_results.js
+++ b/app/frontend/javascript/scihist_viewer/viewer_search_results.js
@@ -60,6 +60,10 @@ export default class ViewerSearchResults {
     return this._resultsByPageId[pageId] || []
   }
 
+  allResultsByPageId() {
+    return this._resultsByPageId;
+  }
+
   // straight json results from server, but with resultIndex too
   jsonResults() {
     return this._jsonResults;

--- a/app/frontend/stylesheets/local/scihist_viewer.scss
+++ b/app/frontend/stylesheets/local/scihist_viewer.scss
@@ -460,7 +460,7 @@ $scihist_image_viewer_thumb_width: 54px; // Needs to match ImageServiceHelper::T
         left: 50%;
         transform: translateX(-50%) translateY(-50%);
 
-        background-color: rgba($shi-red-1, 0.8);
+        background-color: rgba($shi-red-1, 0.9);
         border: 1px solid $shi-red-2;
 
         color: $body-color;

--- a/app/frontend/stylesheets/local/scihist_viewer.scss
+++ b/app/frontend/stylesheets/local/scihist_viewer.scss
@@ -424,6 +424,7 @@ $scihist_image_viewer_thumb_width: 54px; // Needs to match ImageServiceHelper::T
       box-sizing: content-box;
       background: transparent;
       width: $scihist_image_viewer_thumb_width;
+      position: relative; // for overlay
 
       cursor: pointer;
 
@@ -444,6 +445,29 @@ $scihist_image_viewer_thumb_width: 54px; // Needs to match ImageServiceHelper::T
         background-size: 34px 34px;
         background-clip: content-box;
         background-position: center center;
+      }
+    }
+
+    // data-search-result-count attr indicates search results to show
+    .viewer-thumb[data-search-result-count] {
+      &:after {
+        content: attr(data-search-result-count);
+
+        z-index: 2;
+        position: absolute;
+        //min-width: 56%;
+        top: 50%;
+        left: 50%;
+        transform: translateX(-50%) translateY(-50%);
+
+        background-color: rgba($shi-red-1, 0.8);
+        border: 1px solid $shi-red-2;
+
+        color: $body-color;
+        font-weight: bold;
+        text-align: center;
+        font-size: $scihist_image_viewer_thumb_width * 0.4;
+        padding: 0 0.5em;
       }
     }
   }

--- a/app/frontend/stylesheets/local/scihist_viewer.scss
+++ b/app/frontend/stylesheets/local/scihist_viewer.scss
@@ -453,7 +453,6 @@ $scihist_image_viewer_thumb_width: 54px; // Needs to match ImageServiceHelper::T
       &:after {
         content: attr(data-search-result-count);
 
-        z-index: 2;
         position: absolute;
         //min-width: 56%;
         top: 50%;


### PR DESCRIPTION
Bonus, edit img 'alt' attribute for screen-reader-accessible label with result count in thumb list too

- Viewer, add search result count overlays to thumb list
- viewer, record results on thumbs with screen-reader accessible label too

![Screen Shot 2024-05-23 at 3 28 34 PM](https://github.com/sciencehistory/scihist_digicoll/assets/149304/039b84a8-63a1-481b-8604-9aba115fe554)

