### PR TITLE
Put a bot challenge in front of orig downloads

### DIFF
--- a/app/components/download_dropdown_component.rb
+++ b/app/components/download_dropdown_component.rb
@@ -239,10 +239,13 @@ class DownloadDropdownComponent < ApplicationComponent
     ])
 
     if download_option.url.present?
+      # download_original gets target=_blank becuase it's protected by bot protection,
+      # so needs to open a tab for the bot challenge if necessary. A bit kludgey.
       content_tag("a", label,
                         class: "dropdown-item",
                         href: download_option.url,
-                        data: download_option.data_attrs)
+                        data: download_option.data_attrs,
+                        target: ("_blank" if download_option.data_attrs[:analytics_action] == "download_original"))
     else
       # allow non-link label menu items. eg for disabled download notice
       content_tag("div", label, class: "px-4 text-muted text-small")

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -143,9 +143,11 @@ class BotDetectController < ApplicationController
   # Usually in your ApplicationController,
   #
   #     before_action { |controller| BotDetectController.bot_detection_enforce_filter(controller) }
-  def self.bot_detection_enforce_filter(controller)
+  #
+  # @param immediate [Boolean] always force bot protection, ignore any allowed pre-challenge rate limit
+  def self.bot_detection_enforce_filter(controller, immediate: false)
     if self.enabled &&
-        controller.request.env[self.env_challenge_trigger_key] &&
+        (controller.request.env[self.env_challenge_trigger_key] || immediate) &&
         ! self._bot_detect_passed_good?(controller.request) &&
         ! controller.kind_of?(self) && # don't ever guard ourself, that'd be a mess!
         ! self.allow_exempt.call(controller)

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -38,6 +38,9 @@ class DownloadsController < ApplicationController
   before_action :set_asset
   before_action :set_derivative, only: :derivative
 
+  # protect originals only from bots with bot challenge redirect, no allowed pre-challenge
+  # rate limit.
+  before_action(only: :original) { |controller| BotDetectController.bot_detection_enforce_filter(controller, immediate: true) }
 
   #GET /downloads/:asset_id
   def original

--- a/app/views/bot_detect/challenge.html.erb
+++ b/app/views/bot_detect/challenge.html.erb
@@ -56,14 +56,15 @@
         // replace the challenge page in history
         window.location.replace(dest);
 
-      // in case this page stays around (say rediret to media asset), let's add a failsafe message after
+      // in case this page stays around, (say it was rediret to media asset), let's add a failsafe message after
       // a couple seconds.
       window.setTimeout(function() {
         document.querySelector(".cf-turnstile")?.insertAdjacentHTML("afterend", `<div class="alert alert-info" role="alert">
           <i class="fa fa-info-circle" aria-hidden="true"></i>
-          The check has completed, and everything is clear to proceed. If you are seeing this message either something has gone wrong, or perhaps you have what you need and should close this tab and return to original tab.
+          The traffic check has completed. You may need to return to your original browser tab or press the back button.
         </div>`);;
       }, 1200);
+
 
 
       } else {

--- a/app/views/bot_detect/challenge.html.erb
+++ b/app/views/bot_detect/challenge.html.erb
@@ -37,6 +37,15 @@
         throw new Error('bad response: ' + response.status + ": " + response.url);
       }
 
+      // This page may end up staying around on sucesss, stay if the dest url is a media
+      // type that can only be downloaded.
+      //
+      // When so, if the page stays around, it may end up
+      // calling turnstile and this callback over and over again, without an  (that
+      // we're not tracking) this will remove the most recent turnstile widget executed,
+      // we only expect one.
+      turnstile.remove();
+
       result = await response.json();
       if (result["success"] == true) {
         const dest = new URLSearchParams(window.location.search).get("dest");
@@ -46,6 +55,17 @@
         }
         // replace the challenge page in history
         window.location.replace(dest);
+
+      // in case this page stays around (say rediret to media asset), let's add a failsafe message after
+      // a couple seconds.
+      window.setTimeout(function() {
+        document.querySelector(".cf-turnstile")?.insertAdjacentHTML("afterend", `<div class="alert alert-info" role="alert">
+          <i class="fa fa-info-circle" aria-hidden="true"></i>
+          The check has completed, and everything is clear to proceed. If you are seeing this message either something has gone wrong, or perhaps you have what you need and should close this tab and return to original tab.
+        </div>`);;
+      }, 1200);
+
+
       } else {
         console.error("Turnstile response reported as failure: " + JSON.stringify(result))
         _displayChallengeError();

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -145,9 +145,7 @@ Rails.application.config.to_prepare do
     { controller: "collection_show" },
     { controller: "collection_show_controllers/immigrants_and_innovation_collection" },
     { controller: "collection_show_controllers/oral_history_collection"},
-    { controller: "collection_show_controllers/bredig_collection"},
-    '/downloads/orig' # block originals, with exception for PDF originals in other config
-
+    { controller: "collection_show_controllers/bredig_collection"}
   ]
 
   BotDetectController.allow_exempt = ->(controller) {
@@ -173,7 +171,7 @@ Rails.application.config.to_prepare do
       controller.respond_to?(:has_search_parameters?) &&
       !controller.has_search_parameters?
     ) ||
-    ## exempt PDF original downloads
+    ## exempt PDF original downloads, which are protected with an 'immediate' filter
     (
       controller.kind_of?(DownloadsController) &&
       controller.params[:file_category] == "pdf"


### PR DESCRIPTION
On FIRST access -- and with original downloads opening in a separate tab, to provide a somewhat better UX... although it makes it a bit weird flash of tab when there is no challenge; and kind of confusing stuck looking at passed challenge when there is;  we can demo and think more about it, but seems good enough for now maybe, with a much simpler implementation than last try at #2897

- give BotDetectController.bot_detection_enforce_filter an 'immediate' option to ignore rate limit and apply bot challenge on first access
- use bot_detection_enforce_filter on DownloadsController#original with immediate option
- DownloadDropdown does target=_blank on original downloads, to accomodate bot challenge redirect
- remove Downloads from BotDetect standard config, we only use it with immediate filter
