### PR TITLE
Report search-inside-the-book event to google analytics

### DIFF
--- a/app/frontend/javascript/custom_google_analytics_4_events.js
+++ b/app/frontend/javascript/custom_google_analytics_4_events.js
@@ -1,28 +1,67 @@
 // Send a custom Google Analytics event with data-attributes on a link.
 // Details about migrating to the GA4 event tracker are here:
 // https://developers.google.com/analytics/devguides/migration/ua/analyticsjs-to-gtagjs#measure_events_with_the_default_tracker
-// Note that app/frontend/javascript/custom_google_analytics_universal_events.js
-// contains a method that is trigged by the same click.
+
+
+// The easiest way to do this is to add an argument like:
+// data: {
+//   'analytics-category' => 'Work',
+//   'analytics-action' => "transcription_pdf",
+//   'analytics-label' => work.friendlier_id
+// }
+// to a call to `link_to`.
+
+
+// You can also:
+// import reportEventToGA from '../frontend/javascript/custom_google_analytics_4_events';
+// and then just call the reportEventToGA directly (see scihist_viewer.js for an example.)
+
+
 $(document).on('click', '*[data-analytics-category]', function(e) {
+  reportEventToGA(
+    e.target.getAttribute("data-analytics-action"),   // action
+    e.target.getAttribute("data-analytics-category"), // category
+    e.target.getAttribute("data-analytics-label"),    // label
+    e.target.getAttribute("data-analytics-value"),    // value
+  );
+});
+
+
+
+export default function reportEventToGA(action, category, label, value) {
+
+  if (action == null) {
+    return;
+  }
+
+  // alert("Reporting to GA. action is " + action + " and category is " + category + " and label is " + label + " and value is " + value + "!");
 
   // Do not call `gtag` unless the function is defined
   // in app/views/layouts/_google_analytics_4.html.erb .
   // (This in turn is controlled by ScihistDigicoll::Env.lookup(:google_analytics_4_tag_id).
-  if (typeof gtag === 'function') {
+  if (typeof gtag !== 'function') {
+    return;
+  }
 
+  
     gtag( 'event',
-
-      // param eventName
+      
       // A string describing what the user did,
-      // e.g. "download" or "transcription_pdf" or "english_translation_pdf" or "download_original"
-      e.target.getAttribute("data-analytics-action"),
+      // e.g. "download" or "transcription_pdf" or "english_translation_pdf" or "download_original" or "search_inside"
+      action,
+
       {
-        // As of early 2023, this is always the string "work".
-        'event_category': e.target.getAttribute("data-analytics-category"),
-        // As of early 2023, this is always the work's friendlier_id.
-        'event_label':    e.target.getAttribute("data-analytics-label"),
+        // As of 2024, this is always the string "work".
+        'event_category': category,
+
+        // As of 2024, this is always the work's friendlier_id.
+        'event_label':   label,
+
+        // As of 2024 this is only used to send the search phrase in app/frontend/javascript/scihist_viewer.js .
+        // The rest of the time we've just left it null.
+        'event_value':    value
       }
 
     );
-  }
-});
+  
+}

--- a/app/frontend/javascript/custom_google_analytics_4_events.js
+++ b/app/frontend/javascript/custom_google_analytics_4_events.js
@@ -6,35 +6,38 @@
 // The easiest way to do this is to add an argument like:
 // data: {
 //   'analytics-category' => 'Work',
-//   'analytics-action' => "transcription_pdf",
-//   'analytics-label' => work.friendlier_id
+//   'analytics-action' =>   "transcription_pdf",
+//   'analytics-label' =>    work.friendlier_id,
+//   'analytics-value' =>    search_phrase
 // }
-// to a call to `link_to`.
+// to any call to `link_to`.
 
 
-// You can also:
-// import reportEventToGA from '../frontend/javascript/custom_google_analytics_4_events';
-// and then just call the reportEventToGA directly (see scihist_viewer.js for an example.)
+// To report an event to Google Analytics directly from arbitrary JS code, use:
+//
+// import { reportEventToGA } from '../javascript/custom_google_analytics_4_events';
+// [...]
+// reportEventToGA('search_inside', 'work', this.workId, query);
+//
+// See scihist_viewer.js for an example.
 
 
 $(document).on('click', '*[data-analytics-category]', function(e) {
   reportEventToGA(
-    e.target.getAttribute("data-analytics-action"),   // action
-    e.target.getAttribute("data-analytics-category"), // category
-    e.target.getAttribute("data-analytics-label"),    // label
-    e.target.getAttribute("data-analytics-value"),    // value
+    e.target.getAttribute("data-analytics-action"),
+    e.target.getAttribute("data-analytics-category"),
+    e.target.getAttribute("data-analytics-label"),
+    e.target.getAttribute("data-analytics-value"),
   );
 });
 
-
-
-export default function reportEventToGA(action, category, label, value) {
+export function reportEventToGA(action, category, label, value) {
 
   if (action == null) {
     return;
   }
 
-  // alert("Reporting to GA. action is " + action + " and category is " + category + " and label is " + label + " and value is " + value + "!");
+  // alert("Reporting to GA. action is " + action + " and category is " + category + " and label is " + label + " and value is " + value );
 
   // Do not call `gtag` unless the function is defined
   // in app/views/layouts/_google_analytics_4.html.erb .
@@ -43,25 +46,24 @@ export default function reportEventToGA(action, category, label, value) {
     return;
   }
 
-  
-    gtag( 'event',
-      
-      // A string describing what the user did,
-      // e.g. "download" or "transcription_pdf" or "english_translation_pdf" or "download_original" or "search_inside"
-      action,
+  gtag( 'event',
+    
+    // A string describing what the user did,
+    // e.g. "download" or "transcription_pdf" or "english_translation_pdf" or "download_original" or "search_inside"
+    action,
 
-      {
-        // As of 2024, this is always the string "work".
-        'event_category': category,
+    {
+      // As of 2024, this is always the string "work".
+      'event_category': category,
 
-        // As of 2024, this is always the work's friendlier_id.
-        'event_label':   label,
+      // As of 2024, this is always the work's friendlier_id.
+      'event_label':   label,
 
-        // As of 2024 this is only used to send the search phrase in app/frontend/javascript/scihist_viewer.js .
-        // The rest of the time we've just left it null.
-        'event_value':    value
-      }
+      // As of 2024 this is only used to send the search phrase in app/frontend/javascript/scihist_viewer.js .
+      // The rest of the time we've just left it null.
+      'event_value':    value
+    }
 
-    );
+  );
   
 }

--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -27,7 +27,7 @@ import OpenSeadragon from 'openseadragon';
 import ViewerSearchResults from '../javascript/scihist_viewer/viewer_search_results.js';
 import ViewerPageInfo from '../javascript/scihist_viewer/viewer_page_info.js';
 
-import reportEventToGA from '../javascript/custom_google_analytics_4_events';
+import { reportEventToGA } from '../javascript/custom_google_analytics_4_events';
 
 function ScihistImageViewer() {
   var modal = document.querySelector("#scihist-image-viewer-modal");
@@ -809,11 +809,6 @@ ScihistImageViewer.prototype.displayAlert = function(msg) {
   container.insertAdjacentHTML('afterbegin', alertHtml);
 }
 
-// // Report to Google Analytics.
-// // See https://github.com/sciencehistory/scihist_digicoll/issues/2606 .
-// ScihistImageViewer.prototype.reportEventToGoogleAnalytics = function (query, friendlierID) {  
-//   reportEventToGA('search_inside', 'work', friendlierID, query);
-// }
 
 ScihistImageViewer.prototype.getSearchResults = async function(query) {
   const searchResultsContainer = document.querySelector(".viewer-search-area .search-results-container");
@@ -887,8 +882,12 @@ ScihistImageViewer.prototype.getSearchResults = async function(query) {
     throw error;
   } finally {
     // Report to Google Analytics.
+    //
     // See https://github.com/sciencehistory/scihist_digicoll/issues/2606 .
-    // Defined in app/frontend/javascript/custom_google_analytics_4_events.js
+    //
+    // Function reportEventToGA is defined in
+    // app/frontend/javascript/custom_google_analytics_4_events.js
+    // reportEventToGA(action, category, label, value)
     reportEventToGA('search_inside', 'work', this.workId, query);
   }
 };

--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -890,7 +890,7 @@ ScihistImageViewer.prototype.getSearchResults = async function(query) {
       'search_inside',
       {
         'event_category': 'work',
-        'event_label':   _self.workId,
+        'event_label':   this.workId,
         // We're sending the search phrase in event_value.
         // We don't usually make use of this parameter.
         'event_value':    query

--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -27,6 +27,8 @@ import OpenSeadragon from 'openseadragon';
 import ViewerSearchResults from '../javascript/scihist_viewer/viewer_search_results.js';
 import ViewerPageInfo from '../javascript/scihist_viewer/viewer_page_info.js';
 
+import reportEventToGA from '../javascript/custom_google_analytics_4_events';
+
 function ScihistImageViewer() {
   var modal = document.querySelector("#scihist-image-viewer-modal");
   if (!modal) {
@@ -807,9 +809,13 @@ ScihistImageViewer.prototype.displayAlert = function(msg) {
   container.insertAdjacentHTML('afterbegin', alertHtml);
 }
 
+// // Report to Google Analytics.
+// // See https://github.com/sciencehistory/scihist_digicoll/issues/2606 .
+// ScihistImageViewer.prototype.reportEventToGoogleAnalytics = function (query, friendlierID) {  
+//   reportEventToGA('search_inside', 'work', friendlierID, query);
+// }
+
 ScihistImageViewer.prototype.getSearchResults = async function(query) {
-
-
   const searchResultsContainer = document.querySelector(".viewer-search-area .search-results-container");
 
   try {
@@ -879,25 +885,12 @@ ScihistImageViewer.prototype.getSearchResults = async function(query) {
       Sorry, our system experienced a problem and could not provide search results.\
     </p>";
     throw error;
+  } finally {
+    // Report to Google Analytics.
+    // See https://github.com/sciencehistory/scihist_digicoll/issues/2606 .
+    // Defined in app/frontend/javascript/custom_google_analytics_4_events.js
+    reportEventToGA('search_inside', 'work', this.workId, query);
   }
-
-  // Report to Google Analytics.
-  // See https://github.com/sciencehistory/scihist_digicoll/issues/2606 .
-  if (typeof gtag === 'function') {
-    // See app/frontend/javascript/custom_google_analytics_4_events.js
-    // for more details about these parameters and how we are using them.
-    gtag( 'event',
-      'search_inside',
-      {
-        'event_category': 'work',
-        'event_label':   this.workId,
-        // We're sending the search phrase in event_value.
-        // We don't usually make use of this parameter.
-        'event_value':    query
-      }
-    );
-  }
-
 };
 
 ScihistImageViewer.prototype.selectSearchResult = function(resultElement) {
@@ -1113,7 +1106,6 @@ jQuery(document).ready(function($) {
 
     $(document).on("submit", "*[data-trigger='viewer-search']", function(event) {
       event.preventDefault();
-
       const query = $(event.target).find("input").val();
       if (query.trim() != "") {
         chf_image_viewer().getSearchResults( query );

--- a/app/frontend/javascript/scihist_viewer.js
+++ b/app/frontend/javascript/scihist_viewer.js
@@ -808,6 +808,8 @@ ScihistImageViewer.prototype.displayAlert = function(msg) {
 }
 
 ScihistImageViewer.prototype.getSearchResults = async function(query) {
+
+
   const searchResultsContainer = document.querySelector(".viewer-search-area .search-results-container");
 
   try {
@@ -878,6 +880,24 @@ ScihistImageViewer.prototype.getSearchResults = async function(query) {
     </p>";
     throw error;
   }
+
+  // Report to Google Analytics.
+  // See https://github.com/sciencehistory/scihist_digicoll/issues/2606 .
+  if (typeof gtag === 'function') {
+    // See app/frontend/javascript/custom_google_analytics_4_events.js
+    // for more details about these parameters and how we are using them.
+    gtag( 'event',
+      'search_inside',
+      {
+        'event_category': 'work',
+        'event_label':   _self.workId,
+        // We're sending the search phrase in event_value.
+        // We don't usually make use of this parameter.
+        'event_value':    query
+      }
+    );
+  }
+
 };
 
 ScihistImageViewer.prototype.selectSearchResult = function(resultElement) {


### PR DESCRIPTION
Ref #2606.
- Refactored the code in `custom_google_analytics_4_events.js` so that it exports a function we can call from the search code. Seemed like the DRYest thing to do, although I'm open to other ideas.
- We're using the `event_value` parameter, which we don't use anywhere else in the digital collections, to report the query string to GA. (This is a bit of an experiment.)
  - 💡In case we decide to use `event_value` somewhere else later, I tweaked the `custom_google_analytics_4_events.js` to also look for a `data-analytics-value` on the decorated link, and send it to GA along with the other metadata. Does not affect any existing reporting, as `getAttribute` will just return `null` in existing code.