### PR TITLE
Fix sort on admin work page.

### DIFF
--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -703,7 +703,7 @@ class Admin::WorksController < AdminController
       if params[:include_child_works] == 'false'
         scope = scope.where("parent_id IS NULL")
       end
-      scope.order(index_params[:sort_field] => index_params[:sort_order])
+      scope.order!(index_params[:sort_field] => index_params[:sort_order])
       scope.includes(:leaf_representative).page(params[:page]).per(20)
     end
 end

--- a/spec/controllers/admin/works_controller_spec.rb
+++ b/spec/controllers/admin/works_controller_spec.rb
@@ -363,6 +363,24 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
         expect(response).not_to be_redirect
         expect(response.status).to eq(200)
       end
+
+      context "sorting, filtering and pagination" do
+        render_views
+        let!(:works) { [
+          create(:work, title: "work_a"),
+          create(:work, title: "work_b") 
+          ] }
+        it "sorts correctly by title" do
+          get :index, params: { sort_field: :title, sort_order: :asc }
+          rows = response.parsed_body.css('.table.admin-list tbody tr')
+          expect(rows[0].inner_html).to include works[0].title
+          expect(rows[1].inner_html).to include works[1].title
+          get :index, params: { sort_field: :title, sort_order: :desc }
+          rows = response.parsed_body.css('.table.admin-list tbody tr')
+          expect(rows[0].inner_html).to include works[1].title
+          expect(rows[1].inner_html).to include works[0].title
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Ref #2762
Classic blunder - should have used [order!](https://apidock.com/rails/v7.1.3.2/ActiveRecord/QueryMethods/order%21) instead of [order](https://apidock.com/rails/ActiveRecord/QueryMethods/order).