### PR TITLE
Viewer thumb img needs to be block display to have a defined height to reserve space while loading

### DIFF
--- a/app/frontend/stylesheets/local/scihist_viewer.scss
+++ b/app/frontend/stylesheets/local/scihist_viewer.scss
@@ -438,6 +438,7 @@ $scihist_image_viewer_thumb_width: 54px; // Needs to match ImageServiceHelper::T
       }
 
       img {
+        display: inline-block;
         width: 100%;
       }
 


### PR DESCRIPTION
Bug introduced in refactor at #2630, where image was no longer holding appropriate space on screen when loading.
