### PR TITLE
Extract FootnoteComponent

### DIFF
--- a/app/components/oral_history/footnote_component.html.erb
+++ b/app/components/oral_history/footnote_component.html.erb
@@ -1,0 +1,4 @@
+<p class="footnote-page-bottom-container">
+    <a id="footnote-<%= footnote_reference %>" data-role="ohms-navbar-aware-internal-link" href="#footnote-reference-<%= footnote_reference %>" >
+    <%= footnote_reference %>.</a> <span id="footnote-text-<%= footnote_reference %>"><%= footnote_text%></span>
+</p>

--- a/app/components/oral_history/footnote_component.rb
+++ b/app/components/oral_history/footnote_component.rb
@@ -1,0 +1,12 @@
+module OralHistory
+  # An individual footnote, output at bottom of page, with apparatus
+  # to link back and forth to reference
+  class FootnoteComponent < ApplicationComponent
+    attr_reader :footnote_reference, :footnote_text
+
+    def initialize(footnote_reference:, footnote_text:)
+      @footnote_reference = footnote_reference
+      @footnote_text = footnote_text
+    end
+  end
+end

--- a/app/components/oral_history/footnotes_section_component.html.erb
+++ b/app/components/oral_history/footnotes_section_component.html.erb
@@ -2,9 +2,6 @@
 <div class="mx-1 my-2"><strong>NOTES</strong></div>
 <div class="footnote-list mx-1 mb-5">
     <% footnote_array.each_with_index.map do |footnote_text, i| %>
-        <p class="footnote-page-bottom-container">
-            <a id="footnote-<%= i + 1 %>" data-role="ohms-navbar-aware-internal-link" href="#footnote-reference-<%= i + 1 %>" >
-            <%= i + 1 %>.</a> <span id="footnote-text-<%= i + 1 %>"><%= footnote_text%></span>
-        </p>
+        <= render FootnoteComponent.new(footnote_reference: i+1, footnote_text, footnote_text) %>
     <% end %>
 </div>


### PR DESCRIPTION
For re-use in the new-style OHMS vtt transcripts. 

Where I wanted to display the footnotes based on a map from ref => text, rather than assuming the ordered list skipped no numbers. 

But didn't really want to refactor the legacy stuff that's working fine. 

But this does leave the FootnoteSectionComponent not doing much... but hard to get rid of it for inline html, cause of the way LegacyTranscriptComponent uses a #call instead of an erb template. 

One thing on a top of another!  This may be okay as it is, with some inconsistency between legacy and vtt transcripts?  Or what refactor might make sense, any ideas?
