### PR TITLE
5 second timeout for qa autocomplete

### DIFF
--- a/app/frontend/javascript/admin/qa_autocomplete.js
+++ b/app/frontend/javascript/admin/qa_autocomplete.js
@@ -83,6 +83,10 @@ function addAutocomplete(element) {
       showNoSuggestionNotice: true,
       serviceUrl: qa_search_url,
 
+      // see https://github.com/devbridge/jQuery-Autocomplete
+      // see https://api.jquery.com/jquery.ajax/#jQuery-ajax-settings
+      ajaxSettings: { timeout: 5000 },
+
       onSearchError: function (query, jqXHR, textStatus, errorThrown) {
         console.log("autocomplete error fetching results: " + textStatus + ": " + errorThrown);
 


### PR DESCRIPTION
It does not look like we have to mess with the QA gem. [The jquery autocomplete](https://github.com/devbridge/jQuery-Autocomplete) plugin allows you to configure an `ajaxSettings` which allows the underlying [jquery ajax settings](https://api.jquery.com/jquery.ajax/#jQuery-ajax-settings)  to be modified. These last allow a timeout option.