### PR TITLE
rename OralHistoryDeliveryMailer#request to #oh_request to avoid conflict with ViewComponent

### DIFF
--- a/app/mailers/oral_history_delivery_mailer.rb
+++ b/app/mailers/oral_history_delivery_mailer.rb
@@ -8,31 +8,31 @@ class OralHistoryDeliveryMailer < ApplicationMailer
   ASSET_EXPIRATION_TIME = 1.week.to_i
 
   def oral_history_delivery_email
-    raise ArgumentError.new("Required params[:request] missing") unless request.present?
-    raise ArgumentError.new("Required patron email missing") unless request.requester_email.present?
+    raise ArgumentError.new("Required params[:request] missing") unless oh_request.present?
+    raise ArgumentError.new("Required patron email missing") unless oh_request.requester_email.present?
     mail(to: to_address, subject: "Science History Institute: files from #{work.title}", content_type: "text/html")
   end
 
   # NEW style, where we send them a link to their in-browser 'dashboard' instead of
   # links to files
   def approved_with_session_link_email
-    raise ArgumentError.new("Required params[:request] missing") unless request.present?
-    raise ArgumentError.new("Required request.oral_history_requester missing") unless request.oral_history_requester.present?
-    raise ArgumentError.new("params[:request] must be approved or automatic but was #{request.delivery_status}") unless request.delivery_status_approved? || request.delivery_status_automatic?
+    raise ArgumentError.new("Required params[:request] missing") unless oh_request.present?
+    raise ArgumentError.new("Required request.oral_history_requester missing") unless oh_request.oral_history_requester.present?
+    raise ArgumentError.new("params[:request] must be approved or automatic but was #{oh_request.delivery_status}") unless oh_request.delivery_status_approved? || oh_request.delivery_status_automatic?
 
     mail(to: to_address, subject: "Science History Institute Oral History Request: Approved: #{work.title}", content_type: "text/html")
   end
 
   def rejected_with_session_link_email
-    raise ArgumentError.new("Required params[:request] missing") unless request.present?
-    raise ArgumentError.new("Required request.oral_history_requester missing") unless request.oral_history_requester.present?
-    raise ArgumentError.new("params[:request] must be rejected but was #{request.delivery_status}") unless request.delivery_status_rejected?
+    raise ArgumentError.new("Required params[:request] missing") unless oh_request.present?
+    raise ArgumentError.new("Required request.oral_history_requester missing") unless oh_request.oral_history_requester.present?
+    raise ArgumentError.new("params[:request] must be rejected but was #{oh_request.delivery_status}") unless oh_request.delivery_status_rejected?
 
     mail(to: to_address, subject: "Science History Institute Oral History Request: #{work.title}", content_type: "text/html")
   end
 
-  def request
-    @request ||= params[:request]
+  def oh_request
+    @oh_request ||= params[:request]
   end
 
   # warning `message` is a reserved method and param name for ActionMailer, don't override it!
@@ -44,7 +44,7 @@ class OralHistoryDeliveryMailer < ApplicationMailer
   end
 
   def to_address
-    request.requester_email
+    oh_request.requester_email
   end
 
   def download_by_human_readable
@@ -52,15 +52,15 @@ class OralHistoryDeliveryMailer < ApplicationMailer
   end
 
   def created_at
-    request.created_at
+    oh_request.created_at
   end
 
   def patron_name
-    request.patron_name
+    oh_request.patron_name
   end
 
   def work
-    request.work
+    oh_request.work
   end
 
   def assets
@@ -72,7 +72,7 @@ class OralHistoryDeliveryMailer < ApplicationMailer
   end
 
   def login_magic_link
-    token = request.oral_history_requester.generate_token_for(:auto_login)
+    token = oh_request.oral_history_requester.generate_token_for(:auto_login)
 
     login_oral_history_session_url(token)
   end


### PR DESCRIPTION
Turns out ViewComponent 3.15.0 does not like to be used inside an ActionMailer that has it's own #request method!

A bit tricky to debug. This change paves the way for dependency upgrades. 

reported at: https://github.com/ViewComponent/view_component/issues/2177

No test changes becuase no behavior changes, pure refactor keeping tests green. 
