### PR TITLE
Include parents and collections when looking for finding aids

### DIFF
--- a/app/components/work_show_info_component.rb
+++ b/app/components/work_show_info_component.rb
@@ -20,7 +20,7 @@ class WorkShowInfoComponent < ApplicationComponent
     :contained_by, :date_of_work, :department,
     :description, :digitization_funder, :extent,
     :format, :genre, :inscription, :language, :medium,
-    :parent, :physical_container, :provenance, :published?,
+    :parent, :physical_container, :provenance, :pblished?,
     :rights, :rights_holder, :series_arrangement,
     :source, :subject, :title, to: :work
 
@@ -60,8 +60,13 @@ class WorkShowInfoComponent < ApplicationComponent
     @links_to_opac
   end
 
+
+  # We look these up via the collection and its related links.
   def links_to_finding_aids
-    @links_to_finding_aids ||= related_link_filter.finding_aid_related_links.collect(&:url).compact
+    @links_to_finding_aids ||= begin
+      collections =  @work.contained_by
+      collections.map { |col| col.related_link.select { |rl| rl.category == "finding_aid" }.map { |rl| rl.url } }.flatten
+    end
   end
 
   # Our creators are a list of Work::Creator object. We want to group them by

--- a/app/components/work_show_info_component.rb
+++ b/app/components/work_show_info_component.rb
@@ -20,7 +20,7 @@ class WorkShowInfoComponent < ApplicationComponent
     :contained_by, :date_of_work, :department,
     :description, :digitization_funder, :extent,
     :format, :genre, :inscription, :language, :medium,
-    :parent, :physical_container, :provenance, :pblished?,
+    :parent, :physical_container, :provenance, :published?,
     :rights, :rights_holder, :series_arrangement,
     :source, :subject, :title, to: :work
 

--- a/spec/components/work_show_info_component_spec.rb
+++ b/spec/components/work_show_info_component_spec.rb
@@ -27,4 +27,28 @@ describe WorkShowInfoComponent, type: :component do
       expect(page).to have_text(/Exhibited in\s+#{exhibition.title}/)
     end
   end
+
+  context "Collection finding aids for archives works" do
+    let(:coll_finding_aid) { RelatedLink.new(category: "finding_aid", url: "https://example.com/coll")}
+    let(:work_finding_aid) { RelatedLink.new(category: "finding_aid", url: "https://example.com/work")}
+    let!(:other_related_link)  { RelatedLink.new(category: "other_external", url: "https://example.com/other")}
+
+    let(:collection) { build(:collection, related_link: [coll_finding_aid, work_finding_aid ]) }
+    let(:work) { create(:public_work, :with_complete_metadata,
+      contained_by: [collection], related_link: [work_finding_aid, other_related_link]
+    )}
+
+    it "lists finding aid attached directly to the work as well as finding aid attached to the collection" do
+      component = WorkShowInfoComponent.new(work: work)
+      expect(component.links_to_finding_aids.to_a.sort).to eq([coll_finding_aid.url, work_finding_aid.url])
+    end
+
+    context "child work" do
+      let (:child) { create(:public_work, parent: work, title: "child") }
+      it "checks the parent work and its collection" do
+        component = WorkShowInfoComponent.new(work: child)
+        expect(component.links_to_finding_aids.to_a.sort).to eq([coll_finding_aid.url, work_finding_aid.url])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Part of Ref #2627 

See in particular https://github.com/sciencehistory/scihist_digicoll/issues/2627#issuecomment-2274186057 which spells out the metadata guidelines for which works have and don't have finding aid metadata directly attached to them.