### PR TITLE
Switch to use new bootstrap 5 non-jQuery API

### DIFF
--- a/app/frontend/javascript/audio/helpers/ohms_player_helpers.js
+++ b/app/frontend/javascript/audio/helpers/ohms_player_helpers.js
@@ -21,6 +21,7 @@ As we interact with Bootstrap 4 Javascript in here, it does include some JQuery 
 to be available. We try to avoid JQuery except for that.
  */
 
+import * as bootstrap from 'bootstrap';
 
 // Does not switch to tab, assumes ToC tab is open.
 export function gotoTocSegmentAtTimecode(timeinSeconds) {
@@ -64,11 +65,14 @@ export function goToTocCollapsible(collapsible) {
   var elementScrollTarget = collapsible.closest(".card").querySelector(".card-header");
 
   if (collapsible.classList.contains("collapse")) {
-    jQuery(collapsible).collapse("show");
+    bootstrap.Collapse.getOrCreateInstance(collapsible).show();
+
     // We have to wait until it's done being shown to scroll to it, to make
     // sure we're scrolling to correct place.
-    jQuery(collapsible).one("shown.bs.collapse", function(event) {
+    collapsible.addEventListener('shown.bs.collapse', () => {
       scrollToElement(elementScrollTarget);
+    }, {
+      once: true,
     });
   } else {
     scrollToElement(elementScrollTarget);

--- a/app/frontend/javascript/audio/jump_to_text.js
+++ b/app/frontend/javascript/audio/jump_to_text.js
@@ -3,6 +3,7 @@
 
 import {gotoTocSegmentAtTimecode, gotoTranscriptTimecode, getActiveTab} from "./helpers/ohms_player_helpers.js";
 import domready from 'domready';
+import * as bootstrap from 'bootstrap';
 
 domready(function() {
   document.body.addEventListener("click", function (event) {
@@ -18,7 +19,9 @@ domready(function() {
         // if we have anything else, jump to transcript point, activating
         // transcript tab first if needed.
         if (activeTab.id != "ohTranscriptTab") {
-          $('*[data-bs-toggle="tab"][href="#ohTranscript"]').tab("show");
+          bootstrap.Tab.getOrCreateInstance(
+            document.querySelector('*[data-bs-toggle="tab"][href="#ohTranscript"]')
+          ).show();
         }
         gotoTranscriptTimecode(timeCodeSeconds)
       }

--- a/app/frontend/javascript/audio/ohms_search.js
+++ b/app/frontend/javascript/audio/ohms_search.js
@@ -46,6 +46,7 @@
 // including executing the search, and letting tab switches control which search mode we are in,
 // index or transcript.
 
+import * as bootstrap from 'bootstrap';
 
 
 var Search = {};
@@ -230,14 +231,14 @@ Search.scrollToId = function(domID, scrollBehavior) {
     // annoyingly, have to get the actual tab link that corresponds to
     // the pane
     var tab = $(".nav-link[href='#" + tabPane.attr("id") + "']");
-    tab.tab("show");
+    bootstrap.Tab.getOrCreateInstance(tab).show();
   }
 
   // If our target element CONTAINS a bootstrap collapsible that is collapsed,
   // show it. This is intended for our ToC accordion.
-  var collapsible = $(element).find(".collapse.ohms-index-list");
-  if (collapsible && ! collapsible.hasClass("show")) {
-    collapsible.collapse("show");
+  var collapsible = element.querySelector(".collapse.ohms-index-list");
+  if (collapsible && ! collapsible.classList.contains("show")) {
+    bootstrap.Collapse.getOrCreateInstance(collapsible).show();
   }
 
   var elTop = $(element).offset().top;

--- a/app/frontend/javascript/audio/timecode_in_anchor.js
+++ b/app/frontend/javascript/audio/timecode_in_anchor.js
@@ -9,6 +9,7 @@
 
 import domready from 'domready';
 import {gotoTocSegmentAtTimecode, gotoTranscriptTimecode} from './helpers/ohms_player_helpers.js';
+import * as bootstrap from 'bootstrap';
 
 domready(function() {
   var hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ''));
@@ -44,7 +45,9 @@ domready(function() {
         });
       } else {
         if (hashParams.get("tab") != "ohTranscript") {
-          $(`*[data-bs-toggle="tab"][href="#ohTranscript"]`).tab("show");
+          bootstrap.Tab.getOrCreateInstance(
+            document.querySelector('*[data-bs-toggle="tab"][href="#ohTranscript"]')
+          ).show();
         }
         execWhenTabActive("ohTranscript", function() {
           gotoTranscriptTimecode(timeCodeSeconds);

--- a/app/frontend/javascript/tab_selection_in_anchor.js
+++ b/app/frontend/javascript/tab_selection_in_anchor.js
@@ -8,13 +8,16 @@
 // Uses jQuery here only for bootstrap 4 JS tabs which uses/requires it.
 
 import domready from 'domready';
+import * as bootstrap from 'bootstrap';
 
 domready(function() {
   // if there's an #anchor in the URL referencing a bootstrap tab, make that tab selected.
   // should we limit to only certain data tags instead of all bootstrap tab links?
   var anchor = new URLSearchParams(window.location.hash.replace(/^#/, '')).get("tab");
   if (anchor) {
-    $(`*[data-bs-toggle="tab"][href="#${anchor}"]`).tab("show")
+    bootstrap.Tab.getOrCreateInstance(
+      document.querySelector(`*[data-bs-toggle="tab"][href="#${anchor}"]`)
+    ).show();
   }
 
   // when showing on a bootstrap tab, put the relevant ID in anchor,


### PR DESCRIPTION
In Bootstrap 4, the JS API for interacting with tabs and collapsible elements was a jQuery plugin. 

In Bootstrap 5, the jQuery plugin _ought_ to still be supported if you have jQuery installed. But we're going to switch to the new straight-JS API here. This is a head start on likely future switch to not use jQuery, but the main reason we are doing it is in hopes that it will help with some of our super mysterious flakey JS that seems to be around code for showing tabs and collapsibles. 
