### PR TITLE
Add requester email to HoneyBadger context

### DIFF
--- a/app/controllers/oral_history_requests_controller.rb
+++ b/app/controllers/oral_history_requests_controller.rb
@@ -24,7 +24,8 @@ class OralHistoryRequestsController < ApplicationController
     unless current_oral_history_requester.present?
       raise AccessDenied.new
     end
-
+    
+    raise "Eddie here, triggering an error on purpose in staging. See https://github.com/sciencehistory/scihist_digicoll/issues/2579 ."
 
     all_requests = current_oral_history_requester.oral_history_requests.
       includes(:work => [:leaf_representative, { :oral_history_content => :interviewee_biographies } ]).

--- a/app/controllers/oral_history_requests_controller.rb
+++ b/app/controllers/oral_history_requests_controller.rb
@@ -208,7 +208,8 @@ private
 
 
   def add_requester_email_to_honeybadger_context
-    # Get this info either from the session (via current_oral_history_requester) or from the actual parameter.
+    # Get this info either from the session (via current_oral_history_requester) or from the :patron_email parameter.
+    # Note: this method has the side effect of resetting the expiration window of the OH request.
     email = current_oral_history_requester&.email || params[:patron_email]
     Honeybadger.context({ oral_history_requester_email: email  })
   end

--- a/app/controllers/oral_history_requests_controller.rb
+++ b/app/controllers/oral_history_requests_controller.rb
@@ -3,6 +3,7 @@
 # Actions to make requests, and also to view your requsets.
 #
 # Staff-facing actions are in app/controllers/admin/oral_history_requests_controller.rb
+
 class OralHistoryRequestsController < ApplicationController
   # message is publicly visible please
   class AccessDenied < StandardError
@@ -24,51 +25,51 @@ class OralHistoryRequestsController < ApplicationController
     unless current_oral_history_requester.present?
       raise AccessDenied.new
     end
-    
-    raise "Eddie here, triggering an error on purpose in staging. See https://github.com/sciencehistory/scihist_digicoll/issues/2579 ."
+    Honeybadger.context({ requester_email: current_oral_history_requester&.email }) do
+      all_requests = current_oral_history_requester.oral_history_requests.
+        includes(:work => [:leaf_representative, { :oral_history_content => :interviewee_biographies } ]).
+        order(created_at: :asc).
+        strict_loading
 
-    all_requests = current_oral_history_requester.oral_history_requests.
-      includes(:work => [:leaf_representative, { :oral_history_content => :interviewee_biographies } ]).
-      order(created_at: :asc).
-      strict_loading
+      grouped_by = all_requests.group_by(&:delivery_status)
+      null_ts = Time.utc(1,1,1,1,1,1)
 
-    grouped_by = all_requests.group_by(&:delivery_status)
-    null_ts = Time.utc(1,1,1,1,1,1)
+      @pending_requests = grouped_by["pending"] || []
 
-    @pending_requests = grouped_by["pending"] || []
+      @approved_requests = (
+        (grouped_by["approved"]  || []) + (grouped_by["automatic"] || [])
+      ).sort_by do |req|
+        req.delivery_status_changed_at || null_ts
+      end
 
-    @approved_requests = (
-      (grouped_by["approved"]  || []) + (grouped_by["automatic"] || [])
-    ).sort_by do |req|
-      req.delivery_status_changed_at || null_ts
-    end
-
-    @rejected_requests = (grouped_by["rejected"] || []).sort_by do |req|
-      req.delivery_status_changed_at || null_ts
+      @rejected_requests = (grouped_by["rejected"] || []).sort_by do |req|
+        req.delivery_status_changed_at || null_ts
+      end
     end
   end
 
   # GET /oral_history_requests/:id
   def show
     @access_request = OralHistoryRequest.find(params[:id])
-
-    # If they can't see it for any reason, just 404 as if it was not there.
-    unless current_oral_history_requester == @access_request.oral_history_requester &&
-          (@access_request.delivery_status_approved? || @access_request.delivery_status_automatic?)
-      raise ActionController::RoutingError.new("Not found.")
-    end
-
-    # Calculate assets avail by request, broken up by type
-    all_by_request_assets = @access_request.work.members.
-      where(published: false).
-      includes(:leaf_representative).order(:position).strict_loading.
-      to_a.find_all do |member|
-        member.kind_of?(Asset) &&  member.oh_available_by_request?
+    Honeybadger.context({ requester_email: @access_request.requester_email }) do
+      # If they can't see it for any reason, just 404 as if it was not there.
+      unless current_oral_history_requester == @access_request.oral_history_requester &&
+            (@access_request.delivery_status_approved? || @access_request.delivery_status_automatic?)
+        raise ActionController::RoutingError.new("Not found.")
       end
 
-    @transcript_assets = all_by_request_assets.find_all { |a| a.role == "transcript" }
-    @audio_assets = all_by_request_assets.find_all { |a| a.content_type.start_with?("audio/") }
-    @other_assets = all_by_request_assets.find_all { |a| !@transcript_assets.include?(a) && !@audio_assets.include?(a) }
+      # Calculate assets avail by request, broken up by type
+      all_by_request_assets = @access_request.work.members.
+        where(published: false).
+        includes(:leaf_representative).order(:position).strict_loading.
+        to_a.find_all do |member|
+          member.kind_of?(Asset) &&  member.oh_available_by_request?
+        end
+
+      @transcript_assets = all_by_request_assets.find_all { |a| a.role == "transcript" }
+      @audio_assets = all_by_request_assets.find_all { |a| a.content_type.start_with?("audio/") }
+      @other_assets = all_by_request_assets.find_all { |a| !@transcript_assets.include?(a) && !@audio_assets.include?(a) }
+    end
   end
 
   # GET /works/4j03d09fr7t/request_oral_history
@@ -76,18 +77,19 @@ class OralHistoryRequestsController < ApplicationController
   # Form to fill out
   def new
     @work = load_work(params['work_friendlier_id'])
+    Honeybadger.context({ requester_email: current_oral_history_requester&.email }) do
+      # In new mode, check to see if the are logged in, and request already exists,
+      # just send them to their requests!
+      if current_oral_history_requester &&
+            OralHistoryRequest.where(work: @work, oral_history_requester: current_oral_history_requester).exists?
 
-    # In new mode, check to see if the are logged in, and request already exists,
-    # just send them to their requests!
-    if current_oral_history_requester &&
-          OralHistoryRequest.where(work: @work, oral_history_requester: current_oral_history_requester).exists?
+          redirect_to oral_history_requests_path, flash: { success: "You have already requested this Oral History: #{@work.title}" }
 
-        redirect_to oral_history_requests_path, flash: { success: "You have already requested this Oral History: #{@work.title}" }
+          return # abort further processing
+      end
 
-        return # abort further processing
+      @oral_history_request = OralHistoryRequest.new(work: @work)
     end
-
-    @oral_history_request = OralHistoryRequest.new(work: @work)
   end
 
   before_action :setup_create_request, only: :create
@@ -96,40 +98,42 @@ class OralHistoryRequestsController < ApplicationController
   #
   # Action to create request from form
   def create
-    # write entries to a cookie to pre-fill form next time; every time we write
-    # it will bump the TTL expiration too, so they get another day until it expires.
-    # Make sure to include the separate patron_eamil
-    oral_history_request_form_entry_write(
-      oral_history_request_params.merge(patron_email: patron_email_param).to_h
-    )
+    Honeybadger.context({ requester_email: patron_email_param }) do
+      # write entries to a cookie to pre-fill form next time; every time we write
+      # it will bump the TTL expiration too, so they get another day until it expires.
+      # Make sure to include the separate patron_eamil
+      oral_history_request_form_entry_write(
+        oral_history_request_params.merge(patron_email: patron_email_param).to_h
+      )
 
-    saved_valid = @oral_history_request.save
+      saved_valid = @oral_history_request.save
 
-    unless saved_valid
-      render :new
-      return
-    end
-
-    if @work.oral_history_content.available_by_request_automatic?
-      @oral_history_request.update!(delivery_status: "automatic")
-
-      # If they are already logged in, they can just be directed to see this
-      # automatically-approved request. Either way they should get an email,
-      # per specs from OH team.
-      OralHistoryDeliveryMailer.with(request: @oral_history_request).approved_with_session_link_email.deliver_later
-
-      if current_oral_history_requester.present? && current_oral_history_requester.email == @oral_history_request.requester_email
-        redirect_to oral_history_requests_path, flash: { success: "The files you requested from '#{@work.title}' are immediately available." }
-      else
-        redirect_to work_path(@work.friendlier_id), flash: { success: "The files you have requested are immediately available. We've sent an email to #{patron_email_param} with a sign-in link." }
+      unless saved_valid
+        render :new
+        return
       end
-    else # manual review
-      OralHistoryRequestNotificationMailer.
-        with(request: @oral_history_request).
-        notification_email.
-        deliver_later
 
-      redirect_to work_path(@work.friendlier_id), flash: { success: "Thank you for your interest. Your request will be reviewed, usually within 3 business days, and we'll email you at #{@oral_history_request.requester_email}" }
+      if @work.oral_history_content.available_by_request_automatic?
+        @oral_history_request.update!(delivery_status: "automatic")
+
+        # If they are already logged in, they can just be directed to see this
+        # automatically-approved request. Either way they should get an email,
+        # per specs from OH team.
+        OralHistoryDeliveryMailer.with(request: @oral_history_request).approved_with_session_link_email.deliver_later
+
+        if current_oral_history_requester.present? && current_oral_history_requester.email == @oral_history_request.requester_email
+          redirect_to oral_history_requests_path, flash: { success: "The files you requested from '#{@work.title}' are immediately available." }
+        else
+          redirect_to work_path(@work.friendlier_id), flash: { success: "The files you have requested are immediately available. We've sent an email to #{patron_email_param} with a sign-in link." }
+        end
+      else # manual review
+        OralHistoryRequestNotificationMailer.
+          with(request: @oral_history_request).
+          notification_email.
+          deliver_later
+
+        redirect_to work_path(@work.friendlier_id), flash: { success: "Thank you for your interest. Your request will be reviewed, usually within 3 business days, and we'll email you at #{@oral_history_request.requester_email}" }
+      end
     end
   end
 
@@ -203,5 +207,13 @@ private
     @current_oral_history_requester
   end
   helper_method :current_oral_history_requester
+
+  def current_oral_history_requester_for_hb
+    unless defined?(@current_oral_history_requester_for_hb)
+      @current_oral_history_requester_for_hb = OralHistorySessionsController.fetch_oral_history_current_requester(request: request, reset_expiration_window: false)
+    end
+    @current_oral_history_requester_for_hb
+  end
+  helper_method :current_oral_history_requester_for_hb
 
 end

--- a/spec/controllers/oral_history_requests_controller_spec.rb
+++ b/spec/controllers/oral_history_requests_controller_spec.rb
@@ -29,9 +29,11 @@ describe OralHistoryRequestsController, type: :controller do
 
       it "does not throw an error" do
         get :index
+        expect(Honeybadger.get_context[:oral_history_requester_email]).to eq req_1.oral_history_requester.email
       end
     end
   end
+
 
   describe "#show" do
     let(:oh_request) { create(:oral_history_request, delivery_status: "approved") }
@@ -79,6 +81,7 @@ describe OralHistoryRequestsController, type: :controller do
         it "shows" do
           get :show, params: { id: oh_request.id }
           expect(response).to have_http_status(:success)
+          expect(Honeybadger.get_context[:oral_history_requester_email]).to eq oh_request.oral_history_requester.email
         end
       end
 
@@ -88,6 +91,7 @@ describe OralHistoryRequestsController, type: :controller do
         it "shows" do
           get :show, params: { id: oh_request.id }
           expect(response).to have_http_status(:success)
+          expect(Honeybadger.get_context[:oral_history_requester_email]).to eq oh_request.oral_history_requester.email
         end
       end
     end
@@ -120,6 +124,7 @@ describe OralHistoryRequestsController, type: :controller do
 
         expect(response).to redirect_to(oral_history_requests_path)
         expect(flash[:success]).to match /You have already requested this Oral History/
+        expect(Honeybadger.get_context[:oral_history_requester_email]).to eq requester_email.email
       end
     end
   end
@@ -159,6 +164,8 @@ describe OralHistoryRequestsController, type: :controller do
 
             expect(response).to redirect_to(oral_history_requests_path)
             expect(flash[:success]).to match /The files you requested from '#{Regexp.escape work.title}' are immediately available./
+            expect(Honeybadger.get_context[:oral_history_requester_email]).to eq requester_email.email
+
           end
         end
 
@@ -171,6 +178,7 @@ describe OralHistoryRequestsController, type: :controller do
                 expect(action).to eq "approved_with_session_link_email"
             }
 
+            expect(Honeybadger.get_context[:oral_history_requester_email]).to eq full_create_params[:patron_email]
             expect(response).to redirect_to(work_path(work.friendlier_id))
             expect(flash[:success]).to match /The files you have requested are immediately available. We've sent an email to #{Regexp.escape full_create_params[:patron_email]} with a sign-in link/
           end
@@ -191,6 +199,7 @@ describe OralHistoryRequestsController, type: :controller do
 
           expect(response).to redirect_to(work_path(work.friendlier_id))
           expect(flash[:success]).to match /Your request will be reviewed/
+          expect(Honeybadger.get_context[:oral_history_requester_email]).to eq full_create_params[:patron_email]
         end
       end
 
@@ -215,6 +224,7 @@ describe OralHistoryRequestsController, type: :controller do
 
             expect(response).to redirect_to(work_path(work.friendlier_id))
             expect(flash[:success]).to match /We've sent another email to #{Regexp.escape full_create_params[:patron_email]}/
+            expect(Honeybadger.get_context[:oral_history_requester_email]).to eq full_create_params[:patron_email]
           end
         end
         describe "already logged in" do
@@ -229,6 +239,7 @@ describe OralHistoryRequestsController, type: :controller do
 
             expect(response).to redirect_to(oral_history_requests_path)
             expect(flash[:success]).to match /You have already requested this Oral History/
+            expect(Honeybadger.get_context[:oral_history_requester_email]).to eq full_create_params[:patron_email]
           end
         end
       end


### PR DESCRIPTION
#2479.
- I believe the only controller where we need this is `oral_history_requests_controller.rb`, so let's add this in there.
- Just adds a before_action that calls the controller's `current_oral_history_requester` method, which knows how to dig up the info. We also check `params`, as a fallback.
- Adds some tests that prove the value is getting added to the HB context.