### PR TITLE
Avoid an n+1 query on member.leaf_representative.parent with a pre-load includes

### DIFF
--- a/app/serializers/viewer_member_info_serializer.rb
+++ b/app/serializers/viewer_member_info_serializer.rb
@@ -39,9 +39,9 @@ class ViewerMemberInfoSerializer
 
   def included_members
     @included_members ||= begin
-      members = work.members.order(:position)
+      members = work.members.order(:position).strict_loading
       members = members.where(published: true) unless show_unpublished
-      members.includes(:leaf_representative).select do |member|
+      members.includes(:leaf_representative => :parent).select do |member|
         member.leaf_representative &&
         member.leaf_representative.content_type&.start_with?("image/") &&
         member.leaf_representative.stored?


### PR DESCRIPTION
I noticed in dev console that the action to generate the json for members (to power the viewer), had what looked like an n+1 query. Ended up being... for all emmbers that were _child works_, we'd the code would look at the member's leaf_representative (an asset), then that asset's `parent`... which we in fact already had loaded since that's how we got here, but the model graph didn't know it, and would do a seperate SQL query to fetch the parent.

the query was actually triggered several layers of component down, in ImageDownloadOptions. Rather confusing.

      Kithe::Model Load (0.1ms)  SELECT "kithe_models".* FROM "kithe_models" WHERE "kithe_models"."id" = $1 LIMIT $2  [["id", "1b9c0096-dd3e-4cc8-8e65-19a82c3baacf"], ["LIMIT", 1]]
  ↳ app/presenters/download_options/image_download_options.rb:42:in `options'

But one way to "fix" is to just make sure to pre-load that association in the original fetch, which we do here. We also mark it `strict_loading` on fetch, so if some code does try to access some non-pre-loaded association, it'll raise.

This serialization action is already pretty slow, so seemed wise to fix... although I'm not sure it makes much practical difference or improvement in most cases.

Dealing with "child works" in the architecture continues to be a point of complexity!
