### PR TITLE
Fix scrolling to an anchor past the OHMS fixed navbar

### DIFF
--- a/app/frontend/javascript/ohms_footnotes.js
+++ b/app/frontend/javascript/ohms_footnotes.js
@@ -51,5 +51,5 @@ OhmsFootnotes.setUpFootnoteEvents = function() {
 OhmsFootnotes.jump = function(event, destination) {
   event.preventDefault();
   var destination = jQuery(destination);
-  window.scrollTo({top: destination.offset().top - jQuery("#ohmsAudioNavbar").height()});
+  window.scrollTo({top: destination.offset().top - jQuery("#ohmsAudioNavbar").outerHeight() - 8});
 }


### PR DESCRIPTION
It was not scrolling down enough, leaving the target of the scroll mostly under the navabar just peeking out.


We correct using jQuery outerHeight() instead of height(), and also add 8px of extra just to have a bit of space.



## before

![Screenshot 2025-02-03 at 7 17 25 PM](https://github.com/user-attachments/assets/47da8a31-3e71-4182-83ae-d39fd444bd24)

## after

![Screenshot 2025-02-03 at 7 17 11 PM](https://github.com/user-attachments/assets/928b2c55-bc7d-44d3-8e65-32fe300af1cf)