### PR TITLE
fix backwards logic in bot detect exemption

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -160,7 +160,7 @@ Rails.application.config.to_prepare do
     (
       controller.kind_of?(CollectionShowController) &&
       controller.respond_to?(:has_search_parameters?) &&
-      controller.has_search_parameters?
+      !controller.has_search_parameters?
     )
   }
 


### PR DESCRIPTION
We want to let bots in to collection pages WITHOUT query params, not let them in only if htere ARE query params.

Obv some tests would have been good and still would be, but for now.
