### PR TITLE
Let more collection-related pages through bot protection

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -134,7 +134,11 @@ Rails.application.config.to_prepare do
   BotDetectController.rate_limited_locations = [
     '/catalog',
     '/focus',
-    '/collections'
+    # we want to omit `/collections` list page, so we do these by controller
+    { controller: "collection_show" },
+    { controller: "collection_show_controllers/immigrants_and_innovation_collection" },
+    { controller: "collection_show_controllers/oral_history_collection"},
+    { controller: "collection_show_controllers/bredig_collection"}
   ]
 
   # But except any Catalog #facet action that looks like an ajax/fetch request, the redirect


### PR DESCRIPTION
We don't want to bot-protect the '/collection' list page, not necessary and we want those in search results for sure.

We also don't want to protect individual collection show pages *with no search params*, because those are individual colleciton home pages, which we don't want to put anything in the way of getting in search indexes.  Even though those are search pages, it's okay to to allow bot access to them, once they try clicking on a facet limit they'll still be bot-protected.


- Don't include collections list page in bot protection, by specifying by controller instead of path
- exempt collection controllers without search params from bot protection
