### PR TITLE
Stop using `format` as a filtering param: it's a reserved word.

### DIFF
--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -32,7 +32,7 @@ class Admin::WorksController < AdminController
     @index_params ||= params.permit(
       :button,
       :sort_field, :sort_order, :department, :page,
-      :title_or_id, :published, :genre, :format, :include_child_works,
+      :title_or_id, :published, :genre, :work_format, :include_child_works,
       :ocr_requested, :review_requested
     ).tap do |hash|
       unless hash[:sort_field].in? ['friendlier_id', 'title', 'created_at', 'updated_at']
@@ -47,9 +47,14 @@ class Admin::WorksController < AdminController
       if hash[:genre].present? && !hash[:genre].in?(Work::ControlledLists::GENRE)
         raise ArgumentError.new("Unrecognized genre: #{hash[:genre]}")
       end
-      if hash[:format].present? && !hash[:format].in?(Work::ControlledLists::FORMAT)
-        raise ArgumentError.new("Unrecognized format: #{hash[:format]}")
+
+      # format is a reserved word
+      # (see https://stackoverflow.com/questions/70726614/ruby-on-rails-use-format-as-a-url-get-parameter )
+      # so let's use work_format instead.      
+      if hash[:work_format].present? && !hash[:work_format].in?(Work::ControlledLists::FORMAT)
+        raise ArgumentError.new("Unrecognized format: #{hash[:work_format]}")
       end
+
       unless hash[:include_child_works] == "true"
         hash[:include_child_works] = "false"
       end
@@ -678,9 +683,16 @@ class Admin::WorksController < AdminController
       if params[:genre].present?
         scope = scope.where("json_attributes -> 'genre' ? :genre", genre: params[:genre])
       end
-      if params[:format].present?
-        scope = scope.where("json_attributes -> 'format' ? :format", format: params[:format])
+
+
+      # format is a reserved word
+      # (see https://stackoverflow.com/questions/70726614/ruby-on-rails-use-format-as-a-url-get-parameter )
+      # so let's use work_format instead.
+      if params[:work_format].present?
+        scope = scope.where("json_attributes -> 'format' ? :work_format", work_format: params[:work_format])
       end
+
+
       if params[:department].present?
         scope = scope.where("json_attributes ->> 'department' = :department", department: params[:department])
       end

--- a/app/views/admin/works/index.html.erb
+++ b/app/views/admin/works/index.html.erb
@@ -36,9 +36,9 @@
 
 
     <div class="admin-filter">
-        <label for="format">Format</label>
-        <%= select_tag "format",
-              options_for_select(Work::ControlledLists::FORMAT.collect {|t| [t.titleize, t]}, params[:format]),
+        <label for="work_format">Format</label>
+        <%= select_tag "work_format",
+              options_for_select(Work::ControlledLists::FORMAT.collect {|t| [t.titleize, t]}, params[:work_format]),
               include_blank: "Any",
               class: "custom-select" %>
     </div>

--- a/spec/controllers/admin/works_controller_spec.rb
+++ b/spec/controllers/admin/works_controller_spec.rb
@@ -388,6 +388,22 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
           expect(rows[1].inner_html).to include works[0].title
         end
 
+        # format is a reserved word
+        # (see https://stackoverflow.com/questions/70726614/ruby-on-rails-use-format-as-a-url-get-parameter )
+        # so let's use work_format instead.
+        it "can filter on work format using work_format param" do
+          get :index, params: { work_format: "mixed_material" }
+          rows = response.parsed_body.css('.table.admin-list tbody tr')
+          expect(rows.length).to eq 0
+        end
+
+        it "can filter on work format using work_format param" do
+          get :index, params: { work_format: "" }
+          rows = response.parsed_body.css('.table.admin-list tbody tr')
+          expect(rows.length).to eq 2
+        end
+
+
       end
     end
   end


### PR DESCRIPTION
Ref #2783

See [this StackOverflow post](https://stackoverflow.com/questions/70726614/ruby-on-rails-use-format-as-a-url-get-parameter):

"In the context of a URL in Ruby on Rails there are at least five reserved parameter names: method, controller, action, id, format. You cannot use these keys for anything else than for their intended purpose."

Sounds good. Let's not.