### PR TITLE
try to make copy to clipboard test more reliable

### DIFF
--- a/app/frontend/javascript/audio/helpers/ohms_player_helpers.js
+++ b/app/frontend/javascript/audio/helpers/ohms_player_helpers.js
@@ -21,6 +21,7 @@ As we interact with Bootstrap 4 Javascript in here, it does include some JQuery 
 to be available. We try to avoid JQuery except for that.
  */
 
+import * as bootstrap from 'bootstrap';
 
 // Does not switch to tab, assumes ToC tab is open.
 export function gotoTocSegmentAtTimecode(timeinSeconds) {
@@ -64,11 +65,14 @@ export function goToTocCollapsible(collapsible) {
   var elementScrollTarget = collapsible.closest(".card").querySelector(".card-header");
 
   if (collapsible.classList.contains("collapse")) {
-    jQuery(collapsible).collapse("show");
+    bootstrap.Collapse.getOrCreateInstance(collapsible).show();
+
     // We have to wait until it's done being shown to scroll to it, to make
     // sure we're scrolling to correct place.
-    jQuery(collapsible).one("shown.bs.collapse", function(event) {
+    collapsible.addEventListener('shown.bs.collapse', () => {
       scrollToElement(elementScrollTarget);
+    }, {
+      once: true,
     });
   } else {
     scrollToElement(elementScrollTarget);

--- a/app/frontend/javascript/audio/jump_to_text.js
+++ b/app/frontend/javascript/audio/jump_to_text.js
@@ -3,6 +3,7 @@
 
 import {gotoTocSegmentAtTimecode, gotoTranscriptTimecode, getActiveTab} from "./helpers/ohms_player_helpers.js";
 import domready from 'domready';
+import * as bootstrap from 'bootstrap';
 
 domready(function() {
   document.body.addEventListener("click", function (event) {
@@ -18,7 +19,9 @@ domready(function() {
         // if we have anything else, jump to transcript point, activating
         // transcript tab first if needed.
         if (activeTab.id != "ohTranscriptTab") {
-          $('*[data-bs-toggle="tab"][href="#ohTranscript"]').tab("show");
+          bootstrap.Tab.getOrCreateInstance(
+            document.querySelector('*[data-bs-toggle="tab"][href="#ohTranscript"]')
+          ).show();
         }
         gotoTranscriptTimecode(timeCodeSeconds)
       }

--- a/app/frontend/javascript/audio/ohms_search.js
+++ b/app/frontend/javascript/audio/ohms_search.js
@@ -46,6 +46,7 @@
 // including executing the search, and letting tab switches control which search mode we are in,
 // index or transcript.
 
+import * as bootstrap from 'bootstrap';
 
 
 var Search = {};
@@ -231,14 +232,14 @@ Search.scrollToId = function(domID, scrollBehavior) {
     // annoyingly, have to get the actual tab link that corresponds to
     // the pane
     var tab = $(".nav-link[href='#" + tabPane.attr("id") + "']");
-    tab.tab("show");
+    bootstrap.Tab.getOrCreateInstance(tab).show();
   }
 
   // If our target element CONTAINS a bootstrap collapsible that is collapsed,
   // show it. This is intended for our ToC accordion.
-  var collapsible = $(element).find(".collapse");
-  if (collapsible && ! collapsible.hasClass("show")) {
-    collapsible.collapse("show");
+  var collapsible = element.querySelector(".collapse");
+  if (collapsible && ! collapsible.classList.contains("show")) {
+    bootstrap.Collapse.getOrCreateInstance(collapsible).show();
   }
 
   var elTop = $(element).offset().top;

--- a/app/frontend/javascript/audio/timecode_in_anchor.js
+++ b/app/frontend/javascript/audio/timecode_in_anchor.js
@@ -9,6 +9,7 @@
 
 import domready from 'domready';
 import {gotoTocSegmentAtTimecode, gotoTranscriptTimecode} from './helpers/ohms_player_helpers.js';
+import * as bootstrap from 'bootstrap';
 
 domready(function() {
   var hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ''));
@@ -44,7 +45,9 @@ domready(function() {
         });
       } else {
         if (hashParams.get("tab") != "ohTranscript") {
-          $(`*[data-bs-toggle="tab"][href="#ohTranscript"]`).tab("show");
+          bootstrap.Tab.getOrCreateInstance(
+            document.querySelector('*[data-bs-toggle="tab"][href="#ohTranscript"]')
+          ).show();
         }
         execWhenTabActive("ohTranscript", function() {
           gotoTranscriptTimecode(timeCodeSeconds);

--- a/app/frontend/javascript/tab_selection_in_anchor.js
+++ b/app/frontend/javascript/tab_selection_in_anchor.js
@@ -8,13 +8,16 @@
 // Uses jQuery here only for bootstrap 4 JS tabs which uses/requires it.
 
 import domready from 'domready';
+import * as bootstrap from 'bootstrap';
 
 domready(function() {
   // if there's an #anchor in the URL referencing a bootstrap tab, make that tab selected.
   // should we limit to only certain data tags instead of all bootstrap tab links?
   var anchor = new URLSearchParams(window.location.hash.replace(/^#/, '')).get("tab");
   if (anchor) {
-    $(`*[data-bs-toggle="tab"][href="#${anchor}"]`).tab("show")
+    bootstrap.Tab.getOrCreateInstance(
+      document.querySelector(`*[data-bs-toggle="tab"][href="#${anchor}"]`)
+    ).show();
   }
 
   // when showing on a bootstrap tab, put the relevant ID in anchor,

--- a/spec/system/oral_history_with_audio_spec.rb
+++ b/spec/system/oral_history_with_audio_spec.rb
@@ -422,8 +422,17 @@ describe "Oral history with audio display", type: :system, js: true do
 
       # ToC animation has weird jumping around, let's try to make sure
       # our button is actually on-screen before clicking
-      find("body").scroll_to(copy_button, align: :bottom)
-      copy_button.click
+      begin
+        find("body").scroll_to(copy_button, align: :bottom)
+        copy_button.click
+      rescue Selenium::WebDriver::Error::ElementClickInterceptedError
+        # try scrolling again, page may still have been in motion
+        find("body").scroll_to(copy_button, align: :bottom)
+        copy_button.click
+      end
+
+
+
       expect(page).to have_content("Copied to clipboard")
 
       # ToC tab should be selected as it is first tab with results from search

--- a/spec/system/oral_history_with_audio_spec.rb
+++ b/spec/system/oral_history_with_audio_spec.rb
@@ -411,16 +411,19 @@ describe "Oral history with audio display", type: :system, js: true do
 
       copy_to_clipboard = "*[data-trigger='linkClipboardCopy']"
       begin
-        expect(page).to have_selector(copy_to_clipboard, wait: 0.05)
+        copy_button = page.find(copy_to_clipboard, wait: 0.5)
       rescue RSpec::Expectations::ExpectationNotMetError
         # the "copy to clipboard" button sometimes fails to show up fast enough.
         # Just click "search" again.
         # See similar workaround below.
         within("*[data-ohms-search-form]") { click_on "Search" }
-        expect(page).to have_selector(copy_to_clipboard)
+        copy_button = page.find(copy_to_clipboard, wait: 0.5)
       end
 
-      page.find(copy_to_clipboard).click
+      # ToC animation has weird jumping around, let's try to make sure
+      # our button is actually on-screen before clicking
+      find("body").scroll_to(copy_button, align: :bottom)
+      copy_button.click
       expect(page).to have_content("Copied to clipboard")
 
       # ToC tab should be selected as it is first tab with results from search

--- a/spec/system/oral_history_with_audio_spec.rb
+++ b/spec/system/oral_history_with_audio_spec.rb
@@ -423,12 +423,14 @@ describe "Oral history with audio display", type: :system, js: true do
       # ToC animation has weird jumping around, let's try to make sure
       # our button is actually on-screen before clicking
       begin
+        copy_button = page.find(copy_to_clipboard, wait: 0.5)
         find("body").scroll_to(copy_button, align: :bottom)
-        copy_button.click
+        copy_button.lock
       rescue Selenium::WebDriver::Error::ElementClickInterceptedError
         # try scrolling again, page may still have been in motion
+        copy_button = page.find(copy_to_clipboard, wait: 0.5)
         find("body").scroll_to(copy_button, align: :bottom)
-        copy_button.click
+        copy_button.lock
       end
 
 


### PR DESCRIPTION
In some cases the 'copy to clipboard' button is ending up off-screen when capybara tries to click it. I think this is because bootstrap accordion is doing some crazy animation when we automatically open/close the different elements. We can try to work around it by actually scrolling the browser to right position?

a) This may be an actual problem for users of course that we should try to solve, I have kind of noticed it

b) I'm not sure if our previous attempts to improve reliability with the rescue right here are necessary working or not? But leaving them in too!
