### PR TITLE
Remove yarn resolution to bootstrap4 no longer needed or wanted because we are using bootstrap4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,6 @@
     "vite-plugin-ruby": "^5.1.0",
     "vite-plugin-sass-glob-import": "^3.0.2"
   },
-  "resolutions": {
-    "blacklight-frontend/bootstrap": "^4.6.2"
-  },
   "browserslist": [
     "defaults"
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -379,12 +379,7 @@ blacklight-range-limit@9.0.0-beta2:
   dependencies:
     chart.js "^ 4.4.1"
 
-"bootstrap@>=4.3.1 <6.0.0", bootstrap@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.2.tgz#8e0cd61611728a5bf65a3a2b8d6ff6c77d5d7479"
-  integrity sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==
-
-"bootstrap@^ 5.0.0":
+"bootstrap@>=4.3.1 <6.0.0", "bootstrap@^ 5.0.0":
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.3.tgz#de35e1a765c897ac940021900fcbb831602bac38"
   integrity sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==


### PR DESCRIPTION
This may have caused both bootstrap4 and 5 to be loaded in our app? Lucky it didn't cause terrible problems if it didn't!
