### PR TITLE
Reduce amount per zoom unit in OSD

### DIFF
--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -630,6 +630,8 @@ ScihistImageViewer.prototype.initOpenSeadragon = function() {
 
     tabIndex: "",
 
+    zoomPerClick: "1.5", // default 2, zoom slower
+
     preserveImageSizeOnResize: true,
 
     gestureSettingsTouch: {


### PR DESCRIPTION
How much zoom do you get when you click on the image, or click the zoom-in or zoom-out buttons? The default was 2.0 (double), which I thought was actually too much for the use case of finding a comfortable viewing size for text in a scanned image. Changing to 1.5 seems to work better -- so you might have to click a few more times to get to where you want if you really did want a large change, but no big deal.
