### PR TITLE
update vite-plugin-sass-glob-import to latest, compatible with current vite 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "sass": "^1.55.0",
     "vite": "^5.0.13",
     "vite-plugin-ruby": "^5.0.0",
-    "vite-plugin-sass-glob-import": "^2.0"
+    "vite-plugin-sass-glob-import": "^3.0.2"
   },
   "resolutions": {
     "blacklight-frontend/bootstrap": "^4.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -847,10 +847,10 @@ vite-plugin-ruby@^5.0.0:
     debug "^4.3.4"
     fast-glob "^3.3.2"
 
-vite-plugin-sass-glob-import@^2.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/vite-plugin-sass-glob-import/-/vite-plugin-sass-glob-import-2.0.0.tgz#869671385c5752ac240b1657538dd9ee32efdcfc"
-  integrity sha512-lLeuhgouRveN4aCvyojdTXV0LStLCYa24Zua06N5tw2f0MsQSSwBfC6G/CMdHqidTyX1xHd4luNSkc1uudcxzA==
+vite-plugin-sass-glob-import@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/vite-plugin-sass-glob-import/-/vite-plugin-sass-glob-import-3.0.2.tgz#de932204a66ea287f982bf5637870acfeed453ff"
+  integrity sha512-Tu6M6Fn4pFp1Gsvt+uOKAmPQyspNJSAWKV8GepHGR9Rmx4wujfS0wPjfmVk7QGqD+bSzr+P7L5VGGw9nPgiaMA==
   dependencies:
     ansi-colors "^4.1.3"
     glob "^7.2.0"


### PR DESCRIPTION
Avoid error seen when running `./bin/vite --version` that looked like:

```
npm error code ELSPROBLEMS
npm error invalid: vite@5.0.13 /Users/jrochkind/code/scihist_digicoll/node_modules/vite
npm error A complete log of this run can be found in: /Users/jrochkind/.npm/_logs/2024-07-16T16_11_43_855Z-debug-0.log
installed packages:
scihist_digicoll@ /Users/jrochkind/code/scihist_digicoll
├─┬ vite-plugin-ruby@5.0.0
│ └── vite@5.0.13 deduped
├─┬ vite-plugin-sass-glob-import@2.0.0
│ └── vite@5.0.13 deduped invalid: "^3.0.0 || ^4.0.0" from node_modules/vite-plugin-sass-glob-import
└── vite@5.0.13 invalid: "^3.0.0 || ^4.0.0" from node_modules/vite-plugin-sass-glob-import
```
