### PR TITLE
Disable YJIT on heroku non-web (worker, console) to save RAM

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,15 @@ module ScihistDigicoll
 
     # Enables YJIT as of Ruby 3.3, to bring sizeable performance improvements. If you are
     # deploying to a memory constrained environment you may want to set this to `false`.
-    Rails.application.config.yjit = true
+
+    # scihist: on heroku that are NOT web workers (bg workers, console), we are currently
+    # memory constrained, and also don't need this performance, so disable.  Dyno type
+    # is available from Heroku $DYNO. https://devcenter.heroku.com/articles/dynos#local-environment-variables
+    if ENV['DYNO'].present? && ! ENV['DYNO'].start_with?("web.")
+      Rails.application.config.yjit = false
+    else
+      Rails.application.config.yjit = true
+    end
 
     if ScihistDigicoll::Env.lookup("rails_log_level")
       config.log_level = ScihistDigicoll::Env.lookup("rails_log_level")


### PR DESCRIPTION
The performance enhancements of YJIT are less useful and not needed on eg bg worker dynos. Where we also are running dynos that are very tight on RAM, and don't want to spend it on YJIT RAM overhead.

Heroku sets an ENV variable DYNO to eg "worker.2" or "web.1", so we can look at it, and if it set to something other than "web.X", say, nah, disable the otherwise default on YJIT.
