### PR TITLE
Improve admin display around 'ocr' extractec text

### DIFF
--- a/app/frontend/stylesheets/local/admin/admin.scss
+++ b/app/frontend/stylesheets/local/admin/admin.scss
@@ -17,3 +17,10 @@ dl.admin-metadata {
     width: auto;
   }
 }
+
+// try to avoid so many intra-paragraph line breaks in our hOCR text admin display
+.admin-ocr-display {
+  .ocr_line, .ocrx_word,  {
+    display: inline;
+  }
+}

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -433,7 +433,7 @@
       <% end %>
     </ul>
 
-    <h3><a id="ocr">OCR</a></h3>
+    <h3><a id="hocr">hOCR Searchable Text (OCR or PDF extraction)</a></h3>
     <% if @asset.suppress_ocr %>
        <small>
         OCR is suppressed for this asset. Note:<br/>

--- a/app/views/admin/works/_member_list_table.html.erb
+++ b/app/views/admin/works/_member_list_table.html.erb
@@ -36,7 +36,7 @@
                 <% if member.suppress_ocr %>
                   <small>OCR suppressed</small>
                 <% elsif member.hocr.present? %>
-                  <li><small><%=link_to("OCR", admin_asset_path(member, anchor: "ocr"), class: "ocr-link") %></small></li>
+                  <li><small class="badge badge-info"><%=link_to("hOCR Text", admin_asset_path(member, anchor: "hocr"), class: "ocr-link") %></small></li>
                 <% end %>
               <% end %>
             </ul>

--- a/spec/system/work/ocr_info_spec.rb
+++ b/spec/system/work/ocr_info_spec.rb
@@ -30,7 +30,7 @@ describe "Member list displays OCR info", logged_in_user: :editor do
       expect(page).to have_text("OCR enabled, but work does not include languages compatible with OCR.")
 
       click_on "Members"
-      path_to_ocr = admin_asset_path(image_asset_with_hocr, anchor: "ocr")
+      path_to_ocr = admin_asset_path(image_asset_with_hocr, anchor: "hocr")
       expect(page.find_all('table.member-list a.ocr-link').count).to eq 1
       expect(page).to have_link(:href=>path_to_ocr)
     end


### PR DESCRIPTION
- fix admin viewable labels 'OCR' refering to searchable text, to be more generic
- try to avoid so many intra-paragraph line breaks in our hOCR text admin display
