### PR TITLE
PopplerBboxToHocr object to convert from poppler pdftotext bbox-layout to hocr

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -264,3 +264,5 @@ end
 # Barnes reports Ruby runtime metrics to Heroku, where we can monitor them.
 # See https://devcenter.heroku.com/articles/language-runtime-metrics-ruby
 gem "barnes"
+
+gem 'equivalent-xml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,6 +249,8 @@ GEM
       oauth2 (~> 1.1)
     dry-cli (1.0.0)
     dumb_delegator (1.0.0)
+    equivalent-xml (0.6.0)
+      nokogiri (>= 1.4.3)
     erubi (1.12.0)
     ethon (0.16.0)
       ffi (>= 1.15.0)
@@ -797,6 +799,7 @@ DEPENDENCIES
   db-query-matchers (< 2.0)
   device_detector (~> 1.0)
   devise (~> 4.5)
+  equivalent-xml
   factory_bot_rails
   faraday (~> 2.0)
   faraday-retry (~> 2.0)

--- a/app/services/poppler_bbox_to_hocr.rb
+++ b/app/services/poppler_bbox_to_hocr.rb
@@ -46,11 +46,14 @@
 class PopplerBboxToHocr
   XHTML_NS = "http://www.w3.org/1999/xhtml"
 
-  attr_reader :xml, :dpi
+  attr_reader :xml, :dpi, :meta_tags
 
-  def initialize(bbox_string, dpi: nil)
+  # @param meta_tags [Hash] if you'd like to insert additional <meta> tags into the hocr output,
+  #                         pass in hash with key 'name' attribute and value `content' attribute.
+  def initialize(bbox_string, dpi: nil, meta_tags: {})
     @xml = Nokogiri::XML(bbox_string)
     @dpi = dpi
+    @meta_tags = meta_tags
 
     @page_id_counter = 0
     @block_id_counter = 0
@@ -132,6 +135,18 @@ class PopplerBboxToHocr
       word_node["class"] = "ocrx_word"
       word_node["id"] = "word_#{@page_id_counter}_#{@word_id_counter += 1}"
       word_node["title"] = bbox
+    end
+
+    # add meta tags
+    if meta_tags.present?
+      head = xml.at_xpath("//x:head", x: XHTML_NS)
+      meta_tags.each do |name, content|
+        meta = h3 = Nokogiri::XML::Node.new "meta", xml
+        meta["name"] = name
+        meta["content"] = content
+        head.add_child(meta)
+        head.add_child("\n")
+      end
     end
   end
 

--- a/app/services/poppler_bbox_to_hocr.rb
+++ b/app/services/poppler_bbox_to_hocr.rb
@@ -1,0 +1,135 @@
+# The poppler `pdftotext` command can extract text from a PDF, with "bbox-layout" info. This is similar to HOCR
+# format, but not exactly the same.
+#
+# This class can translate from poppler bbox output to HOCR, specifically HOCR matching the struture
+# tesseract 5.x creates (differnet tools create different kinds of HOCR!)
+#
+# Eg, output of poppler tool from pdftotext with -bbox-layout (not just -bbox!)
+#
+#     pdftotext -bbox-layout file.pdf -f $FIRST_PAGE -l $LAST_PAGE output.bbox.xml
+#
+# Converts to something SIMILAR to what you'd get from tesseract with:
+#
+#     tesseract file.tiff outputfile  -l eng hocr
+#
+#   * It has less info, because some things tesseract includes are not applicable or not available, but
+#     should use the same tags for the info there.
+#
+#   * Specifically, pdftotext does not do paragraph segmentation, so our output will not have
+#     <p class='ocr_par'> tags
+#
+#
+# For example intput and output see specs
+#
+class PopplerBboxToHocr
+  XHTML_NS = "http://www.w3.org/1999/xhtml"
+
+  attr_reader :xml
+
+  def initialize(bbox_string)
+    @xml = Nokogiri::XML(bbox_string)
+
+    @page_id_counter = 0
+    @block_id_counter = 0
+    @par_id_counter = 0
+    @line_id_counter = 0
+    @word_id_counter = 0
+  end
+
+  def transformed_to_hocr_nokogiri
+    @transformed ||= begin
+      transform!
+      @xml
+    end
+  end
+
+  def transformed_to_hocr
+    transformed_to_hocr_nokogiri.to_xml
+  end
+
+  protected
+
+  def transform!
+    xml.encoding = 'UTF-8'
+
+    # # just remove doc tag
+    unwrap!("//x:doc", { x: XHTML_NS })
+
+    xml.xpath("//x:page", x: XHTML_NS).each do |page_node|
+      width = page_node["width"].to_f
+      height = page_node["height"].to_f
+
+      remove_all_attributes!(page_node)
+
+      page_node.name = "div"
+      page_node["class"] = "ocr_page"
+      page_node["id"] = "page_#{@page_id_counter += 1}"
+      page_node["title"] = "bbox 0 0 #{width.round} #{height.round}"
+    end
+
+    # # remove it and just unwrap it's children, no equiv in tesseract hocr
+    unwrap!("//x:flow", { x: XHTML_NS })
+
+    # block goes to ocr_carea to match tesseract, although some think this is
+    # a tesseract bug and it shoudl be ocrx_block
+    # https://groups.google.com/g/tesseract-ocr/c/djenIdI5EbI
+    xml.xpath("//x:block", x: XHTML_NS).each do |block_node|
+      bbox = hocr_bbox_from(block_node)
+
+      remove_all_attributes!(block_node)
+
+      block_node.name = "div"
+      block_node["class"] = "ocr_carea"
+      block_node["id"] = "block_#{@page_id_counter}_#{@block_id_counter += 1}"
+      block_node["title"] = bbox
+    end
+
+    xml.xpath("//x:line", x: XHTML_NS).each do |line_node|
+      bbox = hocr_bbox_from(line_node)
+
+      remove_all_attributes!(line_node)
+
+      line_node.name = "div"
+      line_node["class"] = "ocr_line"
+      line_node["id"] = "line_#{@page_id_counter}_#{@line_id_counter += 1}"
+      line_node["title"] = bbox
+    end
+
+    xml.xpath("//x:word", x: XHTML_NS).each do |word_node|
+      bbox = hocr_bbox_from(word_node)
+
+      remove_all_attributes!(word_node)
+
+      word_node.name = "div"
+      word_node["class"] = "ocrx_word"
+      word_node["id"] = "word_#{@page_id_counter}_#{@word_id_counter += 1}"
+      word_node["title"] = bbox
+    end
+  end
+
+  # takes a poppler node with attributes xMin, yMin, xMax, and yMax
+  #
+  # converts to an hocr bbox label.
+  #
+  # Rounds to nearest integer pixel.
+  #
+  def hocr_bbox_from(block_node)
+    xMin, yMin, xMax, yMax = block_node['xMin'].to_f, block_node['yMin'].to_f, block_node['xMax'].to_f, block_node['yMax'].to_f
+
+    "bbox #{xMin.round} #{yMin.round} #{xMax.round} #{yMax.round}"
+  end
+
+  def remove_all_attributes!(node)
+    node.attributes.keys.each {|k| node.remove_attribute(k) }
+  end
+
+  # remove matching nodes, unwrapping their children to be directly in the doc
+  def unwrap!(selector, ns)
+    xml.xpath(selector, **ns).each do |node|
+      node.children.each do |child|
+        child.parent = node.parent
+      end
+      node.remove
+    end
+  end
+end

--- a/spec/services/poppler_bbox_to_hocr_spec.rb
+++ b/spec/services/poppler_bbox_to_hocr_spec.rb
@@ -12,4 +12,16 @@ describe PopplerBboxToHocr do
 
     expect(out).to be_equivalent_to(sample_output).respecting_element_order
   end
+
+  describe "dpi conversion" do
+    let(:dpi) { 300 }
+    let(:sample_output) { File.read(Rails.root + "spec/test_support/hocr_xml/extract_from_pdf_sample.300.hocr") }
+
+    it "translates to correct dpi pixels" do
+      obj = PopplerBboxToHocr.new(sample_input, dpi: dpi)
+      out = obj.transformed_to_hocr
+
+      expect(out).to be_equivalent_to(sample_output).respecting_element_order
+    end
+  end
 end

--- a/spec/services/poppler_bbox_to_hocr_spec.rb
+++ b/spec/services/poppler_bbox_to_hocr_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+#require 'equivalent-xml'
+
+
+describe PopplerBboxToHocr do
+  let(:sample_input) { File.read(Rails.root + "spec/test_support/hocr_xml/extract_from_pdf_sample.bbox") }
+  let(:sample_output) { File.read(Rails.root + "spec/test_support/hocr_xml/extract_from_pdf_sample.72.hocr") }
+
+  it "translates to expected output" do
+    obj = PopplerBboxToHocr.new(sample_input)
+    out = obj.transformed_to_hocr
+
+    expect(out).to be_equivalent_to(sample_output).respecting_element_order
+  end
+end

--- a/spec/services/poppler_bbox_to_hocr_spec.rb
+++ b/spec/services/poppler_bbox_to_hocr_spec.rb
@@ -24,4 +24,24 @@ describe PopplerBboxToHocr do
       expect(out).to be_equivalent_to(sample_output).respecting_element_order
     end
   end
+
+  describe "additional meta tags" do
+    let(:meta_tags) do
+      {
+         "Command-line" => "pdftotext something",
+         "Pdftotext-version" => "pdftotext version 24.04.0",
+         "Process" => "via extracted digital PDF text"
+      }
+    end
+
+    it "are added" do
+      obj = PopplerBboxToHocr.new(sample_input, meta_tags: meta_tags)
+      out = obj.transformed_to_hocr_nokogiri
+      out.remove_namespaces!
+
+      meta_tags.each do |name, content|
+        expect(out.at_xpath("//meta[@name='#{name}'][@content='#{content}']")).to be_present, "<meta name='#{name}' content='#{content}'>"
+      end
+    end
+  end
 end

--- a/spec/test_support/hocr_xml/extract_from_pdf_sample.300.hocr
+++ b/spec/test_support/hocr_xml/extract_from_pdf_sample.300.hocr
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <!-- somehow can't stop nokogiri from adding meta http-equiv, even though we don't really want it
+       https://github.com/sparklemotion/nokogiri/discussions/3302 -->
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title></title>
+  <meta name="Creator" content="Adobe InDesign 14.0 (Macintosh)"/>
+  <meta name="Producer" content="Adobe PDF Library 15.0"/>
+  <meta name="CreationDate" content="2019-12-11T15:41:24-05"/>
+  <meta name="ModDate" content="2019-12-11T15:42:08-05"/>
+ </head>
+ <body>
+  <div class='ocr_page' id='page_1' title='bbox 0 0 5250 3225'>
+    <div class="ocr_carea" id="block_1_1" title="bbox 954 1151 1672 1841">
+      <div class="ocr_line" id="line_1_1" title="bbox 954 1151 1671 1191">
+        <div class="ocrx_word" id="word_1_1" title="bbox 954 1151 1021 1191">Paul</div>
+        <div class="ocrx_word" id="word_1_2" title="bbox 1032 1151 1174 1191">Langevin</div>
+        <div class="ocrx_word" id="word_1_3" title="bbox 1185 1151 1243 1191">and</div>
+        <div class="ocrx_word" id="word_1_4" title="bbox 1254 1151 1406 1191">published</div>
+        <div class="ocrx_word" id="word_1_5" title="bbox 1417 1151 1490 1191">their</div>
+        <div class="ocrx_word" id="word_1_6" title="bbox 1501 1151 1608 1191">private</div>
+        <div class="ocrx_word" id="word_1_7" title="bbox 1619 1151 1671 1191">let-</div>
+      </div>
+      <div class="ocr_line" id="line_1_2" title="bbox 954 1201 1672 1241">
+        <div class="ocrx_word" id="word_1_8" title="bbox 954 1201 1018 1241">ters.</div>
+        <div class="ocrx_word" id="word_1_9" title="bbox 1032 1201 1193 1241">Langevin’s</div>
+        <div class="ocrx_word" id="word_1_10" title="bbox 1208 1201 1272 1241">wife</div>
+        <div class="ocrx_word" id="word_1_11" title="bbox 1287 1201 1452 1241">threatened</div>
+        <div class="ocrx_word" id="word_1_12" title="bbox 1467 1201 1498 1241">to</div>
+        <div class="ocrx_word" id="word_1_13" title="bbox 1513 1201 1562 1241">kill</div>
+        <div class="ocrx_word" id="word_1_14" title="bbox 1577 1201 1672 1241">Curie,</div>
+      </div>
+      <div class="ocr_line" id="line_1_3" title="bbox 954 1251 1671 1291">
+        <div class="ocrx_word" id="word_1_15" title="bbox 954 1251 1012 1291">and</div>
+        <div class="ocrx_word" id="word_1_16" title="bbox 1021 1251 1163 1291">Langevin</div>
+        <div class="ocrx_word" id="word_1_17" title="bbox 1172 1251 1285 1291">himself</div>
+        <div class="ocrx_word" id="word_1_18" title="bbox 1295 1251 1459 1291">challenged</div>
+        <div class="ocrx_word" id="word_1_19" title="bbox 1468 1251 1517 1291">the</div>
+        <div class="ocrx_word" id="word_1_20" title="bbox 1526 1251 1671 1291">publisher</div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/spec/test_support/hocr_xml/extract_from_pdf_sample.72.hocr
+++ b/spec/test_support/hocr_xml/extract_from_pdf_sample.72.hocr
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <!-- somehow can't stop nokogiri from adding meta http-equiv, even though we don't really want it
+       https://github.com/sparklemotion/nokogiri/discussions/3302 -->
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title></title>
+  <meta name="Creator" content="Adobe InDesign 14.0 (Macintosh)"/>
+  <meta name="Producer" content="Adobe PDF Library 15.0"/>
+  <meta name="CreationDate" content="2019-12-11T15:41:24-05"/>
+  <meta name="ModDate" content="2019-12-11T15:42:08-05"/>
+ </head>
+ <body>
+  <div class='ocr_page' id='page_1' title='bbox 0 0 1260 774'>
+    <div class="ocr_carea" id="block_1_1" title="bbox 229 276 401 442">
+     <div class="ocr_line" id="line_1_1" title="bbox 229 276 401 286">
+       <div class="ocrx_word" id="word_1_1" title="bbox 229 276 245 286">Paul</div>
+       <div class="ocrx_word" id="word_1_2" title="bbox 248 276 282 286">Langevin</div>
+       <div class="ocrx_word" id="word_1_3" title="bbox 284 276 298 286">and</div>
+       <div class="ocrx_word" id="word_1_4" title="bbox 301 276 337 286">published</div>
+       <div class="ocrx_word" id="word_1_5" title="bbox 340 276 358 286">their</div>
+       <div class="ocrx_word" id="word_1_6" title="bbox 360 276 386 286">private</div>
+       <div class="ocrx_word" id="word_1_7" title="bbox 389 276 401 286">let-</div>
+     </div>
+     <div class="ocr_line" id="line_1_2" title="bbox 229 288 401 298">
+       <div class="ocrx_word" id="word_1_8" title="bbox 229 288 244 298">ters.</div>
+       <div class="ocrx_word" id="word_1_9" title="bbox 248 288 286 298">Langevin’s</div>
+       <div class="ocrx_word" id="word_1_10" title="bbox 290 288 305 298">wife</div>
+       <div class="ocrx_word" id="word_1_11" title="bbox 309 288 348 298">threatened</div>
+       <div class="ocrx_word" id="word_1_12" title="bbox 352 288 360 298">to</div>
+       <div class="ocrx_word" id="word_1_13" title="bbox 363 288 375 298">kill</div>
+       <div class="ocrx_word" id="word_1_14" title="bbox 378 288 401 298">Curie,</div>
+     </div>
+     <div class="ocr_line" id="line_1_3" title="bbox 229 300 401 310">
+       <div class="ocrx_word" id="word_1_15" title="bbox 229 300 243 310">and</div>
+       <div class="ocrx_word" id="word_1_16" title="bbox 245 300 279 310">Langevin</div>
+       <div class="ocrx_word" id="word_1_17" title="bbox 281 300 308 310">himself</div>
+       <div class="ocrx_word" id="word_1_18" title="bbox 311 300 350 310">challenged</div>
+       <div class="ocrx_word" id="word_1_19" title="bbox 352 300 364 310">the</div>
+       <div class="ocrx_word" id="word_1_20" title="bbox 366 300 401 310">publisher</div>
+     </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/spec/test_support/hocr_xml/extract_from_pdf_sample.bbox
+++ b/spec/test_support/hocr_xml/extract_from_pdf_sample.bbox
@@ -1,0 +1,44 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title></title>
+<meta name="Creator" content="Adobe InDesign 14.0 (Macintosh)"/>
+<meta name="Producer" content="Adobe PDF Library 15.0"/>
+<meta name="CreationDate" content="2019-12-11T15:41:24-05"/>
+<meta name="ModDate" content="2019-12-11T15:42:08-05"/>
+</head>
+<body>
+<doc>
+  <page width="1260.000000" height="774.000000">
+    <flow>
+      <block xMin="228.900000" yMin="276.162000" xMax="401.377550" yMax="441.930000">
+        <line xMin="228.900000" yMin="276.162000" xMax="401.100050" yMax="285.930000">
+          <word xMin="228.900000" yMin="276.162000" xMax="245.097675" yMax="285.930000">Paul</word>
+          <word xMin="247.752425" yMin="276.162000" xMax="281.772075" yMax="285.930000">Langevin</word>
+          <word xMin="284.426825" yMin="276.162000" xMax="298.394325" yMax="285.930000">and</word>
+          <word xMin="301.049075" yMin="276.162000" xMax="337.467250" yMax="285.930000">published</word>
+          <word xMin="340.122000" yMin="276.162000" xMax="357.642425" yMax="285.930000">their</word>
+          <word xMin="360.297175" yMin="276.162000" xMax="385.951125" yMax="285.930000">private</word>
+          <word xMin="388.605875" yMin="276.162000" xMax="401.100050" yMax="285.930000">let-</word>
+        </line>
+        <line xMin="228.900000" yMin="288.162000" xMax="401.353300" yMax="297.930000">
+          <word xMin="228.900000" yMin="288.162000" xMax="244.415025" yMax="297.930000">ters.</word>
+          <word xMin="247.719125" yMin="288.162000" xMax="286.346200" yMax="297.930000">Langevin’s</word>
+          <word xMin="289.925950" yMin="288.162000" xMax="305.391025" yMax="297.930000">wife</word>
+          <word xMin="308.970775" yMin="288.162000" xMax="348.433125" yMax="297.930000">threatened</word>
+          <word xMin="352.012875" yMin="288.162000" xMax="359.562725" yMax="297.930000">to</word>
+          <word xMin="363.142475" yMin="288.162000" xMax="374.842800" yMax="297.930000">kill</word>
+          <word xMin="378.422550" yMin="288.162000" xMax="401.353300" yMax="297.930000">Curie,</word>
+        </line>
+        <line xMin="228.900000" yMin="300.162000" xMax="401.114650" yMax="309.930000">
+          <word xMin="228.900000" yMin="300.162000" xMax="242.867500" yMax="309.930000">and</word>
+          <word xMin="245.022750" yMin="300.162000" xMax="279.041475" yMax="309.930000">Langevin</word>
+          <word xMin="281.196725" yMin="300.162000" xMax="308.456475" yMax="309.930000">himself</word>
+          <word xMin="310.887375" yMin="300.162000" xMax="350.247050" yMax="309.930000">challenged</word>
+          <word xMin="352.402300" yMin="300.162000" xMax="364.075800" yMax="309.930000">the</word>
+          <word xMin="366.231050" yMin="300.162000" xMax="401.114650" yMax="309.930000">publisher</word>
+        </line>
+    </flow>
+  </page>
+</doc>
+</body>
+</html>


### PR DESCRIPTION
Part of #2492, submitting as it's own self-contained thing for easier review!

Converts the output of poppler `pdftotext -bbox-layout` (which is similar to Hocr but not quite) to hocr matching what tesseract outputs (including idiosyncracies of tesseract). 

Tested manually and verified this hocr can be succesfully used to power our viewer search inside the book, hooray. 

So one piece of the project. 

- Basic PopplerBboxToHocr
- PopplerBboxToHocr supports DPI conversion
- PopplerBboxToHocr supports inserting additional meta tags into hocr
