### PR TITLE
Add type=module to package.json to avoid vite deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "scihist_digicoll",
   "private": true,
+  "type": "module",
   "dependencies": {
     "@nathanvda/cocoon": "^1.2.14",
     "@rails/ujs": "^ 6.1.7",


### PR DESCRIPTION
Previous saw this in vite build:

```
The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.
```

Changing package.json to default to type module seems like the current best practice, and fixes this warning, and our JS still builds appropriately.

See https://github.com/ElMassimo/vite_ruby/issues/431
