### PR TITLE
remove local blacklight_range_limit bad-param catching to rely on upstream in plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ gem 'scout_apm'
 # version may require an update with yarn to `blacklight-frontend`, has to be
 # checked manually.
 gem "blacklight", "~> 8.7.0"
-gem "blacklight_range_limit", "9.0.0.beta2", github: "projectblacklight/blacklight_range_limit", branch: "bad_range_limit_params" # version no longer sync'd with blacklight, not sure how we tell what version works with what version of BL
+gem "blacklight_range_limit", "9.0.0.beta2"
 
 # for some code to deal with transcoding video, via AWS MediaConvert
 # Lower than 1.2.1 had far too big gem builds! https://github.com/samvera-labs/active_encode/issues/126

--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ gem 'scout_apm'
 # version may require an update with yarn to `blacklight-frontend`, has to be
 # checked manually.
 gem "blacklight", "~> 8.7.0"
-gem "blacklight_range_limit", "9.0.0.beta2" # version no longer sync'd with blacklight, not sure how we tell what version works with what version of BL
+gem "blacklight_range_limit", "9.0.0.beta2", github: "projectblacklight/blacklight_range_limit", branch: "bad_range_limit_params" # version no longer sync'd with blacklight, not sure how we tell what version works with what version of BL
 
 # for some code to deal with transcoding video, via AWS MediaConvert
 # Lower than 1.2.1 had far too big gem builds! https://github.com/samvera-labs/active_encode/issues/126

--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ gem 'scout_apm'
 # version may require an update with yarn to `blacklight-frontend`, has to be
 # checked manually.
 gem "blacklight", "~> 8.7.0"
-gem "blacklight_range_limit", "9.0.0"
+gem "blacklight_range_limit", "~> 9.0.0" # version no longer sync'd with blacklight, not sure how we tell what version works with what version of BL
 
 # for some code to deal with transcoding video, via AWS MediaConvert
 # Lower than 1.2.1 had far too big gem builds! https://github.com/samvera-labs/active_encode/issues/126

--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ gem 'scout_apm'
 # version may require an update with yarn to `blacklight-frontend`, has to be
 # checked manually.
 gem "blacklight", "~> 8.7.0"
-gem "blacklight_range_limit", "9.0.0.beta2", github: "projectblacklight/blacklight_range_limit"
+gem "blacklight_range_limit", "9.0.0"
 
 # for some code to deal with transcoding video, via AWS MediaConvert
 # Lower than 1.2.1 had far too big gem builds! https://github.com/samvera-labs/active_encode/issues/126

--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ gem 'scout_apm'
 # version may require an update with yarn to `blacklight-frontend`, has to be
 # checked manually.
 gem "blacklight", "~> 8.7.0"
-gem "blacklight_range_limit", "9.0.0.beta2"
+gem "blacklight_range_limit", "9.0.0.beta2", github: "projectblacklight/blacklight_range_limit"
 
 # for some code to deal with transcoding video, via AWS MediaConvert
 # Lower than 1.2.1 had far too big gem builds! https://github.com/samvera-labs/active_encode/issues/126

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/projectblacklight/blacklight_range_limit.git
-  revision: 1239284a6c1cf67cbe0fbfd667fe4489aae0821e
-  specs:
-    blacklight_range_limit (9.0.0.beta2)
-      blacklight (>= 7.25.2, < 9)
-      view_component (>= 2.54, < 4)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -158,6 +150,9 @@ GEM
       rails (>= 6.1, < 9)
       view_component (>= 2.74, < 4)
       zeitwerk
+    blacklight_range_limit (9.0.0)
+      blacklight (>= 7.25.2, < 9)
+      view_component (>= 2.54, < 4)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
     bootstrap4-kaminari-views (1.0.1)
@@ -796,7 +791,7 @@ DEPENDENCIES
   axe-core-rspec (~> 4.3)
   barnes
   blacklight (~> 8.7.0)
-  blacklight_range_limit (= 9.0.0.beta2)!
+  blacklight_range_limit (= 9.0.0)
   bootsnap (>= 1.4.4)
   bootstrap4-kaminari-views
   browse-everything (~> 1.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/projectblacklight/blacklight_range_limit.git
+  revision: c7769415a4e79523d6d43b109036cc65238fafcf
+  branch: bad_range_limit_params
+  specs:
+    blacklight_range_limit (9.0.0.beta2)
+      blacklight (>= 7.25.2, < 9)
+      view_component (>= 2.54, < 4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -150,9 +159,6 @@ GEM
       rails (>= 6.1, < 9)
       view_component (>= 2.74, < 4)
       zeitwerk
-    blacklight_range_limit (9.0.0.beta2)
-      blacklight (>= 7.25.2, < 9)
-      view_component (>= 2.54, < 4)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
     bootstrap4-kaminari-views (1.0.1)
@@ -791,7 +797,7 @@ DEPENDENCIES
   axe-core-rspec (~> 4.3)
   barnes
   blacklight (~> 8.7.0)
-  blacklight_range_limit (= 9.0.0.beta2)
+  blacklight_range_limit (= 9.0.0.beta2)!
   bootsnap (>= 1.4.4)
   bootstrap4-kaminari-views
   browse-everything (~> 1.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -791,7 +791,7 @@ DEPENDENCIES
   axe-core-rspec (~> 4.3)
   barnes
   blacklight (~> 8.7.0)
-  blacklight_range_limit (= 9.0.0)
+  blacklight_range_limit (~> 9.0.0)
   bootsnap (>= 1.4.4)
   bootstrap4-kaminari-views
   browse-everything (~> 1.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
   remote: https://github.com/projectblacklight/blacklight_range_limit.git
-  revision: c7769415a4e79523d6d43b109036cc65238fafcf
-  branch: bad_range_limit_params
+  revision: 1239284a6c1cf67cbe0fbfd667fe4489aae0821e
   specs:
     blacklight_range_limit (9.0.0.beta2)
       blacklight (>= 7.25.2, < 9)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -11,8 +11,6 @@ class CatalogController < ApplicationController
   before_action :catch_bad_request_headers, only: :index
   before_action :catch_bad_format_param,  only: :index
 
-  before_action :screen_params_for_range_limit, only: :range_limit
-
   rescue_from ActionController::UnpermittedParameters, with: :handle_unpermitted_params
 
   # Blacklight wanted Blacklight::Controller included in ApplicationController,
@@ -499,47 +497,6 @@ class CatalogController < ApplicationController
       render(plain: "illegal q query parameter", status: 400) && return
     end
 
-
-    # Correct range facets look like:
-    # params[:range] == {"year_facet_isim"=>{"begin"=>"1900", "end"=>"1950"}}
-    # &range%5Byear_facet_isim%5D%5Bbegin%5D=1900&range%5Byear_facet_isim%5D%5Bend%5D=1950
-    #
-    # Can also be empty string values in there.
-    #
-    # Make sure it has that shape, or just abort, becuase it is likely to make blacklight_range_limit
-    # choke and uncaught exception 500.
-    #
-    # Additionally, newlines and other things that aren't just integers can cause an error too,
-    # just insist on \d+ or empty string only.
-    #
-    # We do allow one exception through: the URL `blacklight_range_limit` uses
-    # to display a link to a search for records with no dates.
-
-    if params[:range].present?
-
-      unless params[:range].respond_to?(:to_hash)
-        render(plain: "Invalid URL query parameter range=#{param_display.call(params[:range])}", status: 400) && return
-      end
-
-      params[:range].each_pair do |_facet_key, range_limits|
-        # Workaround for issue https://github.com/sciencehistory/scihist_digicoll/issues/2231
-        #
-        # `blacklight_range_limit` can show a "date missing" search link,
-        # which adds an extra pair of range parameters:
-        #    range[-year_facet_isim][]=[* TO *]
-        # This would normally trigger our "Invalid URL query parameter" error below,
-        # but we choose to let it through in this one particular case.
-        next if _facet_key == "-year_facet_isim" && range_limits == ["[* TO *]"]
-
-        unless range_limits.respond_to?(:to_hash) && range_limits[:begin].is_a?(String) && range_limits[:end].is_a?(String) &&
-          range_limits[:begin] =~ /\A\d*\z/ && range_limits[:end] =~ /\A\d*\z/ &&
-          range_limits[:begin].to_i < 3000 && range_limits[:end].to_i < 3000
-          render(plain: "Invalid URL query parameter range=#{param_display.call(params[:range])}", status: 400) && return
-        end
-      end
-    end
-
-
     # facet param :f is a hash of keys and values, where each key is a facet name, and
     # each value is an *array* of strings. Anything else, we should reject it as no good,
     # because Blacklight is likely to raise an uncaught exception over it.
@@ -672,11 +629,14 @@ class CatalogController < ApplicationController
 
   # If the user enters an impossible date range with begin after end, swap the dates by actually
   # mutating `params` (ugly but it works), instead of letting blacklight_range_limit raise.
+  #
+  # Could we put this in blacklight_range_limit upstream instead? see:
+  # https://github.com/projectblacklight/blacklight_range_limit/issues/300
   def swap_range_limit_params_if_needed
     return if params.empty?
 
-    start_date = params.dig(:range, :year_facet_isim, :begin)
-    end_date   = params.dig(:range, :year_facet_isim, :end)
+    start_date = params.dig(:range).try(:dig, :year_facet_isim).try(:dig , :begin)
+    end_date   = params.dig(:range).try(:dig, :year_facet_isim).try(:dig, :end)
 
     return unless start_date.present? && end_date.present?
     return unless start_date.to_i > end_date.to_i
@@ -685,20 +645,6 @@ class CatalogController < ApplicationController
     params['range']['year_facet_isim']['end']   = start_date
   end
 
-  # When a user (in practice, a bot) makes a call directly to /catalog/range_limit
-  # rather than the usual /catalog?q=&range, this bypasses the preprocessing normally
-  # performed by the `before_action` methods for #index, which supplies a
-  # range_start and range_end parameter and ensures they are in the correct order,
-  # then makes a second request to #range_limit .
-  def screen_params_for_range_limit
-    if (params['range_end'].class != String) ||
-      (params['range_start'].class != String) ||
-      (params['range_start'].to_i > params['range_end'].to_i)
-        render plain: "Calls to range_limit should have a range_start " +
-          "and a range_end parameter, and range_start " +
-          "should be before range_end.", status: 406
-    end
-  end
 
   # Suppress noisy UnpermittedParameters errors, caused in practice by a bot.
   # Respond instead with :unprocessable_entity.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@rails/ujs": "^ 7.1.3-4",
     "@shopify/draggable": "^1.0.0-beta.8",
     "blacklight-frontend": "^8.7.0",
-    "blacklight-range-limit": "9.0.0-beta2",
+    "blacklight-range-limit": "9.0.0",
     "bootstrap": "^ 5.0.0",
     "domready": "^1.0.8",
     "font-awesome": "^4.7.0",

--- a/spec/requests/bad_blacklight_requests_spec.rb
+++ b/spec/requests/bad_blacklight_requests_spec.rb
@@ -23,26 +23,26 @@ describe CatalogController do
   #    range%5Byear_facet_isim%5D%5Bbegin%5D=1588%0A
   # https://app.honeybadger.io/projects/58989/faults/79191107
   describe "newline in range facet" do
-    it "responds with 400" do
+    it "ignores fine" do
       get "/catalog?range%5Byear_facet_isim%5D%5Bbegin%5D=1588%0A&range%5Byear_facet_isim%5D%5Bend%5D=2020%0A"
-      expect(response.code).to eq("400")
+      expect(response.code).to eq("200")
     end
   end
 
   # This was another one used as some kind of attempt at injection attack, which
   # was causing a Solr 4xx
   describe "weird attack in range value" do
-    it "responds with 400" do
+    it "is ignored fine" do
       get "/catalog?range%5Byear_facet_isim%5D%5Bbegin%5D=1989%27,(;))%23-%20--&range%5Byear_facet_isim%5D%5Bend%5D=1989%27,(;))%23-%20--"
-      expect(response.code).to eq("400")
+      expect(response.code).to eq("200")
     end
 
     describe "on a collection search" do
       let(:collection) { create(:collection) }
 
-      it "responds with 400" do
+      it "is ignored fine" do
         get "/collections/#{collection.friendlier_id}/facet?id=subject_facet&range[year_facet_isim][end]=1894%27[0]"
-        expect(response.code).to eq("400")
+        expect(response.code).to eq("200")
       end
     end
   end

--- a/yarn.lock
+++ b/yarn.lock
@@ -372,10 +372,10 @@ blacklight-frontend@^8.7.0:
   dependencies:
     bootstrap ">=4.3.1 <6.0.0"
 
-blacklight-range-limit@9.0.0-beta2:
-  version "9.0.0-beta2"
-  resolved "https://registry.yarnpkg.com/blacklight-range-limit/-/blacklight-range-limit-9.0.0-beta2.tgz#780e72bb7f21b99aeedac36ecfdf6da6bda7f5ff"
-  integrity sha512-iGeOOkY1Vu/GPdF9DwbuNZtlYHVyZ0owHY1HvfIOsJS50xDjyriKW+LnXTBn3rPQrZzFFKRvQJTi8Oi0rqg0LA==
+blacklight-range-limit@9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/blacklight-range-limit/-/blacklight-range-limit-9.0.0.tgz#89e1e7d36cef7fef205d0266fa0591006801f05d"
+  integrity sha512-Qr+3Rr0jOeoSNN5kN3fmZYqggAgpPpu3LX7HAHkCtrkHG5gPKqV+TK8BLvila9zueAs77dbWV7AmucZEvE+IBg==
   dependencies:
     chart.js "^ 4.4.1"
 


### PR DESCRIPTION
After we upstreamed bad-param protection in blacklight_range_limit, we can remove our custom local protections. 

Ref #2789 

The goal is to prevent any URL given to the app from resulting in an uncaught exception being raised -- bad input should be handled with an intentional recovery or error message, not an uncaught exception, so we don't get an alert from our exception monitoring service. 

In some cases the upstream protection results in a different result after this PR than before (changed test expectations), but the important thing is it still doesn't result in an exception. Almost all of these cases are bots trying weird URLs, they aren't going to work, we just don't want an exception. 

* what before was a 4xx (bad input error) might now be a 200 where bad input is just ignored. (or vice versa). 
* in controller tests, sometimes we test that an `ActionController::BadRequest` is raised, but that will be caught by Rails in production and turned into an http 400, it won't be an uncaught exception. 
* In some cases the bad input will result in StrongParams "unpermitted" -- in production, we just ignore these, but in dev we do raise on them to catch bugs. For those tests, we temporarily make it match production where they are ignored, so we can test properly. 

---

This will remain in draft until we can at least depend on `blacklight_range_limit` *main* branch, instead of an unmerged PR.  (wait for https://github.com/projectblacklight/blacklight_range_limit/pull/305 to merge). 

But it's a beta version anyway, we're okay referring to unreleased main until next beta or release maybe?

---

- update to blacklight_range_limit 9.0.0.beta2
- temporarily update to not yet merged PR in blacklight_range_limit
- remove all local blacklight_range_limit bad-param catching to rely on upstream in plugin
