### PR TITLE
More Capyabara wait conditions

### DIFF
--- a/spec/system/digitization_queue_spec.rb
+++ b/spec/system/digitization_queue_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe "Digitization Queue", logged_in_user: :editor, type: :system, js:
 
     click_on "Create Digitization queue item"
     # return to listing page, make sure we wait for it
-    expect(page).to have_selector("h1", text: "Digitization Queue")
+
+    expect(page).to have_text("was successfully created")
     dq  = Admin::DigitizationQueueItem.order(created_at: :desc).last
     expect(dq.deadline).to eq Date.new(2020, 2, 3)
 

--- a/spec/system/work/edit_work_metadata_spec.rb
+++ b/spec/system/work/edit_work_metadata_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Edit work metadata form", logged_in_user: :editor, type: :system
     click_button "Update Work"
 
     # check page, before checking data, to make sure action has completed.
-    expect(page).to have_css("h1", text: work.title)
+    expect(page).to have_text("was successfully updated.")
 
     # check data
     work.reload
@@ -49,7 +49,7 @@ RSpec.describe "Edit work metadata form", logged_in_user: :editor, type: :system
     click_button "Update Work"
 
     # check page, before checking data, to make sure action has completed.
-    expect(page).to have_css("h1", text: work.title)
+    expect(page).to have_text("was successfully updated.")
     work.reload
 
     expect(work.description).to eq(<<~EOS)

--- a/spec/system/work/new_work_spec.rb
+++ b/spec/system/work/new_work_spec.rb
@@ -176,9 +176,16 @@ RSpec.describe "New Work form", logged_in_user: :editor, type: :system, js: true
       end
     end
 
+    # Collection, try to select reliably from tom-select
     within find("div.work_contained_by") do
       find('div.select').click
       find('input').fill_in with: "#{collection.title}\n"
+    end
+    # make sure selection has happened in hidden select field before we move on
+    expect(page).to have_field("work[contained_by_ids][]",  multiple: true, visible: :all) do |select_tag|
+      # not sure why we had ot do this in a custom block, using `with` arg wasn' working for multiple
+      # value select.
+      select_tag.value == [ collection.id ]
     end
 
     click_button "Create Work"
@@ -199,7 +206,8 @@ RSpec.describe "New Work form", logged_in_user: :editor, type: :system, js: true
       expect(newly_added_work.send(prop)).to eq work.send(prop)
     end
 
-    expect(newly_added_work.contained_by).to include(collection)
+    #newly_added_work.reload
+    expect(newly_added_work.contained_by.to_a).to include(collection)
   end
 
   context "creating a child work" do

--- a/spec/system/work/oral_history_work_spec.rb
+++ b/spec/system/work/oral_history_work_spec.rb
@@ -24,6 +24,8 @@ describe "Oral history work", logged_in_user: :editor, queue_adapter: :test do
         expect(page).to have_css("a", text: /Generate combined audio derivatives/)
 
         click_on "Generate combined audio derivatives"
+        expect(page).to have_text("audio derivative job has been added ")
+
         expect(CreateCombinedAudioDerivativesJob).to have_been_enqueued
         expect(page).to have_text("Attempting to create combined audio derivatives. Job status: queued")
       end


### PR DESCRIPTION
More times Capybara was checking for some state before the code to execute it had completed. Have to put in stuff so it waits for a front-end UX signal indicating the processing has completed.

Similar to #2920 but these were mostly not reproducing on Github CI, although they were easily reproducible on my macbook.

Still not sure why this whole category started getting worse easily, what changed. Hopefully it wasn't our app getting slower.
