### PR TITLE
Box and folder: use multivalued field; leave tokenization to solr. REQUIRES REINDEX.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -365,14 +365,14 @@ class CatalogController < ApplicationController
     config.add_search_field('box') do |field|
       field.label = 'Box'
       field.solr_parameters = {
-        qf: 'box_tsi',
+        qf: 'box_tsim',
       }
     end
 
     config.add_search_field('folder') do |field|
       field.label = 'Folder'
       field.solr_parameters = {
-        qf: 'folder_tsi',
+        qf: 'folder_tsim',
       }
     end
 

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -61,8 +61,8 @@ class WorkIndexer < Kithe::Indexer
       acc.concat(DateIndexHelper.new(record).expanded_years)
     end
 
-    to_field "box_tsi",     obj_extract("physical_container"), transform( ->(v) { v.box    if v.box.present?    })
-    to_field "folder_tsi",  obj_extract("physical_container"), transform( ->(v) { v.folder if v.folder.present? })
+    to_field "box_tsim",     obj_extract("physical_container"), transform( ->(v) { v.box    if v.box.present?    })
+    to_field "folder_tsim",  obj_extract("physical_container"), transform( ->(v) { v.folder if v.folder.present? })
     to_field "box_sort",    obj_extract("physical_container"), transform( ->(v) { v.box[/\d+/]   if v.box.present?    })
     to_field "folder_sort", obj_extract("physical_container"), transform( ->(v) { v.folder[/\d+/] if v.folder.present? })
 

--- a/app/models/search_builder/within_collection_builder.rb
+++ b/app/models/search_builder/within_collection_builder.rb
@@ -9,22 +9,16 @@ class SearchBuilder
   # Used on CollectionShowController search within a collection
   class WithinCollectionBuilder < ::SearchBuilder
     class_attribute :collection_id_solr_field, default: "collection_id_ssim"
-    class_attribute :box_id_solr_field,        default: "box_tsi"
-    class_attribute :folder_id_solr_field,     default: "folder_tsi"
+    class_attribute :box_id_solr_field,        default: "box_tsim"
+    class_attribute :folder_id_solr_field,     default: "folder_tsim"
 
     self.default_processor_chain += [:within_collection]
 
     def within_collection(solr_parameters)
       solr_parameters[:fq] ||= []
       solr_parameters[:fq] << "{!term f=#{collection_id_solr_field}}#{collection_id}"
-
-      box_id&.scan(/[a-zA-Z0-9]+/)&.each do |word|
-        solr_parameters[:fq] << "#{box_id_solr_field}:#{word}"
-      end
-
-      folder_id&.scan(/[a-zA-Z0-9]+/)&.each do |word|
-        solr_parameters[:fq] << "#{folder_id_solr_field}:#{word}"
-      end
+      solr_parameters[:fq] << "#{box_id_solr_field}:(#{box_id})" if box_id.present?
+      solr_parameters[:fq] << "#{folder_id_solr_field}:(#{folder_id})" if folder_id.present?
     end
 
     private

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -43,9 +43,9 @@ describe WorkIndexer do
 
   # See https://github.com/sciencehistory/scihist_digicoll/issues/2585
   describe "box and folder" do
-    let(:box_search_field) {'box_tsi'}
+    let(:box_search_field) {'box_tsim'}
     let(:box_sort_field)  {'box_sort'}
-    let(:folder_search_field) {'folder_tsi'}
+    let(:folder_search_field) {'folder_tsim'}
     let(:folder_sort_field)   {'folder_sort'}
 
     let(:work_2) { create(:work, physical_container: Work::PhysicalContainer.new({"box"=>"1", "folder"=>"3"})) }


### PR DESCRIPTION
I was using a single-valued field for box and folder, and doing the tokenization myself. Instead, let's use a multivalued field and leave the tokenization to SOLR. All the tests still pass.

@jrochkind pointed out the problem - thanks!

- [ ] merge
- [ ] deploy
- [ ] reindex