### PR TITLE
Fix a handful of flakey system tests

### DIFF
--- a/spec/system/collection/new_collection_spec.rb
+++ b/spec/system/collection/new_collection_spec.rb
@@ -45,6 +45,8 @@ RSpec.describe "New Collection form", logged_in_user: :editor, type: :system, js
 
     # the hidden file input used by uppy, we can target directly...
     add_file_via_uppy_dashboard input_name: "files[]", file_path: (Rails.root + "spec/test_support/images/30x30.png").to_s
+    # wait for it to be uploaded async
+    expect(page).to have_text("Will be saved")
 
     click_button "Create Collection"
     expect(page).to have_text("1 error prohibited this collection from being saved")

--- a/spec/system/work_show_spec.rb
+++ b/spec/system/work_show_spec.rb
@@ -20,31 +20,25 @@ describe "Public work show page", type: :system, js: false do
     end
 
 
-    let(:work) {
+    let(:work) do
       create(
         :work, :published, :with_complete_metadata, contained_by: [create(:collection)], parent: create(:work, :published), members: [
           create(:asset_with_faked_file,
             title: "First asset (representative)",
-            faked_derivatives: {},
             position: 0),
           create(:asset_with_faked_file,
             title: "Second asset",
-            faked_derivatives: {},
             position: 1),
           create(:asset_with_faked_file,
             title: "Third asset (private)",
-            faked_derivatives: {},
             published: false,
             position: 2)
           ]
-      )
-    }
-
-    before do
-      work.representative = work.members.first
-      work.save!
+      ).tap do |work|
+        work.representative = work.members.first
+        work.save!
+      end
     end
-
 
     # REALLY doesn't test everything, just a sampling
     it "smoke tests", js: true do
@@ -60,7 +54,6 @@ describe "Public work show page", type: :system, js: false do
 
       thumbnails = page.find_all('.member-image-presentation')
       expect(thumbnails.count). to eq work.members.select {|m| m.published }.count
-
 
       within("header .show-genre") do
         work.genre.each do |g|

--- a/spec/test_support/helper_ruby/uppy_helper_methods.rb
+++ b/spec/test_support/helper_ruby/uppy_helper_methods.rb
@@ -2,14 +2,26 @@ module UppyHelperMethods
   # Uppy is a JS library for a file upload UI. In our tests, we need to sometimes add a file through it.
   # This can't be totally automated 'naturally' because capybara can't automate OS file choosing dialog.
   #
-  # We found an "around the back" way that works, at least at present, if we attach the file to
-  # the hidden file input that we wrapped uppy around, it works!
+  # An around the back way that works is attaching directly to the hidden real <input> behind
+  # uppy input, but to get capybara to interact wiht it, it has to be visible!
   #
-  # input_name is the value of the name attribute  on the hidden field input, eg `<input name="X">
+  # Capybara has a make_visible command that is SUPPOSED to do that, but it doesn't
+  # seem to do enough for uppy, so we use our own custom JS to remove all classes,
+  # all inline styles, and any `hidden` attribute, hoping to make it visible!
+  #
+  # @param input_name [String] the value of the name attribute  on the hidden field input, eg `<input name="X">
   #
   # In uppy 2.x, there can be more than one hidden file input in the DOM, but just picking
   # the first one works.
   def add_file_via_uppy_dashboard(input_name:, file_path:)
-    attach_file input_name, file_path.to_s, make_visible: true, match: :first
+    # make sure it's there even hidden for us to exec JS oni t
+    first("input[name=\"#{input_name}\"]", visible: :all)
+
+    # exec JS to try to make it visible!
+    execute_script("let _inp = document.querySelector('input[name=\"#{input_name}\"]'); _inp.style = ''; _inp.hidden = false; _inp.classList = null;")
+
+    # Now ask capybara to attach file, also asking capybara to do what it can to make visible
+    # if needed -- but not only is this not working, it's CAUSING problems??
+    attach_file input_name, file_path.to_s, match: :first #make_visible: true
   end
 end


### PR DESCRIPTION
So we had some failures that just started happening -- and still happened in a hard to reproduce fashion. Running just the failing test would always work. But running a suite of tests (including just spec/system) would *reliably* produce the failure! Reproduced if and only if run in a suite of a bunch of tests. 
My best guess is that something changed the timing of our tests to make them faster or slower, which revealed some latent race conditions, exposing bugs that were always there waiting for us, but, in the past Capybara/chrome *moves on to next test* before error reveals itself. 

That still doesn't explain the hidden uppy file input and make_visible really though...

But this seems quite reliable to me know, and these fixes more or less make sense to me as actual fixes/improvements, they aren't just bit twiddling. 

- capybara make_visible isn't working on hidden uppy file input anymore, we use our own JS to make it visible
- wait for async collection thumb upload to complete before pressing save
- system spec needs real derivatives, or corrupt urls happen and chrome tries to prefetch them and error
