### PR TITLE
Add a CSS brand light grey border around all thumbnails on work page

### DIFF
--- a/app/frontend/stylesheets/local/search_results.scss
+++ b/app/frontend/stylesheets/local/search_results.scss
@@ -206,7 +206,6 @@
       margin-right: 28px;
       flex-shrink: 0;
       text-align: right;
-      border: 1px solid $table-border-color;
 
       // Keep really high ones from taking up too much space
       max-height: $standard-thumb-width * 2.2;
@@ -226,6 +225,7 @@
 
       img {
         max-width: 100%;
+        border: 1px solid $table-border-color;
       }
     }
 

--- a/app/frontend/stylesheets/local/search_results.scss
+++ b/app/frontend/stylesheets/local/search_results.scss
@@ -206,6 +206,7 @@
       margin-right: 28px;
       flex-shrink: 0;
       text-align: right;
+      border: 1px solid $table-border-color;
 
       // Keep really high ones from taking up too much space
       max-height: $standard-thumb-width * 2.2;

--- a/app/frontend/stylesheets/local/work_show.scss
+++ b/app/frontend/stylesheets/local/work_show.scss
@@ -130,6 +130,7 @@
 
     .thumb {
       display: block; // sometimes an 'a', normalize it to block
+      border: 2px solid $table-border-color;
     }
     .thumb img {
       cursor: zoom-in;

--- a/app/frontend/stylesheets/local/work_show.scss
+++ b/app/frontend/stylesheets/local/work_show.scss
@@ -130,7 +130,7 @@
 
     .thumb {
       display: block; // sometimes an 'a', normalize it to block
-      border: 2px solid $table-border-color;
+      border: 1px solid $table-border-color;
     }
     .thumb img {
       cursor: zoom-in;


### PR DESCRIPTION
Ref #2491

"Try putting a CSS brand light grey border around all thumbnails on work page, see how that looks for Neville and for everything else."


This looks OK, but it would be nice if we can do it without modifying the displayed size of the thumbnail image.