### PR TITLE
try archiving capybara failure screenshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,13 @@ jobs:
           run: |
             bundle exec rspec
 
+        - name: Archive capybara failure screenshots
+          uses: actions/upload-artifact@v4
+          if: failure()
+          with:
+            name: dist-without-markdown
+            path: tmp/capybara/*.png
+            if-no-files-found: ignore
 
 
 


### PR DESCRIPTION
Experiment to get github to store the screenshots taken after failed browser tests by capybara-screenshot gem. 

Have to make sure it doesn't make the github CI pipeline report success on a failure, since we had to get an archive step to run even after failure, need to make sure it doesn't flip job to success!
