### PR TITLE
Lock vite to 5.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "rollup-plugin-gzip": "^3.0.1",
     "sass": "^1.55.0",
-    "vite": "^5.4.12",
+    "vite": "5.3.4",
     "vite-plugin-ruby": "^5.1.0",
     "vite-plugin-sass-glob-import": "^3.0.2"
   },


### PR DESCRIPTION
In our app, SASS sourcemaps break in 5.3.5 and higher (still 5.x, haven't tried 6.x -- our app isn't working with 6.0 and haven't debugged it).

Unclear why. Lock to 5.3.4 for now, becuase we really want SASS sourcemaps, hard to develop CSS in our app without it. Frustrating we can't make the reason for this lock to 5.3.4 in the package.json cause no comments allowed!

https://github.com/ElMassimo/vite_ruby/discussions/522
https://github.com/vitejs/vite/discussions/13845#discussioncomment-12073262
