### PR TITLE
Change ocr_requested boolean attr_json to text_extraction_mode

### DIFF
--- a/app/components/work_image_show_component.html.erb
+++ b/app/components/work_image_show_component.html.erb
@@ -30,7 +30,7 @@
           <%= DescriptionDisplayFormatter.new(work.description).format  %>
         </div>
 
-        <% if ScihistDigicoll::Env.lookup("feature_search_inside_work") && work.ocr_requested? %>
+        <% if ScihistDigicoll::Env.lookup("feature_search_inside_work") && work.has_text_extraction? %>
           <form class="work-page-viewer-search-controls" data-trigger="show-viewer-search">
             <div class="input-group">
               <div class="input-group-prepend">

--- a/app/components/work_show_ocr_component.html.erb
+++ b/app/components/work_show_ocr_component.html.erb
@@ -1,6 +1,6 @@
 <p>
   OCR enabled:
-  <% if @work.ocr_requested %>
+  <% if @work.ocr_requested? %>
     <span class="text-success font-weight-bold">
       <i class="fa fa-check-circle" aria-hidden="true"></i> YES
     </span>

--- a/app/jobs/work_ocr_creator_remover_job.rb
+++ b/app/jobs/work_ocr_creator_remover_job.rb
@@ -1,5 +1,5 @@
 # Background job to ensure a work's assets all have OCR (or don't) consistent
-# with the Work#ocr_requested_attribute
+# with the Work#text_extraction
 #
 class WorkOcrCreatorRemoverJob < ApplicationJob
   if ScihistDigicoll::Env.lookup("active_job_ocr_queue").present?

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -88,7 +88,10 @@ class Work < Kithe::Work
   attr_json :file_creator, :string
   attr_json :admin_note, :text, array: true, default: -> { [] }
 
-  #attr_json :ocr_requested, :boolean, default: false
+  # text_extraction_mode is an expression of intent of if we want to OCR this work; or if we plan
+  # to extract pages with text from a born-digital PDF with text; or neither. It is used to trigger
+  # actual OCR extraction; pdf_extraction is more of a signal that we plan for it to be there, may not
+  # automatically trigger it.
   attr_json :text_extraction_mode, :string
   validates :text_extraction_mode, inclusion: { in: ["ocr", "pdf_extraction"], allow_nil: true }
   normalizes :text_extraction_mode, with: -> text_extraction { text_extraction.presence }
@@ -121,6 +124,10 @@ class Work < Kithe::Work
     text_extraction_mode == "pdf_extraction"
   end
 
+  # to know if we REALLY have text, we'd have to look at the children to see if they contain hocr
+  # But we often want to know without fetching children, so text_extraction_mode at the work
+  # level is used as an expression of intent, that can also be used for triggering extraction routines
+  # etc.
   def has_text_extraction?
     ocr_requested? || pdf_text_extraction?
   end

--- a/app/services/work_ocr_creator_remover.rb
+++ b/app/services/work_ocr_creator_remover.rb
@@ -25,19 +25,20 @@ class WorkOcrCreatorRemover
   end
 
   def process
-    if @work.ocr_requested
-      if AssetOcrCreator.suitable_language?(work)
-        image_assets.each do |a|
-          if a.suppress_ocr
-            maybe_remove(a)
-          else
-            maybe_add(a)
-          end
-        end
-      else
+    if @work.ocr_requested?
+      unless AssetOcrCreator.suitable_language?(work)
         Rails.logger.warn("#{self.class}: OCR enabled for work #{work.friendlier_id}, but it does not have suitable languages: #{work.language.inspect}")
+        return
       end
-    else
+
+      image_assets.each do |a|
+        if a.suppress_ocr
+          maybe_remove(a)
+        else
+          maybe_add(a)
+        end
+      end
+    elsif @work.text_extraction_mode.blank? # not PDF extraction either
       image_assets.each { |a| maybe_remove(a) }
     end
   end

--- a/app/views/admin/works/_work_fields.html.erb
+++ b/app/views/admin/works/_work_fields.html.erb
@@ -54,8 +54,8 @@
     <%= f.repeatable_attr_input :language, build: :at_least_one,
       html_attributes: { "data-scihist-qa-autocomplete" => qa_search_vocab_path("local", "languages")} %>
 
-    <%# ocr_requested does need to be in this form, so that we can include it in batch edits. %>
-    <%= f.input :ocr_requested, label: "OCR features enabled" %>
+    <%# text_extraction does need to be in this form, so that we can include it in batch edits. %>
+    <%= f.input :text_extraction_mode, label: "Text extraction mode (OCR or PDF)", collection: ["ocr", "pdf_extraction"] %>
 
     <%= f.input :description,       as: :text, input_html: { rows: 14 } %>
     <%= f.input :provenance,        as: :text, input_html: { rows: 5 }  %>

--- a/app/views/scihist_image_viewer/_scihist_viewer_modal.html.erb
+++ b/app/views/scihist_image_viewer/_scihist_viewer_modal.html.erb
@@ -16,7 +16,7 @@
       data: {
         "work-id": work.friendlier_id,
         "images-info-path": viewer_images_info_path(work),
-        "search-path": (viewer_search_path(work) if ScihistDigicoll::Env.lookup("feature_search_inside_work") && work.ocr_requested?)
+        "search-path": (viewer_search_path(work) if ScihistDigicoll::Env.lookup("feature_search_inside_work") && work.has_text_extraction?)
       }) do %>
   <div class="modal-dialog" role="document">
     <div class="modal-content">

--- a/config/locales/work.en.yml
+++ b/config/locales/work.en.yml
@@ -94,6 +94,7 @@ en:
         representative: "Select the file with media that represents this Work and is used as a thumbnail."
         contained_by: >
           The sub-Collection within the Digital Collections Application to which the digital work belongs. Select the named collection that the work is part of, if applicable. If a desired entry is not available, contact the Digital Collections Librarian. Required if applicable.
-        ocr_requested: >
-          Enable Optical Character Recognition (OCR) features for suitable works, with text that is believed likely legible to OCR processes, and in a supported language.
+        text_extraction: >
+          "OCR" to Enable Optical Character Recognition (OCR) processing, where software will try to extract text from images. Should be enabled for suitable works, with text that is believed likely legible to OCR processes, and in a supported language.<br>
+          "PDF" for work_source_pdf PDF text extraction, used when we are going to have a born-digital PDF work
 

--- a/lib/tasks/data_fixes/ocr_requested_migration.rake
+++ b/lib/tasks/data_fixes/ocr_requested_migration.rake
@@ -1,0 +1,23 @@
+namespace :scihist do
+  namespace :data_fixes do
+
+    desc """
+      move ocr_requested boolean attr_json to value in new text_extraction_mode
+    """
+    task :ocr_requested_migration => :environment do
+      # has key
+      scope = Work.where("json_attributes ? 'ocr_requested'")
+
+      progress_bar = ProgressBar.create(total: scope.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+
+      scope.find_each do |work|
+        value = work.json_attributes.delete('ocr_requested')
+        if ActiveModel::Type::Boolean.new.cast(value)
+          work.text_extraction_mode = "ocr"
+        end
+        work.save!
+        progress_bar.increment
+      end
+    end
+  end
+end

--- a/spec/components/work_download_links_component_spec.rb
+++ b/spec/components/work_download_links_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe WorkDownloadLinksComponent, type: :component do
 
   describe "multi-item work with OCR" do
     let(:work) do
-      create(:work, :published, ocr_requested: true, members: [
+      create(:work, :published, text_extraction_mode: 'ocr', members: [
         create(:asset_with_faked_file, :with_ocr),
         create(:asset_with_faked_file, :with_ocr)
       ])
@@ -72,7 +72,7 @@ RSpec.describe WorkDownloadLinksComponent, type: :component do
   end
 
   describe "zero item work with OCR requested" do
-    let(:work) { create(:work, :published, members: [], ocr_requested: true) }
+    let(:work) { create(:work, :published, members: [], text_extraction_mode: "ocr") }
 
     it "still has no PDF or zip link" do
       expect(page).not_to have_link("ZIP")

--- a/spec/controllers/admin/works_controller_spec.rb
+++ b/spec/controllers/admin/works_controller_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
     context "work with a png instead of a tiff" do
       let(:png) { create(:asset, :inline_promoted_file) }
       let(:work_with_png) { create(:work, :with_complete_metadata, published: false, members: [png]) }
-      
+
       before do
         controller.current_user.works_in_cart << work_with_png
       end
@@ -172,7 +172,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
 
     context "work with a legitimate portrait png" do
       let(:portrait_png) { create(:asset, :inline_promoted_file, role: "portrait") }
-      let(:work) { create(:work, :with_complete_metadata, published: false, members: [portrait_png]) }      
+      let(:work) { create(:work, :with_complete_metadata, published: false, members: [portrait_png]) }
       before do
         controller.current_user.works_in_cart << work
       end


### PR DESCRIPTION
Part of #2492

text_extraction_mode can be `ocr` (former ocr_requested true), `pdf_extraction` (for extracting text from born-digital pdf), or nil (for no text extraction).

- [ ] Run data migration rake task `heroku run rake scihist:data_fixes:ocr_requested_migration -r production`

We will leave this in draft until we have verified this appraoch is convenient for implementation of PDF extraction

This also changes admin UI on work form for setting OCR, so need to run past staff. 
