### PR TITLE
fix resourceful routing paths to be acceptable to stricter Rails8

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -226,7 +226,7 @@ Rails.application.routes.draw do
       # TODO: Can we get away without actuallymounting Blacklight, just using the CatalogController?
       # mount Blacklight::Engine => '/'
       concern :searchable, Blacklight::Routes::Searchable.new
-      resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
+      resource :catalog, only: [], as: 'catalog', path: '/catalog', controller: 'catalog' do
         concerns :searchable
         concerns :range_searchable # for blacklight_range_limit
       end
@@ -345,7 +345,7 @@ Rails.application.routes.draw do
 
 
     #Cart:
-    resources :cart_items, param: :work_friendlier_id, only: [:index, :update, :destroy, :report] do
+    resources :cart_items, param: :work_friendlier_id, only: [:index, :update, :destroy] do
       collection do
         delete 'clear'
         post 'report'


### PR DESCRIPTION
When in routing you say `resource :something, only: [things]`,  the `things` should be routes that would have been created by the `resource` method/dsl by default. 

If you mention something that wasn't a default route -- in Rails prior to 8, it would just be an ignored no-op. But in Rails 8 it raises, perhaps to keep you from thinking you were doing something that was just a no-op. 

In prep for Rails 8 upgrade, we remove a couple times we did this -- one that was actually generated by Blacklight generator a ways back, and now results in `only: []` (no default routes automatic, only ones our routing concern will add itself!), and one local.  The things we removed werent' having any effect anyway, and in Rails 8 would raise. 

