### PR TITLE
Add box and folder to the search form on the collections page.

### DIFF
--- a/app/controllers/collection_show_controller.rb
+++ b/app/controllers/collection_show_controller.rb
@@ -13,6 +13,13 @@ class CollectionShowController < CatalogController
   ORAL_HISTORY_DEPARTMENT_VALUE = "Center for Oral History"
 
   def index
+    if params[:folder_id].present?
+      if params[:box_id].nil? || params[:box_id].empty?
+        flash[:alert] = "If you specify a folder, please also specify a box."
+        params[:box_id] = nil
+        params[:folder_id] = nil
+      end
+    end
     super
     @collection_opac_urls = CollectionOpacUrls.new(collection)
     @related_link_filter ||= RelatedLinkFilter.new(collection.related_link)
@@ -40,6 +47,8 @@ class CollectionShowController < CatalogController
     # and we need to make sure collection_id is allowed by BL, don't totally
     # understand this, as of BL 7.25
     config.search_state_fields << :collection_id
+    config.search_state_fields << :box_id
+    config.search_state_fields << :folder_id
 
     config.add_sort_field("box_folder") do |field|
       field.label = "box and folder"
@@ -53,7 +62,7 @@ class CollectionShowController < CatalogController
   #   collection id (UUID)
   #   the default sort order for this collection, if specified.
   def search_service_context
-    super.merge!(collection_id: collection.id, collection_default_sort_order: collection_default_sort_order)
+    super.merge!(collection_id: collection.id, collection_default_sort_order: collection_default_sort_order, box_id: params[:box_id], folder_id: params[:folder_id])
   end
 
   # What ViewComponent class to use for a given search result on the results screen, for

--- a/app/controllers/collection_show_controller.rb
+++ b/app/controllers/collection_show_controller.rb
@@ -13,12 +13,10 @@ class CollectionShowController < CatalogController
   ORAL_HISTORY_DEPARTMENT_VALUE = "Center for Oral History"
 
   def index
-    if params[:folder_id].present?
-      if params[:box_id].nil? || params[:box_id].empty?
-        flash[:alert] = "If you specify a folder, please also specify a box."
-        params[:box_id] = nil
-        params[:folder_id] = nil
-      end
+    if params[:folder_id].present? && params[:box_id].blank?
+      flash[:alert] = "If you specify a folder, please also specify a box."
+      params[:box_id] = nil
+      params[:folder_id] = nil
     end
     super
     @collection_opac_urls = CollectionOpacUrls.new(collection)

--- a/app/models/search_builder/within_collection_builder.rb
+++ b/app/models/search_builder/within_collection_builder.rb
@@ -17,14 +17,8 @@ class SearchBuilder
     def within_collection(solr_parameters)
       solr_parameters[:fq] ||= []
       solr_parameters[:fq] << "{!term f=#{collection_id_solr_field}}#{collection_id}"
-
-      box_id&.scan(/[a-zA-Z0-9]+/)&.each do |word|
-        solr_parameters[:fq] << "#{box_id_solr_field}:#{word}"
-      end
-
-      folder_id&.scan(/[a-zA-Z0-9]+/)&.each do |word|
-        solr_parameters[:fq] << "#{folder_id_solr_field}:#{word}"
-      end
+      solr_parameters[:fq] << "#{box_id_solr_field}:(#{box_id})" if box_id.present?
+      solr_parameters[:fq] << "#{folder_id_solr_field}:(#{folder_id})" if folder_id.present?
     end
 
     private

--- a/app/models/search_builder/within_collection_builder.rb
+++ b/app/models/search_builder/within_collection_builder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class SearchBuilder
   # Applies a limit to search just within a given collection, filtering on solr
   # field where we've stored the containing collection ids.
@@ -8,15 +9,26 @@ class SearchBuilder
   # Used on CollectionShowController search within a collection
   class WithinCollectionBuilder < ::SearchBuilder
     class_attribute :collection_id_solr_field, default: "collection_id_ssim"
+    class_attribute :box_id_solr_field,        default: "box_tsi"
+    class_attribute :folder_id_solr_field,     default: "folder_tsi"
 
     self.default_processor_chain += [:within_collection]
 
     def within_collection(solr_parameters)
       solr_parameters[:fq] ||= []
       solr_parameters[:fq] << "{!term f=#{collection_id_solr_field}}#{collection_id}"
+
+      box_id&.scan(/[a-zA-Z0-9]+/)&.each do |word|
+        solr_parameters[:fq] << "#{box_id_solr_field}:#{word}"
+      end
+
+      folder_id&.scan(/[a-zA-Z0-9]+/)&.each do |word|
+        solr_parameters[:fq] << "#{folder_id_solr_field}:#{word}"
+      end
     end
 
     private
+
     # Overrides CustomSortLogic#default_sort_order
     def default_sort_order
       scope.context.dig(:collection_default_sort_order) || super
@@ -25,5 +37,14 @@ class SearchBuilder
     def collection_id
       scope.context.fetch(:collection_id)
     end
+
+    def box_id
+      scope.context.fetch(:box_id)
+    end
+
+    def folder_id
+      scope.context.fetch(:folder_id)
+    end
+
   end
 end

--- a/app/views/collection_show/index.html.erb
+++ b/app/views/collection_show/index.html.erb
@@ -59,6 +59,22 @@
                 </button>
               </div>
               <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>
+
+              <% if collection.department == 'Archives' %>
+                <div class="row mx-0">
+                  <div class="col gx-0">
+                    <label  for="box_id">Box</label>
+                    <%= search_field_tag :box_id,    params[:box_id],    class: "box_id form-control",    id: "box_id",
+                    :"aria-label" => 'Box'
+                    %>
+                  </div>
+                  <div class="col gx-0 ms-3">
+                    <label for="folder_id">Folder</label>
+                    <%= search_field_tag :folder_id, params[:folder_id], class: "folder_id form-control", id: "folder_id",
+                    :"aria-label" => 'Folder' %>
+                  </div>
+                </div>
+              <% end %>
             <% end %>
           </div>
 

--- a/spec/controllers/collection_show_controller_spec.rb
+++ b/spec/controllers/collection_show_controller_spec.rb
@@ -366,7 +366,7 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
         expect(response.body).to include("If you specify a folder, please also specify a box")
       end
     end
-    describe "edge cases" do
+   describe "edge cases" do
       let(:parsed){ parsed = Nokogiri::HTML(response.body) }
       let(:titles_as_displayed) { parsed.css('.scihist-results-list-item-head a').map {|x| x.text} }
       let!(:work) { create(:work, :published,
@@ -378,6 +378,16 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
         contained_by:   [collection])
       }
       let!(:collection) { create(:collection, friendlier_id: "faked", department: "Archives") }
+      it "does not return works that don't match" do
+        get :index, params: {
+          "q"=>"",
+          "box_id"=>"goat",
+          "folder_id"=>"goat",
+          "sort"=>"",
+          "collection_id"=> collection.friendlier_id
+        }
+        expect(response.body).not_to include(work.title)
+      end
       it "matches partial matches" do
         get :index, params: {
           "q"=>"",
@@ -388,15 +398,15 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
         }
         expect(response.body).to include(work.title)
       end
-      it "does not return works that don't match" do
+      it "matches partial matches in any order" do
         get :index, params: {
           "q"=>"",
-          "box_id"=>"goat",
-          "folder_id"=>"goat",
+          "box_id"=>"mangos, pears",
+          "folder_id"=>"bears,lions",
           "sort"=>"",
           "collection_id"=> collection.friendlier_id
         }
-        expect(response.body).not_to include(work.title)
+        expect(response.body).to include(work.title)
       end
       it "returns exact matches" do
         get :index, params: {

--- a/spec/controllers/collection_show_controller_spec.rb
+++ b/spec/controllers/collection_show_controller_spec.rb
@@ -326,6 +326,110 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
     end
   end
 
+  describe "search form with box and folder", indexable_callbacks: true do
+    render_views
+    describe "smoke test" do
+      let(:b1f1) {
+        Work::PhysicalContainer.new({ box:1, folder:1 })
+      }
+      let(:b1f2) {
+        Work::PhysicalContainer.new({ box:1, folder:2 })
+      }
+      let(:b12f1) {
+        Work::PhysicalContainer.new({ box:12, folder:1 })
+      }
+      let!(:works) {
+        [
+          create(:work, :published, physical_container: b1f1, title: "b1_f1_1", contained_by:   [collection]),
+          create(:work, :published, physical_container: b1f1, title: "b1_f1_2", contained_by:   [collection]),
+          create(:work, :published, physical_container: b1f2, title: "b1_f1_3", contained_by:   [collection]),
+          create(:work, :published, physical_container: b1f2, title: "b12_f1",  contained_by:   [collection]),
+        ]
+      }
+      let!(:collection) { create(:collection, friendlier_id: "faked", department: "Archives") }
+      let(:box_and_folder_params) do
+        {"q"=>"", "box_id"=>"1", "folder_id"=>"1", "sort"=>"", "collection_id"=> collection.friendlier_id }
+      end
+      it "finds works by box and folder" do
+        get :index, params: box_and_folder_params
+        expect(response).to have_http_status(200)
+        expect(response.body).to     include(works[0].title)
+        expect(response.body).to     include(works[1].title)
+        expect(response.body).not_to include(works[2].title)
+        # Box numbers treated like integers, not strings:
+        # A search for box "1" should not match box "12"
+        expect(response.body).not_to include(works[3].title)
+      end
+      it "requires user to specify containing box" do
+        get :index, params: {"q"=>"", "folder_id"=>"1", "sort"=>"", "collection_id"=> collection.friendlier_id }
+        expect(response).to have_http_status(200)
+        expect(response.body).to include("If you specify a folder, please also specify a box")
+      end
+    end
+    describe "edge cases" do
+      let(:parsed){ parsed = Nokogiri::HTML(response.body) }
+      let(:titles_as_displayed) { parsed.css('.scihist-results-list-item-head a').map {|x| x.text} }
+      let!(:work) { create(:work, :published,
+        title: "archival_work",
+        physical_container: Work::PhysicalContainer.new({
+          "box"=>"apples, pears and mangos 1234",
+          "folder"=> "lions and tigers and bears oh my 5678"
+        }),
+        contained_by:   [collection])
+      }
+      let!(:collection) { create(:collection, friendlier_id: "faked", department: "Archives") }
+      it "matches partial matches" do
+        get :index, params: {
+          "q"=>"",
+          "box_id"=>"pears",
+          "folder_id"=>"bears",
+          "sort"=>"",
+          "collection_id"=> collection.friendlier_id
+        }
+        expect(response.body).to include(work.title)
+      end
+      it "does not return works that don't match" do
+        get :index, params: {
+          "q"=>"",
+          "box_id"=>"goat",
+          "folder_id"=>"goat",
+          "sort"=>"",
+          "collection_id"=> collection.friendlier_id
+        }
+        expect(response.body).not_to include(work.title)
+      end
+      it "returns exact matches" do
+        get :index, params: {
+          "q"=>"",
+          "box_id"=> work.physical_container.box,
+          "folder_id"=> work.physical_container.folder,
+          "sort"=>"",
+          "collection_id"=> collection.friendlier_id
+        }
+        expect(response.body).to include(work.title)
+      end
+      it "123 should not match 1234" do
+        get :index, params: {
+          "q"=>"",
+          "box_id"=>"12",
+          "sort"=>"",
+          "collection_id"=> collection.friendlier_id
+        }
+        expect(response.body).not_to include(work.title)
+      end
+      it "is case insensitive" do
+        get :index, params: {
+          "q"=>"",
+          "box_id"=>"PeArS",
+          "folder_id"=>"BeArS",
+          "sort"=>"",
+          "collection_id"=> collection.friendlier_id
+        }
+        expect(response.body).to include(work.title)
+      end
+    end
+  end
+
   describe "#facet", indexable_callbacks: true do
     render_views
 


### PR DESCRIPTION
**Building the SOLR params**
In `WithinCollectionBuilder`, we add the box and folder to the SOLR params in the `within_collection` processor.

**Form and controller**
- The form design is standard;
  - The extra vertical space does move the first search result even further down the page, which I'm not thrilled about.
- In `CollectionShowController`, we make sure the user specifies a box when they specify a folder;
- We also add the box and folder metadata to the search context.