### PR TITLE
Correct calculation of when need to scroll thumbnail list in viewer small screen vertical layout

### DIFF
--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -166,7 +166,8 @@ ScihistImageViewer.prototype.scrollElementIntoView = function(elem, container) {
   var elemLeft = $(elem).offset().left - container.offset().left;
   var elemRight = elemLeft + $(elem).width();
 
-  var isTotal = (elemTop >= 0 && elemBottom <= contHeight && elemLeft >= 0 && elemRight <= contWidth);
+  // Not sure why the +1 correction was needed
+  var isTotal = (elemTop >= 0 && elemBottom <= contHeight+1 && elemLeft >= 0 && elemRight <= contWidth);
 
   if (! isTotal) {
     // We'd love to use smooth scroll, but bug in Chrome where it can't do two


### PR DESCRIPTION
Not sure why we had an off by one error before, and have to add one pixel adjustment. Makes no sense to me, but doens't really hurt, and keeps us from scrolling unnecessarily.

(If in some browsers it avoids scrolling when 1px of the thumbnail is off the screen, that's not really a problem, so.)
