### PR TITLE
update one more deprecated form of calling ActiveRecord.enum in Rails 7.2

### DIFF
--- a/app/models/oral_history_request.rb
+++ b/app/models/oral_history_request.rb
@@ -16,8 +16,7 @@ class OralHistoryRequest < ApplicationRecord
     work&.oral_history_content&.available_by_request_manual_review?
   }
 
-  enum delivery_status: %w{pending automatic approved rejected dismissed}.map {|v| [v, v]}.to_h, _prefix: :delivery_status
-
+  enum :delivery_status, %w{pending automatic approved rejected dismissed}.map {|v| [v, v]}.to_h, prefix: :delivery_status
 
   before_save do
     if delivery_status_changed?


### PR DESCRIPTION
Missed this one in #2711 somehow
