### PR TITLE
Create and display a scaled-down PDF derivative for work_source_pdf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         - name: Install apt dependencies
           run: |
             sudo apt-get update
-            sudo apt-get -y install libvips-tools ffmpeg mediainfo tesseract-ocr qpdf imagemagick exiftool poppler-utils
+            sudo apt-get -y install libvips-tools ffmpeg mediainfo tesseract-ocr qpdf imagemagick exiftool poppler-utils ghostscript
 
         # GitHub Actions VMs come with a pre-installed version of node.js - as of early 2024, 18.19.1.
         # See package.json under key "engines", which lists allowed versions of node and yarn.

--- a/Brewfile
+++ b/Brewfile
@@ -27,3 +27,5 @@ brew 'tesseract-lang'
 
 # For characterization
 brew 'exiftool'
+
+brew "ghostscript" # maybe already a dependency of vips but we also use directly for PDF downscaling

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -214,6 +214,11 @@ class Admin::AssetsController < AdminController
       CreatePdfPageImageAssetJob.perform_later(@asset, page_num)
     end
 
+    # if we don't have a scaled_down_pdf derivative yet, kick off a job for that too!
+    unless @asset.file_derivatives[:screen_pdf].present?
+      CreateScaledDownPdfDerivativeJob.perform_later(@asset)
+    end
+
     redirect_to admin_asset_path(@asset), flash: { success: "Started creation of PDF page assets, it could take a few minutes to complete." }
   end
 

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -215,7 +215,7 @@ class Admin::AssetsController < AdminController
     end
 
     # if we don't have a scaled_down_pdf derivative yet, kick off a job for that too!
-    unless @asset.file_derivatives[:screen_pdf].present?
+    unless @asset.file_derivatives[AssetUploader::SCALED_PDF_DERIV_KEY].present?
       CreateScaledDownPdfDerivativeJob.perform_later(@asset)
     end
 

--- a/app/derivative_transformers/scale_down_pdf.rb
+++ b/app/derivative_transformers/scale_down_pdf.rb
@@ -12,19 +12,23 @@ class ScaleDownPdf
   class_attribute :ghostscript_pseudo_device, default: "ebook"
   DPI = 150
 
-  def call(original)
+  # @param linearize [Boolean] "linearizing" with fast web view increases size somewhat, but makes web loading faster.
+  #     matters more the bigger PDFs, caller just tell us if you want it.
+  def call(original, linearize: false)
     output_tempfile = Tempfile.new([self.class.name, ".pdf"])
 
     cmd = TTY::Command.new(printer: :null)
 
     args = [
       ghostscript_command,
+      #
+      ("-dFastWebView" if linearize),
       "-sDEVICE=pdfwrite",
       "-dPDFSETTINGS=/#{ghostscript_pseudo_device}",
       "-q",
       "-o", output_tempfile.path,
       original.path
-    ]
+    ].compact
 
     cmd.run(*args)
 

--- a/app/derivative_transformers/scale_down_pdf.rb
+++ b/app/derivative_transformers/scale_down_pdf.rb
@@ -7,7 +7,10 @@
 #
 class ScaleDownPdf
   class_attribute :ghostscript_command, default: "gs"
-  class_attribute :ghostscript_pseudo_device, default: "screen"
+  # gs ebook pre-set is 150dpi, and we decided was best compromise for a screen view. 72 dpi
+  # "screen" preset looked chunky. 150 "ebook" looks good
+  class_attribute :ghostscript_pseudo_device, default: "ebook"
+  DPI = 150
 
   def call(original)
     output_tempfile = Tempfile.new([self.class.name, ".pdf"])

--- a/app/derivative_transformers/scale_down_pdf.rb
+++ b/app/derivative_transformers/scale_down_pdf.rb
@@ -1,0 +1,30 @@
+# Takes an original (expected use case: born-digital) PDF, and scales images down
+# to 72 dpi by running it through the ghostscript `screen` pseudo-device (screen-optimized
+# according to an old Adobe profile)
+#
+# See relevant ghostscript options and definition of screen pseudo-device and others
+# at https://ghostscript.readthedocs.io/en/gs10.0.0/VectorDevices.html#the-family-of-pdf-and-postscript-output-devices
+#
+class ScaleDownPdf
+  class_attribute :ghostscript_command, default: "gs"
+  class_attribute :ghostscript_pseudo_device, default: "screen"
+
+  def call(original)
+    output_tempfile = Tempfile.new([self.class.name, ".pdf"])
+
+    cmd = TTY::Command.new(printer: :null)
+
+    args = [
+      ghostscript_command,
+      "-sDEVICE=pdfwrite",
+      "-dPDFSETTINGS=/#{ghostscript_pseudo_device}",
+      "-q",
+      "-o", output_tempfile.path,
+      original.path
+    ]
+
+    cmd.run(*args)
+
+    return output_tempfile
+  end
+end

--- a/app/jobs/create_scaled_down_pdf_derivative_job.rb
+++ b/app/jobs/create_scaled_down_pdf_derivative_job.rb
@@ -1,0 +1,11 @@
+class CreateScaledDownPdfDerivativeJob < ApplicationJob
+
+  def perform(asset)
+    unless asset.content_type == "application/pdf"
+      raise ArgumentError.new("Requires an asset with content_type application/pdf, not #{asset.content_type.inspect}")
+    end
+
+    # will overwrite with new if already existed, which is fine
+    asset.create_derivatives(only: [:screen_pdf])
+  end
+end

--- a/app/jobs/create_scaled_down_pdf_derivative_job.rb
+++ b/app/jobs/create_scaled_down_pdf_derivative_job.rb
@@ -1,11 +1,10 @@
 class CreateScaledDownPdfDerivativeJob < ApplicationJob
-
   def perform(asset)
     unless asset.content_type == "application/pdf"
       raise ArgumentError.new("Requires an asset with content_type application/pdf, not #{asset.content_type.inspect}")
     end
 
     # will overwrite with new if already existed, which is fine
-    asset.create_derivatives(only: [:screen_pdf])
+    asset.create_derivatives(only: [AssetUploader::SCALED_PDF_DERIV_KEY])
   end
 end

--- a/app/services/work_download_options_creator.rb
+++ b/app/services/work_download_options_creator.rb
@@ -75,7 +75,7 @@ class WorkDownloadOptionsCreator
         url: download_path(original_pdf_asset.file_category, original_pdf_asset),
         work_friendlier_id: work.friendlier_id,
         analyticsAction: "download_original",
-        subhead: subhead_parts.compact.join(", "),
+        subhead: subhead_parts.compact.join(" — "),
         content_type: "application/pdf"
 
       )
@@ -88,11 +88,11 @@ class WorkDownloadOptionsCreator
     if has_screen_pdf_derivative?
       subhead_parts = []
       #subhead_parts << "#{original_pdf_asset.file_metadata["page_count"]} pages" if original_pdf_asset.file_metadata["page_count"].present?
-      subhead_parts << ScihistDigicoll::Util.simple_bytes_to_human_string(screen_pdf_derivative.size) if screen_pdf_derivative.size
       subhead_parts << "#{ScaleDownPdf::DPI} dpi"
+      subhead_parts << ScihistDigicoll::Util.simple_bytes_to_human_string(screen_pdf_derivative.size) if screen_pdf_derivative.size
 
       options << DownloadOption.new("Screen-Optimized PDF",
-        subhead: subhead_parts.compact.join(", "),
+        subhead: subhead_parts.compact.join(" — "),
         url: download_derivative_path(original_pdf_asset, AssetUploader::SCALED_PDF_DERIV_KEY),
         analyticsAction: "download_pdf_screen",
         work_friendlier_id: work.friendlier_id,

--- a/app/services/work_download_options_creator.rb
+++ b/app/services/work_download_options_creator.rb
@@ -23,6 +23,10 @@ class WorkDownloadOptionsCreator
 
   protected
 
+  def has_screen_pdf_derivative?
+    screen_pdf_derivative.present?
+  end
+
   def has_original_pdf?
     original_pdf_asset.present?
   end
@@ -52,6 +56,13 @@ class WorkDownloadOptionsCreator
     @original_pdf_asset = work.members.where(role: PdfToPageImages::SOURCE_PDF_ROLE).first
   end
 
+  # @return Shrine::UploadedFile
+  def screen_pdf_derivative
+    return @screen_pdf_derivative if defined? @screen_pdf_derivative
+
+    @screen_pdf_derivative = has_original_pdf? && original_pdf_asset.file_derivatives[AssetUploader::SCALED_PDF_DERIV_KEY]
+  end
+
   def construct_options
     options = []
 
@@ -71,6 +82,21 @@ class WorkDownloadOptionsCreator
     elsif has_constructed_pdf?
       options << DownloadOption.for_on_demand_derivative(
         label: "PDF", derivative_type: "pdf_file", work_friendlier_id: work.friendlier_id
+      )
+    end
+
+    if has_screen_pdf_derivative?
+      subhead_parts = []
+      #subhead_parts << "#{original_pdf_asset.file_metadata["page_count"]} pages" if original_pdf_asset.file_metadata["page_count"].present?
+      subhead_parts << ScihistDigicoll::Util.simple_bytes_to_human_string(screen_pdf_derivative.size) if screen_pdf_derivative.size
+      subhead_parts << "#{ScaleDownPdf::DPI} dpi"
+
+      options << DownloadOption.new("Screen-Optimized PDF",
+        subhead: subhead_parts.compact.join(", "),
+        url: download_derivative_path(original_pdf_asset, AssetUploader::SCALED_PDF_DERIV_KEY),
+        analyticsAction: "download_pdf_screen",
+        work_friendlier_id: work.friendlier_id,
+        content_type: "application/pdf"
       )
     end
 

--- a/app/uploaders/asset_uploader.rb
+++ b/app/uploaders/asset_uploader.rb
@@ -93,6 +93,15 @@ class AssetUploader < Kithe::AssetUploader
     AssetGraphicOnlyPdfCreator.new(attacher.record, original_file: original_file).create
   end
 
+  # only for work_source_pdf PDFs, we create a lower resolution "optimized for screen" PDF.
+  # not automatically created by default, we call it was part of our `setup_work_from_pdf_source`
+  # routine in CreatePdfPageImageAssetJob
+  Attacher.define_derivative(:screen_pdf, content_type: "application/pdf", default_create: false) do |original_file, attacher:|
+    if attacher.record.role == PdfToPageImages::SOURCE_PDF_ROLE
+      ScaleDownPdf.new.call(original_file)
+    end
+  end
+
 
   # For FLAC originals, we create a mono m4a derivative.
   # Typically this deriv is only 5% of the size of the original FLAC,

--- a/app/uploaders/asset_uploader.rb
+++ b/app/uploaders/asset_uploader.rb
@@ -100,7 +100,9 @@ class AssetUploader < Kithe::AssetUploader
   # routine in CreatePdfPageImageAssetJob
   Attacher.define_derivative(SCALED_PDF_DERIV_KEY, content_type: "application/pdf", default_create: false) do |original_file, attacher:|
     if attacher.record.role == PdfToPageImages::SOURCE_PDF_ROLE
-      ScaleDownPdf.new.call(original_file)
+      # linearizing increases file size a bit for faster display on download. Do it only for
+      # more than 3 pages and more than 2MB.
+      ScaleDownPdf.new.call(original_file, linearize: (attacher.record.file_metadata["page_count"].to_i > 3 && attacher.record.size > 2.megabytes.to_i))
     end
   end
 

--- a/app/uploaders/asset_uploader.rb
+++ b/app/uploaders/asset_uploader.rb
@@ -1,4 +1,6 @@
 class AssetUploader < Kithe::AssetUploader
+  SCALED_PDF_DERIV_KEY = :scaled_down_pdf
+
   # gives us md5, sha1, sha512
   plugin :kithe_checksum_signatures
 
@@ -96,7 +98,7 @@ class AssetUploader < Kithe::AssetUploader
   # only for work_source_pdf PDFs, we create a lower resolution "optimized for screen" PDF.
   # not automatically created by default, we call it was part of our `setup_work_from_pdf_source`
   # routine in CreatePdfPageImageAssetJob
-  Attacher.define_derivative(:screen_pdf, content_type: "application/pdf", default_create: false) do |original_file, attacher:|
+  Attacher.define_derivative(SCALED_PDF_DERIV_KEY, content_type: "application/pdf", default_create: false) do |original_file, attacher:|
     if attacher.record.role == PdfToPageImages::SOURCE_PDF_ROLE
       ScaleDownPdf.new.call(original_file)
     end

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -392,7 +392,7 @@
       <% if flash[:make_work_source_pdf_errors].present? %>
         <div class="alert alert-danger mt-4" role="alert">
           <ul class="list-unstyled">
-            <h4 class="alert-heading"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Could build create PDF-sourced work</h4>
+            <h4 class="alert-heading"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Could not build create PDF-sourced work</h4>
             <% flash[:make_work_source_pdf_errors].each do |str| %>
               <li class="mb-2"><%= str %></li>
             <% end %>

--- a/spec/controllers/admin/assets_controller_spec.rb
+++ b/spec/controllers/admin/assets_controller_spec.rb
@@ -169,9 +169,9 @@ RSpec.describe Admin::AssetsController, :logged_in_user, type: :controller do
       expect(asset.parent.members.where(role: PdfToPageImages::EXTRACTED_PAGE_ROLE).count).to eq 1
 
       # scaled down derivative created
-      expect(asset.file_derivatives[:screen_pdf]).to be_present
-      expect(asset.file_derivatives[:screen_pdf].content_type).to eq "application/pdf"
-      expect(asset.file_derivatives[:screen_pdf].size).to be > 0
+      expect(asset.file_derivatives[AssetUploader::SCALED_PDF_DERIV_KEY]).to be_present
+      expect(asset.file_derivatives[AssetUploader::SCALED_PDF_DERIV_KEY].content_type).to eq "application/pdf"
+      expect(asset.file_derivatives[AssetUploader::SCALED_PDF_DERIV_KEY].size).to be > 0
     end
   end
 

--- a/spec/controllers/admin/assets_controller_spec.rb
+++ b/spec/controllers/admin/assets_controller_spec.rb
@@ -167,6 +167,11 @@ RSpec.describe Admin::AssetsController, :logged_in_user, type: :controller do
 
       # 1 pdf page extracted
       expect(asset.parent.members.where(role: PdfToPageImages::EXTRACTED_PAGE_ROLE).count).to eq 1
+
+      # scaled down derivative created
+      expect(asset.file_derivatives[:screen_pdf]).to be_present
+      expect(asset.file_derivatives[:screen_pdf].content_type).to eq "application/pdf"
+      expect(asset.file_derivatives[:screen_pdf].size).to be > 0
     end
   end
 

--- a/spec/derivative_transformers/scale_down_pdf_spec.rb
+++ b/spec/derivative_transformers/scale_down_pdf_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+require 'marcel'
+
+describe ScaleDownPdf do
+  let(:original_path) { Rails.root + "spec/test_support/pdf/sample-text-and-image-small.pdf"}
+  let(:original_file) { File.open(original_path) }
+
+  it "creates an output PDF" do
+    output_file = ScaleDownPdf.new.call(original_file)
+
+    expect(output_file).to be_kind_of(Tempfile)
+
+    # In some cases such as this it won't really be smaller cause we already were 72 dpi,
+    # but I think it shouldn't be bigger?
+    expect(output_file.size).to be <= original_file.size
+
+    expect(Marcel::MimeType.for(output_file)).to eq "application/pdf"
+
+    output_file.close
+    output_file.unlink
+  end
+end

--- a/spec/derivative_transformers/scale_down_pdf_spec.rb
+++ b/spec/derivative_transformers/scale_down_pdf_spec.rb
@@ -10,9 +10,9 @@ describe ScaleDownPdf do
 
     expect(output_file).to be_kind_of(Tempfile)
 
-    # In some cases such as this it won't really be smaller cause we already were 72 dpi,
-    # but I think it shouldn't be bigger?
-    expect(output_file.size).to be <= original_file.size
+    # In some cases such as this tiny original it might not be smaller, but it shouldn't
+    # be much bigger?
+    expect(output_file.size).to be <= (original_file.size * 1.1)
 
     expect(Marcel::MimeType.for(output_file)).to eq "application/pdf"
 

--- a/spec/factories/asset_factory.rb
+++ b/spec/factories/asset_factory.rb
@@ -88,6 +88,7 @@ FactoryBot.define do
         faked_audio_sample_rate { nil }
         faked_md5 { Digest::MD5.hexdigest rand(10000000).to_s }
         faked_sha512 { Digest::SHA512.hexdigest rand(10000000).to_s }
+        faked_page_count { nil }
 
         # other arbitrary metadata
         faked_metadata { {} }
@@ -227,7 +228,8 @@ FactoryBot.define do
           sha512: evaluator.faked_sha512,
           filename: evaluator.faked_filename,
           size: evaluator.faked_size,
-          other_metadata: evaluator.faked_metadata)
+          other_metadata: evaluator.faked_metadata,
+          page_count: evaluator.faked_page_count)
 
         asset.file_data = uploaded_file.as_json
 
@@ -265,5 +267,11 @@ FactoryBot.define do
       faked_width { nil }
     end
 
+    factory :asset_with_faked_source_pdf, parent: :asset_with_faked_file do
+      pdf
+      role { PdfToPageImages::SOURCE_PDF_ROLE }
+      faked_derivatives { { AssetUploader::SCALED_PDF_DERIV_KEY => create(:stored_uploaded_file, content_type: "application/pdf") } }
+      faked_page_count  { 10 }
+    end
   end
 end

--- a/spec/factories/uploaded_file_factory.rb
+++ b/spec/factories/uploaded_file_factory.rb
@@ -24,6 +24,7 @@ FactoryBot.define do
       filename { nil }
       size { nil }
       other_metadata { {} }
+      page_count { nil }
     end
 
     id { SecureRandom.hex }
@@ -41,7 +42,8 @@ FactoryBot.define do
         "audio_bitrate" => audio_bitrate,
         "video_bitrate" => video_bitrate,
         "audio_sample_rate" => audio_sample_rate,
-        "sha512" => sha512
+        "sha512" => sha512,
+        "page_count" => page_count
       }.merge(other_metadata).compact
     end
 

--- a/spec/services/work_download_options_creator_spec.rb
+++ b/spec/services/work_download_options_creator_spec.rb
@@ -45,6 +45,37 @@ describe WorkDownloadOptionsCreator do
     end
   end
 
+  describe "work_source_pdf with derivative" do
+    let(:source_pdf_asset) { build(:asset_with_faked_source_pdf) }
+    let(:work) do
+      create(:public_work, members: [
+        source_pdf_asset,
+        build(:asset_with_faked_file)
+      ])
+    end
+
+    it "has original PDF and scaled PDF options" do
+      original_option =  options.find { |o| o.label == "Original PDF" }
+      expect(original_option).to be_present
+      # 10 pages, 80.5 MB
+      expect(original_option.subhead).to match /\d+ pages, (\d+\.?)+ [A-Z]{2}/
+      expect(original_option.work_friendlier_id).to eq work.friendlier_id
+      expect(original_option.url).to include source_pdf_asset.friendlier_id
+      expect(original_option.analyticsAction).to eq "download_original"
+      expect(original_option.content_type).to eq "application/pdf"
+
+      scaled = options.find { |o| o.label == "Screen-Optimized PDF" }
+      expect(scaled).to be_present
+      # 124 MB, 150 dpi
+      expect(scaled.subhead).to match /(\d+\.?)+ [A-Z]{2}, 150 dpi/
+      expect(scaled.work_friendlier_id).to eq work.friendlier_id
+      expect(scaled.url).to include source_pdf_asset.friendlier_id
+      expect(scaled.url).to include AssetUploader::SCALED_PDF_DERIV_KEY.to_s
+      expect(scaled.analyticsAction).to eq "download_pdf_screen"
+      expect(scaled.content_type).to eq "application/pdf"
+    end
+  end
+
   describe "unpublished parent work" do
     let(:work) do
       create(:work, published: false, members: [build(:asset_with_faked_file), build(:asset_with_faked_file)])

--- a/spec/services/work_download_options_creator_spec.rb
+++ b/spec/services/work_download_options_creator_spec.rb
@@ -58,7 +58,7 @@ describe WorkDownloadOptionsCreator do
       original_option =  options.find { |o| o.label == "Original PDF" }
       expect(original_option).to be_present
       # 10 pages, 80.5 MB
-      expect(original_option.subhead).to match /\d+ pages, (\d+\.?)+ [A-Z]{2}/
+      expect(original_option.subhead).to match /\d+ pages — (\d+\.?)+ [A-Z]{2}/
       expect(original_option.work_friendlier_id).to eq work.friendlier_id
       expect(original_option.url).to include source_pdf_asset.friendlier_id
       expect(original_option.analyticsAction).to eq "download_original"
@@ -67,7 +67,7 @@ describe WorkDownloadOptionsCreator do
       scaled = options.find { |o| o.label == "Screen-Optimized PDF" }
       expect(scaled).to be_present
       # 124 MB, 150 dpi
-      expect(scaled.subhead).to match /(\d+\.?)+ [A-Z]{2}, 150 dpi/
+      expect(scaled.subhead).to match /150 dpi — (\d+\.?)+ [A-Z]{2}/
       expect(scaled.work_friendlier_id).to eq work.friendlier_id
       expect(scaled.url).to include source_pdf_asset.friendlier_id
       expect(scaled.url).to include AssetUploader::SCALED_PDF_DERIV_KEY.to_s

--- a/system_env_spec/system_env_spec.rb
+++ b/system_env_spec/system_env_spec.rb
@@ -211,4 +211,16 @@ describe "System Environment" do
       expect(version).to match_version_requirements(">= 22.0")
     end
   end
+
+  # Should be on heroku automatically, but some issues with heroku-24. custom build script
+  # may be needed. See https://www.reddit.com/r/Heroku/comments/1fj3cr4/ghostscript_on_heroku24/
+  describe "ghostscript" do
+    it "is present with acceptable version" do
+      out = `gs -v 2>&1`
+
+      expect(out).to match(/GPL Ghostscript (\d+\.\d+\.\d+)/)
+      version = $1
+      expect(version).to match_version_requirements(">= 9.55.0")
+    end
+  end
 end


### PR DESCRIPTION
On top of #2747 

When we have a PDF Asset with `work_source_pdf` role, we want to make a _pdf derivative_, with a smaller file size and scaled down images.  Some of our "born digital" Distillations PDFs have 300 dpi images for printing, and are quite big. 

* We define a derivative on `AssetUploader`, in the standard way -- it will be stored in the derivatives hash in the shrine file!
   *  we mark it `default_create: false`, so it won't be automatically created on ingest, it will be triggered manually. (on ingest, role isn't set yet telling us this is a `work_source_pdf` we want to create the deriv for!)
   * The `setup_work_from_pdf_source` action -- which was already extracting page images as Assets -- will now also see if the derivative is already on the `work_source_pdf`, and if not launch a `CreateScaledDownPdfDerivativeJob` to create one. (It can take 120+ seconds to create)

* The actual work of creating the PDF is done by `ScaleDownPdf` class -- which shells out to `gs` (ghostscript) command line
  *  Ghost script has a "pseudo-device" pre-set for `ebook`, that downsamples images to 150dpi, among other things. We're using that. There was a `screen` preset for 72dpi, but that made images look noticeably bad. 150 dpi was fine on devices I tested, still with significant file size reduction for our sample files.       https://ghostscript.readthedocs.io/en/gs10.0.0/VectorDevices.html#the-family-of-pdf-and-postscript-output-devices

  * Added check for `gs` to system_env_spec
  * `gs` was already present on my Mac (prob a brew dependency of vips?) and on heroku
  * But it was removed from heroku-24. Could be re-added with a custom buildpack, but it also looks like they may be re-adding it back. https://www.reddit.com/r/Heroku/comments/1fj3cr4/ghostscript_on_heroku24/. 
   
* Then the recently added `WorkDownloadOptionsCreator` class was enhanced to notice the presence of the derivative (called `scaled_down_pdf`, with key kept in a constant), and add it to the whole-work options shown on Work page and in Downloads popup menu. 

