### PR TITLE
Tell Capybara to disable animations to try to increase test reliability

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,6 +59,12 @@ RSpec.configure do |config|
   Capybara.default_driver = :rack_test # Faster but doesn't do Javascript
   Capybara.javascript_driver = $capybara_js_driver
 
+  # telling browser to reduce motion helps with some of our flakey browser
+  # tests involving lots of scrolling and moving around, such as in OHMS ToC
+  unless ENV['DISABLE_BROWSER_ANIMATION'] == "false"
+    Capybara.disable_animation = true
+  end
+
 
   # https://viewcomponent.org/guide/testing.html#rspec-configuration
   config.include ViewComponent::TestHelpers, type: :component


### PR DESCRIPTION
Some of the OHMS table of contents stuff especially, combined with search, involves a lot of opening/closing/moving things. Advancing to next search result may involve automatic switching of tabs and opening of a collaped ToC section.  One particular text also involves opening up the "share link" section collapse. 

The share link/copy to clipboard test in particular has been really flakey -- mostly on Github hard to reproduce locally. 

Some googling suggested that perhaps any animations including scrolling animations can be especially unexpectedly slow on an ARM cpu (which perhaps Github Actions uses), or that in general setting `Capybara.disable_animations` could help with flakey specs where animations are involved. 

Which could apply to our current flakey modal test as well. 

I think `Capybara.disable_animations` may set browser-settings "reduce motion" settings.  

A test seems to reveal it is helping with our flakey specs, re-running tests here hard to reproduce failures that were easy to reproduce before. Worth a shot. 

Here is the current most fail-y test, and it's somewhat mysterious why -- screenshots reveal that the "copy to clipboard" button was underneath the fixed header, instead of properly scrolled to be visible. But unclear why and hard to reproduce locally, and putting in explicit commands to scroll window to have button at bottom didn't help. Maybe the scroll was animated and much too slow?


```
  1) Oral history with audio display With OHMS synchronized transcript and ToC can display, and search, without errors
     Failure/Error: page.find(copy_to_clipboard).click

     Selenium::WebDriver::Error::ElementClickInterceptedError:
       element click intercepted: Element <button class="btn btn-outline-secondary" data-trigger="linkClipboardCopy">...</button> is not clickable at point (648, 213). Other element would receive the click: <div class="ohms-search-results">...</div>
         (Session info: chrome=131.0.6778.85)
```

