### PR TITLE
Upgrade to Rails 8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ ruby "~> #{File.read(File.join(__dir__ , '.ruby-version')).chomp.split('.').slic
 gem 'lockbox'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 7.2.0'
+gem 'rails', '~> 8.0.0'
 
 # We no longer COMPILE/BUNDLE any assets with sprockets, that's all in vite now.
 # But we're using sprockets for terminal static asset delivery of vite-bundled, as
@@ -123,8 +123,8 @@ gem "traject", ">= 3.5" # to include support for HTTP basic auth in Solr url
 
 gem 'simple_form', "~> 5.0"
 
-gem "browse-everything", "~> 1.4"
-gem "qa", "~> 5.2", ">= 5.13.0"
+gem "browse-everything", "~> 1.4", github: "samvera/browse-everything"
+gem "qa", "~> 5.2", ">= 5.13.0", github: "samvera/questioning_authority"
 gem "shrine", "~> 3.3" #, path: "../shrine"
 # shrine-compat endpoint to get uppy to direct upload to S3 with resumable multi-part upload
 gem "uppy-s3_multipart"

--- a/Gemfile
+++ b/Gemfile
@@ -124,7 +124,7 @@ gem "traject", ">= 3.5" # to include support for HTTP basic auth in Solr url
 gem 'simple_form', "~> 5.0"
 
 gem "browse-everything", "~> 1.4", github: "samvera/browse-everything"
-gem "qa", "~> 5.2", ">= 5.13.0", github: "samvera/questioning_authority"
+gem "qa", "~> 5.2", ">= 5.14.0"
 gem "shrine", "~> 3.3" #, path: "../shrine"
 # shrine-compat endpoint to get uppy to direct upload to S3 with resumable multi-part upload
 gem "uppy-s3_multipart"

--- a/Gemfile
+++ b/Gemfile
@@ -123,7 +123,7 @@ gem "traject", ">= 3.5" # to include support for HTTP basic auth in Solr url
 
 gem 'simple_form', "~> 5.0"
 
-gem "browse-everything", "~> 1.4", github: "samvera/browse-everything"
+gem "browse-everything", "~> 1.5"
 gem "qa", "~> 5.2", ">= 5.14.0"
 gem "shrine", "~> 3.3" #, path: "../shrine"
 # shrine-compat endpoint to get uppy to direct upload to S3 with resumable multi-part upload

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,3 @@
-GIT
-  remote: https://github.com/samvera/browse-everything.git
-  revision: 6aa0c78b66d978c937f48ab146155fae077d1c5c
-  specs:
-    browse-everything (1.4.0)
-      addressable (~> 2.5)
-      aws-sdk-s3
-      dropbox_api (>= 0.1.20)
-      google-apis-drive_v3
-      googleauth (>= 0.6.6, < 2.0)
-      rails (>= 4.2, < 8.1)
-      ruby-box
-      signet (~> 0.8)
-      typhoeus
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -173,6 +158,16 @@ GEM
     bootstrap4-kaminari-views (1.0.1)
       kaminari (>= 0.13)
       rails (>= 3.1)
+    browse-everything (1.5.0)
+      addressable (~> 2.5)
+      aws-sdk-s3
+      dropbox_api (>= 0.1.20)
+      google-apis-drive_v3
+      googleauth (>= 0.6.6, < 2.0)
+      rails (>= 4.2, < 8.1)
+      ruby-box
+      signet (~> 0.8)
+      typhoeus
     browser (6.2.0)
     builder (3.3.0)
     byebug (11.1.3)
@@ -799,7 +794,7 @@ DEPENDENCIES
   blacklight_range_limit (= 9.0.0.beta2)
   bootsnap (>= 1.4.4)
   bootstrap4-kaminari-views
-  browse-everything (~> 1.4)!
+  browse-everything (~> 1.5)
   browser (~> 6.0)
   capybara (>= 2.15)
   capybara-screenshot

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,48 +1,76 @@
+GIT
+  remote: https://github.com/samvera/browse-everything.git
+  revision: 6aa0c78b66d978c937f48ab146155fae077d1c5c
+  specs:
+    browse-everything (1.4.0)
+      addressable (~> 2.5)
+      aws-sdk-s3
+      dropbox_api (>= 0.1.20)
+      google-apis-drive_v3
+      googleauth (>= 0.6.6, < 2.0)
+      rails (>= 4.2, < 8.1)
+      ruby-box
+      signet (~> 0.8)
+      typhoeus
+
+GIT
+  remote: https://github.com/samvera/questioning_authority.git
+  revision: 652d95a404b7d93d8c422a623c62069fe45d0e04
+  specs:
+    qa (5.13.0)
+      activerecord-import
+      deprecation
+      faraday (< 3.0, != 2.0.0)
+      geocoder
+      ldpath
+      nokogiri (~> 1.6)
+      rails (>= 5.0, < 8.1)
+      rdf
+
 GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (2.0.1)
     access-granted (1.3.3)
-    actioncable (7.2.2.1)
-      actionpack (= 7.2.2.1)
-      activesupport (= 7.2.2.1)
+    actioncable (8.0.0.1)
+      actionpack (= 8.0.0.1)
+      activesupport (= 8.0.0.1)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
       zeitwerk (~> 2.6)
-    actionmailbox (7.2.2.1)
-      actionpack (= 7.2.2.1)
-      activejob (= 7.2.2.1)
-      activerecord (= 7.2.2.1)
-      activestorage (= 7.2.2.1)
-      activesupport (= 7.2.2.1)
+    actionmailbox (8.0.0.1)
+      actionpack (= 8.0.0.1)
+      activejob (= 8.0.0.1)
+      activerecord (= 8.0.0.1)
+      activestorage (= 8.0.0.1)
+      activesupport (= 8.0.0.1)
       mail (>= 2.8.0)
-    actionmailer (7.2.2.1)
-      actionpack (= 7.2.2.1)
-      actionview (= 7.2.2.1)
-      activejob (= 7.2.2.1)
-      activesupport (= 7.2.2.1)
+    actionmailer (8.0.0.1)
+      actionpack (= 8.0.0.1)
+      actionview (= 8.0.0.1)
+      activejob (= 8.0.0.1)
+      activesupport (= 8.0.0.1)
       mail (>= 2.8.0)
       rails-dom-testing (~> 2.2)
-    actionpack (7.2.2.1)
-      actionview (= 7.2.2.1)
-      activesupport (= 7.2.2.1)
+    actionpack (8.0.0.1)
+      actionview (= 8.0.0.1)
+      activesupport (= 8.0.0.1)
       nokogiri (>= 1.8.5)
-      racc
-      rack (>= 2.2.4, < 3.2)
+      rack (>= 2.2.4)
       rack-session (>= 1.0.1)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
       useragent (~> 0.16)
-    actiontext (7.2.2.1)
-      actionpack (= 7.2.2.1)
-      activerecord (= 7.2.2.1)
-      activestorage (= 7.2.2.1)
-      activesupport (= 7.2.2.1)
+    actiontext (8.0.0.1)
+      actionpack (= 8.0.0.1)
+      activerecord (= 8.0.0.1)
+      activestorage (= 8.0.0.1)
+      activesupport (= 8.0.0.1)
       globalid (>= 0.6.0)
       nokogiri (>= 1.8.5)
-    actionview (7.2.2.1)
-      activesupport (= 7.2.2.1)
+    actionview (8.0.0.1)
+      activesupport (= 8.0.0.1)
       builder (~> 3.1)
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
@@ -50,27 +78,27 @@ GEM
     active_encode (1.2.3)
       addressable (~> 2.8)
       rails
-    activejob (7.2.2.1)
-      activesupport (= 7.2.2.1)
+    activejob (8.0.0.1)
+      activesupport (= 8.0.0.1)
       globalid (>= 0.3.6)
-    activemodel (7.2.2.1)
-      activesupport (= 7.2.2.1)
-    activerecord (7.2.2.1)
-      activemodel (= 7.2.2.1)
-      activesupport (= 7.2.2.1)
+    activemodel (8.0.0.1)
+      activesupport (= 8.0.0.1)
+    activerecord (8.0.0.1)
+      activemodel (= 8.0.0.1)
+      activesupport (= 8.0.0.1)
       timeout (>= 0.4.0)
     activerecord-import (2.0.0)
       activerecord (>= 4.2)
     activerecord-postgres_enum (2.1.0)
       activerecord (>= 5.2)
       pg
-    activestorage (7.2.2.1)
-      actionpack (= 7.2.2.1)
-      activejob (= 7.2.2.1)
-      activerecord (= 7.2.2.1)
-      activesupport (= 7.2.2.1)
+    activestorage (8.0.0.1)
+      actionpack (= 8.0.0.1)
+      activejob (= 8.0.0.1)
+      activerecord (= 8.0.0.1)
+      activesupport (= 8.0.0.1)
       marcel (~> 1.0)
-    activesupport (7.2.2.1)
+    activesupport (8.0.0.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -82,6 +110,7 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     afm (0.2.2)
@@ -158,16 +187,6 @@ GEM
     bootstrap4-kaminari-views (1.0.1)
       kaminari (>= 0.13)
       rails (>= 3.1)
-    browse-everything (1.4.0)
-      addressable (~> 2.5)
-      aws-sdk-s3
-      dropbox_api (>= 0.1.20)
-      google-apis-drive_v3
-      googleauth (>= 0.6.6, < 2.0)
-      rails (>= 4.2, < 8.0)
-      ruby-box
-      signet (~> 0.8)
-      typhoeus
     browser (6.2.0)
     builder (3.3.0)
     byebug (11.1.3)
@@ -502,15 +521,6 @@ GEM
     public_suffix (6.0.1)
     puma (6.5.0)
       nio4r (~> 2.0)
-    qa (5.13.0)
-      activerecord-import
-      deprecation
-      faraday (< 3.0, != 2.0.0)
-      geocoder
-      ldpath
-      nokogiri (~> 1.6)
-      rails (>= 5.0, < 8.0)
-      rdf
     racc (1.8.1)
     rack (3.1.8)
     rack-attack (6.7.0)
@@ -527,20 +537,20 @@ GEM
       rack (>= 1.3)
     rackup (2.2.1)
       rack (>= 3)
-    rails (7.2.2.1)
-      actioncable (= 7.2.2.1)
-      actionmailbox (= 7.2.2.1)
-      actionmailer (= 7.2.2.1)
-      actionpack (= 7.2.2.1)
-      actiontext (= 7.2.2.1)
-      actionview (= 7.2.2.1)
-      activejob (= 7.2.2.1)
-      activemodel (= 7.2.2.1)
-      activerecord (= 7.2.2.1)
-      activestorage (= 7.2.2.1)
-      activesupport (= 7.2.2.1)
+    rails (8.0.0.1)
+      actioncable (= 8.0.0.1)
+      actionmailbox (= 8.0.0.1)
+      actionmailer (= 8.0.0.1)
+      actionpack (= 8.0.0.1)
+      actiontext (= 8.0.0.1)
+      actionview (= 8.0.0.1)
+      activejob (= 8.0.0.1)
+      activemodel (= 8.0.0.1)
+      activerecord (= 8.0.0.1)
+      activestorage (= 8.0.0.1)
+      activesupport (= 8.0.0.1)
       bundler (>= 1.15.0)
-      railties (= 7.2.2.1)
+      railties (= 8.0.0.1)
     rails-controller-testing (1.0.5)
       actionpack (>= 5.0.1.rc1)
       actionview (>= 5.0.1.rc1)
@@ -552,9 +562,9 @@ GEM
     rails-html-sanitizer (1.6.1)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
-    railties (7.2.2.1)
-      actionpack (= 7.2.2.1)
-      activesupport (= 7.2.2.1)
+    railties (8.0.0.1)
+      actionpack (= 8.0.0.1)
+      activesupport (= 8.0.0.1)
       irb (~> 1.13)
       rackup (>= 1.0.0)
       rake (>= 12.2)
@@ -794,7 +804,7 @@ DEPENDENCIES
   blacklight_range_limit (= 9.0.0.beta2)
   bootsnap (>= 1.4.4)
   bootstrap4-kaminari-views
-  browse-everything (~> 1.4)
+  browse-everything (~> 1.4)!
   browser (~> 6.0)
   capybara (>= 2.15)
   capybara-screenshot
@@ -837,10 +847,10 @@ DEPENDENCIES
   prawn-svg (< 2)
   pry-byebug
   puma (~> 6.4)
-  qa (~> 5.2, >= 5.13.0)
+  qa (~> 5.2, >= 5.13.0)!
   rack (>= 3.0)
   rack-attack (~> 6.6)
-  rails (~> 7.2.0)
+  rails (~> 8.0.0)
   rails-controller-testing
   reline (>= 0.2.1)
   resque (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,20 +13,6 @@ GIT
       signet (~> 0.8)
       typhoeus
 
-GIT
-  remote: https://github.com/samvera/questioning_authority.git
-  revision: 652d95a404b7d93d8c422a623c62069fe45d0e04
-  specs:
-    qa (5.13.0)
-      activerecord-import
-      deprecation
-      faraday (< 3.0, != 2.0.0)
-      geocoder
-      ldpath
-      nokogiri (~> 1.6)
-      rails (>= 5.0, < 8.1)
-      rdf
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -521,6 +507,15 @@ GEM
     public_suffix (6.0.1)
     puma (6.5.0)
       nio4r (~> 2.0)
+    qa (5.14.0)
+      activerecord-import
+      deprecation
+      faraday (< 3.0, != 2.0.0)
+      geocoder
+      ldpath
+      nokogiri (~> 1.6)
+      rails (>= 5.0, < 8.1)
+      rdf
     racc (1.8.1)
     rack (3.1.8)
     rack-attack (6.7.0)
@@ -847,7 +842,7 @@ DEPENDENCIES
   prawn-svg (< 2)
   pry-byebug
   puma (~> 6.4)
-  qa (~> 5.2, >= 5.13.0)!
+  qa (~> 5.2, >= 5.14.0)
   rack (>= 3.0)
   rack-attack (~> 6.6)
   rails (~> 8.0.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,7 +48,7 @@ module ScihistDigicoll
 
     # Initialize configuration defaults for originally generated Rails version,
     # or Rails version we have upgraded to and verified for new defaults.
-    config.load_defaults 7.2
+    config.load_defaults 8.0
 
     config.time_zone = "US/Eastern"
 

--- a/config/initializers/devise_rails8_patch.rb
+++ b/config/initializers/devise_rails8_patch.rb
@@ -1,0 +1,16 @@
+# Devise needs to be fixed to work with Rails8, not yet released.
+# https://github.com/heartcombo/devise/pull/5728
+SanePatch.patch('devise', '<= 4.9.4') do
+  require 'devise'
+  Devise # make sure it's already loaded
+
+  module Devise
+    def self.mappings
+      # Starting from Rails 8.0, routes are lazy-loaded by default in test and development environments.
+      # However, Devise's mappings are built during the routes loading phase.
+      # To ensure it works correctly, we need to load the routes first before accessing @@mappings.
+      Rails.application.try(:reload_routes_unless_loaded)
+      @@mappings
+    end
+  end
+end

--- a/config/initializers/patch_irb_console.rb
+++ b/config/initializers/patch_irb_console.rb
@@ -1,6 +1,4 @@
- require "rails/console/methods"
- require "rails/commands/console/irb_console"
-
+require "rails/commands/console/irb_console"
 
 # Over-ride rails method that puts the env in console prompt,
 # so console prompt in staging says 'staging'.
@@ -8,7 +6,6 @@
 # even though our staging uses "production" env, we want it to
 # show up differently in console, so prompt can serve it's cautionary function to
 # distinguish production
-
 
 module OverrideIrbConsoleColorizedEnv
   def colorized_env

--- a/spec/controllers/admin/works_controller_spec.rb
+++ b/spec/controllers/admin/works_controller_spec.rb
@@ -368,7 +368,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
         render_views
         let!(:works) { [
           create(:work, title: "work_a"),
-          create(:work, title: "work_b") 
+          create(:work, title: "work_b")
           ] }
         it "sorts correctly by title" do
           get :index, params: { sort_field: :title, sort_order: :asc }
@@ -430,7 +430,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
       let(:work_child) { build(:work, :published, published: false) }
       let(:asset_child) { build(:asset_with_faked_file, :tiff, published: false) }
       let(:work) do
-        create(:work, :published, published: false, published_at: false, members: [asset_child, work_child])
+        create(:work, :published, published: false, published_at: nil, members: [asset_child, work_child])
       end
 
       describe "publishing" do


### PR DESCRIPTION
- rails 8, with updated samvera dependencies that support rails 8
- Rails8 was pickier about that bad formatted date, we want to set it to nil, we should say that
- patch devise for Rails 8
- update to Rails 8.0 framework defaults
- Remove require that is no longer required in Rails 8 to patch IRB how we like


upstream merged but unreleased devise patch to work with Rails 8: https://github.com/heartcombo/devise/pull/5728