### PR TITLE
update package.json to allow node 22, which is now on my Mac

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "science_history_institute_comment_about_engines" :
     "Heroku installs the latest version of node and yarn that conform to the requirements below. (As of early 2024, Heroku installs node 20.9, and GitHub Actions VMs come with node 18.19. Hence the range of versions below.)",
   "engines": {
-    "node": ">=18.19.0 <21.0.0",
+    "node": ">=18.19.0 <23.0.0",
     "yarn": "^1.22.19"
   }
 }


### PR DESCRIPTION
the Node version on my mac somehow became 22.1.0. Which was not allowed by our package.json. It's fairly new we have our package.json specifying bounds of allowable node versions. I wonder if we want to just let it be unbounded on the upper end after all? We'll see.

But for now, node 22 seems to work fine, update package.json to allow it.
