### PR TITLE
Try adding some chrome options to avoid recent capybara/selenium/chrome race conditions

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -51,9 +51,41 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
+
+  Capybara.register_driver :local_selenium_chrome_headless do |app|
+    version = Capybara::Selenium::Driver.load_selenium
+    options_key = Capybara::Selenium::Driver::CAPS_VERSION.satisfied_by?(version) ? :capabilities : :options
+    browser_options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+      # These are defaults from capybara
+      # https://github.com/teamcapybara/capybara/blob/0480f90168a40780d1398c75031a255c1819dce8/lib/capybara/registrations/drivers.rb#L31-L39
+
+      opts.add_argument('--headless=new')
+      opts.add_argument('--disable-gpu') if Gem.win_platform?
+      # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
+      opts.add_argument('--disable-site-isolation-trials')
+
+      # These are ones we are adding to try to workaround chrome race condition
+      # weirdness.
+      # https://github.com/teamcapybara/capybara/issues/2800#issuecomment-2750363862
+      # Disable timers being throttled in background pages/tabs
+      opts.add_argument '--disable-background-timer-throttling'
+
+      # Normally, Chrome will treat a 'foreground' tab instead as backgrounded if the surrounding window is occluded (aka
+      # visually covered) by another window. This flag disables that.
+      opts.add_argument '--disable-backgrounding-occluded-windows'
+
+      # This disables non-foreground tabs from getting a lower process priority.
+      opts.add_argument '--disable-renderer-backgrounding'
+    end
+
+    Capybara::Selenium::Driver.new(app, **{ :browser => :chrome, options_key => browser_options })
+  end
+
+
+
   # eg `SHOW_BROWSER=true ./bin/rspec` will show you an actual chrome browser
   # being operated by capybara.
-  $capybara_js_driver = ENV['SHOW_BROWSER'] ? :selenium_chrome : :selenium_chrome_headless
+  $capybara_js_driver = ENV['SHOW_BROWSER'] ? :selenium_chrome : :local_selenium_chrome_headless
 
   # Capyabara.javascript_driver setting directly applies to 'feature' spec
   Capybara.default_driver = :rack_test # Faster but doesn't do Javascript


### PR DESCRIPTION
Such as `Node with given id does not belong to the document`

These suggestions from: https://github.com/teamcapybara/capybara/issues/2800#issuecomment-2750363862
