### PR TITLE
different way of handling html-safety in FootnoteReferenceComponent

### DIFF
--- a/app/components/oral_history/footnote_reference_component.html.erb
+++ b/app/components/oral_history/footnote_reference_component.html.erb
@@ -1,7 +1,7 @@
 <a  class="footnote"
     data-toggle="ohms-reference"
-    data-bs-content="<%= footnote_text %>"
-    <% if footnote_text.html_safe? %> data-bs-html="true" <% end %>
+    data-bs-content="<%= escaped_footnote_text %>"
+    <% if footnote_is_html %> data-bs-html="true" <% end %>
     data-bs-custom-class="ohms-footnote-popover"
     data-bs-trigger="hover focus"
     aria-label="footnote <%= number %>"

--- a/app/components/oral_history/footnote_reference_component.rb
+++ b/app/components/oral_history/footnote_reference_component.rb
@@ -8,19 +8,26 @@ module OralHistory
   # The tooltip hover is based on:
   # http://hiphoff.com/creating-hover-over-footnotes-with-bootstrap/
   class FootnoteReferenceComponent < ApplicationComponent
-    attr_reader :footnote_text, :number, :show_dom_id, :link_content
+    attr_reader :escaped_footnote_text, :number, :show_dom_id, :link_content, :footnote_is_html
 
-    # @param footnote_text [String] the footnote itself. If marked html_safe, can contain html
+    # @param footnote_text [String] the footnote itself.
+    #
+    # @param footnote_is_html [Boolean] if footnote is sanitized html code, default false
+    #
     # @param number: [String] footnote number
+    #
     # @param show_dom_id: [Boolean] if true, link element will be given a dom ID
     #    false for cases wehre it would be illegal to give it a duplicate
+    #
     # @param link_content [String] optional additoinal content to put inside footnote
     #    link, before numeric footnote reference
-    def initialize(footnote_text:, number:, show_dom_id: true, link_content:nil)
-      @footnote_text = footnote_text
+    def initialize(footnote_text:, number:, show_dom_id: true, link_content:nil, footnote_is_html: false)
+      # need to fully html-escape it for inclusion in ERB attribute, whether marked html_safe or not.
+      @escaped_footnote_text = ERB::Util.html_escape(footnote_text.to_str)
       @number = number
       @show_dom_id = show_dom_id
       @link_content = link_content
+      @footnote_is_html = footnote_is_html
     end
   end
 end

--- a/spec/components/oral_history/footnote_reference_component_spec.rb
+++ b/spec/components/oral_history/footnote_reference_component_spec.rb
@@ -7,11 +7,12 @@ describe OralHistory::FootnoteReferenceComponent, type: :component do
     let(:footnote_text) { "The mathematician's \"daughter\" proved that x > 4." }
     let(:number) { 1 }
 
-    it "includes text in attribute" do
+    it "includes text in attribute, properly escaped" do
       result = render_inline described_class.new(footnote_text: footnote_text, number: number, show_dom_id:true)
 
       expect(result.at_css("a")["data-bs-content"]).to eq(footnote_text)
       expect(result.at_css("a")['id']).to eq("footnote-reference-1")
+      expect(result.at_css("a")['data-bs-html']).not_to eq "true"
     end
 
     it "does not include html-safety by default" do
@@ -35,9 +36,12 @@ describe OralHistory::FootnoteReferenceComponent, type: :component do
       expect(result.at_css("a").text.strip).to eq "extra text [#{number}]"
     end
 
-    it "tells bootstrap html if footnote_text is html_safe" do
-      result = render_inline described_class.new(footnote_text: "This is <b>html safe</b>".html_safe, number: number)
-      expect(result.at_css("a")["data-bs-content"]).to eq("This is <b>html safe</b>")
+    it "includes html footnote text with bootstrap html attribute" do
+      result = render_inline described_class.new(
+        footnote_text: 'footnote with <b>bold</b> and <a href="http://example.com">link</a>',
+        footnote_is_html: true,
+        number: number)
+      expect(result.at_css("a")["data-bs-content"]).to eq('footnote with <b>bold</b> and <a href="http://example.com">link</a>')
       expect(result.at_css("a")['data-bs-html']).to eq "true"
     end
   end


### PR DESCRIPTION
The other way didn't work and got too confusing. Replaced with more complex example in spec too.

Now we need to actually pass in an arg to say the content is html, not rely on .html_safe?
