### PR TITLE
Whole-work download uses original PDF instead of constructed PDF where appropriate

### DIFF
--- a/app/components/download_dropdown_component.rb
+++ b/app/components/download_dropdown_component.rb
@@ -207,7 +207,13 @@ class DownloadDropdownComponent < ApplicationComponent
     end
 
     if has_work_download_options?
-      elements << content_tag("h3", "Download all #{display_parent_work.member_count} images", class:'dropdown-header')
+      heading = if display_parent_work.text_extraction_mode == "pdf_extraction"
+        "Download entire document"
+      else
+        "Download all #{display_parent_work.member_count} images"
+      end
+
+      elements << content_tag("h3", heading, class:'dropdown-header')
       work_download_options.each do |download_option|
         elements << format_download_option(download_option)
       end

--- a/app/components/work_download_links_component.rb
+++ b/app/components/work_download_links_component.rb
@@ -36,18 +36,18 @@ class WorkDownloadLinksComponent < ApplicationComponent
 
 
   def download_button_label(download_option)
-    case download_option.data_attrs[:derivative_type].to_s
-    when "pdf_file" ; "Download PDF"
-    when "zip_file" ; "Download ZIP"
+    case download_option.content_type
+    when "application/pdf" ; "Download PDF"
+    when "application/zip" ; "Download ZIP"
     else "Download"
     end
   end
 
   def download_file_icon(download_option)
-    case download_option.data_attrs[:derivative_type].to_s
-    when "pdf_file" ; helpers.file_earmark_pdf_fill_svg
-    when "zip_file" ; helpers.file_earmark_zip_fill_svg
-    else "x"
+    case download_option.content_type
+    when "application/pdf" ; helpers.file_earmark_pdf_fill_svg
+    when "application/zip" ; helpers.file_earmark_zip_fill_svg
+    else helpers.file_earmark_fill_svg
     end
   end
 end

--- a/app/helpers/bootstrap_file_icon_svg_helper.rb
+++ b/app/helpers/bootstrap_file_icon_svg_helper.rb
@@ -31,6 +31,14 @@ module BootstrapFileIconSvgHelper
     EOS
   end
 
+  def file_earmark_fill_svg
+    <<-EOS.strip_heredoc.html_safe
+      <svg xmlns="http://www.w3.org/2000/svg" width="12" height="16" fill="currentColor" class="bi bi-file-earmark-fill" viewBox="0 0 12 16">
+        <path d="M 2,0 H 7.293 A 1,1 0 0 1 8,0.293 L 11.707,4 A 1,1 0 0 1 12,4.707 V 14 a 2,2 0 0 1 -2,2 H 2 A 2,2 0 0 1 0,14 V 2 A 2,2 0 0 1 2,0 m 5.5,1.5 v 2 a 1,1 0 0 0 1,1 h 2 z" id="path2" />
+      </svg>
+    EOS
+  end
+
   def bi_check_circle_fill_svg
     <<-EOS.strip_heredoc.html_safe
       <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check-circle-fill" viewBox="0 0 16 16">
@@ -38,6 +46,7 @@ module BootstrapFileIconSvgHelper
       </svg>
     EOS
   end
+
 
   # okay, actually from fontawesome.
   # https://fontawesome.com/icons/file-audio?f=classic&s=solid

--- a/app/models/download_option.rb
+++ b/app/models/download_option.rb
@@ -116,6 +116,6 @@ class DownloadOption
   # sometimes we want to modify one, treat as immutable but let modify like this!
   # Can override any element as if it were initializer
   def dup_with(label=self.label, url: self.url, work_friendlier_id: self.work_friendlier_id, subhead:self.subhead, analyticsAction:self.analyticsAction, data_attrs: self.data_attrs, content_type: self.content_type)
-    self.class.new(label, url: url, work_friendlier_id: work_friendlier_id, subhead:subhead, analyticsAction:analyticsAction, data_attrs: data_attrs)
+    self.class.new(label, url: url, work_friendlier_id: work_friendlier_id, subhead:subhead, analyticsAction:analyticsAction, data_attrs: data_attrs, content_type: content_type)
   end
 end

--- a/app/models/download_option.rb
+++ b/app/models/download_option.rb
@@ -3,7 +3,7 @@
 # A simple value object representing a download option, used for constructing our download
 # menus
 class DownloadOption
-  attr_reader :label, :subhead, :url, :analyticsAction, :data_attrs, :work_friendlier_id
+  attr_reader :label, :subhead, :url, :analyticsAction, :data_attrs, :work_friendlier_id, :content_type
 
 
   # Create a DownloadOption for one of our on-demand derivatives, DRY it up here
@@ -20,6 +20,11 @@ class DownloadOption
       "zip_file" => "download_zip"
     }[derivative_type]
 
+    content_type = {
+      "pdf_file" => "application/pdf",
+      "zip_file" => "application/zip"
+    }[derivative_type]
+
     # defaults\
     subhead ||= {
      "pdf_file" => nil,
@@ -29,6 +34,7 @@ class DownloadOption
     DownloadOption.new(label, url: "#", analyticsAction: analytics_action,
       work_friendlier_id: work_friendlier_id,
       subhead: subhead,
+      content_type: content_type,
       data_attrs: {
         trigger: "on-demand-download",
         derivative_type: derivative_type,
@@ -54,6 +60,7 @@ class DownloadOption
   # @param data_attrs[Hash] hash compatible with rails content_tag `data:` argument, for additional data attributes
   #   to add to link.
   # @param work_friendlier_id [String] used for analytics data attributes
+  # @param content_type [String] MIME/IANA content-type, sometimes used for icons and such on display
   def self.with_formatted_subhead(label, url:, work_friendlier_id:, analyticsAction:nil, width: nil, height: nil, size: nil, content_type: nil)
     parts = []
     parts << ScihistDigicoll::Util.humanized_content_type(content_type) if content_type.present?
@@ -73,13 +80,14 @@ class DownloadOption
   # @param subhead [String] a subheading/hint/more info for the label for the download link
   # @param analyticsAction [String] a key to record in our analytics logging, up to caller
   #   to decide what to do with it, but probably will turn into a data- attribute for JS.
-  def initialize(label, url:, work_friendlier_id:, subhead:nil, analyticsAction:nil, data_attrs: {})
+  def initialize(label, url:, work_friendlier_id:, subhead:nil, analyticsAction:nil, content_type: nil, data_attrs: {})
     @label = label
     @subhead = subhead
     @url = url
     @analyticsAction = analyticsAction
     @data_attrs = data_attrs
     @work_friendlier_id = work_friendlier_id
+    @content_type = content_type
 
     # Add in analytics data- attributes
     @data_attrs.merge!(analytics_data_attributes)
@@ -107,7 +115,7 @@ class DownloadOption
 
   # sometimes we want to modify one, treat as immutable but let modify like this!
   # Can override any element as if it were initializer
-  def dup_with(label=self.label, url: self.url, work_friendlier_id: self.work_friendlier_id, subhead:self.subhead, analyticsAction:self.analyticsAction, data_attrs: self.data_attrs)
+  def dup_with(label=self.label, url: self.url, work_friendlier_id: self.work_friendlier_id, subhead:self.subhead, analyticsAction:self.analyticsAction, data_attrs: self.data_attrs, content_type: self.content_type)
     self.class.new(label, url: url, work_friendlier_id: work_friendlier_id, subhead:subhead, analyticsAction:analyticsAction, data_attrs: data_attrs)
   end
 end

--- a/app/presenters/download_filename_helper.rb
+++ b/app/presenters/download_filename_helper.rb
@@ -44,14 +44,15 @@ class DownloadFilenameHelper
   # For image files, the original_filename is pretty opaque, derive
   # a base filename from first words of title of parent work.
   #
-  # But for audio and PDF, use original filename with friendlier_id for guaranteed uniqueness.
+  # But for audio and Oral History PDF, use original filename with friendlier_id for guaranteed uniqueness.
   # Intended use case for these is oral history files, where the original filenames
   # are possibly meaningful to users and usually unique -- but work titles all
   # begin with "oral history"
   #
   def self.filename_base_for_asset(asset)
     raise ArgumentError, 'Pass in an asset.' unless asset.is_a? Asset
-    if asset.content_type && asset.content_type.start_with?("audio/") || asset.content_type == "application/pdf"
+
+    if asset.content_type && asset.content_type.start_with?("audio/") || (asset.content_type == "application/pdf" && asset.role.in?(["transcript", "front_matter"]))
       return [File.basename(asset.original_filename, ".*"), asset.friendlier_id].join("_")
     end
 

--- a/app/services/work_download_options_creator.rb
+++ b/app/services/work_download_options_creator.rb
@@ -12,6 +12,8 @@
 # for "not ready")
 #
 class WorkDownloadOptionsCreator
+  include Rails.application.routes.url_helpers
+
   attr_reader :work, :options
 
   def initialize(work)
@@ -20,6 +22,10 @@ class WorkDownloadOptionsCreator
   end
 
   protected
+
+  def has_original_pdf?
+    original_pdf_asset.present?
+  end
 
   def has_constructed_pdf?
     return @has_constructed_pdf if defined? @has_constructed_pdf
@@ -40,10 +46,29 @@ class WorkDownloadOptionsCreator
   end
 
 
+  def original_pdf_asset
+    return @original_pdf_asset if defined? @original_pdf_asset
+
+    @original_pdf_asset = work.members.where(role: PdfToPageImages::SOURCE_PDF_ROLE).first
+  end
+
   def construct_options
     options = []
 
-    if has_constructed_pdf?
+    if has_original_pdf?
+      subhead_parts = []
+      subhead_parts << "#{original_pdf_asset.file_metadata["page_count"]} pages" if original_pdf_asset.file_metadata["page_count"].present?
+      subhead_parts << ScihistDigicoll::Util.simple_bytes_to_human_string(original_pdf_asset.size) if original_pdf_asset.size
+
+      options << DownloadOption.new("Original PDF",
+        url: download_path(original_pdf_asset.file_category, original_pdf_asset),
+        work_friendlier_id: work.friendlier_id,
+        analyticsAction: "download_original",
+        subhead: subhead_parts.compact.join(", "),
+        content_type: "application/pdf"
+
+      )
+    elsif has_constructed_pdf?
       options << DownloadOption.for_on_demand_derivative(
         label: "PDF", derivative_type: "pdf_file", work_friendlier_id: work.friendlier_id
       )

--- a/spec/components/download_dropdown_component_spec.rb
+++ b/spec/components/download_dropdown_component_spec.rb
@@ -217,6 +217,15 @@ describe DownloadDropdownComponent, type: :component do
       end
     end
 
+    describe "with text_extraction_mode pdf_extraction" do
+      let(:asset) { create(:asset_with_faked_file, :pdf, role: "work_source_pdf", ) }
+      let(:work) { create(:public_work, text_extraction_mode: "pdf_extraction", members: [asset, build(:asset_with_faked_file)]) }
+
+      it "uses custom heading" do
+        expect(div).to have_selector(".dropdown-header", text: "Download entire document")
+      end
+    end
+
     describe "with empty whole-work options" do
       let(:component) { DownloadDropdownComponent.new(asset, display_parent_work: work, work_download_options: []) }
 

--- a/spec/mailers/oral_history_delivery_spec.rb
+++ b/spec/mailers/oral_history_delivery_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe OralHistoryDeliveryMailer, :type => :mailer do
         representative,
         create(:asset_with_faked_file, :mp3, published: false,
           oh_available_by_request: true, title: "Protected mp3", faked_filename: "Protected mp3", position: 2),
-        create(:asset_with_faked_file, :pdf, published: false,
+        create(:asset_with_faked_file, :pdf, published: false, role: "transcript",
           oh_available_by_request: true,  title: "Protected PDF", faked_filename: "Protected PDF", position: 3),
-        create(:asset_with_faked_file, :pdf, published: false,
+        create(:asset_with_faked_file, :pdf, published: false, role: "transcript",
           title: "We will get sued if you send this out.", position: 4)
       ]
     end

--- a/spec/presenters/download_filename_helper_spec.rb
+++ b/spec/presenters/download_filename_helper_spec.rb
@@ -102,10 +102,17 @@ describe DownloadFilenameHelper, type: :model do
       expect(DownloadFilenameHelper.filename_for_asset(asset, derivative_key: derivative_key)).to eq "plastics_make_the_#{asset.parent.friendlier_id}_12_#{asset.friendlier_id}_#{derivative_key}.jpeg"
     end
 
-    describe "PDF asset" do
-      let(:asset) { create(:asset_with_faked_file, :pdf) }
+    describe "OH PDF asset" do
+      let(:asset) { create(:asset_with_faked_file, :pdf, role: "front_matter") }
       it "uses original filename plus ID" do
         expect(DownloadFilenameHelper.filename_for_asset(asset)).to eq("#{File.basename(asset.original_filename, '.*')}_#{asset.friendlier_id}#{File.extname(asset.original_filename)}")
+      end
+    end
+
+    describe "non-OH PDF asset" do
+      let(:asset) { create(:asset_with_faked_file, :pdf, position: 1, parent: create(:work, title: "Plastics make the package Dow makes the plastics")) }
+      it "uses work title" do
+        expect(DownloadFilenameHelper.filename_for_asset(asset)).to eq("plastics_make_the_#{asset.parent.friendlier_id}_1_#{asset.friendlier_id}.pdf")
       end
     end
 


### PR DESCRIPTION
On top of #2746

- DownloadOption now has content_type to effect display
- DownloadOption@dup_with properly pass on content_type
- WorkDownloadLinksComponent uses DownloadOption#content_type to determine icon and wording
- whole-work downloads can include original PDF instead of constructed PDF
