### PR TITLE
upgrade blacklight to just released 8.7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'scout_apm'
 # NOTE ALSO: We are using `blacklight-frontend` JS NPM package, updating blacklight
 # version may require an update with yarn to `blacklight-frontend`, has to be
 # checked manually.
-gem "blacklight", "~> 8.6.1"
+gem "blacklight", "~> 8.7.0"
 gem "blacklight_range_limit", "9.0.0.beta1" # version no longer sync'd with blacklight, not sure how we tell what version works with what version of BL
 
 # for some code to deal with transcoding video, via AWS MediaConvert

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,13 +138,13 @@ GEM
     bcrypt (3.1.20)
     bigdecimal (3.1.8)
     bindex (0.8.1)
-    blacklight (8.6.1)
+    blacklight (8.7.0)
       globalid
       i18n (>= 1.7.0)
       jbuilder (~> 2.7)
       kaminari (>= 0.15)
       ostruct (>= 0.3.2)
-      rails (>= 6.1, < 8)
+      rails (>= 6.1, < 9)
       view_component (>= 2.74, < 4)
       zeitwerk
     blacklight_range_limit (9.0.0.beta1)
@@ -786,7 +786,7 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1.0)
   axe-core-rspec (~> 4.3)
   barnes
-  blacklight (~> 8.6.1)
+  blacklight (~> 8.7.0)
   blacklight_range_limit (= 9.0.0.beta1)
   bootsnap (>= 1.4.4)
   bootstrap (~> 4.6, >= 4.6.2)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@popperjs/core": "^2.11.8",
     "@rails/ujs": "^ 7.1.3-4",
     "@shopify/draggable": "^1.0.0-beta.8",
-    "blacklight-frontend": "^8.6.1",
+    "blacklight-frontend": "^8.7.0",
     "blacklight-range-limit": "9.0.0-beta1",
     "bootstrap": "^ 5.0.0",
     "domready": "^1.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -355,10 +355,10 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-blacklight-frontend@^8.6.1:
-  version "8.6.1"
-  resolved "https://registry.yarnpkg.com/blacklight-frontend/-/blacklight-frontend-8.6.1.tgz#27c1c0f3c2797a05d6289511c1a6b65dedc27e38"
-  integrity sha512-g5+hkN4rUMPrzCLBcHNoo/Wwrty/s5SCLn/+6H5VL6z1Ht/Q+8SqX/oLbSU0L9nr2AnyM3gSF3Fi0u0xqqONgw==
+blacklight-frontend@^8.7.0:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/blacklight-frontend/-/blacklight-frontend-8.7.0.tgz#4ef0d5c984ea41addf42914dd37157f7eee3f3f5"
+  integrity sha512-iDPNfD+QQo5+ZoLLl4uRXtgzvPFup4JnzAa1MnxdP+7cxkHm24cidJ+c/9UBZjk9mrOOnFdlMfWZnbX+zG+mkQ==
   dependencies:
     bootstrap ">=4.3.1 <6.0.0"
 


### PR DESCRIPTION
This release is compat with Rails 8, so starts setting us up for that upgrade.

Did not upgrade other related dependencies because some are causing problems, just strictly BL.

Edited Gemfile to require BL 8.7.0, then ran `bundle install`. Sync'd package.json to matching blacklight-frontend. 
