### PR TITLE
update rexml to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -590,8 +590,8 @@ GEM
       rake (>= 10.0, < 14.0)
       resque (>= 1.22, < 3)
     retriable (3.1.2)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.2)
+      strscan
     rinku (2.0.6)
     roda (3.80.0)
       rack


### PR DESCRIPTION
just with

     bundle update rexml

then commit Gemfile.lock

Per dependabot warning that we needed to upgrade to get a new rexml, but dependabot for some reason was unable to PR the update itself in this case. But this is the version depandabot wanted, 3.3.2.
