### PR TITLE
OHMS new-style XML WebVTT parsing and transcript display

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -190,6 +190,8 @@ gem "warning", "~> 1.2" # managing ruby warning output
 
 gem "rack-attack", "~> 6.6" # throttling excessive requests
 
+gem "webvtt", "< 2" # https://github.com/jronallo/webvtt
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'pry-byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -767,6 +767,7 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    webvtt (0.0.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yell (2.2.2)
@@ -869,6 +870,7 @@ DEPENDENCIES
   warning (~> 1.2)
   web-console (>= 4.1.0)
   webmock (~> 3.5)
+  webvtt (< 2)
 
 RUBY VERSION
    ruby 3.3.6p108

--- a/app/models/oral_history_content.rb
+++ b/app/models/oral_history_content.rb
@@ -89,10 +89,12 @@ class OralHistoryContent < ApplicationRecord
   end
 
   def has_ohms_transcript?
-    @has_ohms_transcript ||= begin
-      transcript_text = ohms_xml&.parsed&.at_xpath("//ohms:record/ohms:transcript[normalize-space(text())]", ohms: OhmsXml::OHMS_NS)
-      # OHMS gives you a transcript body that says "No transcript.", argh!
-      transcript_text && transcript_text.text != "No transcript."
+    return @has_ohms_transcript if defined?(@has_ohms_transcript)
+
+    @has_ohms_transcript = begin
+      transcript_text = ohms_xml&.transcript_text
+      # OHMS sometimes gives you a transcript body that says "No transcript.", argh!
+      transcript_text.present? && transcript_text != "No transcript."
     end
   end
 

--- a/app/models/oral_history_content/ohms_xml/legacy_transcript.rb
+++ b/app/models/oral_history_content/ohms_xml/legacy_transcript.rb
@@ -20,7 +20,7 @@ class OralHistoryContent
       end
 
       def transcript_text
-       @transcript_text = nokogiri_xml.at_xpath("//ohms:transcript", ohms: OHMS_NS).text
+       @transcript_text = nokogiri_xml.at_xpath("//ohms:transcript", ohms: OHMS_NS)&.text
       end
 
       # An array of footnotes, such that [[footnote]]1[[/footnote]]

--- a/app/models/oral_history_content/ohms_xml/vtt_transcript.rb
+++ b/app/models/oral_history_content/ohms_xml/vtt_transcript.rb
@@ -1,0 +1,109 @@
+require 'webvtt'
+
+class OralHistoryContent
+  class OhmsXml
+
+    # Can parse WebVTT content -- or at least the subset delivered by the OHMS
+    # new-style 2025 OHMS transcript with <vtt_transcript> element in xml.
+    # https://www.w3.org/TR/webvtt1/
+    #
+    # Uses the `webvtt` gem for initial parsing, but that gem is basic and
+    # not very maintained, so we need some massaging and post-processing
+    # to get what we need.
+    #
+    # For OHMS, the WebVTT `<v>` voice tag is crucial for labelling speakers.
+    class VttTranscript
+      attr_reader :transcript_txt
+
+      # @param transcript_txt [String] WebVTT text as included in an OHMS xml export
+      def initialize(transcript_txt)
+        @transcript_txt = transcript_txt || ""
+      end
+
+      def cues
+        @cues ||= begin
+          # parser requires initial WEBVTT line, which OHMS omits
+          src = transcript_txt
+          unless src.start_with?('WEBVTT')
+            src = "WEBVTT\n" + src
+          end
+
+          Webvtt::File.new(src).cues.collect { |webvtt_cue| Cue.new(webvtt_cue) }
+        end
+      end
+
+      # our cue wraps webvtt cue with further parsed escaped content
+      #
+      # Each queue has an array of 0 or more 'paragraphs', each paragraph
+      # can include <b>, <i>, and <u> tags, but has other html stripped,
+      # and is html safe.
+      #
+      # Each paragraph may have an option speaker voice name
+      #
+      # Actual OHMS content at present will only put that on the first one,
+      # and always has it, but this is not required by the standard or this code
+      class Cue
+        delegate :identifier, :start, :end, :settings, :text, to: :@webvtt_cue
+
+        def initialize(webvtt_cue)
+          @webvtt_cue = webvtt_cue
+        end
+
+        # parse start str into number of seconds as float
+        def start_sec_f
+          @start_sec_f ||= begin
+            start =~ /(\d+):(\d\d)(\.\d\d\d)?/
+            ($1.to_i * 60) + $2.to_i + $3.to_f
+          end
+        end
+
+        #  parase end str into number of seconds as float
+        def end_sec_f
+          @end_sec_f ||= begin
+            self.end =~ /(\d+):(\d\d)(\.\d\d\d)?/
+            ($1.to_i * 60) + $2.to_i + $3.to_f
+          end
+        end
+
+        def paragraphs
+          @paragraphs ||= begin
+            # This tricky regex using both positive lookahead and negative lookahead
+            # will split into voice tags, taking into account that some text might not
+            # be in a voice tag, and that voice tag does not have to ber closed when it's the whole cue
+            text.split(/(?=\<v[ .])|(?<=\<\/v>)/).collect do |voice_span|
+              # <v some name> or <v.class1.class2 some name>, in some cases ended with </v>
+              if voice_span.gsub!(/\A\<v(?:\.[\w.]+)?\ ([^>]+)>/, '')
+                speaker_name = $1
+              end
+
+              # \R is any kind of linebreak
+              voice_span.split(/\R/).collect do |paragraph_text|
+                Paragraph.new(speaker_name: speaker_name, raw_html: paragraph_text)
+              end
+            end.flatten
+          end
+        end
+      end
+
+      class Paragraph
+        Scrubber = Rails::Html::PermitScrubber.new.tap do |scrubber|
+          scrubber.tags = ['i', 'b', 'u']
+        end
+
+        attr_reader :speaker_name, :safe_html
+
+        def initialize(speaker_name:, raw_html:)
+          @speaker_name = speaker_name
+
+          html_fragment = Loofah.fragment(raw_html)
+          html_fragment.scrub!(Scrubber)
+
+          @safe_html = html_fragment.to_s.strip.html_safe
+        end
+      end
+
+    end
+
+
+  end
+end

--- a/app/models/oral_history_content/ohms_xml/vtt_transcript.rb
+++ b/app/models/oral_history_content/ohms_xml/vtt_transcript.rb
@@ -12,6 +12,8 @@ class OralHistoryContent
     # to get what we need.
     #
     # For OHMS, the WebVTT `<v>` voice tag is crucial for labelling speakers.
+    #
+    # See an example mock OHMS XML with WebVTT at ./spec/test_support/ohms_xml/small-sample-vtt-ohms.xml
     class VttTranscript
       FullSanitizer = Rails::HTML5::FullSanitizer.new
 

--- a/lib/ohms/ohms.xsd
+++ b/lib/ohms/ohms.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="https://www.weareavp.com/nunncenter/ohms" xmlns="https://www.weareavp.com/nunncenter/ohms/ohms.xsd" version="5.4" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="https://www.weareavp.com/nunncenter/ohms" xmlns="https://www.weareavp.com/nunncenter/ohms/ohms.xsd" version="6.0" elementFormDefault="qualified" attributeFormDefault="unqualified">
     <xs:element name="ROOT">
         <xs:complexType>
             <xs:sequence>
@@ -58,6 +58,7 @@
                                                     <xs:enumeration value="Vimeo" />
                                                     <xs:enumeration value="YouTube" />
                                                     <xs:enumeration value="Other" />
+                                                    <xs:enumeration value="" />
                                                 </xs:restriction>
                                             </xs:simpleType>
                                         </xs:element>
@@ -70,6 +71,7 @@
                                                 <xs:restriction base="xs:string">
                                                     <xs:enumeration value="audio" />
                                                     <xs:enumeration value="video" />
+                                                    <xs:enumeration value="" />
                                                 </xs:restriction>
                                             </xs:simpleType>
                                         </xs:element>
@@ -101,34 +103,34 @@
                                                             <xs:sequence>
                                                                 <xs:element name="gps" minOccurs="0" maxOccurs="1" type="xs:string"></xs:element>
                                                                 <xs:element name='gps_zoom'>
-		                                                        	<xs:simpleType>
-			                                                            <xs:union>
-			                                                                <xs:simpleType>
-			                                                                    <xs:restriction base='xs:string'>
-			                                                                        <xs:length value='0'/>
-			                                                                    </xs:restriction>
-			                                                                </xs:simpleType>
-			                                                                <xs:simpleType>
-			                                                                    <xs:restriction base='xs:integer'>
-			                                                                    </xs:restriction>
-			                                                                </xs:simpleType>
-			                                                            </xs:union>
-			                                                        </xs:simpleType>
-			                                                    </xs:element>
+                                                                    <xs:simpleType>
+                                                                        <xs:union>
+                                                                            <xs:simpleType>
+                                                                                <xs:restriction base='xs:string'>
+                                                                                    <xs:length value='0'/>
+                                                                                </xs:restriction>
+                                                                            </xs:simpleType>
+                                                                            <xs:simpleType>
+                                                                                <xs:restriction base='xs:integer'>
+                                                                                </xs:restriction>
+                                                                            </xs:simpleType>
+                                                                        </xs:union>
+                                                                    </xs:simpleType>
+                                                                </xs:element>
                                                                 <xs:element name="gps_text" minOccurs="0" maxOccurs="1" type="xs:string"></xs:element>
                                                                 <xs:element name="gps_text_alt" minOccurs="0" maxOccurs="1" type="xs:string"></xs:element>
                                                             </xs:sequence>
                                                         </xs:complexType>
-	                                                </xs:element>
-	                                                <xs:element name="hyperlinks" minOccurs="0" maxOccurs="unbounded">
-	                                                    <xs:complexType>
-	                                                        <xs:sequence>
-	                                                            <xs:element name="hyperlink" minOccurs="0" maxOccurs="1" type="xs:string"></xs:element>
-	                                                            <xs:element name="hyperlink_text" minOccurs="0" maxOccurs="1" type="xs:string"></xs:element>
-	                                                            <xs:element name="hyperlink_text_alt" minOccurs="0" maxOccurs="1" type="xs:string"></xs:element>
-	                                                        </xs:sequence>
-	                                                    </xs:complexType>
-	                                                </xs:element>
+                                                    </xs:element>
+                                                    <xs:element name="hyperlinks" minOccurs="0" maxOccurs="unbounded">
+                                                        <xs:complexType>
+                                                            <xs:sequence>
+                                                                <xs:element name="hyperlink" minOccurs="0" maxOccurs="1" type="xs:string"></xs:element>
+                                                                <xs:element name="hyperlink_text" minOccurs="0" maxOccurs="1" type="xs:string"></xs:element>
+                                                                <xs:element name="hyperlink_text_alt" minOccurs="0" maxOccurs="1" type="xs:string"></xs:element>
+                                                            </xs:sequence>
+                                                        </xs:complexType>
+                                                    </xs:element>
                                                 </xs:sequence>
                                             </xs:complexType>
                                         </xs:element>
@@ -140,6 +142,8 @@
                             <xs:element name="rel" type="xs:string" minOccurs="0" maxOccurs="1" />
                             <xs:element name="transcript" type="xs:string" minOccurs="0" maxOccurs="1" />
                             <xs:element name="transcript_alt" type="xs:string" minOccurs="0" maxOccurs="1" />
+                            <xs:element name="vtt_transcript" type="xs:string" minOccurs="0" maxOccurs="1" />
+                            <xs:element name="vtt_transcript_alt" type="xs:string" minOccurs="0" maxOccurs="1" />
                             <xs:element name="rights" type="xs:string" minOccurs="0" maxOccurs="1" />
                             <xs:element name="fmt" minOccurs="0" maxOccurs="1">
                                 <xs:simpleType>
@@ -171,4 +175,3 @@
         </xs:complexType>
     </xs:element>
 </xs:schema>
-

--- a/spec/models/oral_history_content/ohms_xml_spec.rb
+++ b/spec/models/oral_history_content/ohms_xml_spec.rb
@@ -35,6 +35,25 @@ describe OralHistoryContent::OhmsXml do
         ])
       end
     end
+
+    describe "with legacy transcript" do
+      it "has transcript" do
+        expect(ohms_xml.vtt_transcript).not_to be_present
+        expect(ohms_xml.legacy_transcript).to be_present
+      end
+    end
+
+    describe "with vtt transcript" do
+      let(:ohms_xml_path) { Rails.root + "spec/test_support/ohms_xml/small-sample-vtt-ohms.xml" }
+
+      it "has transcript with correct number of cues" do
+        expect(ohms_xml.vtt_transcript).to be_present
+        expect(ohms_xml.legacy_transcript).not_to be_present
+
+        expect(ohms_xml.vtt_transcript.cues.length).to eq 15
+      end
+    end
+
   end
 
   describe OralHistoryContent::OhmsXml::IndexPoint do

--- a/spec/models/oral_history_content/ohms_xml_validator_spec.rb
+++ b/spec/models/oral_history_content/ohms_xml_validator_spec.rb
@@ -40,8 +40,17 @@ describe OralHistoryContent::OhmsXmlValidator do
     end
   end
 
-  describe "valid OHMS xml" do
+  describe "valid OHMS xml with legacy transcript" do
     let(:xml_str) { duarte_xml }
+
+    it "is valid" do
+      expect(validator.valid?).to be(true)
+      expect(validator.errors).to be_empty
+    end
+  end
+
+  describe "valid OHMS xml with vtt transcript" do
+    let(:xml_str) { File.read(Rails.root + "spec/test_support/ohms_xml/small-sample-vtt-ohms.xml") }
 
     it "is valid" do
       expect(validator.valid?).to be(true)

--- a/spec/models/oral_history_content/vtt_transcript_spec.rb
+++ b/spec/models/oral_history_content/vtt_transcript_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+describe OralHistoryContent::OhmsXml::VttTranscript do
+  let(:sample_webvtt) do
+    # Example includes what OHMS might, but also some extra stuff in WebVTT
+    # standard (but not necessarily everything!), to be a bit forward looking.
+    <<~EOS
+
+      NOTE
+      TRANSCRIPTION BEGIN
+
+      00:00.000 --> 00:02.000 align:left size:50%
+      <v.first.loud Esme Johnson>It’s a <i>blue</i> <script>apple</script> tree!
+
+      00:02.400 --> 00:04.000
+      <v Mary>This content has some internal line breaks.
+         Like this is a paragraph two.
+         And even three.
+
+      00:04.400 --> 00:06.000
+      <v Esme>Hee!</v> <i>laughter</i>
+
+      00:06.000 --> 00:08.000
+      <v Mary>Why did the chicken cross the road</v>
+      <v Doug>To get to the other side</v>
+
+      NOTE
+      TRANSCRIPTION END
+
+    EOS
+  end
+
+  let(:vtt_transcript) { described_class.new(sample_webvtt) }
+
+  it "parses" do
+    cues = vtt_transcript.cues
+
+    first_cue = cues[0]
+    expect(first_cue.start).to eq "00:00.000"
+    expect(first_cue.start_sec_f).to eq 0.0
+    expect(first_cue.end).to eq "00:02.000"
+    expect(first_cue.end_sec_f).to eq 2.0
+    expect(first_cue.paragraphs.length).to eq 1
+    expect(first_cue.paragraphs[0].speaker_name).to eq "Esme Johnson"
+    expect(first_cue.paragraphs[0].safe_html).to eq "It’s a <i>blue</i> apple tree!"
+    expect(first_cue.paragraphs[0].safe_html.html_safe?).to be true
+
+    second_cue = cues[1]
+    expect(second_cue.start).to eq "00:02.400"
+    expect(second_cue.start_sec_f).to eq 2.4
+    expect(second_cue.end).to eq "00:04.000"
+    expect(second_cue.end_sec_f).to eq 4.0
+
+    expect(second_cue.paragraphs.length).to eq 3
+    expect(second_cue.paragraphs.collect(&:safe_html)).to eq [
+      "This content has some internal line breaks.",
+      "Like this is a paragraph two.",
+      "And even three."
+    ]
+    expect(second_cue.paragraphs.collect(&:speaker_name)).to eq ['Mary','Mary','Mary']
+
+    third_cue = cues[2]
+    expect(third_cue.paragraphs.length).to eq 2
+    expect(third_cue.paragraphs.collect(&:safe_html)).to eq ['Hee!', '<i>laughter</i>']
+    expect(third_cue.paragraphs.collect(&:speaker_name)).to eq ['Esme', nil]
+    expect(third_cue.paragraphs.collect(&:safe_html).all? {|a| a.html_safe?}).to be true
+
+    fourth_cue = cues[3]
+    expect(fourth_cue.paragraphs.length).to eq 2
+    expect(fourth_cue.paragraphs.collect(&:safe_html)).to eq ['Why did the chicken cross the road', 'To get to the other side']
+    expect(fourth_cue.paragraphs.collect(&:speaker_name)).to eq ['Mary', 'Doug']
+  end
+end

--- a/spec/models/oral_history_content/vtt_transcript_spec.rb
+++ b/spec/models/oral_history_content/vtt_transcript_spec.rb
@@ -35,6 +35,8 @@ describe OralHistoryContent::OhmsXml::VttTranscript do
   it "parses" do
     cues = vtt_transcript.cues
 
+    expect(cues.length).to eq 4
+
     first_cue = cues[0]
     expect(first_cue.start).to eq "00:00.000"
     expect(first_cue.start_sec_f).to eq 0.0
@@ -69,5 +71,13 @@ describe OralHistoryContent::OhmsXml::VttTranscript do
     expect(fourth_cue.paragraphs.length).to eq 2
     expect(fourth_cue.paragraphs.collect(&:safe_html)).to eq ['Why did the chicken cross the road', 'To get to the other side']
     expect(fourth_cue.paragraphs.collect(&:speaker_name)).to eq ['Mary', 'Doug']
+  end
+
+  it "has transcript_text" do
+    text = vtt_transcript.transcript_text
+    expect(text).to be_present
+
+    expect(text).to include "Esme Johnson: It’s a blue apple tree!"
+    expect(text).to include "Why did the chicken cross the road"
   end
 end

--- a/spec/test_support/ohms_xml/small-sample-vtt-ohms.xml
+++ b/spec/test_support/ohms_xml/small-sample-vtt-ohms.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ROOT xmlns="https://www.weareavp.com/nunncenter/ohms" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.weareavp.com/nunncenter/ohms/ohms.xsd">
+  <record id="36809" dt="2025-01-23">
+    <version>6.0</version>
+    <date value="" format="yyyy-mm-dd"/>
+    <date_nonpreferred_format/>
+    <cms_record_id/>
+    <title>Jonathan Rochkind Test Record Only</title>
+    <accession/>
+    <duration>00:00:00</duration>
+    <collection_id/>
+    <collection_name/>
+    <series_id/>
+    <series_name/>
+    <repository>Science History Institute</repository>
+    <funding/>
+    <repository_url>sciencehistory</repository_url>
+    <interviewee/>
+    <interviewer/>
+    <format/>
+    <file_name/>
+    <transcript_alt_lang/>
+    <translate>0</translate>
+    <media_id/>
+    <media_url/>
+    <mediafile>
+      <host>Other</host>
+      <avalon_target_domain/>
+      <host_account_id/>
+      <host_player_id/>
+      <host_clip_id/>
+      <clip_format>audio</clip_format>
+    </mediafile>
+    <kembed/>
+    <language/>
+    <user_notes/>
+    <index/>
+    <type/>
+    <description/>
+    <rel/>
+    <vtt_transcript><![CDATA[WEBVTT
+
+NOTE
+TRANSCRIPTION BEGIN
+
+00:00:00.000 --> 00:00:03.000
+Sample Time Stamp Document (with fake interview content)<br><br>How it looks when exported from Sonix: Time stamps are to the left of the speaker names here. There is a time stamp and speaker name at each paragraph change.
+
+00:00:03.000 --> 00:00:18.000
+<v SCHNEIDER>  Today is December 16, 2024. I am Sarah Schneider and I am conducting an oral history interview with name of interviewee in Philadelphia, Pennsylvania at the Science History Institute. I wanted to start off by asking you about your childhood in Washington, DC. What was it like growing up there?
+
+00:00:18.000 --> 00:00:31.000
+<v NAME OF INTERVIEWEE>  It was a lot of fun growing up there. I had five siblings and we were always going on adventures around town, like visiting museums and monuments. We lived near the subway so it was easy to travel around town.
+
+00:00:31.000 --> 00:00:38.000
+<v SCHNEIDER>  Did you have a favorite museum to visit? What kinds of other activities were you involved in as a child?
+
+00:00:38.000 --> 00:00:42.000
+<v NAME OF INTERVIEWEE>  I liked the Museum of Natural History quite a bit. We always went there. I memorized some of the text in the exhibits, and the staff got to know me because I was there so much on summer breaks. I think that was part of what led to my interest in science and interest in learning.
+
+00:00:42.000 --> 00:00:54.000
+<v NAME OF INTERVIEWEE>  One day, we got lost on our way home. We went a different direction and I had trouble finding my way. It was confusing because there was some construction, so I couldn’t follow the normal path that we would take.
+
+00:00:54.000 --> 00:01:14.000
+<v NAME OF INTERVIEWEE>  Another time, we were outside walking around a park and saw the President! We would see the motorcade go by quite frequently, but this time, he was walking around and greeting people, shaking their hands. We almost got to meet him, but then he had to leave by the time he would have made our way towards us.
+
+00:01:14.000 --> 00:01:22.000
+<v SCHNEIDER>  Wow, that sounds like a memorable experience. Did you spend all of your childhood in DC?
+
+00:01:22.000 --> 01:00:03.000
+<v NAME OF INTERVIEWEE>  Yes, I lived there my whole childhood. But my parents have since moved into the suburbs in Maryland.<br><br> How the document will look after our formatting: Time stamps are on the line above the speaker name. There is only one time stamp per speaker change (so when someone speaks for a while with multiple paragraph breaks, there is only a time stamp before the first paragraph for that set of speech, until someone else speaks).<br><br>We can use the advanced find and replace function to add line breaks before the speaker names to move each time stamp to the line prior: Find what box: Type in the name of a speaker and colon [for example: “SCHNEIDER:”]<br><br>Replace with box: Choose “Special” and select “Manual Line Break” and then type in the speaker name and colon (no space between the line break symbol and name). It should look like: For interviewer<br><br>Find what box: “SCHNEIDER:” (no quotes typed in)<br><br>Replace with box: “^lSCHNEIDER:” (no quotes typed in)<br><br>Replace All<br><br>Repeat this process for each of the speakers in the interview
+
+01:00:03.000 --> 01:00:18.000
+<v SCHNEIDER>  Today is December 16, 2024. I am Sarah Schneider and I am conducting an oral history interview with name of interviewee in Philadelphia, Pennsylvania at the Science History Institute. I wanted to start off by asking you about your childhood in Washington, DC. What was it like growing up there?
+
+01:00:18.000 --> 01:00:31.000
+<v NAME OF INTERVIEWEE>  It was a lot of fun growing up there. I had five siblings and we were always going on adventures around town, like visiting museums and monuments. We lived near the subway so it was easy to travel around town.
+
+01:00:31.000 --> 01:00:38.000
+<v SCHNEIDER>  Did you have a favorite museum to visit? What kinds of other activities were you involved in as a child?
+
+01:00:38.000 --> 01:01:14.000
+<v NAME OF INTERVIEWEE>  I liked the Museum of Natural History quite a bit. We always went there. I memorized some of the text in the exhibits, and the staff got to know me because I was there so much on summer breaks. I think that was part of what led to my interest in science and interest in learning.<br><br>One day, we got lost on our way home. We went a different direction and I had trouble finding my way. It was confusing because there was some construction, so I couldn’t follow the normal path that we would take.<br><br>Another time, we were outside walking around a park and saw the President! We would see the motorcade go by quite frequently, but this time, he was walking around and greeting people, shaking their hands. We almost got to meet him, but then he had to leave by the time he would have made our way towards us.
+
+01:01:14.000 --> 01:01:22.000
+<v SCHNEIDER>  Wow, that sounds like a memorable experience. Did you spend all of your childhood in DC?
+
+01:01:22.000 --> 00:00:00.000
+<v NAME OF INTERVIEWEE>  Yes, I lived there my whole childhood. But my parents have since moved into the suburbs in Maryland.
+
+NOTE
+TRANSCRIPTION END
+
+]]></vtt_transcript>
+    <rights/>
+    <fmt>audio</fmt>
+    <usage/>
+    <userestrict>0</userestrict>
+    <xmllocation>/render.php?cachefile=</xmllocation>
+    <xmlfilename/>
+    <collection_link/>
+    <series_link/>
+  </record>
+</ROOT>


### PR DESCRIPTION
New OHMS transcripts have (a certain subset of) WebVTT in a `vtt_transcript` tag 

1. New class to parse WebVTT https://www.w3.org/TR/webvtt1/
2. OhmsXML class can recognize presence of either legacy or new vtt transcript, and parse either one
3. Indexer can get indexable transcript_text from either one to index to solr

There's more coming for actual display of VTT transcripts, but this is (more than) enough for first PR. 