### PR TITLE
[WIP] Do not show all members at first

### DIFF
--- a/app/components/work_image_show_component.html.erb
+++ b/app/components/work_image_show_component.html.erb
@@ -74,6 +74,13 @@
         <%= render MemberImageComponent.new(member_for_thumb.member, lazy: (index > 5), image_label: member_for_thumb.image_label) %>
       </div>
   <% end %>
+
+  <% if more_members_to_show? %>
+    <div><%= link_to "Show #{hidden_viewable_members_count} more #{pluralize(hidden_viewable_members_count, 'item')} ...", show_all: true %></div>
+  <% else %>
+    <div>No more members to show. You already see all <%= viewable_members_count %> and <%= hidden_viewable_members_count %> is zero.</div>
+  <% end %>
+
 </div>
 
 <%# hidden modal used by viewer %>

--- a/app/components/work_image_show_component.html.erb
+++ b/app/components/work_image_show_component.html.erb
@@ -76,9 +76,7 @@
   <% end %>
 
   <% if more_members_to_show? %>
-    <div><%= link_to "Show #{hidden_viewable_members_count} more #{pluralize(hidden_viewable_members_count, 'item')} ...", show_all: true %></div>
-  <% else %>
-    <div>No more members to show. You already see all <%= viewable_members_count %> and <%= hidden_viewable_members_count %> is zero.</div>
+    <div><%= link_to "Show #{pluralize(hidden_viewable_members_count, 'more item')} ...", show_all: true %></div>
   <% end %>
 
 </div>

--- a/app/components/work_image_show_component.rb
+++ b/app/components/work_image_show_component.rb
@@ -6,7 +6,7 @@
 class WorkImageShowComponent < ApplicationComponent
   delegate :construct_page_title, :current_user, to: :helpers
 
-  DEFAULT_THUMBNAIL_NUMBER = 2.freeze
+  DEFAULT_THUMBNAIL_NUMBER = 80.freeze
 
   attr_reader :work, :work_download_options
 
@@ -32,15 +32,14 @@ class WorkImageShowComponent < ApplicationComponent
   # So we return MemberForThumbnailDisplay objects that have both the "member"
   # (Work or Asset), AND it's accessible label eg "Image 5"
   #
-
-  # We only want to show a maximum of DEFAULT_THUMBNAIL_NUMBER thumbnails to the user by default,
-  # to speed up the page.
-  # See https://github.com/sciencehistory/scihist_digicoll/issues/905
-  # See https://github.com/sciencehistory/scihist_digicoll/issues/2491
   def member_list_for_display
     @member_list_for_display ||= begin
       members = ordered_viewable_members
-
+   
+      # We only want to show a maximum of DEFAULT_THUMBNAIL_NUMBER thumbnails to the user by default,
+      # to speed up the page.
+      # See https://github.com/sciencehistory/scihist_digicoll/issues/905
+      # See https://github.com/sciencehistory/scihist_digicoll/issues/2491
       unless @show_all_members
         members = members.limit DEFAULT_THUMBNAIL_NUMBER
       end
@@ -62,22 +61,28 @@ class WorkImageShowComponent < ApplicationComponent
 
   # All DISPLAYABLE (to current user) members, in order, and
   # with proper pre-fetches.
+  #
+  # This includes members that might be hidden
+  # because there are more than DEFAULT_THUMBNAIL_NUMBER of them.
+  #
+  # Returns a Kithe::Model::ActiveRecord_AssociationRelation .
   def ordered_viewable_members
     @ordered_viewable_members ||= work.ordered_viewable_members(current_user: current_user).
-        where("role is null OR role != ?", PdfToPageImages::SOURCE_PDF_ROLE)
+      where("role is null OR role != ?", PdfToPageImages::SOURCE_PDF_ROLE)
+  end
+
+  def more_members_to_show?
+    @show_all_members ? false : (hidden_viewable_members_count > 0)
+  end
+
+  def hidden_viewable_members_count
+    @hidden_viewable_members_count ||= viewable_members_count - DEFAULT_THUMBNAIL_NUMBER
   end
 
   def viewable_members_count
     @viewable_members_count ||= ordered_viewable_members.count
   end
 
-  def hidden_viewable_members_count
-    @hidden_viewable_members_count ||= @show_all_members ? 0 : (viewable_members_count - DEFAULT_THUMBNAIL_NUMBER)
-  end
-
-  def more_members_to_show?
-    more_members_to_show? ||= viewable_members_count > DEFAULT_THUMBNAIL_NUMBER && !@show_all_members
-  end
 
   def transcription_texts
     @transcription_texts ||= Work::TextPage.compile(ordered_viewable_members, accessor: :transcription)

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -80,8 +80,16 @@ class WorksController < ApplicationController
       WorkVideoShowComponent.new(@work)
     else
       # standard image-based template.
-      WorkImageShowComponent.new(@work)
+      WorkImageShowComponent.new(@work, show_all_members: show_all_members?)
     end
+  end
+
+  # We only want to show a maximum of DEFAULT_THUMBNAIL_NUMBER thumbnails to the user by default,
+  # to speed up the page.
+  # See https://github.com/sciencehistory/scihist_digicoll/issues/905
+  # See https://github.com/sciencehistory/scihist_digicoll/issues/2491
+  def show_all_members?
+    params[:show_all] == 'true'
   end
 
   # Is an Oral History with at least one audio member?


### PR DESCRIPTION
Ref #2491 
The specification for this PR is:
_"Cap at say 400 page thumbs on work page, with a message "more pages available, not displayed", maybe even with a count of how many."_ (taken from [this comment](https://github.com/sciencehistory/scihist_digicoll/issues/2491#issuecomment-2468582828).) 
Do not merge, do not review. Contains known bugs!

