### PR TITLE
Prepare for heroku-24

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -14,6 +14,9 @@ libglib2.0-0
 libglib2.0-dev
 libpoppler-glib8
 
+# to get vips CLI tools we need
+libvips-tools
+
 # we use qpdf for assembling text+graphic pdf files for OCR
 qpdf
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,7 +50,7 @@ module ScihistDigicoll
     # or Rails version we have upgraded to and verified for new defaults.
     config.load_defaults 7.2
 
-    config.time_zone = "US/Eastern"
+    config.time_zone = ENV['TZ'].presence || "America/New_York"
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/system_env_spec/README.md
+++ b/system_env_spec/README.md
@@ -18,9 +18,9 @@ App needs to be installed to heroku first. By default, Heroku does not install g
 
 First, tell the app you want to install `rspec` on the next deploy:
 
-    heroku config:set BUNDLE_WITHOUT=""
-   
-This sets `BUNDLE_WITHOUT` to the empty string (by default, the variable doesn't exist). Although this restarts the dyno, it doesn't actually trigger a deploy.
+    heroku config:set BUNDLE_WITHOUT=" "
+
+This sets `BUNDLE_WITHOUT` to be a space (by default, the variable doesn't exist; empty string is ignored by heroku, need one space!). Although this restarts the dyno, it doesn't actually trigger a deploy.
 
 Next, trigger a deploy.  Use a null commit if you have to, and deploy it to Heroku. On deploy, `rspec` will be installed.
 


### PR DESCRIPTION
Minor tweaks necessary for moving to heroku-24 (ref #2688 ), as well as doc improvement encountered. 

All these changes are backwards compat, so can be merged into master and deployed on heroku-22 as well, no problem. 

To switch to heroku-24:

1. Merge this
2. Remove `https://github.com/brandoncc/heroku-buildpack-vips` from buildpacks, no longer necessary
3. Upgrade to heroku-24 in web UI or `heroku stacks` -- wont' take effect until next deploy
5. Deploy app
6. On relevant app (eg production), need to re-set `heroku config:set TESSDATA_PREFIX="/app/.apt/usr/share/tesseract-ocr/5/tessdata/" -r production`


Note there may be a brief period after deploy but before you set `TESSDATA_PREFIX` where tesseract can't find non-English language modules. Shouldn't really be an issue. 


This has been tested on staging, with `heroku run "rspec system_env_spec"` passing, plus a manual test of ingesting a TIFF and OCR'ing it. (Haven't manually tested everything, just that one, counting on tests!)

- [ ] heroku-24 migration complete