### PR TITLE
Attempt to fix flakey copy to clipboard spec

### DIFF
--- a/app/frontend/javascript/audio/helpers/ohms_player_helpers.js
+++ b/app/frontend/javascript/audio/helpers/ohms_player_helpers.js
@@ -21,6 +21,7 @@ As we interact with Bootstrap 4 Javascript in here, it does include some JQuery 
 to be available. We try to avoid JQuery except for that.
  */
 
+import * as bootstrap from 'bootstrap';
 
 // Does not switch to tab, assumes ToC tab is open.
 export function gotoTocSegmentAtTimecode(timeinSeconds) {
@@ -64,11 +65,14 @@ export function goToTocCollapsible(collapsible) {
   var elementScrollTarget = collapsible.closest(".card").querySelector(".card-header");
 
   if (collapsible.classList.contains("collapse")) {
-    jQuery(collapsible).collapse("show");
+    bootstrap.Collapse.getOrCreateInstance(collapsible).show();
+
     // We have to wait until it's done being shown to scroll to it, to make
     // sure we're scrolling to correct place.
-    jQuery(collapsible).one("shown.bs.collapse", function(event) {
+    collapsible.addEventListener('shown.bs.collapse', () => {
       scrollToElement(elementScrollTarget);
+    }, {
+      once: true,
     });
   } else {
     scrollToElement(elementScrollTarget);

--- a/app/frontend/javascript/audio/jump_to_text.js
+++ b/app/frontend/javascript/audio/jump_to_text.js
@@ -3,6 +3,7 @@
 
 import {gotoTocSegmentAtTimecode, gotoTranscriptTimecode, getActiveTab} from "./helpers/ohms_player_helpers.js";
 import domready from 'domready';
+import * as bootstrap from 'bootstrap';
 
 domready(function() {
   document.body.addEventListener("click", function (event) {
@@ -18,7 +19,9 @@ domready(function() {
         // if we have anything else, jump to transcript point, activating
         // transcript tab first if needed.
         if (activeTab.id != "ohTranscriptTab") {
-          $('*[data-bs-toggle="tab"][href="#ohTranscript"]').tab("show");
+          bootstrap.Tab.getOrCreateInstance(
+            document.querySelector('*[data-bs-toggle="tab"][href="#ohTranscript"]')
+          ).show();
         }
         gotoTranscriptTimecode(timeCodeSeconds)
       }

--- a/app/frontend/javascript/audio/ohms_search.js
+++ b/app/frontend/javascript/audio/ohms_search.js
@@ -46,6 +46,7 @@
 // including executing the search, and letting tab switches control which search mode we are in,
 // index or transcript.
 
+import * as bootstrap from 'bootstrap';
 
 
 var Search = {};
@@ -231,14 +232,14 @@ Search.scrollToId = function(domID, scrollBehavior) {
     // annoyingly, have to get the actual tab link that corresponds to
     // the pane
     var tab = $(".nav-link[href='#" + tabPane.attr("id") + "']");
-    tab.tab("show");
+    bootstrap.Tab.getOrCreateInstance(tab).show();
   }
 
   // If our target element CONTAINS a bootstrap collapsible that is collapsed,
   // show it. This is intended for our ToC accordion.
-  var collapsible = $(element).find(".collapse");
-  if (collapsible && ! collapsible.hasClass("show")) {
-    collapsible.collapse("show");
+  var collapsible = element.querySelector(".collapse");
+  if (collapsible && ! collapsible.classList.contains("show")) {
+    bootstrap.Collapse.getOrCreateInstance(collapsible).show();
   }
 
   var elTop = $(element).offset().top;

--- a/app/frontend/javascript/audio/ohms_search.js
+++ b/app/frontend/javascript/audio/ohms_search.js
@@ -211,8 +211,7 @@ Search.clearSearchResults = function() {
 //
 //   * If id is in a tab that isn't currently visible, switch to that tab.
 //
-//   * If id is in a bootstrap collapsed that isn't currently expanded, expand it.
-//     (intended for Table of Contents section)
+//   * If id contains a collapsible ToC that isn't shown, show it.
 //
 // Second optional argument is either "smooth" or "auto", with "auto" being the
 // default. As in HTML5 scroll functions which it will be passed to, "smooth"
@@ -235,11 +234,10 @@ Search.scrollToId = function(domID, scrollBehavior) {
     bootstrap.Tab.getOrCreateInstance(tab).show();
   }
 
-  // If our target element CONTAINS a bootstrap collapsible that is collapsed,
-  // show it. This is intended for our ToC accordion.
-  var collapsible = element.querySelector(".collapse");
-  if (collapsible && ! collapsible.classList.contains("show")) {
-    bootstrap.Collapse.getOrCreateInstance(collapsible).show();
+  // If our target element contains a collapsed ToC, show it.
+  var collapsibleToc = element.querySelector(".collapse.ohms-index-list");
+  if (collapsibleToc && ! collapsibleToc.classList.contains("show")) {
+    bootstrap.Collapse.getOrCreateInstance(collapsibleToc).show();
   }
 
   var elTop = $(element).offset().top;

--- a/app/frontend/javascript/audio/timecode_in_anchor.js
+++ b/app/frontend/javascript/audio/timecode_in_anchor.js
@@ -9,6 +9,7 @@
 
 import domready from 'domready';
 import {gotoTocSegmentAtTimecode, gotoTranscriptTimecode} from './helpers/ohms_player_helpers.js';
+import * as bootstrap from 'bootstrap';
 
 domready(function() {
   var hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ''));
@@ -44,7 +45,9 @@ domready(function() {
         });
       } else {
         if (hashParams.get("tab") != "ohTranscript") {
-          $(`*[data-bs-toggle="tab"][href="#ohTranscript"]`).tab("show");
+          bootstrap.Tab.getOrCreateInstance(
+            document.querySelector('*[data-bs-toggle="tab"][href="#ohTranscript"]')
+          ).show();
         }
         execWhenTabActive("ohTranscript", function() {
           gotoTranscriptTimecode(timeCodeSeconds);

--- a/app/frontend/javascript/tab_selection_in_anchor.js
+++ b/app/frontend/javascript/tab_selection_in_anchor.js
@@ -8,13 +8,16 @@
 // Uses jQuery here only for bootstrap 4 JS tabs which uses/requires it.
 
 import domready from 'domready';
+import * as bootstrap from 'bootstrap';
 
 domready(function() {
   // if there's an #anchor in the URL referencing a bootstrap tab, make that tab selected.
   // should we limit to only certain data tags instead of all bootstrap tab links?
   var anchor = new URLSearchParams(window.location.hash.replace(/^#/, '')).get("tab");
   if (anchor) {
-    $(`*[data-bs-toggle="tab"][href="#${anchor}"]`).tab("show")
+    bootstrap.Tab.getOrCreateInstance(
+      document.querySelector(`*[data-bs-toggle="tab"][href="#${anchor}"]`)
+    ).show();
   }
 
   // when showing on a bootstrap tab, put the relevant ID in anchor,

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -58,6 +58,7 @@ RSpec.configure do |config|
   # Capyabara.javascript_driver setting directly applies to 'feature' spec
   Capybara.default_driver = :rack_test # Faster but doesn't do Javascript
   Capybara.javascript_driver = $capybara_js_driver
+  Capybara.disable_animation = true
 
   # Customized from driver built into capybara to add custom chrome options, like
   # disable smooth scrolling.

--- a/spec/system/oral_history_with_audio_spec.rb
+++ b/spec/system/oral_history_with_audio_spec.rb
@@ -422,6 +422,8 @@ describe "Oral history with audio display", type: :system, js: true do
         expect(page).to have_selector(copy_to_clipboard)
       end
 
+      # Make sure we're scrolled to it, below the fixed navbar
+      page.find("body").scroll_to(page.find(copy_to_clipboard), align: :bottom)
       page.find(copy_to_clipboard).click
       expect(page).to have_content("Copied to clipboard")
 

--- a/spec/system/oral_history_with_audio_spec.rb
+++ b/spec/system/oral_history_with_audio_spec.rb
@@ -409,6 +409,8 @@ describe "Oral history with audio display", type: :system, js: true do
         click_on "Search"
       end
 
+      click_on "Share link"
+
       copy_to_clipboard = "*[data-trigger='linkClipboardCopy']"
       begin
         expect(page).to have_selector(copy_to_clipboard, wait: 0.05)


### PR DESCRIPTION
- more precise opening up of ToC in OHMS search, with fixed more precise capybara script
- make sure the copy to clipboard button is scrolled visible before clicking
