### PR TITLE
more precise opening up of ToC in OHMS search, with fixed more precise capybara script

### DIFF
--- a/app/frontend/javascript/audio/ohms_search.js
+++ b/app/frontend/javascript/audio/ohms_search.js
@@ -210,8 +210,7 @@ Search.clearSearchResults = function() {
 //
 //   * If id is in a tab that isn't currently visible, switch to that tab.
 //
-//   * If id is in a bootstrap collapsed that isn't currently expanded, expand it.
-//     (intended for Table of Contents section)
+//   * If id contains a collapsible ToC that isn't shown, show it.
 //
 // Second optional argument is either "smooth" or "auto", with "auto" being the
 // default. As in HTML5 scroll functions which it will be passed to, "smooth"
@@ -236,7 +235,7 @@ Search.scrollToId = function(domID, scrollBehavior) {
 
   // If our target element CONTAINS a bootstrap collapsible that is collapsed,
   // show it. This is intended for our ToC accordion.
-  var collapsible = $(element).find(".collapse");
+  var collapsible = $(element).find(".collapse.ohms-index-list");
   if (collapsible && ! collapsible.hasClass("show")) {
     collapsible.collapse("show");
   }

--- a/spec/system/oral_history_with_audio_spec.rb
+++ b/spec/system/oral_history_with_audio_spec.rb
@@ -409,6 +409,8 @@ describe "Oral history with audio display", type: :system, js: true do
         click_on "Search"
       end
 
+      click_on "Share link"
+
       copy_to_clipboard = "*[data-trigger='linkClipboardCopy']"
       begin
         expect(page).to have_selector(copy_to_clipboard, wait: 0.05)


### PR DESCRIPTION
When we do an OH search and a hit is inside the ToC, we switch to ToC tab and open the section of ToC with the hit. But previous code tried to open ANY collapsible in a given area, and ended up maybe targetting the "share link" hidden link too. This possibly led to undesirable UX (share link initially open), and/or contributed to flaky tests, where there was perhaps a race condition on what was opened when or what position the scroll was in. 

Better to be more intentional -- and to actually click on "Share Link" in relavent test to OPEN the share link section that should not be default open!
