### PR TITLE
Block accidental JPEGs from publication

### DIFF
--- a/spec/controllers/admin/works_controller_spec.rb
+++ b/spec/controllers/admin/works_controller_spec.rb
@@ -122,16 +122,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
   end
 
   context "#batch_publish_toggle", logged_in_user: :admin do
-    let(:representative) {
-      create(
-        :asset,
-        :inline_promoted_file,
-        file: File.open('spec/test_support/images/mini_page_scan.tiff'),
-        published:true
-      )
-    }
-
-    
+    let(:representative) {  build(:asset_with_faked_file, :tiff, published: true)}
     let(:publishable_work) { create(:work, :with_complete_metadata, published: false, members: [representative], representative: representative) }
     let(:unpublishable_work) { create(:work, published: false) }
 


### PR DESCRIPTION
Ref #2407 .

All image assets in the digital collections should be TIFFs except if they are portraits or collection thumbnails.

Otherwise stated:
**IF** you're publishing, or bulk publishing, a work or set of works,
**AND** one of their members is an asset with an image file attached,
**AND** the asset is not a tiff,
**AND** the asset is not a portrait,
**THEN** we you may not publish the work.

I'm putting this code in an existing method, `works_with_members_with_invalid_files`, modifying the method slightly.

Note that our commonly-used factory call, `build(:asset_with_faked_file)` actually uses a `.png` as its default file, and thus breaks the new rule. Turns out this isn't such a big deal; only a few tests need to be adjusted.