### PR TITLE
fix to non-deprecated version of config for mailer preview paths

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
 
   # use ActionMailer previews feature, with previews in our rspec folder.
   # https://guides.rubyonrails.org/action_mailer_basics.html#previewing-emails
-  config.action_mailer.preview_path = "#{Rails.root}/spec/mailers/previews"
+  config.action_mailer.preview_paths = ["#{Rails.root}/spec/mailers/previews"]
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log


### PR DESCRIPTION
Not sure if it was cauisng problems in some cases, but does not hurt. 
