### PR TITLE
Avoid gap in viewer footer for child works with very large windows

### DIFF
--- a/app/frontend/stylesheets/local/scihist_viewer.scss
+++ b/app/frontend/stylesheets/local/scihist_viewer.scss
@@ -364,6 +364,7 @@ $scihist_image_viewer_thumb_width: 54px; // Needs to match ImageServiceHelper::T
         padding: $btn-padding-y-lg $btn-padding-x-lg;
 
         border: 1px solid $primary;
+        max-width: unset;
         flex-grow: 4;
         white-space: nowrap;
         overflow: hidden;

--- a/app/frontend/stylesheets/local/scihist_viewer.scss
+++ b/app/frontend/stylesheets/local/scihist_viewer.scss
@@ -370,8 +370,6 @@ $scihist_image_viewer_thumb_width: 54px; // Needs to match ImageServiceHelper::T
         overflow: hidden;
         text-overflow: ellipsis;
         text-align: left;
-
-        text-transform: uppercase;
       }
       .viewer-spacer {
         width: 0;


### PR DESCRIPTION
This CSS has gotten a bit hack on top of hack, but good enough for now.

## Before
![Screenshot 2024-12-12 at 2 56 59 PM](https://github.com/user-attachments/assets/dbda167d-7fc7-4393-8079-4abf66916354)

## After

![Screenshot 2024-12-12 at 4 20 56 PM](https://github.com/user-attachments/assets/849c26e6-0cf2-45f6-9722-190c2dbd88d0)
