### PR TITLE
DownloadOption can have a separate 'download_url' to force downloads

### DIFF
--- a/app/components/work_download_links_component.html.erb
+++ b/app/components/work_download_links_component.html.erb
@@ -2,13 +2,13 @@
   <% download_options.each do |download_option| %>
     <div class="on-page-work-downloads-item">
       <div class="image">
-        <%= link_to(download_option.url, data: download_option.data_attrs, tabindex: -1, "aria-label": download_button_label(download_option)) do %>
+        <%= link_to(download_option.url, data: download_option.data_attrs, tabindex: -1, "aria-label": download_button_label(download_option), target: "_blank") do %>
           <%= download_file_icon(download_option) %>
         <% end %>
       </div>
 
       <div class="text">
-          <%= link_to(download_option.url, data: download_option.data_attrs, tabindex: -1) do %>
+          <%= link_to(download_option.url, data: download_option.data_attrs, target: "_blank") do %>
             <%= download_option.label %>
           <% end %>
 
@@ -20,7 +20,7 @@
       </div>
 
       <div class="action">
-        <%= link_to(download_option.url, data: download_option.data_attrs, class: "btn btn-brand-main less-padding") do %>
+        <%= link_to(download_option.download_url, data: download_option.data_attrs, class: "btn btn-brand-main less-padding") do %>
           <%= download_button_label(download_option) %>
         <% end %>
       </div>

--- a/app/models/download_option.rb
+++ b/app/models/download_option.rb
@@ -61,7 +61,7 @@ class DownloadOption
   #   to add to link.
   # @param work_friendlier_id [String] used for analytics data attributes
   # @param content_type [String] MIME/IANA content-type, sometimes used for icons and such on display
-  def self.with_formatted_subhead(label, url:, work_friendlier_id:, analyticsAction:nil, width: nil, height: nil, size: nil, content_type: nil)
+  def self.with_formatted_subhead(label, url:, work_friendlier_id:, analyticsAction:nil, width: nil, height: nil, size: nil, content_type: nil, download_url: nil)
     parts = []
     parts << ScihistDigicoll::Util.humanized_content_type(content_type) if content_type.present?
     parts << "#{width.to_s} x #{height.to_s}px" if width.present? && height.present?
@@ -71,7 +71,7 @@ class DownloadOption
 
     subhead = parts.join(" — ") # em-dash
 
-    new(label, url: url, work_friendlier_id: work_friendlier_id, analyticsAction: analyticsAction, subhead: subhead.presence)
+    new(label, url: url, work_friendlier_id: work_friendlier_id, analyticsAction: analyticsAction, subhead: subhead.presence, download_url: download_url)
   end
 
   # @param label [String] main label for the download link
@@ -80,7 +80,9 @@ class DownloadOption
   # @param subhead [String] a subheading/hint/more info for the label for the download link
   # @param analyticsAction [String] a key to record in our analytics logging, up to caller
   #   to decide what to do with it, but probably will turn into a data- attribute for JS.
-  def initialize(label, url:, work_friendlier_id:, subhead:nil, analyticsAction:nil, content_type: nil, data_attrs: {})
+  # @param download_url [String] some options have a separate "force download" URL, when the main url is viewed inline.
+  #    Some of our UI offers both options. Optionally provide an alternate force download url.
+  def initialize(label, url:, work_friendlier_id:, subhead:nil, analyticsAction:nil, content_type: nil, data_attrs: {}, download_url: nil)
     @label = label
     @subhead = subhead
     @url = url
@@ -88,6 +90,7 @@ class DownloadOption
     @data_attrs = data_attrs
     @work_friendlier_id = work_friendlier_id
     @content_type = content_type
+    @download_url = download_url
 
     # Add in analytics data- attributes
     @data_attrs.merge!(analytics_data_attributes)
@@ -113,9 +116,17 @@ class DownloadOption
     }
   end
 
+  # Some of our UI offers a main link to view inline, and a download link to force download.
+  #
+  # If we have an alternate download_url great, if not just use the main url here
+  def download_url
+    @download_url.presence || url
+  end
+
+
   # sometimes we want to modify one, treat as immutable but let modify like this!
   # Can override any element as if it were initializer
-  def dup_with(label=self.label, url: self.url, work_friendlier_id: self.work_friendlier_id, subhead:self.subhead, analyticsAction:self.analyticsAction, data_attrs: self.data_attrs, content_type: self.content_type)
-    self.class.new(label, url: url, work_friendlier_id: work_friendlier_id, subhead:subhead, analyticsAction:analyticsAction, data_attrs: data_attrs, content_type: content_type)
+  def dup_with(label=self.label, url: self.url, work_friendlier_id: self.work_friendlier_id, subhead:self.subhead, analyticsAction:self.analyticsAction, data_attrs: self.data_attrs, content_type: self.content_type, download_url: self.download_url)
+    self.class.new(label, url: url, work_friendlier_id: work_friendlier_id, subhead:subhead, analyticsAction:analyticsAction, data_attrs: data_attrs, content_type: content_type, download_url: download_url)
   end
 end

--- a/app/services/work_download_options_creator.rb
+++ b/app/services/work_download_options_creator.rb
@@ -72,7 +72,8 @@ class WorkDownloadOptionsCreator
       subhead_parts << ScihistDigicoll::Util.simple_bytes_to_human_string(original_pdf_asset.size) if original_pdf_asset.size
 
       options << DownloadOption.new("Original PDF",
-        url: download_path(original_pdf_asset.file_category, original_pdf_asset),
+        url: download_path(original_pdf_asset.file_category, original_pdf_asset, disposition: :inline),
+        download_url: download_path(original_pdf_asset.file_category, original_pdf_asset),
         work_friendlier_id: work.friendlier_id,
         analyticsAction: "download_original",
         subhead: subhead_parts.compact.join(", "),
@@ -93,7 +94,8 @@ class WorkDownloadOptionsCreator
 
       options << DownloadOption.new("Screen-Optimized PDF",
         subhead: subhead_parts.compact.join(", "),
-        url: download_derivative_path(original_pdf_asset, AssetUploader::SCALED_PDF_DERIV_KEY),
+        url: download_derivative_path(original_pdf_asset, AssetUploader::SCALED_PDF_DERIV_KEY, disposition: :inline),
+        download_url: download_derivative_path(original_pdf_asset, AssetUploader::SCALED_PDF_DERIV_KEY),
         analyticsAction: "download_pdf_screen",
         work_friendlier_id: work.friendlier_id,
         content_type: "application/pdf"


### PR DESCRIPTION
Which is used by our born-digital PDF links so that we can have a link for 'inline' viewing of the PDFs on the link itself (opening in new tab); and separate url for forced-dopwnload (with content-disposition headers) on the "download" button.

This wasn't relevant before, because the AJAXy stuff for our on-demand derivatives -- its' not feasible to have inline view links at all (or at least we haven't tackled the challenge), so it was all forced download.

But with THESE NEW links, we can provide an inline view option. (Is it bad it's not consistent? I think it's okay)

On top of #2749


![Screenshot 2024-09-18 at 5 06 58 PM](https://github.com/user-attachments/assets/a231a82c-3ca9-4b2d-9731-7bc4efbccfa6)

