### PR TITLE
Bot Detection with Turnstile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,8 @@ gem "resque-pool"
 gem "resque-heroku-signals" # gah, weirdly needed for graceful shutdown on heroku. https://github.com/resque/resque#heroku
 
 
+gem "http", "~> 5.2" # for http client access
+
 # using memcached for Rails.cache in production, requires dalli
 gem "dalli", "~> 3.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -816,6 +816,7 @@ DEPENDENCIES
   hirefire-resource (>= 0.10.1)
   honeybadger (~> 5.0)
   html_aware_truncation (~> 1.0)
+  http (~> 5.2)
   irb (>= 1.3.1)
   jbuilder (~> 2.5)
   kaminari (~> 1.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,6 +23,8 @@ class ApplicationController < ActionController::Base
 
   around_action :batch_kithe_indexable
 
+  before_action { |controller| BotDetectController.bot_detection_enforce_filter(controller) }
+
   def batch_kithe_indexable
     Kithe::Indexable.index_with(batching: true) do
       yield

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -1,5 +1,8 @@
 class BotDetectController < ApplicationController
   # Config for bot detection is held here in class_attributes, kind of wonky, but it works
+  #
+  # These are defaults ready for extraction to a gem, in general here at Sci Hist if we want
+  # to set config we do it in ./config/initializers/rack_attack.rb
 
   class_attribute :enabled, default: false # Must set to true to turn on at all
 
@@ -9,7 +12,7 @@ class BotDetectController < ApplicationController
 
   # up to rate_limit_count requests in rate_limit_period before challenged
   class_attribute :rate_limit_period, default: 12.hour
-  class_attribute :rate_limit_count, default: 3
+  class_attribute :rate_limit_count, default: 10
 
   # how long is a challenge pass good for before re-challenge?
   class_attribute :session_passed_good_for, default: 24.hours

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -74,7 +74,7 @@ class BotDetectController < ApplicationController
   class_attribute :env_challenge_trigger_key, default: "bot_detect.should_challenge"
 
   # for allowing unsubscribe for testing
-  class_attribute :_track_notification_subsription, instance_accessor: false
+  class_attribute :_track_notification_subscription, instance_accessor: false
 
   # perhaps in an initializer, and after changing any config, run:
   #
@@ -103,7 +103,7 @@ class BotDetectController < ApplicationController
       end
     end
 
-    self._track_notification_subsription = ActiveSupport::Notifications.subscribe("track.rack_attack") do |_name, _start, _finish, request_id, payload|
+    self._track_notification_subscription = ActiveSupport::Notifications.subscribe("track.rack_attack") do |_name, _start, _finish, request_id, payload|
       rack_request = payload[:request]
       rack_env     = rack_request.env
       match_name = rack_env["rack.attack.matched"]  # name of rack-attack rule

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -1,3 +1,13 @@
+# This controller has actions for issuing a challenge page for CloudFlare Turnstile product,
+# and then redirecting back to desired page.
+#
+# It also includes logic for configuring rack attack and a Rails controller filter to enforce
+# redirection to these actions. All the logic related to bot detection with turnstile is
+# mostly in this file -- with very flexible configuration in class_attributes -- to faciliate
+# future extraction to a re-usable gem if desired.
+#
+# See more local docs at https://sciencehistory.atlassian.net/wiki/spaces/HDC/pages/2645098498/Cloudflare+Turnstile+bot+detection
+#
 class BotDetectController < ApplicationController
   # Config for bot detection is held here in class_attributes, kind of wonky, but it works
   #

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -141,7 +141,7 @@ class BotDetectController < ApplicationController
       remoteip: request.remote_ip
     }
 
-    http = HTTP.timeout(timeout: self.cf_timeout)
+    http = HTTP.timeout(self.cf_timeout)
     response = http.post(self.cf_turnstile_validation_url,
       json: body)
 

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -68,6 +68,20 @@ class BotDetectController < ApplicationController
     end
   end
 
+  # Usually in your ApplicationController,
+  #
+  #     before_action &BotDetectController.bot_detection_enforce_filter
+  def self.bot_detection_enforce_filter
+    _bot_detection_controller = self # in case there's a subclass, capture under closure
+    lambda do |controller|
+      if controller.request.env[_bot_detection_controller.env_challenge_trigger_key] &&
+         !controller.session[_bot_detection_controller.session_passed_key].try { |date| Time.now - Time.new(date) < _bot_detection_controller.session_passed_good_for }
+        # status code temporary
+        controller.redirect_to bot_detect_challenge_path(dest: controller.request.original_fullpath), status: 307
+      end
+    end
+  end
+
 
   def challenge
   end

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -130,8 +130,8 @@ class BotDetectController < ApplicationController
 
   def self._rack_attack_uninit
     Rack::Attack.track("bot_detect/rate_exceeded") {} # overwrite track name with empty proc
-    ActiveSupport::Notifications.unsubscribe(self._track_notification_subsription) if self._track_notification_subsription
-    self._track_notification_subsription = nil
+    ActiveSupport::Notifications.unsubscribe(self._track_notification_subscription) if self._track_notification_subscription
+    self._track_notification_subscription = nil
   end
 
   # Usually in your ApplicationController,

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -1,0 +1,101 @@
+class BotDetectController < ApplicationController
+  # Config for bot detection is held here in class_attributes, kind of wonky, but it works
+  class_attribute :env_challenge_trigger_key, default: "bot_detect.should_challenge"
+
+  # up to rate_limit_count requests in rate_limit_period before challenged
+  class_attribute :rate_limit_period, default: 1.hour
+  class_attribute :rate_limit_count, default: 3
+
+  # discriminator is how we batch requests for counting rate limit, ordinarily by ip,
+  # but we could expand to subnet instead, or use user-agent or whatever. If it returns
+  # nil, then won't be tracked.
+  class_attribute :rate_limit_discriminator, default: ->(req) { req.ip }
+  class_attribute :rate_limited_paths, default: [  # regexp
+                                                  %r{\A/catalog([/?]|\Z)}
+                                                ]
+
+  class_attribute :cf_turnstile_sitekey , default: "1x00000000000000000000AA" # a testing key that always passes
+  class_attribute :cf_turnstile_secret_key, default: "1x0000000000000000000000000000000AA" # a testing key always passes
+  # '3x00000000000000000000FF' # testing, manual check required
+
+  class_attribute :cf_turnstile_js_url, default: "https://challenges.cloudflare.com/turnstile/v0/api.js"
+  class_attribute :cf_turnstile_validation_url, default:  "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+  class_attribute :cf_timeout, default: 3 # max timeout seconds waiting on Cloudfront Turnstile api
+  helper_method :cf_turnstile_js_url, :cf_turnstile_sitekey
+
+  # key stored in Rails session object with channge passed confirmed
+  class_attribute :session_passed_key, default: "bot_detection-passed"
+  # how long is a challenge pass good for before re-challenge?
+  class_attribute :session_passed_good_for, default: 24.hours
+
+
+  # perhaps in an initializer, and after changing any config, run:
+  #
+  #     Rails.application.config.to_prepare do
+  #       BotDetectController.rack_attack_init
+  #     end
+  def self.rack_attack_init
+    ## Turnstile bot detection throttling
+    #
+    # for paths matched by `rate_limited_paths`, after over rate_limit count requests in rate_limit_period,
+    # token will be stored in rack env instructing challenge is required.
+    #
+    # For actual challenge, need before_action in controller.
+    #
+    # You could rate limit detect on wider paths than you actually challenge on, or the same. You probably
+    # don't want to rate-limit detect on narrower list of paths than you challenge on!
+    Rack::Attack.track("bot_detect/rate_exceeded",
+        limit: self.rate_limit_count,
+        period: self.rate_limit_period) do |req|
+
+      if self.rate_limited_paths.any? { |re| re =~ req.path }
+        self.rate_limit_discriminator.call(req)
+      end
+    end
+
+    ActiveSupport::Notifications.subscribe("track.rack_attack") do |_name, _start, _finish, request_id, payload|
+      rack_request = payload[:request]
+      rack_env     = rack_request.env
+      match_name = rack_env["rack.attack.matched"]  # name of rack-attack rule
+
+      if match_name == "bot_detect/rate_exceeded"
+        match_data   = rack_env["rack.attack.match_data"]
+        match_data_formatted = match_data.slice(:count, :limit, :period).map { |k, v| "#{k}=#{v}"}.join(" ")
+        discriminator = rack_env["rack.attack.match_discriminator"] # unique key for rate limit, usually includes ip
+
+        rack_env[self.env_challenge_trigger_key] = true
+      end
+    end
+  end
+
+
+  def challenge
+  end
+
+  def verify_challenge
+    body = {
+      secret: self.cf_turnstile_secret_key,
+      response: params["cf_turnstile_response"],
+      remoteip: request.remote_ip
+    }
+
+    http = HTTP.timeout(timeout: self.cf_timeout)
+    response = http.post(self.cf_turnstile_validation_url,
+      json: body)
+
+    result = response.parse
+    # {"success"=>true, "error-codes"=>[], "challenge_ts"=>"2025-01-06T17:44:28.544Z", "hostname"=>"example.com", "metadata"=>{"result_with_testing_key"=>true}}
+
+    if result["success"]
+      # mark it as succesful in session, and record time. They do need a session/cookies
+      # to get through the challenge.
+      session[self.session_passed_key] = Time.now.utc.iso8601
+    end
+
+    # let's just return the whole thing to client? Is there anything confidential there?
+    render json: result
+  rescue HTTP::Error => e
+    byebug
+    1+1
+  end
+end

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -70,15 +70,12 @@ class BotDetectController < ApplicationController
 
   # Usually in your ApplicationController,
   #
-  #     before_action &BotDetectController.bot_detection_enforce_filter
-  def self.bot_detection_enforce_filter
-    _bot_detection_controller = self # in case there's a subclass, capture under closure
-    lambda do |controller|
-      if controller.request.env[_bot_detection_controller.env_challenge_trigger_key] &&
-         !controller.session[_bot_detection_controller.session_passed_key].try { |date| Time.now - Time.new(date) < _bot_detection_controller.session_passed_good_for }
-        # status code temporary
-        controller.redirect_to bot_detect_challenge_path(dest: controller.request.original_fullpath), status: 307
-      end
+  #     before_action { |controller| BotDetectController.bot_detection_enforce_filter(controller) }
+  def self.bot_detection_enforce_filter(controller)
+    if controller.request.env[self.env_challenge_trigger_key] &&
+       !controller.session[self.session_passed_key].try { |date| Time.now - Time.new(date) < self.session_passed_good_for }
+      # status code temporary
+      controller.redirect_to controller.bot_detect_challenge_path(dest: controller.request.original_fullpath), status: 307
     end
   end
 

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -1,10 +1,13 @@
 class BotDetectController < ApplicationController
   # Config for bot detection is held here in class_attributes, kind of wonky, but it works
-  class_attribute :env_challenge_trigger_key, default: "bot_detect.should_challenge"
 
   # up to rate_limit_count requests in rate_limit_period before challenged
   class_attribute :rate_limit_period, default: 1.hour
   class_attribute :rate_limit_count, default: 3
+
+  class_attribute :cf_turnstile_sitekey , default: "1x00000000000000000000AA" # a testing key that always passes
+  class_attribute :cf_turnstile_secret_key, default: "1x0000000000000000000000000000000AA" # a testing key always passes
+  # '3x00000000000000000000FF' # testing, manual check required
 
   # discriminator is how we batch requests for counting rate limit, ordinarily by ip,
   # but we could expand to subnet instead, or use user-agent or whatever. If it returns
@@ -12,12 +15,6 @@ class BotDetectController < ApplicationController
   class_attribute :rate_limit_discriminator, default: ->(req) { req.ip }
   class_attribute :rate_limited_paths, default: [  # regexp
                                                   %r{\A/catalog([/?]|\Z)}
-                                                ]
-
-  class_attribute :cf_turnstile_sitekey , default: "1x00000000000000000000AA" # a testing key that always passes
-  class_attribute :cf_turnstile_secret_key, default: "1x0000000000000000000000000000000AA" # a testing key always passes
-  # '3x00000000000000000000FF' # testing, manual check required
-
   class_attribute :cf_turnstile_js_url, default: "https://challenges.cloudflare.com/turnstile/v0/api.js"
   class_attribute :cf_turnstile_validation_url, default:  "https://challenges.cloudflare.com/turnstile/v0/siteverify"
   class_attribute :cf_timeout, default: 3 # max timeout seconds waiting on Cloudfront Turnstile api
@@ -28,6 +25,8 @@ class BotDetectController < ApplicationController
   # how long is a challenge pass good for before re-challenge?
   class_attribute :session_passed_good_for, default: 24.hours
 
+  # key in rack env that says challenge is required
+  class_attribute :env_challenge_trigger_key, default: "bot_detect.should_challenge"
 
   # perhaps in an initializer, and after changing any config, run:
   #

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -140,7 +140,8 @@ class BotDetectController < ApplicationController
   def self.bot_detection_enforce_filter(controller)
     if self.enabled &&
         controller.request.env[self.env_challenge_trigger_key] &&
-        !controller.session[self.session_passed_key].try { |date| Time.now - Time.new(date) < self.session_passed_good_for }
+        !controller.session[self.session_passed_key].try { |date| Time.now - Time.new(date) < self.session_passed_good_for } &&
+        !controller.kind_of?(self) # don't ever guard ourself, that'd be a mess!
 
       # we can only do GET requests right now
       if !controller.request.get?

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -58,7 +58,7 @@ class BotDetectController < ApplicationController
         end
       when String
         # string complete path at beginning, must end in ?, or end of string
-        /\A#{Regexp.escape val}(\?|\Z)/ =~ rack_req.path
+        /\A#{Regexp.escape val}(\/|\?|\Z)/ =~ rack_req.path
       end
     end
   }

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -117,6 +117,8 @@ class BotDetectController < ApplicationController
   def self.bot_detection_enforce_filter(controller)
     if controller.request.env[self.env_challenge_trigger_key] &&
        !controller.session[self.session_passed_key].try { |date| Time.now - Time.new(date) < self.session_passed_good_for }
+
+      Rails.logger.info("#{self.name}: Cloudflare Turnstile challenge redirect: (#{controller.request.remote_ip}, #{controller.request.user_agent}): from #{controller.request.url}")
       # status code temporary
       controller.redirect_to controller.bot_detect_challenge_path(dest: controller.request.original_fullpath), status: 307
     end

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -2,11 +2,11 @@ class BotDetectController < ApplicationController
   # Config for bot detection is held here in class_attributes, kind of wonky, but it works
 
   class_attribute :cf_turnstile_sitekey, default: "1x00000000000000000000AA" # a testing key that always passes
-  class_attribute :cf_turnstile_secret_key, default: "1x0000000000000000000000000000000AA" # a testing key always passes
+  class_attribute :cf_turnstile_secret_key, default: "2x0000000000000000000000000000000AA" #"1x0000000000000000000000000000000AA" # a testing key always passes
   # Turnstile testing keys: https://developers.cloudflare.com/turnstile/troubleshooting/testing/
 
   # up to rate_limit_count requests in rate_limit_period before challenged
-  class_attribute :rate_limit_period, default: 1.hour
+  class_attribute :rate_limit_period, default: 12.hour
   class_attribute :rate_limit_count, default: 3
 
   # how long is a challenge pass good for before re-challenge?
@@ -145,6 +145,8 @@ class BotDetectController < ApplicationController
       # mark it as succesful in session, and record time. They do need a session/cookies
       # to get through the challenge.
       session[self.session_passed_key] = Time.now.utc.iso8601
+    else
+      Rails.logger.warn("#{self.class.name}: Cloudflare Turnstile validation failed (#{request.remote_ip}, #{request.user_agent}): #{result}")
     end
 
     # let's just return the whole thing to client? Is there anything confidential there?

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -20,10 +20,7 @@ class BotDetectController < ApplicationController
   #     or `{ controller: "something", action: "index" }
   #
   # Used by default :location_matcher, if set custom may not be used
-  class_attribute :rate_limited_locations, default: [
-                                                  '/catalog',
-                                                  { controller: "collection_show" }
-                                                ]
+  class_attribute :rate_limited_locations, default: []
 
   class_attribute :location_matcher, default: ->(path) {
     parsed_route = nil

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -139,8 +139,14 @@ class BotDetectController < ApplicationController
   #     before_action { |controller| BotDetectController.bot_detection_enforce_filter(controller) }
   def self.bot_detection_enforce_filter(controller)
     if self.enabled &&
-       controller.request.env[self.env_challenge_trigger_key] &&
-       !controller.session[self.session_passed_key].try { |date| Time.now - Time.new(date) < self.session_passed_good_for }
+        controller.request.env[self.env_challenge_trigger_key] &&
+        !controller.session[self.session_passed_key].try { |date| Time.now - Time.new(date) < self.session_passed_good_for }
+
+      # we can only do GET requests right now
+      if !controller.request.get?
+        Rails.logger.warn("#{self}: Asked to protect request we could not, unprotected: #{controller.requet.method} #{controller.request.url}, (#{controller.request.remote_ip}, #{controller.request.user_agent})")
+        return
+      end
 
       Rails.logger.info("#{self.name}: Cloudflare Turnstile challenge redirect: (#{controller.request.remote_ip}, #{controller.request.user_agent}): from #{controller.request.url}")
       # status code temporary

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -1,9 +1,9 @@
 class BotDetectController < ApplicationController
   # Config for bot detection is held here in class_attributes, kind of wonky, but it works
 
-  class_attribute :cf_turnstile_sitekey , default: "1x00000000000000000000AA" # a testing key that always passes
-  class_attribute :cf_turnstile_secret_key, default: "1x0000000000000000000000000000000AA" # a testing key always passes
-  # '3x00000000000000000000FF' # testing, manual check required
+  class_attribute :cf_turnstile_sitekey, default: "1x00000000000000000000AA" # a testing key that always passes
+  class_attribute :cf_turnstile_secret_key, default: "2x0000000000000000000000000000000AA" #default: "1x0000000000000000000000000000000AA" # a testing key always passes
+  # Turnstile testing keys: https://developers.cloudflare.com/turnstile/troubleshooting/testing/
 
   # up to rate_limit_count requests in rate_limit_period before challenged
   class_attribute :rate_limit_period, default: 1.hour
@@ -117,6 +117,7 @@ class BotDetectController < ApplicationController
 
     result = response.parse
     # {"success"=>true, "error-codes"=>[], "challenge_ts"=>"2025-01-06T17:44:28.544Z", "hostname"=>"example.com", "metadata"=>{"result_with_testing_key"=>true}}
+    # {"success"=>false, "error-codes"=>["invalid-input-response"], "messages"=>[], "metadata"=>{"result_with_testing_key"=>true}}
 
     if result["success"]
       # mark it as succesful in session, and record time. They do need a session/cookies

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -15,13 +15,7 @@ class CatalogController < ApplicationController
 
   rescue_from ActionController::UnpermittedParameters, with: :handle_unpermitted_params
 
-  before_action { |controller|
-    if controller.request.env[BotDetectController.env_challenge_trigger_key] &&
-       !controller.session[BotDetectController.session_passed_key].try { |date| Time.now - Time.new(date) < BotDetectController.session_passed_good_for }
-      # status code temporary
-      redirect_to bot_detect_challenge_path(dest: controller.request.original_fullpath), status: 307
-    end
-  }
+  before_action &BotDetectController.bot_detection_enforce_filter
 
   # Blacklight wanted Blacklight::Controller included in ApplicationController,
   # we do it just here instead.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -15,6 +15,14 @@ class CatalogController < ApplicationController
 
   rescue_from ActionController::UnpermittedParameters, with: :handle_unpermitted_params
 
+  before_action { |controller|
+    if controller.request.env[$bot_detect_config.env_challenge_trigger_key!] &&
+       !controller.session[$bot_detect_config.session_passed_key].try { |date| Time.now - Time.new(date) < $bot_detect_config.session_passed_good_for }
+      # status code temporary
+      redirect_to bot_detect_challenge_path(dest: controller.request.original_fullpath), status: 307
+    end
+  }
+
   # Blacklight wanted Blacklight::Controller included in ApplicationController,
   # we do it just here instead.
   include Blacklight::Controller

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -16,8 +16,8 @@ class CatalogController < ApplicationController
   rescue_from ActionController::UnpermittedParameters, with: :handle_unpermitted_params
 
   before_action { |controller|
-    if controller.request.env[$bot_detect_config.env_challenge_trigger_key!] &&
-       !controller.session[$bot_detect_config.session_passed_key].try { |date| Time.now - Time.new(date) < $bot_detect_config.session_passed_good_for }
+    if controller.request.env[BotDetectController.env_challenge_trigger_key] &&
+       !controller.session[BotDetectController.session_passed_key].try { |date| Time.now - Time.new(date) < BotDetectController.session_passed_good_for }
       # status code temporary
       redirect_to bot_detect_challenge_path(dest: controller.request.original_fullpath), status: 307
     end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -15,8 +15,6 @@ class CatalogController < ApplicationController
 
   rescue_from ActionController::UnpermittedParameters, with: :handle_unpermitted_params
 
-  before_action &BotDetectController.bot_detection_enforce_filter
-
   # Blacklight wanted Blacklight::Controller included in ApplicationController,
   # we do it just here instead.
   include Blacklight::Controller

--- a/app/views/bot_detect/challenge.html.erb
+++ b/app/views/bot_detect/challenge.html.erb
@@ -42,7 +42,13 @@
       // replace the challenge page in history
       window.location.replace(dest);
     } else {
-      // error message?
+      console.log("Turnstile response reported as failure: " + JSON.stringify(result))
+      document.querySelector(".cf-turnstile").outerHTML = `
+        <div class="alert alert-danger" role="alert">
+          <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+          Check failed. Sorry, something has gone wrong, or your traffic looks unusual to us. You can try refreshing this page to try again.
+        </div>
+      `;
     }
     //todo catch JS errors too
   }

--- a/app/views/bot_detect/challenge.html.erb
+++ b/app/views/bot_detect/challenge.html.erb
@@ -20,36 +20,48 @@
 
 <script type="text/javascript">
   async function turnstileCallback(token) {
-    // I don't know if we should be disabling CSRF for this one, but we'll just use it
-    const csrfToken = document.querySelector("[name='csrf-token']");
+    try {
+      // I don't know if we should be disabling CSRF for this one, but we'll just use it
+      const csrfToken = document.querySelector("[name='csrf-token']");
 
-    const response = await fetch('<%= bot_detect_challenge_path %>', {
-      method: 'POST',
-      headers: {
-        "X-CSRF-Token": csrfToken?.content,
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({ cf_turnstile_response: token }),
-    });
+      const response = await fetch('<%= bot_detect_challenge_path %>', {
+        method: 'POST',
+        headers: {
+          "X-CSRF-Token": csrfToken?.content,
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({ cf_turnstile_response: token }),
+      });
 
-    result = await response.json();
-    if (result["success"]) {
-      const dest = new URLSearchParams(window.location.search).get("dest");
-      // For security make sure it only has path and on
-      if (!dest.startsWith("/") || dest.startsWith("//")) {
-        throw new Error("illegal non-local redirect: " + dest);
+      if (!response.ok) {
+        throw new Error('bad response: ' + response.status + ": " + response.url);
       }
-      // replace the challenge page in history
-      window.location.replace(dest);
-    } else {
-      console.log("Turnstile response reported as failure: " + JSON.stringify(result))
-      document.querySelector(".cf-turnstile").outerHTML = `
-        <div class="alert alert-danger" role="alert">
-          <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-          Check failed. Sorry, something has gone wrong, or your traffic looks unusual to us. You can try refreshing this page to try again.
-        </div>
-      `;
+
+      result = await response.json();
+      if (result["success"] == true) {
+        const dest = new URLSearchParams(window.location.search).get("dest");
+        // For security make sure it only has path and on
+        if (!dest.startsWith("/") || dest.startsWith("//")) {
+          throw new Error("illegal non-local redirect: " + dest);
+        }
+        // replace the challenge page in history
+        window.location.replace(dest);
+      } else {
+        console.error("Turnstile response reported as failure: " + JSON.stringify(result))
+        _displayChallengeError();
+      }
+    } catch(error) {
+      console.error("Error processing turnstile challenge backend action: " + error);
+      _displayChallengeError();
     }
-    //todo catch JS errors too
+  }
+
+  function _displayChallengeError() {
+    document.querySelector(".cf-turnstile").outerHTML = `
+      <div class="alert alert-danger" role="alert">
+        <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+        Check failed. Sorry, something has gone wrong, or your traffic looks unusual to us. You can try refreshing this page to try again.
+      </div>
+    `;
   }
 </script>

--- a/app/views/bot_detect/challenge.html.erb
+++ b/app/views/bot_detect/challenge.html.erb
@@ -16,7 +16,7 @@
   <div class="alert alert-danger">Sorry, Javascript is required to be enabled for our traffic check, and does not appear available.</div>
 </noscript>
 
-<p class="mt-2">We are happy to share our data and content, but poorly behaving bot traffic volume was causing us problems. If you would like to use our content or data, please <a href="mailto:digital@sciencehistory.org">get in touch</a>, and/or see our information on <a href="https://digital.sciencehistory.org/api_docs">API and Machine Access</a>.</p>
+<p>We strive to make our content freely available. If this check is preventing you from making use of our resources, make sure you have cookies enabled. If you still have trouble, please <a href="mailto:digital@sciencehistory.org">get in touch</a>. You can also take a look at our information on <a href="https://digital.sciencehistory.org/api_docs">API and Machine Access</a>.</p>
 
 <script type="text/javascript">
   async function turnstileCallback(token) {

--- a/app/views/bot_detect/challenge.html.erb
+++ b/app/views/bot_detect/challenge.html.erb
@@ -1,0 +1,49 @@
+<% content_for(:head) do %>
+  <script src="<%= cf_turnstile_js_url %>" async defer></script>
+  <meta name="robots" content="noindex">
+<% end %>
+
+
+<h1 class="brand-alt-h1 mb-4">Traffic control and bot detection...</h2>
+
+<div
+  class="cf-turnstile"
+  data-sitekey="<%= cf_turnstile_sitekey %>"
+  data-callback="turnstileCallback"
+></div>
+
+<noscript>
+  <div class="alert alert-danger">Sorry, Javascript is required to be enabled for our traffic check, and does not appear available.</div>
+</noscript>
+
+<p class="mt-2">We are happy to share our data and content, but poorly behaving bot traffic volume was causing us problems. If you would like to use our content or data, please <a href="mailto:digital@sciencehistory.org">get in touch</a>, and/or see our information on <a href="https://digital.sciencehistory.org/api_docs">API and Machine Access</a>.</p>
+
+<script type="text/javascript">
+  async function turnstileCallback(token) {
+    // I don't know if we should be disabling CSRF for this one, but we'll just use it
+    const csrfToken = document.querySelector("[name='csrf-token']");
+
+    const response = await fetch('<%= bot_detect_challenge_path %>', {
+      method: 'POST',
+      headers: {
+        "X-CSRF-Token": csrfToken?.content,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ cf_turnstile_response: token }),
+    });
+
+    result = await response.json();
+    if (result["success"]) {
+      const dest = new URLSearchParams(window.location.search).get("dest");
+      // For security make sure it only has path and on
+      if (!dest.startsWith("/") || dest.startsWith("//")) {
+        throw new Error("illegal non-local redirect: " + dest);
+      }
+      // replace the challenge page in history
+      window.location.replace(dest);
+    } else {
+      // error message?
+    }
+    //todo catch JS errors too
+  }
+</script>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,7 +17,7 @@ Rails.application.configure do
   # use custom error pages when consider_all_requests_local = false
   config.exceptions_app = self.routes
 
-  # Enable/disable caching. By default caching is disabled.
+  # Enable/disable other caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
@@ -29,8 +29,11 @@ Rails.application.configure do
     }
   else
     config.action_controller.perform_caching = false
+  end
 
-    config.cache_store = :null_store
+  # But force Rails.cache to memory store if we're doing turnstile bot detection,
+  if ScihistDigicoll::Env.lookup(:cf_turnstile_enabled)
+    config.cache_store = :memory_store
   end
 
   # Only in dev or test, let us know if we are passing params that haven't

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -116,6 +116,9 @@ ActiveSupport::Notifications.subscribe(/throttle\.rack_attack|track\.rack_attack
 end
 
 Rails.application.config.to_prepare do
+  BotDetectController.cf_turnstile_sitekey = ScihistDigicoll::Env.lookup(:cf_turnstile_sitekey)
+  BotDetectController.cf_turnstile_secret_key = ScihistDigicoll::Env.lookup(:cf_turnstile_secret_key)
+
   # any custom collection controllers or other controllers that offer search have to be listed here
   # to rate-limit them!
   BotDetectController.rate_limited_locations = [

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -132,9 +132,9 @@ Rails.application.config.to_prepare do
   # any custom collection controllers or other controllers that offer search have to be listed here
   # to rate-limit them!
   BotDetectController.rate_limited_locations = [
-    '/catalog/',
-    '/focus/',
-    '/collections/'
+    '/catalog',
+    '/focus',
+    '/collections'
   ]
 
   BotDetectController.rack_attack_init

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -120,7 +120,7 @@ end
 Rails.application.config.to_prepare do
   # allow rate_limit_count requests in rate_limit_period, before issuing challenge
   BotDetectController.rate_limit_period = 12.hour
-  BotDetectController.rate_limit_count = 3
+  BotDetectController.rate_limit_count = 10
 
   # How long a challenge pass is good for
   BotDetectController.session_passed_good_for = 24.hours

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -116,5 +116,16 @@ ActiveSupport::Notifications.subscribe(/throttle\.rack_attack|track\.rack_attack
 end
 
 Rails.application.config.to_prepare do
+  # any custom collection controllers or other controllers that offer search have to be listed here
+  # to rate-limit them!
+  BotDetectController.rate_limited_locations = [
+    { controller: "catalog" },
+    { controller: "featured_topic" },
+    { controller: "collection_show" },
+    { controller: "collection_show_controllers/immigrants_and_innovation_collection" },
+    { controller: "collection_show_controllers/oral_history_collection"},
+    { controller: "collection_show_controllers/bredig_collection"}
+  ]
+
   BotDetectController.rack_attack_init
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -120,7 +120,7 @@ end
 Rails.application.config.to_prepare do
   # allow rate_limit_count requests in rate_limit_period, before issuing challenge
   BotDetectController.rate_limit_period = 12.hour
-  BotDetectController.rate_limit_count = 10
+  BotDetectController.rate_limit_count = 2
 
   # How long a challenge pass is good for
   BotDetectController.session_passed_good_for = 24.hours
@@ -136,6 +136,15 @@ Rails.application.config.to_prepare do
     '/focus',
     '/collections'
   ]
+
+  # But except any Catalog #facet action that looks like an ajax/fetch request, the redirect
+  # ain't gonna work there, we just exempt it.
+  #
+  # sec-fetch-dest is set to 'empty' by browser on fetch requests, to limit us further;
+  # sure an attacker could fake it, we don't mind if someone determined can avoid rate-limiting on this one action
+  BotDetectController.allow_exempt = ->(controller) {
+    controller.params[:action] == "facet" && controller.request.headers["sec-fetch-dest"] == "empty" && controller.kind_of?(CatalogController)
+  }
 
   BotDetectController.rack_attack_init
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -114,3 +114,57 @@ ActiveSupport::Notifications.subscribe(/throttle\.rack_attack|track\.rack_attack
     Rack::Attack.cache.write(last_logged_key, JSON.dump(last_logged_info), alert_only_per)
   end
 end
+
+
+## Turnstile bot detection throttling
+#
+# for paths matched by `rate_limited_paths`, after over rate_limit count requests in rate_limit_period,
+# token will be stored in rack env instructing challenge is required.
+#
+# For actual challenge, need before_action in controller.
+#
+# You could rate limit detect on wider paths than you actually challenge on, or the same. You probably
+# don't want to rate-limit detect on narrower list of paths than you challenge on!
+$bot_detect_config = ActiveSupport::OrderedOptions.new
+$bot_detect_config.env_challenge_trigger_key = "bot_detect.should_challenge"
+$bot_detect_config.rate_limit_period        =  1.hour
+$bot_detect_config.rate_limit_count         = 3
+# discriminator could expand to subnet instead, or use user-agent or whatever. If it returns
+# nil, then won't be tracked.
+$bot_detect_config.rate_limit_discriminator = ->(req) { req.ip }
+$bot_detect_config.rate_limited_paths       = [  # regexp
+                                                %r{\A/catalog([/?]|\Z)}
+                                              ]
+$bot_detect_config.cf_turnstile_sitekey = "1x00000000000000000000AA" # testing key that always passes
+$bot_detect_config.cf_turnstile_secret_key = "1x0000000000000000000000000000000AA" # testing always passes
+#$bot_detect_config.cf_turnstile_sitekey = '3x00000000000000000000FF' # testing, manual check required
+$bot_detect_config.cf_turnstile_js_url = "https://challenges.cloudflare.com/turnstile/v0/api.js"
+$bot_detect_config.cf_turnstile_validation_url = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+$bot_detect_config.cf_timeout = 3
+
+$bot_detect_config.session_passed_key = "bot_detection-passed"
+$bot_detect_config.session_passed_good_for = 24.hours
+
+Rack::Attack.track("bot_detect/rate_exceeded",
+    limit: $bot_detect_config.rate_limit_count!,
+    period: $bot_detect_config.rate_limit_period!) do |req|
+
+  if $bot_detect_config.rate_limited_paths!.any? { |re| re =~ req.path }
+    $bot_detect_config.rate_limit_discriminator!.call(req)
+  end
+end
+
+  ActiveSupport::Notifications.subscribe("track.rack_attack") do |_name, _start, _finish, request_id, payload|
+    rack_request = payload[:request]
+    rack_env     = rack_request.env
+    match_name = rack_env["rack.attack.matched"]  # name of rack-attack rule
+
+  if match_name == "bot_detect/rate_exceeded"
+    match_data   = rack_env["rack.attack.match_data"]
+    match_data_formatted = match_data.slice(:count, :limit, :period).map { |k, v| "#{k}=#{v}"}.join(" ")
+    discriminator = rack_env["rack.attack.match_discriminator"] # unique key for rate limit, usually includes ip
+
+    rack_env[$bot_detect_config.env_challenge_trigger_key!] = true
+  end
+end
+

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -132,12 +132,9 @@ Rails.application.config.to_prepare do
   # any custom collection controllers or other controllers that offer search have to be listed here
   # to rate-limit them!
   BotDetectController.rate_limited_locations = [
-    { controller: "catalog" },
-    { controller: "featured_topic" },
-    { controller: "collection_show" },
-    { controller: "collection_show_controllers/immigrants_and_innovation_collection" },
-    { controller: "collection_show_controllers/oral_history_collection"},
-    { controller: "collection_show_controllers/bredig_collection"}
+    '/catalog/',
+    '/focus/',
+    '/collections/'
   ]
 
   BotDetectController.rack_attack_init

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -116,7 +116,8 @@ ActiveSupport::Notifications.subscribe(/throttle\.rack_attack|track\.rack_attack
 end
 
 Rails.application.config.to_prepare do
-  BotDetectController.cf_turnstile_sitekey = ScihistDigicoll::Env.lookup(:cf_turnstile_sitekey)
+  BotDetectController.enabled                 = ScihistDigicoll::Env.lookup(:cf_turnstile_enabled)
+  BotDetectController.cf_turnstile_sitekey    = ScihistDigicoll::Env.lookup(:cf_turnstile_sitekey)
   BotDetectController.cf_turnstile_secret_key = ScihistDigicoll::Env.lookup(:cf_turnstile_secret_key)
 
   # any custom collection controllers or other controllers that offer search have to be listed here

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -115,6 +115,8 @@ ActiveSupport::Notifications.subscribe(/throttle\.rack_attack|track\.rack_attack
   end
 end
 
+
+# Explained at https://sciencehistory.atlassian.net/wiki/spaces/HDC/pages/2645098498/Cloudflare+Turnstile+bot+detection
 Rails.application.config.to_prepare do
   # allow rate_limit_count requests in rate_limit_period, before issuing challenge
   BotDetectController.rate_limit_period = 12.hour

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -116,6 +116,13 @@ ActiveSupport::Notifications.subscribe(/throttle\.rack_attack|track\.rack_attack
 end
 
 Rails.application.config.to_prepare do
+  # allow rate_limit_count requests in rate_limit_period, before issuing challenge
+  BotDetectController.rate_limit_period = 12.hour
+  BotDetectController.rate_limit_count = 3
+
+  # How long a challenge pass is good for
+  BotDetectController.session_passed_good_for = 24.hours
+
   BotDetectController.enabled                 = ScihistDigicoll::Env.lookup(:cf_turnstile_enabled)
   BotDetectController.cf_turnstile_sitekey    = ScihistDigicoll::Env.lookup(:cf_turnstile_sitekey)
   BotDetectController.cf_turnstile_secret_key = ScihistDigicoll::Env.lookup(:cf_turnstile_secret_key)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   class CanAccessStaffFunctionsConstraint
     def self.matches?(request)
-      AccessPolicy.new(request.env['warden'].user).can? :access_staff_functions
+      AccessPolicy.new(request.env['warden']&.user).can? :access_staff_functions
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,10 @@ Rails.application.routes.draw do
   end
 
 
+  # bot detection challenge
+  get "/challenge", to: "bot_detect#challenge", as: :bot_detect_challenge
+  post "/challenge", to: "bot_detect#verify_challenge"
+
   # custom error pages
   # https://www.marcelofossrj.com/recipe/2019/04/14/custom-errors.html
   get "/404", to: "errors#not_found", :via => :all

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -199,8 +199,10 @@ module ScihistDigicoll
     define_key :logins_disabled, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM
 
     # https://www.cloudflare.com/application-services/products/turnstile/
-    define_key :cf_turnstile_sitekey
-    define_key :cf_turnstile_secret_key
+    # Default to some always-good testing keys if in development
+    # https://developers.cloudflare.com/turnstile/troubleshooting/testing/
+    define_key :cf_turnstile_sitekey, default: ("1x00000000000000000000AA" if Rails.env.development?)
+    define_key :cf_turnstile_secret_key, default: ("1x0000000000000000000000000000000AA" if Rails.env.development?)
     define_key :cf_turnstile_enabled, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM, default: false
 
 

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -198,6 +198,11 @@ module ScihistDigicoll
     # for maintenance tasks.
     define_key :logins_disabled, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM
 
+    # https://www.cloudflare.com/application-services/products/turnstile/
+    define_key :cf_turnstile_sitekey
+    define_key :cf_turnstile_secret_key
+
+
     # Logic to get network location of the Redis instance we will
     # use for persistent data -- such as our jobs queue for resque.
     #

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -201,6 +201,7 @@ module ScihistDigicoll
     # https://www.cloudflare.com/application-services/products/turnstile/
     define_key :cf_turnstile_sitekey
     define_key :cf_turnstile_secret_key
+    define_key :cf_turnstile_enabled, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM, default: false
 
 
     # Logic to get network location of the Redis instance we will

--- a/spec/controllers/bot_detect_controller_spec.rb
+++ b/spec/controllers/bot_detect_controller_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe BotDetectController, type: :controller do
+  include WebmockTurnstileHelperMethods
+
+  describe "#verify_challenge" do
+    it "handles turnstile success" do
+      turnstile_response = stub_turnstile_success
+
+      post :verify_challenge, params: { cf_turnstile_response: "XXXX.DUMMY.TOKEN.XXXX" }
+      expect(response.status).to be 200
+      expect(response.body).to eq turnstile_response.to_json
+
+      expect(session[BotDetectController.session_passed_key]).to be_present
+      expect(Time.new(session[BotDetectController.session_passed_key])).to be_within(60).of(Time.now.utc)
+    end
+
+    it "handles turnstile failure" do
+      turnstile_response = stub_turnstile_failure
+
+      post :verify_challenge, params: { cf_turnstile_response: "XXXX.DUMMY.TOKEN.XXXX" }
+      expect(response.status).to be 200
+      expect(response.body).to eq turnstile_response.to_json
+
+      expect(session[BotDetectController.session_passed_key]).not_to be_present
+    end
+  end
+end

--- a/spec/controllers/bot_detect_protection_spec.rb
+++ b/spec/controllers/bot_detect_protection_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+# We spec that the BotDetect filter is actually applying protection, as well as exempting what
+# we want
+describe CatalogController, type: :controller do
+
+  # Temporarily enable bot detection
+  around(:each) do |example|
+    orig_enabled = BotDetectController.enabled
+
+    BotDetectController.enabled = true
+    BotDetectController.rack_attack_init
+
+    example.run
+
+    BotDetectController.enabled = orig_enabled
+    BotDetectController.rack_attack_init
+  end
+
+
+  it "redirects when requested" do
+    request.env[BotDetectController.env_challenge_trigger_key] = "true"
+    get :index
+
+    expect(response).to redirect_to(bot_detect_challenge_path(dest: search_catalog_path))
+  end
+
+  # we configured this to try to exempt fetch/ajax to #facet
+  it "does not redirect from exempted action and request state" do
+    request.headers["sec-fetch-dest"] = "empty"
+    get :facet, params: { id: "subject_facet" }
+
+    expect(response).to have_http_status(:success) # not a redirect
+  end
+end

--- a/spec/system/bot_limiting_system_spec.rb
+++ b/spec/system/bot_limiting_system_spec.rb
@@ -20,10 +20,12 @@ describe "Cart and Batch Edit" do
   # Temporarily change desired mocked config
   # Kinda hacky because we need to keep re-registering the tracks
   around(:each) do |example|
+    orig_enabled = BotDetectController.enabled
     orig_sitekey = BotDetectController.cf_turnstile_sitekey
     orig_secretkey = BotDetectController.cf_turnstile_secret_key
     orig_ratelimitcount = BotDetectController.rate_limit_count
 
+    BotDetectController.enabled = true
     BotDetectController.cf_turnstile_sitekey = cf_turnstile_sitekey
     BotDetectController.cf_turnstile_secret_key = cf_turnstile_secret_key
     BotDetectController.rate_limit_count = rate_limit_count
@@ -31,6 +33,8 @@ describe "Cart and Batch Edit" do
     BotDetectController.rack_attack_init
 
     example.run
+
+    BotDetectController.enabled = orig_enabled
 
     BotDetectController.cf_turnstile_sitekey = orig_sitekey
     BotDetectController.cf_turnstile_secret_key = orig_secretkey

--- a/spec/system/bot_limiting_system_spec.rb
+++ b/spec/system/bot_limiting_system_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe "Cart and Batch Edit" do
+  include WebmockTurnstileHelperMethods
+
+  # We need an actual cache to keep track of rate limit, while in test we normally have nullstore
+  before do
+    memstore = ActiveSupport::Cache::MemoryStore.new
+    allow(Rack::Attack.cache).to receive(:store).and_return(memstore)
+  end
+
+
+  let (:cf_turnstile_sitekey_pass) { "1x00000000000000000000AA" } # a test key
+  let (:cf_turnstile_secret_key_pass) { "1x0000000000000000000000000000000AA" } # a testing key always passes
+
+  let(:rate_limit_count) { 1 } # one hit then challenge
+
+
+  # Temporarily change desired mocked config
+  # Kinda hacky because we need to keep re-registering the tracks
+  around(:each) do |example|
+    orig_sitekey = BotDetectController.cf_turnstile_sitekey
+    orig_secretkey = BotDetectController.cf_turnstile_secret_key
+    orig_ratelimitcount = BotDetectController.rate_limit_count
+
+    BotDetectController.cf_turnstile_sitekey = cf_turnstile_sitekey
+    BotDetectController.cf_turnstile_secret_key = cf_turnstile_secret_key
+    BotDetectController.rate_limit_count = rate_limit_count
+
+    BotDetectController.rack_attack_init
+
+    example.run
+
+    BotDetectController.cf_turnstile_sitekey = orig_sitekey
+    BotDetectController.cf_turnstile_secret_key = orig_secretkey
+    BotDetectController.rate_limit_count = orig_ratelimitcount
+
+    BotDetectController.rack_attack_init
+  end
+
+  describe "succesful challenge" do
+    let(:cf_turnstile_sitekey) { cf_turnstile_sitekey_pass }
+    let(:cf_turnstile_secret_key) { cf_turnstile_secret_key_pass }
+
+
+    it "smoke tests" do
+      stub_turnstile_success(request_body: {"secret"=>BotDetectController.cf_turnstile_secret_key, "response"=>"XXXX.DUMMY.TOKEN.XXXX", "remoteip"=>"127.0.0.1"})
+
+      visit search_catalog_path(q: "foo")
+      expect(page).to have_content(/You Searched For/i) # one search results page
+
+      # on second try, we're gonna get redirected to bot check page
+      visit search_catalog_path(q: "bar")
+      expect(page).to have_content("Traffic control and bot detection")
+
+      # which eventually will redirect back to search
+      expect(page).to have_content(/You Searched For/i)
+    end
+  end
+end

--- a/spec/system/bot_limiting_system_spec.rb
+++ b/spec/system/bot_limiting_system_spec.rb
@@ -44,6 +44,7 @@ describe "Cart and Batch Edit" do
     let(:cf_turnstile_secret_key) { cf_turnstile_secret_key_pass }
 
     before do
+      allow(Rails.logger).to receive(:info)
       stub_turnstile_success(request_body: {"secret"=>BotDetectController.cf_turnstile_secret_key, "response"=>"XXXX.DUMMY.TOKEN.XXXX", "remoteip"=>"127.0.0.1"})
     end
 
@@ -57,6 +58,8 @@ describe "Cart and Batch Edit" do
 
       # which eventually will redirect back to search
       expect(page).to have_content(/You Searched For/i)
+
+      expect(Rails.logger).to have_received(:info).with(/BotDetectController: Cloudflare Turnstile challenge redirect/)
     end
   end
 

--- a/spec/test_support/helper_ruby/webmock_turnstile_helper_methods.rb
+++ b/spec/test_support/helper_ruby/webmock_turnstile_helper_methods.rb
@@ -1,0 +1,38 @@
+module WebmockTurnstileHelperMethods
+  def stub_turnstile_success(turnstile_response: {},
+      request_body: {"secret"=>BotDetectController.cf_turnstile_secret_key, "response"=>"XXXX.DUMMY.TOKEN.XXXX", "remoteip"=>"0.0.0.0"})
+
+    turnstile_response.reverse_merge!(
+        {"success"=>true, "error-codes"=>[], "challenge_ts"=>Time.now.utc.iso8601(3), "hostname"=>"example.com", "metadata"=>{"result_with_testing_key"=>true}}
+    )
+
+    stub_request(:post, BotDetectController.cf_turnstile_validation_url).
+         with(
+           body: request_body.to_json
+         ).to_return(status: 200,
+          body: turnstile_response.to_json,
+          headers: { 'Content-Type'=>'application/json; charset=utf-8' }
+         )
+
+    return turnstile_response
+  end
+
+  def stub_turnstile_failure(turnstile_response: {},
+    request_body: {"secret"=>BotDetectController.cf_turnstile_secret_key, "response"=>"XXXX.DUMMY.TOKEN.XXXX", "remoteip"=>"0.0.0.0"})
+
+    turnstile_response.reverse_merge!(
+      {"success"=>false, "error-codes"=>["invalid-input-response"], "messages"=>[], "metadata"=>{"result_with_testing_key"=>true}}
+    )
+
+    stub_request(:post,  BotDetectController.cf_turnstile_validation_url).
+         with(
+           body: request_body.to_json
+         ).to_return(status: 200,
+          body: turnstile_response.to_json,
+          headers: { 'Content-Type'=>'application/json; charset=utf-8' }
+         )
+
+    return turnstile_response
+  end
+
+end


### PR DESCRIPTION
Making everything configurable and architecting in a way that should be not too rough to extract into a gem if desired.  All of the actual logic is really just in the BotDetectController, including methods that are called in other places to "install" it in routes, and init rate limit tracking with rack-attack. 

See more in wiki at https://sciencehistory.atlassian.net/wiki/spaces/HDC/pages/2645098498/Cloudflare+Turnstile+bot+detection