### PR TITLE
More tweaks to OHMS WebVTT parsing, for OHMS quirks

### DIFF
--- a/app/models/oral_history_content/ohms_xml/vtt_transcript.rb
+++ b/app/models/oral_history_content/ohms_xml/vtt_transcript.rb
@@ -7,6 +7,8 @@ class OralHistoryContent
     # new-style 2025 OHMS transcript with <vtt_transcript> element in xml.
     # https://www.w3.org/TR/webvtt1/
     #
+    # Also handles some OHMS quirks.
+    #
     # Uses the `webvtt` gem for initial parsing, but that gem is basic and
     # not very maintained, so we need some massaging and post-processing
     # to get what we need.
@@ -31,6 +33,10 @@ class OralHistoryContent
           unless src.start_with?('WEBVTT')
             src = "WEBVTT\n" + src
           end
+
+          # and OHMS also often omits final empty line also required, adding an
+          # extra doesn't hurt
+          src = src + "\n"
 
           # original gem is sometimes picking up empty cues, which is annoying
           Webvtt::File.new(src).cues.collect { |webvtt_cue| Cue.new(webvtt_cue) }
@@ -126,9 +132,6 @@ class OralHistoryContent
           @safe_html = html_fragment.to_s.strip.html_safe
         end
       end
-
     end
-
-
   end
 end

--- a/app/models/oral_history_content/ohms_xml/vtt_transcript.rb
+++ b/app/models/oral_history_content/ohms_xml/vtt_transcript.rb
@@ -95,6 +95,13 @@ class OralHistoryContent
           end
         end
 
+        # split text inside a cue into paragraphs.
+        #
+        # Paragraphs are split on newlines (WebVTT standard) -- also on <br><br> (two in a row br tag),
+        # which OHMS at least sometimes does.
+        #
+        # A change in WebVTT "voice" (speaker) will also result in a paragraph split, which
+        # isn't quite right, but works out fine for how OHMS does things.
         def paragraphs
           @paragraphs ||= begin
             # This tricky regex using both positive lookahead and negative lookahead
@@ -107,7 +114,9 @@ class OralHistoryContent
               end
 
               # \R is any kind of linebreak
-              voice_span.split(/\R/).collect do |paragraph_text|
+              # Things coming from OHMS separate paragraphs by `<br><br>` instead
+              # sometimes annoyingly
+              voice_span.split(/\R|(?:\<br\>\<br\>)/).collect do |paragraph_text|
                 Paragraph.new(speaker_name: speaker_name, raw_html: paragraph_text)
               end
             end.flatten

--- a/spec/models/oral_history_content/vtt_transcript_spec.rb
+++ b/spec/models/oral_history_content/vtt_transcript_spec.rb
@@ -109,4 +109,28 @@ describe OralHistoryContent::OhmsXml::VttTranscript do
       expect(vtt_transcript.cues.second.end_sec_f).to eq 4
     end
   end
+
+  describe "no newline at end of terminal note" do
+    # While I think the spec actually requires it, WebVTT from OHMS doesn't always
+    # have a trailing newline after last note
+    let(:sample_webvtt) do
+      <<~EOS
+      WEBVTT
+
+      00:00:04.400 --> 00:00:06.000
+      One
+
+      00:00:06.000 --> 00:00:08.000
+      Two
+
+      NOTE
+      TRANSCRIPTION END
+      EOS
+    end
+
+    it "parses all cues" do
+      expect(vtt_transcript.cues.length).to eq 2
+      expect(vtt_transcript.cues.last.text).to eq "Two"
+    end
+  end
 end

--- a/spec/models/oral_history_content/vtt_transcript_spec.rb
+++ b/spec/models/oral_history_content/vtt_transcript_spec.rb
@@ -133,4 +133,22 @@ describe OralHistoryContent::OhmsXml::VttTranscript do
       expect(vtt_transcript.cues.last.text).to eq "Two"
     end
   end
+
+  describe "paragraphs split by br tags ala OHMS" do
+    let(:sample_webvtt) do
+      <<~EOS
+      WEBVTT
+
+      00:00:04.400 --> 00:00:06.000
+      Paragraph One<br><br>Paragraph Two
+
+      EOS
+    end
+
+    it "splits paragraphs" do
+      expect(vtt_transcript.cues.first.paragraphs.length).to eq 2
+      expect(vtt_transcript.cues.first.paragraphs.first.raw_html).to eq "Paragraph One"
+      expect(vtt_transcript.cues.first.paragraphs.second.raw_html).to eq "Paragraph Two"
+    end
+  end
 end


### PR DESCRIPTION
- Handle OHMS WebVTT with omitted terminal blank line
- also split vtt paragraphs on `<br><br>` tags as OHMS uses
