### PR TITLE
Add some PDF-specific technical metadata in admin screen

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,7 +346,7 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    kithe (2.13.0)
+    kithe (2.14.0)
       attr_json (~> 2.0)
       fastimage (~> 2.0)
       fx (>= 0.6.0, < 1)

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -350,6 +350,20 @@
           <%= @exiftool_result.camera_iso %>
         </dd>
       <% end %>
+
+      <% if @exiftool_result.pdf_version.present? %>
+        <dt class="col-sm-4">PDF Version</dt>
+        <dd class="col-sm-8">
+          <%= @exiftool_result.pdf_version %>
+        </dd>
+      <% end %>
+
+      <% if @exiftool_result.page_count.present? %>
+        <dt class="col-sm-4">Page Count</dt>
+        <dd class="col-sm-8">
+          <%= @exiftool_result.page_count %>
+        </dd>
+      <% end %>
     </dl>
 
     <h2 class="mt-4">Derivatives</h2>


### PR DESCRIPTION
From EXIF data, added recognition to kithe 2.14, https://github.com/sciencehistory/kithe/pull/180
