### PR TITLE
Get sitemap URL to go through cloudfront

### DIFF
--- a/app/views/application/robots.text.erb
+++ b/app/views/application/robots.text.erb
@@ -1,6 +1,6 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 
-<% if true || ScihistDigicoll::Env.production? %>
+<% if ScihistDigicoll::Env.production? %>
 # Link to sitemap
 Sitemap: https://<%= ScihistDigicoll::Env.lookup("s3_sitemap_bucket_host") %>/<%= ScihistDigicoll::Env.lookup("sitemap_path") %>sitemap.xml.gz
 

--- a/app/views/application/robots.text.erb
+++ b/app/views/application/robots.text.erb
@@ -1,8 +1,8 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 
-<% if ScihistDigicoll::Env.production? %>
+<% if true || ScihistDigicoll::Env.production? %>
 # Link to sitemap
-Sitemap: https://s3.amazonaws.com/<%= ScihistDigicoll::Env.lookup("s3_sitemap_bucket") %>/<%= ScihistDigicoll::Env.lookup("sitemap_path") %>sitemap.xml.gz
+Sitemap: https://<%= ScihistDigicoll::Env.lookup("s3_sitemap_bucket_host") %>/<%= ScihistDigicoll::Env.lookup("sitemap_path") %>sitemap.xml.gz
 
 # Disallow some sort of search 'extra' that there is really no reason to be web crawling.
 # Both from /catalog, and off various /collections/$collection_id pages.

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -25,7 +25,9 @@ unless $force_local_sitemap_generation
     aws_access_key_id: ScihistDigicoll::Env.lookup!("aws_access_key_id"),
     aws_secret_access_key: ScihistDigicoll::Env.lookup!("aws_secret_access_key"),
     aws_region: ScihistDigicoll::Env.lookup!("aws_region"),
-    acl: '' # parent default public ACL would be rejectec by our S3 bucket, now fronted by cloudfront
+    acl: '', # parent default public ACL would be rejectec by our S3 bucket, now fronted by cloudfront
+    # while we only re-gen once a day, we don't want lag time. Let cloudfront cache 10 minutes.
+    cache_control: 'max-age=600, public'
   )
 end
 

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -24,7 +24,8 @@ unless $force_local_sitemap_generation
     ScihistDigicoll::Env.lookup!("s3_sitemap_bucket"),
     aws_access_key_id: ScihistDigicoll::Env.lookup!("aws_access_key_id"),
     aws_secret_access_key: ScihistDigicoll::Env.lookup!("aws_secret_access_key"),
-    aws_region: ScihistDigicoll::Env.lookup!("aws_region")
+    aws_region: ScihistDigicoll::Env.lookup!("aws_region"),
+    acl: '' # parent default public ACL would be rejectec by our S3 bucket, now fronted by cloudfront
   )
 end
 

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -285,6 +285,10 @@ module ScihistDigicoll
       # for now we keep Google sitemaps in our derivatives bucket
       ScihistDigicoll::Env.lookup(:s3_bucket_derivatives)
     }
+    define_key :s3_sitemap_bucket_host, default: -> {
+      # hacky way to deal with the fact that we need to use the cloudfront host as public host
+      ScihistDigicoll::Env.lookup(:s3_bucket_derivatives_host)
+    }
     define_key :sitemap_path, default: "__sitemaps/"
 
 


### PR DESCRIPTION
Sitemap is stored on derivatives, which is no longer directly accessible, we need to access it thorugh cloudfront, and tell crawlers to do such.

This is a quick and easy way to do so, just add another config variable. "Cleaner" would be using a shrine storage or something, but that would require more refacotring and you know what this is good enough.

Also ensure code does not try to store generated sitemap with public S3 ACL, as our S3 bucket will now reject that!

And let cloudfront cache for 10 minutes, instead of the default from SiteMap gem of no caching. 
