### PR TITLE
scihist:solr_cloud:create_collection rake task can handle an already existing configset, and use that

### DIFF
--- a/lib/tasks/solr_cloud.rake
+++ b/lib/tasks/solr_cloud.rake
@@ -12,7 +12,15 @@ namespace :scihist do
     task :create_collection => :environment do
       updater = SolrConfigsetUpdater.configured
 
-      updater.upload_and_create_collection(configset_name: updater.configset_digest_name)
+      configset_name = updater.configset_digest_name
+
+      # if configset name already exists, assume it's the one we want, since we put
+      # a digest value in configset name, it ought to be! If it's not, we need to upload it
+      unless updater.list.include?(configset_name)
+        updater.upload(configset_name: configset_name)
+      end
+
+      updater.create_collection(configset_name: configset_name)
     end
 
     desc "upload configset and (re-)attach to collection, only if it is not already up to date"


### PR DESCRIPTION
Normally doesn't happen, but ran into that state when trying delete and re-create a collection in #2683

So this makes this task more resilient to that condition, so it does what it needs even when we're in that state trying to deal with a problem!

It's okay to assume an existing configset with same name is the same configset, because we put a digest code into config set name. If you need more precise things, like manualy deleting the config set instead of re-using it, you just gotta open a console and use SolrConfigsetUpdater helper directly.
