### PR TITLE
Protect original downloads with turnstile bot challenge in modal

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -124,6 +124,9 @@ class DownloadsController < ApplicationController
   # in local BotDetectController, being extracted to BotChallengePage gem. Or maybe it's
   # okay like so!
   def turnstile_protect
+    # don't protect PDFs, we want google to crawl them
+    return if @asset.content_type == "application/pdf"
+
     body = {
       secret: BotDetectController.cf_turnstile_secret_key,
       response: params["cf_turnstile_response"],

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -40,8 +40,7 @@ class DownloadsController < ApplicationController
 
   before_action :turnstile_protect, only: :original, if: -> { ScihistDigicoll::Env.lookup(:cf_turnstile_downloads_enabled) }
 
-
-  #GET /downloads/:asset_id
+  #GET /downloads/original/:asset_id
   def original
     # for IMAGES only, when we have downloads disable, simply refuse to redirect IF the user
     # is not logged in. PHEW lots of exceptions, trying to avoid breaking LOTS of our app.
@@ -126,6 +125,10 @@ class DownloadsController < ApplicationController
   def turnstile_protect
     # don't protect PDFs, we want google to crawl them
     return if @asset.content_type == "application/pdf"
+
+    if params["cf_turnstile_response"].blank?
+      raise HTTP::Error.new("No cf_turnstile_response param")
+    end
 
     body = {
       secret: BotDetectController.cf_turnstile_secret_key,

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -38,7 +38,7 @@ class DownloadsController < ApplicationController
   before_action :set_asset
   before_action :set_derivative, only: :derivative
 
-  before_action :turnstile_protect, only: :original
+  before_action :turnstile_protect, only: :original, if: -> { ScihistDigicoll::Env.lookup(:cf_turnstile_downloads_enabled) }
 
 
   #GET /downloads/:asset_id

--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -86,3 +86,4 @@ import "../javascript/audio/clipboard_copy_input.js";
 import "../javascript/video_player.js";
 
 import "../javascript/main_nav_collapse_toggle.js";
+import "../javascript/turnstile_protected_link.js";

--- a/app/frontend/javascript/turnstile_protected_link.js
+++ b/app/frontend/javascript/turnstile_protected_link.js
@@ -1,0 +1,68 @@
+// If an ordinary hyperlink is marked with data-turnstile-protected=true,
+// we will put up a quick bootstrap modal form to do a turnstile bot challenge
+// before sending them on to their ordinary destination via a GET request.
+//
+// Also target data-analytics-action=downloadOriginal, lazy way to avoid having
+// to add attribute to those links thanks.
+
+import domready from 'domready';
+import * as bootstrap from 'bootstrap';
+
+domready(function() {
+  var loadedWidgetId;
+
+  document.querySelector("a[data-turnstile-protection=true],a[data-analytics-action=download_original]")?.addEventListener("click", function(event) {
+    event.preventDefault();
+    const origHref = event.currentTarget.getAttribute("href");
+
+    addTurnstileJsIfNecessary().then(() => {
+      const modal = bootstrap.Modal.getOrCreateInstance(document.getElementById("turnstile-protected-link-modal"));
+      modal.show();
+
+      const widgetWrapper = document.getElementById('turnstile-protected-link-widget');
+      const siteKey = widgetWrapper.getAttribute("data-sitekey");
+
+      if (loadedWidgetId) {
+        window.turnstile.reset(loadedWidgetId);
+      } else {
+        loadedWidgetId = window.turnstile.render(widgetWrapper, {
+          sitekey: siteKey,
+          callback: function(token) {
+            // We're going to redirect with token visible in URL, but since
+            // we plan to use this right now only for URL that's going to immediately
+            // redirect anyway, no problem.
+
+            var newUrl;
+            if (origHref.indexOf('?') === -1) {
+              newUrl = origHref + "?cf_turnstile_response=" + encodeURIComponent(token);
+            } else {
+              url += '&' + "cf_turnstile_response=" + encodeURIComponent(token);
+            }
+
+            // likely media that will download and not actualy change browser
+            window.location.assign(newUrl);
+            modal.hide();
+          }
+        });
+      }
+
+    });
+  });
+});
+
+
+function addTurnstileJsIfNecessary() {
+  if (window.turnstile) {
+    // Already loaded, return immediate promise
+    return Promise.resolve(undefined);
+  } else {
+    // Add a script tag, with promise that will resolve after
+    return new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+      script.onload = resolve;
+      script.onerror = reject;
+      document.head.appendChild(script);
+    });
+  }
+}

--- a/app/frontend/javascript/turnstile_protected_link.js
+++ b/app/frontend/javascript/turnstile_protected_link.js
@@ -11,50 +11,65 @@ import * as bootstrap from 'bootstrap';
 domready(function() {
   var loadedWidgetId;
 
-  document.querySelector("a[data-turnstile-protection=true],a[data-analytics-action=download_original]")?.addEventListener("click", function(event) {
+  document.addEventListener("click", function(event) {
+    const link = event.target.closest("a[data-turnstile-protection=true],a[data-analytics-action=download_original]");
+
+    if (!link) {
+      // not the droids we are looking for
+      return;
+    }
+
     // Hacky exempt if it's a PDF download, because we want google to crawl PDFs
     // We can tell only by href path sorry
-    if (event.currentTarget.getAttribute("href")?.includes('downloads/orig/pdf')) {
+    if (link.getAttribute("href")?.includes('downloads/orig/pdf')) {
       return;
     }
 
     event.preventDefault();
-    const origHref = event.currentTarget.getAttribute("href");
 
     addTurnstileJsIfNecessary().then(() => {
-      const modal = bootstrap.Modal.getOrCreateInstance(document.getElementById("turnstile-protected-link-modal"));
+      const modalDom = document.getElementById("turnstile-protected-link-modal");
+      const modal = bootstrap.Modal.getOrCreateInstance(modalDom);
+      var origHref = link.getAttribute("href");
+
       modal.show();
 
       const widgetWrapper = document.getElementById('turnstile-protected-link-widget');
       const siteKey = widgetWrapper.getAttribute("data-sitekey");
 
       if (loadedWidgetId) {
-        window.turnstile.reset(loadedWidgetId);
-      } else {
-        loadedWidgetId = window.turnstile.render(widgetWrapper, {
-          sitekey: siteKey,
-          callback: function(token) {
-            // We're going to redirect with token visible in URL, but since
-            // we plan to use this right now only for URL that's going to immediately
-            // redirect anyway, no problem.
-
-            var newUrl;
-            if (origHref.indexOf('?') === -1) {
-              newUrl = origHref + "?cf_turnstile_response=" + encodeURIComponent(token);
-            } else {
-              url += '&' + "cf_turnstile_response=" + encodeURIComponent(token);
-            }
-
-            // likely media that will download and not actualy change browser
-            window.location.assign(newUrl);
-            modal.hide();
-          }
-        });
+        // Remove turnstile so we can re-init with callback with correct values
+        // for current link.
+        window.turnstile.remove(loadedWidgetId);
       }
 
+      loadedWidgetId = window.turnstile.render(widgetWrapper, {
+        sitekey: siteKey,
+        callback: createTurnstileCallback(siteKey, modal, origHref)
+      });
     });
   });
 });
+
+// Return the closure that will do the right thing for current origHref!
+function createTurnstileCallback(siteKey, modal, origHref) {
+  return (token) => {
+    // We're going to redirect with token visible in URL, but since
+    // we plan to use this right now only for URL that's going to immediately
+    // redirect anyway, no problem.
+
+    var newUrl;
+    if (origHref.indexOf('?') === -1) {
+      newUrl = origHref + "?cf_turnstile_response=" + encodeURIComponent(token);
+    } else {
+      url += '&' + "cf_turnstile_response=" + encodeURIComponent(token);
+    }
+
+    // likely media that will download and not actualy change browser
+    modal.hide();
+    window.location.assign(newUrl);
+  }
+}
 
 
 function addTurnstileJsIfNecessary() {

--- a/app/frontend/javascript/turnstile_protected_link.js
+++ b/app/frontend/javascript/turnstile_protected_link.js
@@ -2,9 +2,6 @@
 // we will put up a quick bootstrap modal form to do a turnstile bot challenge
 // before sending them on to their ordinary destination via a GET request.
 //
-// Also target data-analytics-action=downloadOriginal, lazy way to avoid having
-// to add attribute to those links thanks.
-
 import domready from 'domready';
 import * as bootstrap from 'bootstrap';
 
@@ -12,7 +9,7 @@ domready(function() {
   var loadedWidgetId;
 
   document.addEventListener("click", function(event) {
-    const link = event.target.closest("a[data-turnstile-protection=true],a[data-analytics-action=download_original]");
+    const link = event.target.closest("a[data-turnstile-protection=true]");
 
     if (!link) {
       // not the droids we are looking for

--- a/app/frontend/javascript/turnstile_protected_link.js
+++ b/app/frontend/javascript/turnstile_protected_link.js
@@ -12,6 +12,12 @@ domready(function() {
   var loadedWidgetId;
 
   document.querySelector("a[data-turnstile-protection=true],a[data-analytics-action=download_original]")?.addEventListener("click", function(event) {
+    // Hacky exempt if it's a PDF download, because we want google to crawl PDFs
+    // We can tell only by href path sorry
+    if (event.currentTarget.getAttribute("href")?.includes('downloads/orig/pdf')) {
+      return;
+    }
+
     event.preventDefault();
     const origHref = event.currentTarget.getAttribute("href");
 

--- a/app/models/download_option.rb
+++ b/app/models/download_option.rb
@@ -97,7 +97,7 @@ class DownloadOption
 
     # Sneakily add in data-turnstile-protection-true for originals that aren't PDFs
     if @analyticsAction == "download_original" && @content_type != "application/pdf" && ScihistDigicoll::Env.lookup(:cf_turnstile_downloads_enabled)
-      @data_attrs.merge!({"turnstile-protection" => "true"})
+      @data_attrs.merge!({turnstile_protection: "true"})
     end
   end
 

--- a/app/models/download_option.rb
+++ b/app/models/download_option.rb
@@ -94,6 +94,11 @@ class DownloadOption
 
     # Add in analytics data- attributes
     @data_attrs.merge!(analytics_data_attributes)
+
+    # Sneakily add in data-turnstile-protection-true for originals that aren't PDFs
+    if @analyticsAction == "download_original" && @content_type != "application/pdf" && ScihistDigicoll::Env.lookup(:cf_turnstile_downloads_enabled)
+      @data_attrs.merge!({"turnstile-protection" => "true"})
+    end
   end
 
   # trigger analytics JS, eg Google Analytics prob

--- a/app/views/application/_turnstile_protected_link_modal.html.erb
+++ b/app/views/application/_turnstile_protected_link_modal.html.erb
@@ -1,0 +1,25 @@
+<div class="modal" tabindex="-1" id="turnstile-protected-link-modal">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Traffic control and bot detection...</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+
+            <%# implicit render turnstile %>
+            <div
+              id="turnstile-protected-link-widget"
+              data-sitekey="<%= BotDetectController.cf_turnstile_sitekey %>"
+            ></div>
+
+            <div id="turnstile-protected-link-modal-error" class="mt-3"></div>
+
+            <p class="mt-3">We strive to make our content freely available. If this check is preventing you from making use of our resources, make sure you have cookies enabled. If you still have trouble, please <a href="mailto:digital@sciencehistory.org">get in touch</a>. You can also take a look at our information on <a href="https://digital.sciencehistory.org/api_docs">API and Machine Access</a>.</p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+          </div>
+        </div>
+      </div>
+    </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -109,5 +109,8 @@
       </section>
     <% end %>
     <%= render ScihistFooterComponent.new %>
+
+    <%# include modal so JS can use it %>
+    <%= render "turnstile_protected_link_modal" %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -110,7 +110,9 @@
     <% end %>
     <%= render ScihistFooterComponent.new %>
 
-    <%# include modal so JS can use it %>
-    <%= render "turnstile_protected_link_modal" %>
+    <% if ScihistDigicoll::Env.lookup(:cf_turnstile_downloads_enabled) %>
+      <%# include modal so JS can use it %>
+      <%= render "turnstile_protected_link_modal" %>
+    <% end %>
   </body>
 </html>

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -146,8 +146,6 @@ Rails.application.config.to_prepare do
     { controller: "collection_show_controllers/immigrants_and_innovation_collection" },
     { controller: "collection_show_controllers/oral_history_collection"},
     { controller: "collection_show_controllers/bredig_collection"},
-    '/downloads/orig' # block originals, with exception for PDF originals in other config
-
   ]
 
   BotDetectController.allow_exempt = ->(controller) {
@@ -172,11 +170,6 @@ Rails.application.config.to_prepare do
       controller.kind_of?(CollectionShowController) &&
       controller.respond_to?(:has_search_parameters?) &&
       !controller.has_search_parameters?
-    ) ||
-    ## exempt PDF original downloads
-    (
-      controller.kind_of?(DownloadsController) &&
-      controller.params[:file_category] == "pdf"
     )
   }
 

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -212,6 +212,9 @@ module ScihistDigicoll
     define_key :cf_turnstile_sitekey, default: ("1x00000000000000000000AA" if Rails.env.development?)
     define_key :cf_turnstile_secret_key, default: ("1x0000000000000000000000000000000AA" if Rails.env.development?)
     define_key :cf_turnstile_enabled, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM, default: false
+    # specifically for downloads, can be turned on/off independently
+    define_key :cf_turnstile_downloads_enabled, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM, default: -> { ScihistDigicoll::Env.lookup(:cf_turnstile_enabled) }
+
 
 
     # Logic to get network location of the Redis instance we will

--- a/spec/models/download_option_spec.rb
+++ b/spec/models/download_option_spec.rb
@@ -77,4 +77,21 @@ describe DownloadOption do
     end
   end
 
+  describe "turnstile protect data attribute" do
+    before do
+      allow(ScihistDigicoll::Env).to receive(:lookup).and_call_original
+      allow(ScihistDigicoll::Env).to receive(:lookup).with(:cf_turnstile_downloads_enabled).and_return(true)
+    end
+
+    it "is automatically included for analyticsAction download_original" do
+      download_option = DownloadOption.new("some label", work_friendlier_id: "work-id", analyticsAction: "download_original", url: "#")
+      expect(download_option.data_attrs[:turnstile_protection]).to eq "true"
+    end
+
+    it "but not with content-type pdf" do
+      download_option = DownloadOption.new("some label", content_type: "application/pdf", work_friendlier_id: "work-id", analyticsAction: "download_original", url: "#")
+      expect(download_option.data_attrs[:turnstile_protection]).to be_nil
+    end
+  end
+
 end

--- a/spec/system/bot_limiting_system_spec.rb
+++ b/spec/system/bot_limiting_system_spec.rb
@@ -9,7 +9,6 @@ describe "Turnstile bot limiting", js:true do
     allow(Rack::Attack.cache).to receive(:store).and_return(memstore)
   end
 
-
   let(:cf_turnstile_sitekey_pass) { "1x00000000000000000000AA" } # a test key
   let(:cf_turnstile_secret_key_pass) { "1x0000000000000000000000000000000AA" } # a testing key always passes
   let(:cf_turnstile_secret_key_fail) { "2x0000000000000000000000000000000AA" } # a testing key that produces failure
@@ -45,49 +44,98 @@ describe "Turnstile bot limiting", js:true do
     BotDetectController.rack_attack_init
   end
 
-  describe "succesful challenge" do
+  describe "search" do
+    describe "succesful challenge" do
+      let(:cf_turnstile_sitekey) { cf_turnstile_sitekey_pass }
+      let(:cf_turnstile_secret_key) { cf_turnstile_secret_key_pass }
+
+      before do
+        allow(Rails.logger).to receive(:info)
+        stub_turnstile_success(request_body: {"secret"=>BotDetectController.cf_turnstile_secret_key, "response"=>"XXXX.DUMMY.TOKEN.XXXX", "remoteip"=>"127.0.0.1"})
+      end
+
+      it "smoke tests" do
+        visit search_catalog_path(q: "foo")
+        expect(page).to have_content(/you searched for/i)
+
+        # on second try, we're gonna get redirected to bot check page
+        visit search_catalog_path(q: "bar")
+        expect(page).to have_content(/traffic control/i)
+
+        # which eventually will redirect back to search.
+        expect(page).to have_content(turnstile_success_re, wait: 4)
+        expect(Rails.logger).to have_received(:info).with(/BotDetectController: Cloudflare Turnstile challenge redirect/)
+      end
+    end
+
+    describe "failed challenge" do
+      let(:cf_turnstile_sitekey) { cf_turnstile_sitekey_pass }
+      let(:cf_turnstile_secret_key) { cf_turnstile_secret_key_fail }
+
+      before do
+        allow(Rails.logger).to receive(:warn)
+        stub_turnstile_failure(request_body: {"secret"=>BotDetectController.cf_turnstile_secret_key, "response"=>"XXXX.DUMMY.TOKEN.XXXX", "remoteip"=>"127.0.0.1"})
+      end
+
+      it "stays on page with failure" do
+        visit search_catalog_path(q: "foo")
+        expect(page).to have_content(/you searched for/i)
+
+        # on second try, we're gonna get redirected to bot check page
+        visit search_catalog_path(q: "bar")
+        expect(page).to have_content(/traffic control/i)
+
+        # which is going to get a failure message
+        expect(page).to have_content(turnstile_failure_re, wait: 4)
+        expect(Rails.logger).to have_received(:warn).with(/BotDetectController: Cloudflare Turnstile validation failed/)
+      end
+    end
+  end
+
+  describe "downloads" do
     let(:cf_turnstile_sitekey) { cf_turnstile_sitekey_pass }
     let(:cf_turnstile_secret_key) { cf_turnstile_secret_key_pass }
 
     before do
-      allow(Rails.logger).to receive(:info)
+      allow(ScihistDigicoll::Env).to receive(:lookup).and_call_original
+      allow(ScihistDigicoll::Env).to receive(:lookup).with(:cf_turnstile_downloads_enabled).and_return(true)
+
       stub_turnstile_success(request_body: {"secret"=>BotDetectController.cf_turnstile_secret_key, "response"=>"XXXX.DUMMY.TOKEN.XXXX", "remoteip"=>"127.0.0.1"})
     end
 
-    it "smoke tests" do
-      visit search_catalog_path(q: "foo")
-      expect(page).to have_content(/you searched for/i)
-
-      # on second try, we're gonna get redirected to bot check page
-      visit search_catalog_path(q: "bar")
-      expect(page).to have_content(/traffic control/i)
-
-      # which eventually will redirect back to search.
-      expect(page).to have_content(turnstile_success_re, wait: 4)
-      expect(Rails.logger).to have_received(:info).with(/BotDetectController: Cloudflare Turnstile challenge redirect/)
-    end
-  end
-
-  describe "failed challenge" do
-    let(:cf_turnstile_sitekey) { cf_turnstile_sitekey_pass }
-    let(:cf_turnstile_secret_key) { cf_turnstile_secret_key_fail }
-
-    before do
-      allow(Rails.logger).to receive(:warn)
-      stub_turnstile_failure(request_body: {"secret"=>BotDetectController.cf_turnstile_secret_key, "response"=>"XXXX.DUMMY.TOKEN.XXXX", "remoteip"=>"127.0.0.1"})
+    let(:work) do
+      create(
+        :work, :published, members: [
+          create(:asset_with_faked_file,
+            title: "First asset",
+            faked_derivatives: {},
+            position: 0),
+          ]
+      )
     end
 
-    it "stays on page with failure" do
-      visit search_catalog_path(q: "foo")
-      expect(page).to have_content(/you searched for/i)
-      
-      # on second try, we're gonna get redirected to bot check page
-      visit search_catalog_path(q: "bar")
-      expect(page).to have_content(/traffic control/i)
+    it "provides turnstile captcha which leads to download" do
+      visit work_path(work)
 
-      # which is going to get a failure message
-      expect(page).to have_content(turnstile_failure_re, wait: 4)
-      expect(Rails.logger).to have_received(:warn).with(/BotDetectController: Cloudflare Turnstile validation failed/)
+      click_button("Download", :match => :first)
+      click_link("Original file")
+
+      expect(page).to have_text("Traffic control and bot detection...")
+      # There is no great way to test download actually happened!
+      # And selenium may be showing picture in browser instead of downloading.
+      # But we can test that the dialog eventually goes away, and there are no
+      # browser errors
+
+      browser_logs = page.driver.browser.logs.get(:browser)
+      expect(browser_logs.collect { |l| l.level == "SERVERE"}).to be_empty, browser_logs.collect { |m| m.message }.inspect
+
+      expect(page).not_to have_text("Traffic control and bot detection...")
+
+      browser_logs = page.driver.browser.logs.get(:browser)
+      expect(browser_logs.collect { |l| l.level == "SERVERE"}).to be_empty, browser_logs.collect { |m| m.message }.inspect
+
+      # hopefully we're not on 403 error message from downloads!
+      expect(page).not_to have_text("Denied")
     end
   end
 end


### PR DESCRIPTION
Since originals download usually results in a download directly to device with no browser page change -- our other generic method of bot protecting by REDIRECTING to a bot challenge and then back to originally desired page -- does not work well. 

Instead, we want to put up a modal with turnstile bot challenge, and if it passes, remove the modal, and navigate to download URL. 

This is a pretty hacky implementation, that still has some rough edges. But maybe enough for now?

- probably ought to re-use more of the bot challenge page stuff, which we are trying to extract into gem. instead we do it again, differently -- also we need to bot check downloads on FIRST try, even allowing 2 free ones was potentially no good. 

- not very DRY or well organized in general

- If close modal in media res, need to cancel turnstile redirect to download

- need to make work in viewer for original downloads, right now it won't and sometimes you'll get blocked from download. 

- Right now, you get challenge on EVERY download, we really want to exempt you if you've already passed bot challenge recently, hopefully sharing mechanism and code from other bot challenge page redirect stuff (but race condition is a mess).  

-----

- client-side turnstile for orig downloads, in modal
- server-side for turnstile protection of orig downloads
- Do NOT block downloads using bot-challenge-page, we need to do it with modal instead
- exempt PDF originals from bot challenge protection
- fix to work for multiple links on page, with delegation
- config variable for turnstile protection of download links, requires actually generating data attr for protection on link
- controller specs for turnstile download orig protection
- test auto add of data-turnstile-protected=true on download option
- system spec for turnstile-protected orig downloads
