### PR TITLE
Fix eager_loading to be false again in development mode

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -9,7 +9,7 @@ Rails.application.configure do
   config.enable_reloading = true
 
   # Do not eager load code on boot.
-  config.eager_load = true
+  config.eager_load = false
 
   # Show full error reports. Chagne to false to see production-style error page
   config.consider_all_requests_local = true


### PR DESCRIPTION
Much more convenient for development that way. Looks like I accidentally committed setting it to true at e0fe8dea last month.
