### PR TITLE
Stop logging bot-challenged requests, but do save them in DB

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,13 @@ class ApplicationController < ActionController::Base
     BotChallengePage::BotChallengePageController.bot_challenge_enforce_filter(controller)
   end
 
+  # Store bot challenged requests to database, because we won't be logging them
+  after_action do |controller|
+    if controller.request.env["bot_detect.blocked_for_challenge"]
+      BotChallengedRequest.save_from_request(controller.request)
+    end
+  end
+
   # Blacklight tried to add some things to ApplicationController, but
   # we pretty much only want to use CatalogController from Blacklight, so
   # are trying just doing these things there instead

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,13 +5,6 @@ class ApplicationController < ActionController::Base
     BotChallengePage::BotChallengePageController.bot_challenge_enforce_filter(controller)
   end
 
-  # Store bot challenged requests to database, because we won't be logging them
-  after_action do |controller|
-    if controller.request.env["bot_detect.blocked_for_challenge"]
-      BotChallengedRequest.save_from_request(controller.request)
-    end
-  end
-
   # Blacklight tried to add some things to ApplicationController, but
   # we pretty much only want to use CatalogController from Blacklight, so
   # are trying just doing these things there instead

--- a/app/models/bot_challenged_request.rb
+++ b/app/models/bot_challenged_request.rb
@@ -1,0 +1,13 @@
+class BotChallengedRequest < ApplicationRecord
+  def self.save_from_request!(request)
+    self.create!(
+      path: request.filtered_path,
+      request_id: request.id,
+      client_ip: request.ip,
+      user_agent: request.user_agent,
+      normalized_user_agent: CompactUserAgent.new(request.user_agent).compact,
+      # http headers, but not cookie, it's encrypted and long and useless
+      headers: request.headers.find_all {|k, v| k.start_with?("HTTP_") && k != "HTTP_COOKIE"}.to_h
+    )
+  end
+end

--- a/app/models/bot_challenged_request.rb
+++ b/app/models/bot_challenged_request.rb
@@ -2,7 +2,7 @@ class BotChallengedRequest < ApplicationRecord
   def self.save_from_request!(request)
     self.create!(
       path: request.filtered_path,
-      request_id: request.id,
+      request_id: request.request_id,
       client_ip: request.ip,
       user_agent: request.user_agent,
       normalized_user_agent: CompactUserAgent.new(request.user_agent).compact,

--- a/app/models/bot_challenged_request.rb
+++ b/app/models/bot_challenged_request.rb
@@ -13,8 +13,12 @@ class BotChallengedRequest < ApplicationRecord
       client_ip: request.ip,
       user_agent: request.user_agent,
       normalized_user_agent: CompactUserAgent.new(request.user_agent).compact,
-      # http headers, but not cookie, it's encrypted and long and useless
-      headers: request.headers.find_all {|k, v| k.start_with?("HTTP_") && k != "HTTP_COOKIE"}.to_h
+      # http headers
+      # but not cookie, it's encrypted and long and useless. Or things we're already
+      # including in their own columns, or otherwise uninteresting.
+      headers: request.headers.find_all do |k, v|
+        k.start_with?("HTTP_") && ! k.in?(["HTTP_COOKIE", "HTTP_USER_AGENT", "HTTP_CONNECTION", "HTTP_X_REQUEST_ID", "HTTP_VIA"])
+      end.to_h
     )
   end
 end

--- a/app/models/bot_challenged_request.rb
+++ b/app/models/bot_challenged_request.rb
@@ -1,4 +1,11 @@
 class BotChallengedRequest < ApplicationRecord
+
+  #  bin/rails runner 'BotChallengedRequest.trim_old'
+  def self.trim_old(since: 2.weeks.ago)
+    self.where("created_at <= ?", since).delete_all
+  end
+
+
   def self.save_from_request!(request)
     self.create!(
       path: request.filtered_path,

--- a/config/application.rb
+++ b/config/application.rb
@@ -67,6 +67,12 @@ module ScihistDigicoll
       }.compact
     end
 
+    config.lograge.ignore_custom = lambda do |event|
+      # omit logging of bot-challenged requests, there are too many, filling up
+      # our papertrail account. We still store them in db BotChallengedRequest
+      event.payload[:request].env["bot_detect.should_challenge"]
+    end
+
     # Initialize configuration defaults for originally generated Rails version,
     # or Rails version we have upgraded to and verified for new defaults.
     config.load_defaults 8.0

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,6 +46,27 @@ module ScihistDigicoll
       config.log_level = ScihistDigicoll::Env.lookup("rails_log_level")
     end
 
+    # lograge config. lograge is turned on in production.rb with
+    # config.lograge.enabled = true
+    #
+    # custom_payload is merged into log data automatically
+    config.lograge.custom_payload do |controller|
+      # default lograge in `path` would put just eg `/catalog`, we want the whole
+      # URL in there eg `/catalog?q=foo`, so we override. Alternately, you could
+      # of course add this as `fullpath` to have both.
+      # https://bibwild.wordpress.com/2021/08/04/logging-uri-query-params-with-lograge/
+      #
+      # Also we include some user-agent info, but compressed with device_detector gem
+      {
+        path: controller.request.filtered_path,
+        ua: CompactUserAgent.new(controller.request.user_agent).compact,
+        # wasn't sure if we should use request.remote_ip or request.ip, the
+        # difference is not clear, or what it seems, in docs or online info
+        ip: controller.request.ip,
+        bot_chlng: controller.request.env["bot_detect.blocked_for_challenge"]
+      }.compact
+    end
+
     # Initialize configuration defaults for originally generated Rails version,
     # or Rails version we have upgraded to and verified for new defaults.
     config.load_defaults 8.0

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -200,26 +200,9 @@ Rails.application.configure do
 
 
   # Actually use lograge instead https://github.com/roidrage/lograge
-
+  # lograge config in config/application.rb
   config.lograge.enabled = true
-  #
-  # custom_payload is merged into log data automatically
-  config.lograge.custom_payload do |controller|
-    # default lograge in `path` would put just eg `/catalog`, we want the whole
-    # URL in there eg `/catalog?q=foo`, so we override. Alternately, you could
-    # of course add this as `fullpath` to have both.
-    # https://bibwild.wordpress.com/2021/08/04/logging-uri-query-params-with-lograge/
-    #
-    # Also we include some user-agent info, but compressed with device_detector gem
-    {
-      path: controller.request.filtered_path,
-      ua: CompactUserAgent.new(controller.request.user_agent).compact,
-      # wasn't sure if we should use request.remote_ip or request.ip, the
-      # difference is not clear, or what it seems, in docs or online info
-      ip: controller.request.ip,
-      bot_chlng: controller.request.env["bot_detect.blocked_for_challenge"]
-    }.compact
-  end
+
 
   # This default Rails log config probably doesn't do anything if we're using
   # lograge anyway, but we leave it here in case we turn lograge off again,

--- a/config/initializers/bot_challenge_page.rb
+++ b/config/initializers/bot_challenge_page.rb
@@ -56,7 +56,6 @@ config = BotChallengePage::BotChallengePageController.bot_challenge_config
   }
 
   config.after_blocked = ->(bot_detect_class) {
-    logger.info "challenge blocked"
     request.env["bot_detect.blocked_for_challenge"] = true
 
     # Log it in our local DB

--- a/config/initializers/bot_challenge_page.rb
+++ b/config/initializers/bot_challenge_page.rb
@@ -58,6 +58,9 @@ config = BotChallengePage::BotChallengePageController.bot_challenge_config
   config.after_blocked = ->(bot_detect_class) {
     logger.info "challenge blocked"
     request.env["bot_detect.blocked_for_challenge"] = true
+
+    # Log it in our local DB
+    BotChallengedRequest.save_from_request!(request)
   }
 
   BotChallengePage::BotChallengePageController.rack_attack_init

--- a/db/migrate/20250423154128_create_bot_challenged_requests.rb
+++ b/db/migrate/20250423154128_create_bot_challenged_requests.rb
@@ -1,0 +1,18 @@
+class CreateBotChallengedRequests < ActiveRecord::Migration[8.0]
+  def change
+    create_table :bot_challenged_requests do |t|
+      t.string :path
+      t.string :request_id
+      t.string :client_ip
+      t.string :user_agent
+      t.string :normalized_user_agent
+      t.jsonb :headers
+
+      # no updated_at, won't mutate
+      t.datetime :created_at, null: false
+    end
+
+    add_index :bot_challenged_requests, :client_ip
+    add_index :bot_challenged_requests, :request_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_09_195338) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_23_154128) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -81,6 +81,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_09_195338) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "bot_challenged_requests", force: :cascade do |t|
+    t.string "path"
+    t.string "request_id"
+    t.string "client_ip"
+    t.string "user_agent"
+    t.string "normalized_user_agent"
+    t.jsonb "headers"
+    t.datetime "created_at", null: false
+    t.index ["client_ip"], name: "index_bot_challenged_requests_on_client_ip"
+    t.index ["request_id"], name: "index_bot_challenged_requests_on_request_id"
+  end
+
   create_table "cart_items", force: :cascade do |t|
     t.bigint "user_id"
     t.uuid "work_id"


### PR DESCRIPTION
Goal is to stay within our papertrail logs. We can't control how many bots hit us, so how many challenges we issue. But if we're keeping neough out with our challenges, then if we stop logging the challenges themselves -- our remaining traffic to log should be reasonable. 

One way this isn't entirely true though is that HEROKU still logs all requests as heroku.router logs. But at least we can avoid double logging them. 

If we want to see them, they are all still in the db -- there is no admin UI at present for this, devs can just go to db or whatever. In fact, we're logging MORE in the db than we log in request log, including complete user-agent and complete http headers.

After merge and deploy, we need to add cleanup Heroku scheduled job:

    bin/rails runner 'BotChallengedRequest.trim_old

- [ ] Added in staging
- [ ] Added in prod

- move lograge config into application.rb for any env testing easier
- add model BotChallengedRequests for logging them
- save BotChallengedRequests to db
- do not log bot-challenged requests, try to keep within our papertrail log plan limits. We are writing them to db with BotChallengedReqeusts
- method to trim old BotChallengedRequest
