### PR TITLE
update device_detector gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,7 +230,7 @@ GEM
       activesupport
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    device_detector (1.1.2)
+    device_detector (1.1.3)
     devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)

--- a/spec/models/compact_user_agent_spec.rb
+++ b/spec/models/compact_user_agent_spec.rb
@@ -7,14 +7,14 @@ describe CompactUserAgent do
   subject { CompactUserAgent.new(user_agent).compact }
 
   describe "bad user agent" do
-    let(:user_agent) { "bad user agent" }
-    it { is_expected.to eq "bad_user_agent" }
+    let(:user_agent) { "bad value" }
+    it { is_expected.to eq "bad_value" }
   end
 
   describe "long bad user agent" do
-    let(:user_agent) { "a quite very long and terrible user agent that is very very long" }
+    let(:user_agent) { "a quite very long and terrible value that is very very long" }
     # truncates
-    it { is_expected.to eq "a_quite_very_long_and_terrible_user_agent_that_is_" }
+    it { is_expected.to eq "a_quite_very_long_and_terrible_value_that_is_very_" }
   end
 
   describe "nil user agent" do


### PR DESCRIPTION
For making sense of user-agent strings. When updating all deps to prepare for Rails 7.2, I noticed that updating device_detector from 1.1.2 to 1.1.3 caused our test to fail... it's for weird reasons not even worth going into, particular string we were using for 'bad' user agent was triggering a new detector, doens't really matter, just fixed to green.
