### PR TITLE
default feature flag search_inside_work to on

### DIFF
--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -621,7 +621,7 @@ module ScihistDigicoll
     #   ScihistDigicoll::Env.staging? || !Rails.env.production?
     # }, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM
 
-    define_key "feature_search_inside_work", default: false, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM
+    define_key "feature_search_inside_work", default: true, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM
 
     define_key "disable_downloads", default: false, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM
   end


### PR DESCRIPTION
As this is now live in production. Leave it toggle-able, to make ti less likely we'll accidentally toggle off, default on.
