### PR TITLE
Make Work#ordered_viewable_members return an ActiveRecord::Relation not yet fetched

### DIFF
--- a/app/components/work_image_show_component.rb
+++ b/app/components/work_image_show_component.rb
@@ -44,7 +44,7 @@ class WorkImageShowComponent < ApplicationComponent
   # All DISPLAYABLE (to current user) members, in order, and
   # with proper pre-fetches.
   def ordered_viewable_members
-    @ordered_members ||= work.ordered_viewable_members(current_user: current_user)
+    @ordered_members ||= work.ordered_viewable_members(current_user: current_user).to_a
   end
 
   def transcription_texts

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -127,6 +127,8 @@ class Work < Kithe::Work
 
   # All DISPLAYABLE (to current user) members, in order, and
   # with proper pre-fetches.
+  #
+  # @return [ActiveRecord::Relation] relation, not yet fetched, fetching desired records. Call #to_a on it if you want to trigger fetch to db.
   def ordered_viewable_members(current_user:)
 
 
@@ -142,7 +144,7 @@ class Work < Kithe::Work
     # it turns out you can do on an association/relation
     members = members.strict_loading
 
-    members.to_a
+    members
   end
 
   # Ensures the optional sidecar OralHistoryContent is present if it wans't already

--- a/app/services/trans_text_pdf.rb
+++ b/app/services/trans_text_pdf.rb
@@ -138,7 +138,7 @@ class TransTextPdf
 
   def text_page_objects
     # whether user is administrator or not, we don't include private pages for now.
-    @text_page_objects ||= Work::TextPage.compile(work.ordered_viewable_members(current_user: nil), accessor: mode)
+    @text_page_objects ||= Work::TextPage.compile(work.ordered_viewable_members(current_user: nil).to_a, accessor: mode)
   end
 
   # some trying-to-keep-it-simple CSS, that will be converted to PDF by


### PR DESCRIPTION
Caller can add on the .to_a themselves if they want to trigger fetch. But returning the Relation is more flexible, as it lets the caller also chain on other things, say `work.ordered_viewable_members.where(role: something)`, which I am looking to use for PDF work, ref #2492
