### PR TITLE
change images_per_page variables to members_per_batch

### DIFF
--- a/app/components/fetch_more_pages_link_component.rb
+++ b/app/components/fetch_more_pages_link_component.rb
@@ -1,12 +1,12 @@
 class FetchMorePagesLinkComponent < ApplicationComponent
-  def initialize(start_index:, images_per_page:, total_count:)
+  def initialize(start_index:, members_per_batch:, total_count:)
     @start_index = start_index
-    @images_per_page = images_per_page
+    @members_per_batch = members_per_batch
     @total_count = total_count
   end
 
   def call
-    link_to("#", class:"lazy-member-images-link show-member-list-item", data: { trigger: "lazy-member-images", start_index: @start_index, images_per_page: @images_per_page }) do
+    link_to("#", class:"lazy-member-images-link show-member-list-item", data: { trigger: "lazy-member-images", start_index: @start_index, members_per_batch: @members_per_batch }) do
       content_tag("span", "Load #{remaining_items_count} more #{'item'.pluralize(remaining_items_count)}")
     end
   end

--- a/app/components/work_image_show_component.html.erb
+++ b/app/components/work_image_show_component.html.erb
@@ -70,7 +70,7 @@
       <%= render MemberImageComponent.new(member_for_thumb.member, lazy: (index > 5), image_label: member_for_thumb.image_label) %>
     </div>
   <% end %>
-  <%= render FetchMorePagesLinkComponent.new(start_index: start_index, images_per_page: images_per_page, total_count: total_count) if more_pages_to_load? %>
+  <%= render FetchMorePagesLinkComponent.new(start_index: start_index, members_per_batch: members_per_batch, total_count: total_count) if more_pages_to_load? %>
 </div>
 
 <%# hidden modal used by viewer %>

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -35,21 +35,22 @@ class WorksController < ApplicationController
   # Takes an offset and a limit.
   # See also WorkImageShowComponent, which shows the first batch of images and provides the script with what it needs.
   def lazy_member_images
-    if !(params[:start_index] =~ /\A\d+\Z/) || !(params[:images_per_page]  =~ /\A\d+\Z/ )
+    if !(params[:start_index] =~ /\A\d+\Z/) || !(params[:members_per_batch]  =~ /\A\d+\Z/ )
       render :nothing => true, :layout => false
       return
     end
+
     @start_index = params[:start_index].to_i
-    @images_per_page = params[:images_per_page].to_i
+    @members_per_batch = params[:members_per_batch].to_i
     @lazy_member_images = ordered_viewable_members_excluding_pdf_source.
       offset(@start_index).
-      limit(@images_per_page).
+      limit(@members_per_batch).
       strict_loading.
       collect.with_index do |member, i|
         WorkImageShowComponent::MemberForThumbnailDisplay.new(member: member, image_label: "Image #{@start_index + i}")
     end
     @total_count = @ordered_viewable_members_excluding_pdf_source.count
-    @more_pages_to_load = @start_index + @images_per_page <= @total_count
+    @more_pages_to_load = @start_index + @members_per_batch <= @total_count
 
     render :layout => false
   end

--- a/app/frontend/javascript/lazy_member_images.js
+++ b/app/frontend/javascript/lazy_member_images.js
@@ -1,5 +1,5 @@
 // GET a batch of thumbnails from the lazy images method in the public works controller. A typical path to GET would be:
-//      /works/WORK_FRIENDLIER_ID/lazy_member_images?start_index=100&images_per_page=100
+//      /works/WORK_FRIENDLIER_ID/lazy_member_images?start_index=100&members_per_batch=100
 // and then insert them directly into the DOM.
 //
 // This is intended to speed up the perceived loading of books with over 500 pages.
@@ -7,7 +7,7 @@
 //
 // See also :
 //   app/components/work_image_show_component.rb
-//      (provides this script with friendlierID, startIndex, and imagesPerPage)
+//      (provides this script with friendlierID, startIndex, and membersPerBatch)
 //   app/controllers/works_controller.rb#lazy_member_images
 //      (provides this script with the images)
 //
@@ -48,9 +48,9 @@ class LazyMemberImages {
     const startIndex = parseInt(linkEl.getAttribute("data-start-index"));
 
     // How many images to request.
-    const imagesPerPage = parseInt(linkEl.getAttribute("data-images-per-page"));
+    const membersPerBatch = parseInt(linkEl.getAttribute("data-members-per-batch"));
 
-    var urlForMoreImages = this.#constructUrl(startIndex, imagesPerPage);
+    var urlForMoreImages = this.#constructUrl(startIndex, membersPerBatch);
     if (urlForMoreImages) {
       this.#fetchAndInsertLazyMemberImages(urlForMoreImages);
     }
@@ -58,17 +58,17 @@ class LazyMemberImages {
 
 
   // Calculate the URL where the images can be GETted from
-  #constructUrl(startIndex, imagesPerPage) {
+  #constructUrl(startIndex, membersPerBatch) {
     var friendlierId =  this.#getFriendlierId();
 
-    if (friendlierId === null || !Number.isInteger( startIndex + imagesPerPage)) {
-      console.error('Could not calculate friendlier ID, start index, or images per page:');
+    if (friendlierId === null || !Number.isInteger( startIndex + membersPerBatch)) {
+      console.error('Could not calculate friendlier ID, start index, or members per batch:');
       return;
     }
 
     return window.location.origin + "/works/" +
       friendlierId + "/lazy_member_images?" +
-      "start_index=" + startIndex + '&images_per_page=' + imagesPerPage;
+      "start_index=" + startIndex + '&members_per_batch=' + membersPerBatch;
   }
 
   #triggerIntersectionCallback(entries, observer) {

--- a/app/views/works/lazy_member_images.html.erb
+++ b/app/views/works/lazy_member_images.html.erb
@@ -6,6 +6,6 @@
 	<% end %>
 
   <% if @more_pages_to_load %>
-    <%= render FetchMorePagesLinkComponent.new(start_index: @start_index + @images_per_page, total_count: @total_count, images_per_page: @images_per_page) %>
+    <%= render FetchMorePagesLinkComponent.new(start_index: @start_index + @members_per_batch, total_count: @total_count, members_per_batch: @members_per_batch) %>
   <% end %>
 <% end %>

--- a/spec/components/work_image_show_component_lazy_load_images_spec.rb
+++ b/spec/components/work_image_show_component_lazy_load_images_spec.rb
@@ -27,8 +27,8 @@ describe WorkImageShowComponent, type: :component do
       hero.first("a.thumb")["data-member-id"]
     end
 
-    let(:images_per_page) do
-      page.first('*[data-trigger="lazy-member-images"]')['data-images-per-page']
+    let(:members_per_batch) do
+      page.first('*[data-trigger="lazy-member-images"]')['data-members-per-batch']
     end
 
     let(:other_thumbs_friendlier_id_list) do
@@ -37,8 +37,9 @@ describe WorkImageShowComponent, type: :component do
     context "published work" do
       context "first image is representative" do
         it "shows the representative at the top, two more images underneath" do
-          render_inline described_class.new(work, images_per_page: 3)
-          expect(images_per_page).to eq "3"
+          html = render_inline described_class.new(work, members_per_batch: 3)
+
+          expect(members_per_batch).to eq "3"
           expect(hero_friendlier_id).to eq asset1.friendlier_id
           thumbs = page.all(".show-member-list-item .member-image-presentation")
           expect(thumbs.length).to be(2)
@@ -54,7 +55,7 @@ describe WorkImageShowComponent, type: :component do
           create(:work, :published, :with_complete_metadata, members: members, representative: asset2)
         }
         it "displays all three thumbnails in small thumb list" do
-          render_inline described_class.new(work, images_per_page: 3)
+          render_inline described_class.new(work, members_per_batch: 3)
           expect(hero_friendlier_id).to eq(asset2.friendlier_id)
           expect(other_thumbs_friendlier_id_list).to eq [ asset1.friendlier_id, asset2.friendlier_id, asset3.friendlier_id ]
           expect(page.first('*[data-trigger="lazy-member-images"]')['data-start-index']).to eq "3"
@@ -79,14 +80,14 @@ describe WorkImageShowComponent, type: :component do
           expect(page.find_all(".show-hero .member-image-presentation a.thumb").count).to eq 0
         end
         it "if the user requests two images, the first two viewable images are shown (asset3 and asset4)" do
-          render_inline described_class.new(work, images_per_page: 2)
+          render_inline described_class.new(work, members_per_batch: 2)
           # no hero image
           expect(page.find_all(".show-hero .member-image-presentation a.thumb").count).to eq 0
           # shows 3 and 4
           expect(other_thumbs_friendlier_id_list).to eq [ asset3.friendlier_id, asset4.friendlier_id ]
         end
         it "the next batch of thumbnails fetched will start with asset5)" do
-          component = described_class.new(work, images_per_page: 2)
+          component = described_class.new(work, members_per_batch: 2)
           render_inline component
           viewable_members = component.ordered_viewable_members_scope.to_a
           # next start index is 2 (i.e. the third VIEWABLE member)
@@ -97,7 +98,7 @@ describe WorkImageShowComponent, type: :component do
         end
       end
       it "does show unpublished assets to a logged-in user", logged_in_user: :admin do
-        render_inline described_class.new(work, images_per_page: 3)
+        render_inline described_class.new(work, members_per_batch: 3)
         expect(hero_friendlier_id).to eq(asset1.friendlier_id)
         expect(other_thumbs_friendlier_id_list).to eq [ asset2.friendlier_id, asset3.friendlier_id ]
         expect(page.first('*[data-trigger="lazy-member-images"]')['data-start-index']).to eq "3"
@@ -110,7 +111,7 @@ describe WorkImageShowComponent, type: :component do
       let(:child_work) { create(:work, :published, position: 1) }
       let(:members) {[asset1, child_work, asset3, asset4, asset5]}
       it "unpublished assets are counted towards the images-per-page total" do
-        render_inline described_class.new(work, images_per_page: 4)
+        render_inline described_class.new(work, members_per_batch: 4)
         expect(hero_friendlier_id).to eq(asset1.friendlier_id)
         expect(other_thumbs_friendlier_id_list).to eq [
           child_work.friendlier_id,


### PR DESCRIPTION
More accurate/specific/less confusing.  Double meaning of a 'page' (a single asset might be a page of a book, vs a batch of members) seemed a particular land mine
