### PR TITLE
fix featured topic controller #facet action for blacklight 8

### DIFF
--- a/app/controllers/featured_topic_controller.rb
+++ b/app/controllers/featured_topic_controller.rb
@@ -2,27 +2,6 @@
 class FeaturedTopicController < CatalogController
   before_action :set_featured_topic
 
-  # params[:id] is being hogged by Blacklight.
-  # It refers to the facet id.
-  def facet
-    unless (params[:id] && blacklight_config.facet_fields[params[:id]])
-      raise ActionController::RoutingError, 'Not Found'
-    end
-    @facet = blacklight_config.facet_fields[params[:id]]
-
-    @response = search_service.facet_field_response(@facet.key)
-    @display_facet = @response.aggregations[@facet.field]
-    @pagination = facet_paginator(@facet, @display_facet)
-    respond_to do |format|
-      format.html do
-        # Draw the partial for the "more" facet modal window:
-        return render layout: false if request.xhr?
-        # Otherwise draw the facet selector for users who have javascript disabled.
-      end
-      format.json
-    end
-  end
-
   configure_blacklight do |config|
     # Limit just to items in the featured topic.
     config.search_builder_class = ::SearchBuilder::WithinFeaturedTopicBuilder

--- a/app/models/featured_topic.rb
+++ b/app/models/featured_topic.rb
@@ -441,6 +441,10 @@ class FeaturedTopic
     end
   end
 
+  def subjects
+    definition[:subject]
+  end
+
   def solr_fq
     fq_elements = []
 

--- a/spec/controllers/featured_topic_controller_spec.rb
+++ b/spec/controllers/featured_topic_controller_spec.rb
@@ -25,4 +25,32 @@ RSpec.describe FeaturedTopicController, solr: true, type: :controller do
       end
     end
   end
+
+   describe "#facet", indexable_callbacks: true do
+    render_views
+
+    let(:topic_id) { 'color' }
+
+    let(:featured_subjects) { FeaturedTopic.from_slug(topic_id).subjects.slice(0..7) }
+
+    let!(:featured_work) { create(:public_work, subject: featured_subjects) }
+    let!(:non_featured_work) { create(:public_work, subject: ["Outside Subject 1", "Outside Subject 2"]) }
+
+    it "includes only featured work values" do
+      get :facet, params: {
+        id:    "subject_facet",
+        slug:  topic_id
+      }
+
+      doc = Nokogiri::HTML(response.body)
+
+      featured_work.subject.each do |subject|
+        expect(doc).to have_selector(".facet-values li", text: subject)
+      end
+
+      non_featured_work.subject.each do |subject|
+        expect(doc).not_to have_selector(".facet-values li", text: subject)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Parallel to #2791 for collection controller, must do the same for featured topic controller. No longer need #facet action method override, which had become out of date in BL8."
