### PR TITLE
Tweak hard rate limits to restrict less

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -29,7 +29,7 @@ end
 #
 # May 1 2024: Limiting much more extensively to 30 req per minute -- one per every two seconds
 # averaging over a minute -- after bot  attacks costing us money from s3.
-Rack::Attack.throttle('req/ip', limit: 80, period: 1.minutes) do |req|
+Rack::Attack.throttle('req/ip', limit: 180, period: 1.minutes) do |req|
   # On heroku, we may be delivering assets via rack, I think.
   # We also try to exempt our "api" responses from rate limit, although
   # we still include them in tracking logging below.
@@ -44,7 +44,7 @@ end
 
 # But we're also going to TRACK at half that limit, for ease
 # of understanding what's going on in our logs
-Rack::Attack.track("req/ip_track", limit: 60, period: 1.minute) do |req|
+Rack::Attack.track("req/ip_track", limit: 90, period: 1.minute) do |req|
   req.ip unless req.path.start_with?('/assets')
 end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -34,6 +34,7 @@ Rack::Attack.throttle('req/ip', limit: 80, period: 1.minutes) do |req|
   # We also try to exempt our "api" responses from rate limit, although
   # we still include them in tracking logging below.
   req.ip unless (
+                  req.ip.in?(ScihistDigicoll::Env.lookup(:main_office_ips)) || # exempt 315 chestnut from this rate limit
                   req.path.start_with?('/assets') ||
                   req.path.end_with?(".atom") ||
                   req.path.end_with?(".xml") ||

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -193,6 +193,14 @@ module ScihistDigicoll
 
     define_key :main_website_base, default: "https://sciencehistory.org"
 
+    # IPs at 315 chestnut
+    define_key :main_office_ips,
+      default: [ '173.161.142.4', '173.167.214.146'],
+      system_env_transform: ->(v) {
+        # YAML load can turn "['string', 'string']" into the array represented
+        YAML.safe_load(v.to_s)
+      }
+
     # set in ENV LOGINS_DISABLED or local_env.yml, to globally
     # prevent access to pages requiring authentication. May be useful
     # for maintenance tasks.


### PR DESCRIPTION
- exempt 315 Chestnut IPs from hard rate limits
- restore hard rate limit to 180/min with logged track at 90, what it was before bot troubles. See 39fde487b13e
