### PR TITLE
Permanently remove museum hours from header and footer

### DIFF
--- a/app/components/scihist_footer_component.html.erb
+++ b/app/components/scihist_footer_component.html.erb
@@ -78,14 +78,14 @@
                 </div>
                 <div class="footer__column">
                     <nav class="footer__nav" aria-labelledby="footerMuseumHours">
-                        <ul id="menu-footer-2" class="menu-footer-ul flex fdc"><li id="menu-item-19116" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-19116"><a id="footerMuseumHours" href="<%= URI::join(ScihistDigicoll::Env.lookup(:main_website_base), '/visit/hours-admission') %>">MUSEUM HOURS: CLOSED</a></li>
+                        <ul id="menu-footer-2" class="menu-footer-ul flex fdc"><li id="menu-item-19116" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-19116"><a id="footerMuseumHours" href="<%= URI::join(ScihistDigicoll::Env.lookup(:main_website_base), '/visit/hours-admission') %>">MUSEUM HOURS</a></li>
                             <li id="menu-item-19123" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-19123"><a target="_blank" href="https://www.explorableplaces.com/places/science-history-institute">Virtual Tour</a></li>
                             <li id="menu-item-19124" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-19124"><a href="https://sciencehistory.org/visit/exhibitions/sensational-science-a-century-of-microbe-hunters/">Outdoor Exhibition</a></li>
                             <li id="menu-item-19125" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-19125"><a href="https://sciencehistory.org/visit/exhibitions/#digital-exhibitions">Digital Exhibitions</a></li>
                             <li id="menu-item-19126" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-19126"><a href="https://sciencehistory.org/stories/magazine/">Magazine</a></li>
                             <li id="menu-item-19127" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-19127"><a href="https://sciencehistory.org/stories/#podcasts">Podcasts</a></li>
                             <li id="menu-item-19128" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-19128"><a href="https://sciencehistory.org/collections/blog/">Blog</a></li>
-                            <li id="menu-item-19129" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-19129"><a href="https://digital.sciencehistory.org/">Digital Collections</a></li>
+                            <li id="menu-item-19129" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-19129"><a href="https://sciencehistory.org/collections">Collections</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/app/components/scihist_masthead.html.erb
+++ b/app/components/scihist_masthead.html.erb
@@ -19,7 +19,7 @@
             </div>
 
             <div class="shi-top-bar__hours">
-                  <span class="shi-top-bar__bold"><a href="<%= URI::join(ScihistDigicoll::Env.lookup(:main_website_base), "/visit/hours-admission") %>" style="text-decoration: none">Museum Hours</a>:</span><span class="shi-top-bar__regular">Closed until March 8, 2025</span>
+                  <span class="shi-top-bar__bold"><a href="<%= URI::join(ScihistDigicoll::Env.lookup(:main_website_base), "/visit/hours-admission") %>" style="text-decoration: none">Museum Hours</a></span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Closes #2899, closes #2898


- remove museum hours specifics from header
- Set footer to specs from #2899 for permanently not having specific museum hours
