### PR TITLE
WorkOcrCreatorRemover should skip assets with role extracted_pdf_page

### DIFF
--- a/app/services/work_ocr_creator_remover.rb
+++ b/app/services/work_ocr_creator_remover.rb
@@ -25,7 +25,6 @@ class WorkOcrCreatorRemover
   end
 
   def process
-    byebug
     if @work.ocr_requested
       if AssetOcrCreator.suitable_language?(work)
         image_assets.each do |a|

--- a/app/services/work_ocr_creator_remover.rb
+++ b/app/services/work_ocr_creator_remover.rb
@@ -25,6 +25,7 @@ class WorkOcrCreatorRemover
   end
 
   def process
+    byebug
     if @work.ocr_requested
       if AssetOcrCreator.suitable_language?(work)
         image_assets.each do |a|
@@ -68,9 +69,13 @@ class WorkOcrCreatorRemover
   end
 
   def image_assets
+    # ignore extracted_pdf_page Assets entirely, not our responsibilty, they are the product of
+    # of a PDF page render, and in our present use cases should not get OCR'd, and if they did
+    # get OCR'd it might accidentally overwrite a PDF text extraction stored in hocr field
     @work.
       members.
       where(type: 'Asset').
+      where("role is null OR role != ?", PdfToPageImages::EXTRACTED_PAGE_ROLE).
       order(:position).
       select { |m| m.content_type.start_with?("image/") }
   end


### PR DESCRIPTION
They are the product of a PDF page render, and in our present use cases should not need OCRing. If they accidentally did get OCR'd, that might overwrite an extracted PDF text

Part of ongoing work on #2492 see also #2702
