### PR TITLE
Fix admin asset layout to stay on screen

### DIFF
--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -165,7 +165,7 @@
 
       <%if @asset.stored? %>
         <dt class="col-sm-4">File in S3</dt>
-        <dd class="col-sm-8"><%= link_to @asset.file.url(public: true).split('/').last, S3ConsoleUri.from_shrine_uploaded_file(@asset.file).console_uri %></dd>
+        <dd class="col-sm-8 text-break"><%= link_to @asset.file.url(public: true).split('/').last, S3ConsoleUri.from_shrine_uploaded_file(@asset.file).console_uri %></dd>
 
         <dt class="col-sm-4">Stored in S3 bucket</dt>
         <dd class="col-sm-8"><%= @asset.file.storage.try(:bucket).try(:name) || "UNKNOWN" %></dd>

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -165,7 +165,7 @@
 
       <%if @asset.stored? %>
         <dt class="col-sm-4">File in S3</dt>
-        <dd class="col-sm-8 text-break"><%= link_to @asset.file.url(public: true).split('/').last, S3ConsoleUri.from_shrine_uploaded_file(@asset.file).console_uri %></dd>
+        <dd class="col-sm-8 text-break"><%= link_to File.basename(URI.parse(@asset.file.url(public: true)).path), S3ConsoleUri.from_shrine_uploaded_file(@asset.file).console_uri %></dd>
 
         <dt class="col-sm-4">Stored in S3 bucket</dt>
         <dd class="col-sm-8"><%= @asset.file.storage.try(:bucket).try(:name) || "UNKNOWN" %></dd>

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -20,7 +20,7 @@
   <% end %>
 </p>
 
-<div class="row">
+<div class="row overflow-hidden">
   <div class="col-sm-6">
     <% if @asset.file_derivatives[:thumb_large] && @asset.file_derivatives[:thumb_large_2X] %>
       <%= thumb_image_tag @asset, size: :large, style: "max-width: 100%" %>

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -164,7 +164,7 @@
 
 
       <%if @asset.stored? %>
-        <dt class="col-sm-4">File in s3</dt>
+        <dt class="col-sm-4">File in S3</dt>
         <dd class="col-sm-8"><%= link_to @asset.file.url(public: true).split('/').last, S3ConsoleUri.from_shrine_uploaded_file(@asset.file).console_uri %></dd>
 
         <dt class="col-sm-4">Stored in S3 bucket</dt>

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -44,9 +44,11 @@
     <% end %>
 
     <% if @asset.file %>
-      <%= link_to "Download Original",
-            @asset.file.url(response_content_disposition: ContentDisposition.format(disposition: :attachment, filename: DownloadFilenameHelper.filename_for_asset(@asset))),
-            class: "btn btn-outline-secondary btn-lg mt-4" %>
+      <p>
+        <%= link_to "Download Original",
+              @asset.file.url(response_content_disposition: ContentDisposition.format(disposition: :attachment, filename: DownloadFilenameHelper.filename_for_asset(@asset))),
+              class: "btn btn-outline-secondary btn-lg mt-4" %>
+      </p>
     <% end %>
 
 


### PR DESCRIPTION
- make sure Admin Asset download button gets own line
- capitalize 'S3' in label
- keep long text from pushing container bigger with overflow-hidden
- line-break long file-names on narrow columns
- keep long signature query string off of admin asset filename print

## before
![Screenshot 2024-09-03 at 12 09 41 PM](https://github.com/user-attachments/assets/43d1b377-0d8f-4cae-9910-74e122964bb0)


## after
![Screenshot 2024-09-03 at 12 47 52 PM](https://github.com/user-attachments/assets/91fa209e-8121-448c-8f35-f81096127e2a)
