### PR TITLE
OHMS new VTT transcripts support footnotes

### DIFF
--- a/app/components/oral_history/footnote_reference_component.html.erb
+++ b/app/components/oral_history/footnote_reference_component.html.erb
@@ -1,6 +1,7 @@
 <a  class="footnote"
     data-toggle="ohms-reference"
     data-bs-content="<%= footnote_text %>"
+    <% if footnote_text.html_safe? %> data-bs-html="true" <% end %>
     data-bs-custom-class="ohms-footnote-popover"
     data-bs-trigger="hover focus"
     aria-label="footnote <%= number %>"
@@ -9,5 +10,5 @@
     aria-describedby="footnote-text-<%=number%>"
     <% if show_dom_id %> id="footnote-reference-<%= number %>"<% end %>
     >
-  [<%= number %>]
+  <%= link_content %> [<%= number %>]
 </a>

--- a/app/components/oral_history/footnote_reference_component.rb
+++ b/app/components/oral_history/footnote_reference_component.rb
@@ -8,12 +8,19 @@ module OralHistory
   # The tooltip hover is based on:
   # http://hiphoff.com/creating-hover-over-footnotes-with-bootstrap/
   class FootnoteReferenceComponent < ApplicationComponent
-    attr_reader :footnote_text, :number, :show_dom_id
+    attr_reader :footnote_text, :number, :show_dom_id, :link_content
 
-    def initialize(footnote_text:, number:, show_dom_id:)
+    # @param footnote_text [String] the footnote itself. If marked html_safe, can contain html
+    # @param number: [String] footnote number
+    # @param show_dom_id: [Boolean] if true, link element will be given a dom ID
+    #    false for cases wehre it would be illegal to give it a duplicate
+    # @param link_content [String] optional additoinal content to put inside footnote
+    #    link, before numeric footnote reference
+    def initialize(footnote_text:, number:, show_dom_id: true, link_content:nil)
       @footnote_text = footnote_text
       @number = number
       @show_dom_id = show_dom_id
+      @link_content = link_content
     end
   end
 end

--- a/app/components/oral_history/vtt_transcript_component.html.erb
+++ b/app/components/oral_history/vtt_transcript_component.html.erb
@@ -21,3 +21,18 @@
     </p>
   <% end %>
 </div>
+
+<% if sanitized_footnotes.present? %>
+  <hr />
+
+  <div class="mx-1 my-2"><strong>NOTES</strong></div>
+
+  <div class="footnote-list mx-1 mb-5">
+    <% sanitized_footnotes.each_pair do |reference, footnote_text| %>
+        <%= render ::OralHistory::FootnoteComponent.new(footnote_reference: reference, footnote_text: footnote_text) %>
+    <% end %>
+  </div>
+<% end %>
+
+
+

--- a/app/components/oral_history/vtt_transcript_component.rb
+++ b/app/components/oral_history/vtt_transcript_component.rb
@@ -2,16 +2,29 @@ module OralHistory
   class VttTranscriptComponent < ApplicationComponent
     delegate :format_ohms_timestamp, to: :helpers
 
+    TextScrubber = Rails::Html::PermitScrubber.new.tap do |scrubber|
+      scrubber.tags = ['i', 'b', 'u']
+    end
+
     def initialize(vtt_transcript)
       @vtt_transcript = vtt_transcript
+    end
+
+    def scrub_text(raw_html)
+      Loofah.fragment(raw_html).
+        tap { |frag| frag.scrub!(TextScrubber) }.
+        then { |frag| frag.to_s.strip.html_safe }
     end
 
     def display_paragraphs
       last_speaker = nil # don't do same speaker twice in a row
       @vtt_transcript.cues.each do |cue|
         start_sec_f = cue.start_sec_f # we only want to do this once per cue
+                                      #
         cue.paragraphs.each do |paragraph|
-          yield start_sec_f, (paragraph.speaker_name if paragraph.speaker_name != last_speaker), paragraph.safe_html
+          paragraph_safe_html = scrub_text(paragraph.raw_html)
+
+          yield start_sec_f, (paragraph.speaker_name if paragraph.speaker_name != last_speaker), paragraph_safe_html
           last_speaker = paragraph.speaker_name
           start_sec_f = nil
         end

--- a/app/components/oral_history/vtt_transcript_component.rb
+++ b/app/components/oral_history/vtt_transcript_component.rb
@@ -19,6 +19,10 @@ module OralHistory
       @vtt_transcript = vtt_transcript
     end
 
+    def sanitized_footnotes
+      @sanitized_footnotes ||= vtt_transcript.footnotes.collect { |ref, text| [ref, scrub_footnote_text(text)] }.to_h
+    end
+
     # Replace the VTT <c.N> tags used by OHMS for annotation/footnote references
     # with our footnote <a> tags.
     #
@@ -37,10 +41,8 @@ module OralHistory
         refNum = $1
         inner_content = $2.html_safe
 
-        footnote_text = scrub_footnote_text(vtt_transcript.footnotes[refNum])
-
         render(OralHistory::FootnoteReferenceComponent.new(
-          footnote_text: footnote_text,
+          footnote_text: sanitized_footnotes[refNum],
           footnote_is_html: true,
           number: refNum,
           link_content: inner_content

--- a/app/components/oral_history/vtt_transcript_component.rb
+++ b/app/components/oral_history/vtt_transcript_component.rb
@@ -60,7 +60,7 @@ module OralHistory
         scrub!(FootnoteTextScrubber).
         scrub!(:targetblank).
         scrub!(:noopener).
-        to_s
+        to_s.html_safe
     end
 
     def display_paragraphs

--- a/app/components/oral_history/vtt_transcript_component.rb
+++ b/app/components/oral_history/vtt_transcript_component.rb
@@ -3,17 +3,64 @@ module OralHistory
     delegate :format_ohms_timestamp, to: :helpers
 
     TextScrubber = Rails::Html::PermitScrubber.new.tap do |scrubber|
-      scrubber.tags = ['i', 'b', 'u']
+      # 'c' is WebVTT 'class' object, which we only expect in the form
+      # of c.1, c.12 etc for OHMS annotation references.
+      scrubber.tags = ['i', 'b', 'u', 'c']
+      scrubber.attributes = ['cref'] # for our weird custom c tag
     end
+
+    FootnoteTextScrubber = Rails::Html::PermitScrubber.new.tap do |scrubber|
+      scrubber.tags = ['i', 'b', 'u', 'a']
+    end
+
+    attr_reader :vtt_transcript
 
     def initialize(vtt_transcript)
       @vtt_transcript = vtt_transcript
     end
 
+    # Replace the VTT <c.N> tags used by OHMS for annotation/footnote references
+    # with our footnote <a> tags.
+    #
+    # And html sanitize the rest
     def scrub_text(raw_html)
-      Loofah.fragment(raw_html).
-        tap { |frag| frag.scrub!(TextScrubber) }.
-        then { |frag| frag.to_s.strip.html_safe }
+      # Turn <c.1> tags to XML-legal <c ref='1'> tags with the one in a ref attribute
+      str = raw_html.gsub(/<c\.(\d+)/, "<c cref='\\1'")
+
+      str = Loofah.fragment(str).
+        scrub!(TextScrubber).
+        to_s
+
+      # And now we need to turn those <c> tags into our footnote reference links!
+      # Note non-greedy regex match '+?' or '*?' operator so it gets first </c>. They can't be nested!
+      str.gsub!(/<c cref="(\d+)"[^>]*>(.+?)<\/c>/) do |_matched|
+        refNum = $1
+        inner_content = $2.html_safe
+
+        footnote_text = scrub_footnote_text(vtt_transcript.footnotes[refNum])
+
+        render(OralHistory::FootnoteReferenceComponent.new(
+          footnote_text: footnote_text,
+          footnote_is_html: true,
+          number: refNum,
+          link_content: inner_content
+        ))
+      end
+
+      # we have sanitized and replaced with a component, it should be html_safe
+      str.html_safe
+    end
+
+    # Footnote text, unlike our main text, can have links, but
+    # we want to ensure they all have rel=opener and target=_blank set
+    # (Which some built-in scrubbers in Loofah can do)
+    #
+    def scrub_footnote_text(raw_html)
+      str = Loofah.fragment(raw_html).
+        scrub!(FootnoteTextScrubber).
+        scrub!(:targetblank).
+        scrub!(:noopener).
+        to_s
     end
 
     def display_paragraphs
@@ -30,6 +77,5 @@ module OralHistory
         end
       end
     end
-
   end
 end

--- a/app/frontend/stylesheets/local/oh_audio.scss
+++ b/app/frontend/stylesheets/local/oh_audio.scss
@@ -311,6 +311,9 @@
   // URLs in footnotes should be forced to break if needed to fit on screen
   .footnote-list {
     overflow-wrap: break-word;
+    a {
+      @extend .text-link;
+    }
   }
 }
 

--- a/app/frontend/stylesheets/local/oh_audio.scss
+++ b/app/frontend/stylesheets/local/oh_audio.scss
@@ -344,6 +344,12 @@
 
   .ohms-footnote-popover {
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
+
+    a {
+      // Make it look like a link, not sure why it wasn't looking like any kind
+      // of link otherwise
+      @extend .text-link;
+    }
   }
 }
 

--- a/app/models/oral_history_content/ohms_xml/vtt_transcript.rb
+++ b/app/models/oral_history_content/ohms_xml/vtt_transcript.rb
@@ -65,6 +65,12 @@ class OralHistoryContent
         end
       end
 
+      # scrubbed, ordered, html_safe values for printing footnotes at bottom
+      def safe_footnote_values
+        safe_footnote_values ||= footnote_array
+      end
+
+
       # eg for indexing, actual human-readable indexable plain text after parsed and extracted webVTT
       def transcript_text
         @transcript_text ||= cues.collect { |c| c.paragraphs }.flatten.collect do |p|

--- a/app/models/oral_history_content/ohms_xml/vtt_transcript.rb
+++ b/app/models/oral_history_content/ohms_xml/vtt_transcript.rb
@@ -125,7 +125,7 @@ class OralHistoryContent
 
         # split text inside a cue into paragraphs.
         #
-        # Paragraphs are split on newlines (WebVTT standard) -- also on <br><br> (two in a row br tag),
+        # Paragraphs are split on newlines (WebVTT standard) -- also on <br><br> (two+ in a row br tag),
         # which OHMS at least sometimes does.
         #
         # A change in WebVTT "voice" (speaker) will also result in a paragraph split, which
@@ -142,9 +142,9 @@ class OralHistoryContent
               end
 
               # \R is any kind of linebreak
-              # Things coming from OHMS separate paragraphs by `<br><br>` instead
-              # sometimes annoyingly
-              voice_span.split(/\R|(?:\<br\>\<br\>)/).collect do |paragraph_text|
+              # Things coming from OHMS can separate paragraphs by `<br><br>`, annoyingly:
+              # Split paragraphs on two more consecutive <br>
+              voice_span.split(/\R|(?:\<br\>){2,}/).collect do |paragraph_text|
                 paragraph_text.gsub!("</v>", "") # remove stray ending tags
                 Paragraph.new(speaker_name: speaker_name, raw_html: paragraph_text)
               end

--- a/spec/components/oral_history/footnote_reference_component_spec.rb
+++ b/spec/components/oral_history/footnote_reference_component_spec.rb
@@ -7,17 +7,38 @@ describe OralHistory::FootnoteReferenceComponent, type: :component do
     let(:footnote_text) { "The mathematician's \"daughter\" proved that x > 4." }
     let(:number) { 1 }
 
-    it "includes text in title attribute with proper escaping" do
+    it "includes text in attribute" do
       result = render_inline described_class.new(footnote_text: footnote_text, number: number, show_dom_id:true)
 
       expect(result.at_css("a")["data-bs-content"]).to eq(footnote_text)
       expect(result.at_css("a")['id']).to eq("footnote-reference-1")
     end
 
-    it "only includes an HTML id for the first reference" do
+    it "does not include html-safety by default" do
+      result = render_inline described_class.new(footnote_text: footnote_text, number: number, show_dom_id:true)
+
+      expect(result.at_css("a")['data-bs-html']).to be nil
+    end
+
+    it "has footnote reference in link text" do
+      result = render_inline described_class.new(footnote_text: footnote_text, number: number, show_dom_id:true)
+      expect(result.at_css("a").text.strip).to eq "[#{number}]"
+    end
+
+    it "does not include HTML id if suppressed" do
       result = render_inline described_class.new(footnote_text: footnote_text, number: number, show_dom_id:false)
       expect(result.at_css("a")['id']).to be_nil
     end
 
+    it "includes prefatory link_content when asked" do
+      result = render_inline described_class.new(footnote_text: footnote_text, number: number, link_content: "extra text")
+      expect(result.at_css("a").text.strip).to eq "extra text [#{number}]"
+    end
+
+    it "tells bootstrap html if footnote_text is html_safe" do
+      result = render_inline described_class.new(footnote_text: "This is <b>html safe</b>".html_safe, number: number)
+      expect(result.at_css("a")["data-bs-content"]).to eq("This is <b>html safe</b>")
+      expect(result.at_css("a")['data-bs-html']).to eq "true"
+    end
   end
 end

--- a/spec/components/oral_history/vtt_transcript_component_spec.rb
+++ b/spec/components/oral_history/vtt_transcript_component_spec.rb
@@ -98,7 +98,7 @@ describe OralHistory::VttTranscriptComponent, type: :component do
     end
 
     it "replaces WebVTT <c.1> classes with our footnote references, html-safely" do
-      parsed = render_inline vtt_transcript_component # need to set up test so we can do inline render next
+      parsed = render_inline vtt_transcript_component
 
       footnote_link = parsed.at_css("a.footnote")
 
@@ -110,6 +110,21 @@ describe OralHistory::VttTranscriptComponent, type: :component do
         'Lorem ipsum <b>dolor</b> sit <i>amet</i>, consectetur no script tag <a href="https://example.com" target="_blank" rel="noopener">internal link</a>'
       )
       expect(footnote_link['data-bs-html']).to eq "true"
+    end
+
+    it "renders footnotes at the bottom" do
+      parsed = render_inline vtt_transcript_component
+
+      footnotes = parsed.css(".footnote-list .footnote-page-bottom-container")
+
+      expect(footnotes.length).to eq 1
+      expect(footnotes.first.inner_html.strip.gsub(/\s+/, ' ')).to eq(
+        <<~EOS.gsub(/\s+/, ' ').strip
+          <a id="footnote-1" data-role="ohms-navbar-aware-internal-link" href="#footnote-reference-1"> 1.</a>
+          <span id="footnote-text-1">Lorem ipsum <b>dolor</b> sit <i>amet</i>,
+            consectetur no script tag <a href="https://example.com" target="_blank" rel="noopener">internal link</a></span>
+        EOS
+      )
     end
   end
 end

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -215,7 +215,7 @@ describe WorkIndexer do
         output_hash = WorkIndexer.new.map_record(work)
 
         expect(output_hash["searchable_fulltext_en"]).to be_present
-        expect(output_hash["searchable_fulltext_en"].first).to start_with("SCHNEIDER:   Today is December 16, 2024. I am Sarah Schneider")
+        expect(output_hash["searchable_fulltext_en"].first).to start_with("SCHNEIDER: Today is December 16, 2024. I am Sarah Schneider")
         # exactly how many entries depends on how many toc entries have synopsis, keywords, etc.
         expect(output_hash["searchable_fulltext_en"].length).to be >= (1 + index_toc_entries_count)
       end

--- a/spec/models/oral_history_content/vtt_transcript_spec.rb
+++ b/spec/models/oral_history_content/vtt_transcript_spec.rb
@@ -151,4 +151,47 @@ describe OralHistoryContent::OhmsXml::VttTranscript do
       expect(vtt_transcript.cues.first.paragraphs.second.raw_html).to eq "Paragraph Two"
     end
   end
+
+  describe "ohms annotation references" do
+    let(:sample_webvtt) do
+      <<~EOS
+      WEBVTT
+
+      00:00:04.400 --> 00:00:06.000
+      One
+
+      NOTE
+      TRANSCRIPTION END
+
+      NOTE
+      ANNOTATIONS BEGIN
+      Annotation Set Title: Lorem Ipsum Transcript Annotations
+      Annotation Set Creator: Lorem Ipsum Generator
+      Annotation Set Date: 1985-10-26
+
+      NOTE
+      <annotation ref="1">Lorem ipsum <b>dolor</b> sit <i>amet</i>, consectetur adipiscing elit</annotation>
+      <annotation ref="2">Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</annotation>
+      <annotation ref="3">Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. See:<a href="https://en.wikipedia.org/wiki/Lorem_ipsum" target="_blank" rel="noopener">Lorem Ipsum</a></annotation>
+
+      NOTE
+      ANNOTATIONS END
+
+      EOS
+    end
+
+    it "gets annotations as indexed footnotes" do
+      expect(vtt_transcript.footnotes).to be_present
+      expect(vtt_transcript.footnotes.length).to eq 3
+
+      expect(vtt_transcript.footnotes.keys).to eq ["1", "2", "3"]
+
+      # strings have not been sanitized and should not be marked html-safe
+      expect(vtt_transcript.footnotes.values).not_to include( be_html_safe )
+
+      expect(vtt_transcript.footnotes["1"]).to eq "Lorem ipsum <b>dolor</b> sit <i>amet</i>, consectetur adipiscing elit"
+      expect(vtt_transcript.footnotes["2"]).to eq "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"
+      expect(vtt_transcript.footnotes["3"]).to eq 'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. See:<a href="https://en.wikipedia.org/wiki/Lorem_ipsum" target="_blank" rel="noopener">Lorem Ipsum</a>'
+    end
+  end
 end

--- a/spec/models/oral_history_content/vtt_transcript_spec.rb
+++ b/spec/models/oral_history_content/vtt_transcript_spec.rb
@@ -45,8 +45,7 @@ describe OralHistoryContent::OhmsXml::VttTranscript do
     expect(first_cue.end_sec_f).to eq 2.0
     expect(first_cue.paragraphs.length).to eq 1
     expect(first_cue.paragraphs[0].speaker_name).to eq "Esme Johnson"
-    expect(first_cue.paragraphs[0].safe_html).to eq "It’s a <i>blue</i> apple tree!"
-    expect(first_cue.paragraphs[0].safe_html.html_safe?).to be true
+    expect(first_cue.paragraphs[0].raw_html).to eq "It’s a <i>blue</i> <script>apple</script> tree!"
 
     second_cue = cues[1]
     expect(second_cue.start).to eq "00:00:02.400"
@@ -55,7 +54,7 @@ describe OralHistoryContent::OhmsXml::VttTranscript do
     expect(second_cue.end_sec_f).to eq 4.0
 
     expect(second_cue.paragraphs.length).to eq 3
-    expect(second_cue.paragraphs.collect(&:safe_html)).to eq [
+    expect(second_cue.paragraphs.collect(&:raw_html)).to eq [
       "This content has some internal line breaks.",
       "Like this is a paragraph two.",
       "And even three."
@@ -64,13 +63,13 @@ describe OralHistoryContent::OhmsXml::VttTranscript do
 
     third_cue = cues[2]
     expect(third_cue.paragraphs.length).to eq 2
-    expect(third_cue.paragraphs.collect(&:safe_html)).to eq ['Hee!', '<i>laughter</i>']
+    expect(third_cue.paragraphs.collect(&:raw_html)).to eq ['Hee!', '<i>laughter</i>']
     expect(third_cue.paragraphs.collect(&:speaker_name)).to eq ['Esme', nil]
-    expect(third_cue.paragraphs.collect(&:safe_html).all? {|a| a.html_safe?}).to be true
+    expect(third_cue.paragraphs.collect(&:raw_html)).not_to include( be_html_safe)
 
     fourth_cue = cues[3]
     expect(fourth_cue.paragraphs.length).to eq 2
-    expect(fourth_cue.paragraphs.collect(&:safe_html)).to eq ['Why did the chicken cross the road', 'To get to the other side']
+    expect(fourth_cue.paragraphs.collect(&:raw_html)).to eq ['Why did the chicken cross the road', 'To get to the other side']
     expect(fourth_cue.paragraphs.collect(&:speaker_name)).to eq ['Mary', 'Doug']
   end
 


### PR DESCRIPTION
The OHMS editor lets you put some limited HTML in footnotes/annotations, and the sample OHMS VTT transcripts they provided had HTML in footnotes/annotations. So I wrote this feature to support limited html, and wrote specs ensuring that. (Which actually complicated things quite q bit!)

But, when I was nearly done with this, i noticed that current OHMS doesn't actually support this feature!  When I try to actually do this in OHMS Studio, while the editor lets me add HTML, the preview strips it out. And the exported OHMS xml has it stripped out too!  

So we can't currently take advantage of it; but I completed and left in the feature to handle html in annotations/footnotes -- in case it's a bug that OHMS can't currently do them, and they'll fix it? Shouldn't hurt to leave it in. 

Ref #2878


- extract OHMS vtt annotations/footnotes
- move OHMS vtt html scrubbing from model to view_component
- render OHMS new-style vtt transcript annotation references
- style links included in ohms popover
- VttTranscriptComponent outputs footnotes at bottom
- fix spec now that whitespace is normalized again
