### PR TITLE
Capybara specs should wait for page to be returned before checking for database change

### DIFF
--- a/spec/system/digitization_queue_spec.rb
+++ b/spec/system/digitization_queue_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe "Digitization Queue", logged_in_user: :editor, type: :system, js:
     fill_in "Location", with: "Some location"
 
     click_on "Create Digitization queue item"
-    # return to listing page, now click on item we just made
-
+    # return to listing page, make sure we wait for it
+    expect(page).to have_selector("h1", text: "Digitization Queue")
     dq  = Admin::DigitizationQueueItem.order(created_at: :desc).last
     expect(dq.deadline).to eq Date.new(2020, 2, 3)
 

--- a/spec/system/oral_history_by_request_spec.rb
+++ b/spec/system/oral_history_by_request_spec.rb
@@ -70,6 +70,7 @@ describe "Oral History with by-request delivery", type: :system, js: true, queue
 
       expect(OralHistoryRequest.count).to eq 0
       click_on 'Submit request'
+      expect(page).to have_text("The files you have requested are immediately available")
       expect(OralHistoryRequest.count).to eq 1
 
       new_req = OralHistoryRequest.last
@@ -121,6 +122,7 @@ describe "Oral History with by-request delivery", type: :system, js: true, queue
 
       expect(OralHistoryRequest.count).to eq 0
       click_on 'Submit request'
+      expect(page).to have_text("Your request will be reviewed")
       expect(OralHistoryRequest.count).to eq 1
 
       new_req = OralHistoryRequest.last

--- a/spec/system/oral_history_magic_link_spec.rb
+++ b/spec/system/oral_history_magic_link_spec.rb
@@ -49,6 +49,7 @@ describe "Login with Oral Histories magic link", queue_adapter: :inline do
     visit oral_history_requests_path
     click_on "Sign out"
     # make sure we're really signed out
+    expect(page).to have_text("You have been signed out")
     visit oral_history_requests_path
     expect(page).not_to have_selector("h2", text: "Oral History Requests")
     expect(page).to have_content("Please fill out your email address, and you will be emailed a sign-in link")


### PR DESCRIPTION
Otherwise, if the app is slower than capybara, when we're checking for a db change, maybe it hasn't been done yet. We actually have to wait for the app to return the next page to ensure it finished the action before checking for DB change.

Not really sure why this has started becoming a problem recently, hopefully we haven't slowed down our app. But these are corrections to do things actually reliably correct regardless.
