### PR TITLE
Enable YJIT in Ruby 3.3

### DIFF
--- a/config/initializers/enable_yjit.rb
+++ b/config/initializers/enable_yjit.rb
@@ -1,0 +1,12 @@
+# Automatically enable YJIT if running Ruby 3.3 or newer,
+# as it brings very sizeable performance improvements.
+# Many users reported 15-25% improved latency.
+
+# If you are deploying to a memory-constrained environment,
+# you may want to delete this file, but otherwise, it's free
+# performance.
+if defined? RubyVM::YJIT.enable
+  Rails.application.config.after_initialize do
+    RubyVM::YJIT.enable
+  end
+end


### PR DESCRIPTION
The ruby YJIT just-in-time compiler improves speed of execution, at some cost of increased RAM. In Ruby 3.3 it is very mature and effective, and being used by others in production.

Since we switched to a performance-l dyno, we have plenty of RAM headroom, so there's no need to even worry about increased RAM usage.  Looking at dashboard currently, over past 7 days we used max 4GB out of 14GB available!  (We have enough processes to use all cpu's on performance-l, but due to copy-on-write RAM efficiencies that leaves us plenty of RAM headroom).

This particular initializer file to turn on YJIT will be default in new apps created with Rails 7.2, and was copied from there.  https://github.com/rails/rails/pull/49947

