### PR TITLE
FootnoteReferenceComponent html content and extra link text

### DIFF
--- a/app/components/oral_history/footnote_reference_component.html.erb
+++ b/app/components/oral_history/footnote_reference_component.html.erb
@@ -1,6 +1,7 @@
 <a  class="footnote"
     data-toggle="ohms-reference"
     data-bs-content="<%= footnote_text %>"
+    <% if footnote_text.html_safe? %> data-bs-html="true" <% end %>
     data-bs-custom-class="ohms-footnote-popover"
     data-bs-trigger="hover focus"
     aria-label="footnote <%= number %>"
@@ -9,5 +10,5 @@
     aria-describedby="footnote-text-<%=number%>"
     <% if show_dom_id %> id="footnote-reference-<%= number %>"<% end %>
     >
-  [<%= number %>]
+  <%= link_content %> [<%= number %>]
 </a>

--- a/app/components/oral_history/footnote_reference_component.rb
+++ b/app/components/oral_history/footnote_reference_component.rb
@@ -8,12 +8,19 @@ module OralHistory
   # The tooltip hover is based on:
   # http://hiphoff.com/creating-hover-over-footnotes-with-bootstrap/
   class FootnoteReferenceComponent < ApplicationComponent
-    attr_reader :footnote_text, :number, :show_dom_id
+    attr_reader :footnote_text, :number, :show_dom_id, :link_content
 
-    def initialize(footnote_text:, number:, show_dom_id:)
+    # @param footnote_text [String] the footnote itself. If marked html_safe, can contain html
+    # @param number: [String] footnote number
+    # @param show_dom_id: [Boolean] if true, link element will be given a dom ID
+    #    false for cases wehre it would be illegal to give it a duplicate
+    # @param link_content [String] optional additoinal content to put inside footnote
+    #    link, before numeric footnote reference
+    def initialize(footnote_text:, number:, show_dom_id: true, link_content:nil)
       @footnote_text = footnote_text
       @number = number
       @show_dom_id = show_dom_id
+      @link_content = link_content
     end
   end
 end

--- a/spec/components/oral_history/footnote_reference_component_spec.rb
+++ b/spec/components/oral_history/footnote_reference_component_spec.rb
@@ -7,17 +7,38 @@ describe OralHistory::FootnoteReferenceComponent, type: :component do
     let(:footnote_text) { "The mathematician's \"daughter\" proved that x > 4." }
     let(:number) { 1 }
 
-    it "includes text in title attribute with proper escaping" do
+    it "includes text in attribute" do
       result = render_inline described_class.new(footnote_text: footnote_text, number: number, show_dom_id:true)
 
       expect(result.at_css("a")["data-bs-content"]).to eq(footnote_text)
       expect(result.at_css("a")['id']).to eq("footnote-reference-1")
     end
 
-    it "only includes an HTML id for the first reference" do
+    it "does not include html-safety by default" do
+      result = render_inline described_class.new(footnote_text: footnote_text, number: number, show_dom_id:true)
+
+      expect(result.at_css("a")['data-bs-html']).to be nil
+    end
+
+    it "has footnote reference in link text" do
+      result = render_inline described_class.new(footnote_text: footnote_text, number: number, show_dom_id:true)
+      expect(result.at_css("a").text.strip).to eq "[#{number}]"
+    end
+
+    it "does not include HTML id if suppressed" do
       result = render_inline described_class.new(footnote_text: footnote_text, number: number, show_dom_id:false)
       expect(result.at_css("a")['id']).to be_nil
     end
 
+    it "includes prefatory link_content when asked" do
+      result = render_inline described_class.new(footnote_text: footnote_text, number: number, link_content: "extra text")
+      expect(result.at_css("a").text.strip).to eq "extra text [#{number}]"
+    end
+
+    it "tells bootstrap html if footnote_text is html_safe" do
+      result = render_inline described_class.new(footnote_text: "This is <b>html safe</b>".html_safe, number: number)
+      expect(result.at_css("a")["data-bs-content"]).to eq("This is <b>html safe</b>")
+      expect(result.at_css("a")['data-bs-html']).to eq "true"
+    end
   end
 end


### PR DESCRIPTION
Two new features,to be used with new OHMS vtt-style transcripts

1. If footnote_text is marked html_safe, we'll give Bootstrap popover the data-bs-html=true attribute to allow html tags in content
2. Can supply additional link_content to go before the `[1]` numeric footnote reference, inside the link
