### PR TITLE
Deal better with logging to rails log after ActiveJob::DeserializationError

### DIFF
--- a/app/jobs/single_asset_checker_job.rb
+++ b/app/jobs/single_asset_checker_job.rb
@@ -13,6 +13,8 @@ class SingleAssetCheckerJob < ApplicationJob
   discard_on ActiveJob::DeserializationError do |job, error|
     # This is probably already logged by Rails with these same details,
     # but just to be sure we have it logged, let's do it too.
-    Rails.logger.error("#{job.class.name} (#{job&.id}): Cancelling job due to ActiveJob::DeserializationError: #{error&.message}")
+
+
+    Rails.logger.error("#{job.class.name} (#{ job.nil? ? 'No job ID available' : job.id}): Cancelling job due to ActiveJob::DeserializationError: #{error&.message}")
   end
 end

--- a/app/jobs/single_asset_checker_job.rb
+++ b/app/jobs/single_asset_checker_job.rb
@@ -15,6 +15,6 @@ class SingleAssetCheckerJob < ApplicationJob
     # but just to be sure we have it logged, let's do it too.
 
 
-    Rails.logger.error("#{job.class.name} (#{ job.nil? ? 'No job ID available' : job.id}): Cancelling job due to ActiveJob::DeserializationError: #{error&.message}")
+    Rails.logger.error("#{job.class.name} (#{job.job_id}): Cancelling job due to ActiveJob::DeserializationError: #{error&.message}")
   end
 end

--- a/app/jobs/single_asset_checker_job.rb
+++ b/app/jobs/single_asset_checker_job.rb
@@ -13,6 +13,6 @@ class SingleAssetCheckerJob < ApplicationJob
   discard_on ActiveJob::DeserializationError do |job, error|
     # This is probably already logged by Rails with these same details,
     # but just to be sure we have it logged, let's do it too.
-    Rails.logger.error("#{job.class.name} (#{job.id}): Cancelling job due to ActiveJob::DeserializationError: #{error.message}")
+    Rails.logger.error("#{job.class.name} (#{job&.id}): Cancelling job due to ActiveJob::DeserializationError: #{error&.message}")
   end
 end

--- a/app/jobs/single_asset_checker_job.rb
+++ b/app/jobs/single_asset_checker_job.rb
@@ -13,8 +13,6 @@ class SingleAssetCheckerJob < ApplicationJob
   discard_on ActiveJob::DeserializationError do |job, error|
     # This is probably already logged by Rails with these same details,
     # but just to be sure we have it logged, let's do it too.
-
-
     Rails.logger.error("#{job.class.name} (#{job.job_id}): Cancelling job due to ActiveJob::DeserializationError: #{error&.message}")
   end
 end


### PR DESCRIPTION
This took two tries, but it's actually a simple problem - a `ApplicationJob` does not have an `id` but it does have a `job_id`. (Putting `id` in the error message was throwing a NoMethodError.)
Ref #2626