### PR TITLE
update bot_challenge_page gem to get new default expanded subnet buckets for rate limits

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
     bootstrap4-kaminari-views (1.0.1)
       kaminari (>= 0.13)
       rails (>= 3.1)
-    bot_challenge_page (0.3.1)
+    bot_challenge_page (0.4.0)
       http (~> 5.2)
       rack-attack (~> 6.7)
       rails (>= 7.1, < 8.1)


### PR DESCRIPTION
meaning you are rate limited with people in same x.y.*.* as you, instead of x.y.z.*.  So more people might get no "free" requests, and more bots might get caught by challenge instead of sneaking in under hte limit.

it's possible our traffic has become distributed enough that they are all from entirely different subnets, and no subnet batching will matter at all -- which may mean we have to stop doing rate limits, and just apply challenge on FIRST request. But we're trying.
