### PR TITLE
Drop solr timeout to 2s, with one retry after 300 ms wait

### DIFF
--- a/app/models/scihist/blacklight_solr_repository.rb
+++ b/app/models/scihist/blacklight_solr_repository.rb
@@ -41,8 +41,8 @@ module Scihist
           interval: (zero_interval_retry ? 0 : 0.300),
           # exponential backoff 2 means: 1) 0.300; 2) .600; 3) 1.2; 4) 2.4
           backoff_factor: 2,
-          # But we only allow the first two before giving up.
-          max: 2,
+          # But we only actually only ONE retry at present, so it should be 300ms
+          max: 1,
           exceptions: [
             # default faraday retry exceptions
             Errno::ETIMEDOUT,

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -7,4 +7,4 @@ test: &test
 production:
   adapter: solr
   url: <%= ScihistDigicoll::Env.lookup!(:solr_url) %>
-  timeout: 4
+  timeout: 2

--- a/spec/models/scihist/blacklight_solr_repository_spec.rb
+++ b/spec/models/scihist/blacklight_solr_repository_spec.rb
@@ -48,15 +48,15 @@ describe Scihist::BlacklightSolrRepository do
         stub_request(:any, solr_select_url_regex).to_return(status: 404, body: "error")
       end
 
-      it "retries twice" do
+      it "retries once" do
         expect {
           response = repository.search
         }.to raise_error(Blacklight::Exceptions::InvalidRequest)
 
-        expect(WebMock).to have_requested(:any, solr_select_url_regex).times(3)
+        expect(WebMock).to have_requested(:any, solr_select_url_regex).times(2)
       end
 
-      it "logs retries twice" do
+      it "logs retries once" do
         logged = []
         allow(Rails.logger).to receive(:warn) do |log_str|
           logged << log_str
@@ -67,7 +67,7 @@ describe Scihist::BlacklightSolrRepository do
         }.to raise_error(Blacklight::Exceptions::InvalidRequest)
 
         expect(logged).to include /\AScihist::BlacklightSolrRepository: Retrying Solr request: HTTP 404: Faraday::ResourceNotFound: retry 1/
-        expect(logged).to include /\AScihist::BlacklightSolrRepository: Retrying Solr request: HTTP 404: Faraday::ResourceNotFound: retry 2/
+        #expect(logged).to include /\AScihist::BlacklightSolrRepository: Retrying Solr request: HTTP 404: Faraday::ResourceNotFound: retry 2/
       end
     end
   end


### PR DESCRIPTION
So maximum end-to-end time should be around 2000ms + 300ms + 2000ms == 4.3s

Previously maximum wait time was:

4000ms + 300ms + 4000ms + 600ms + 4000ms == 12.9 seconds.

That's far too long for a single puma thread to be held up waiting on solr, and definitely caused problems when solr was having a brief outage with all our puma threads in use.

This may still be enough time to caues problems, depending on our traffic volume. We will see.

We are having ~4 times a day where Solr is unresponsive for 8-10s, very frustrating, have to figure that one out.


![Screenshot 2025-04-24 at 10 22 29 AM](https://github.com/user-attachments/assets/3cd8f945-bd60-433a-aeaa-b93ffe054a44)

Note bumps where all puma workers are in use coincide with max request time being 13.3 seconds -- strongly suggesting it's workers waiting on solr for max timeout period -- yes, it's weird how *regular* these are (but they do differ day to day by 30-60 minutes, they aren't at exactly the same time every day or anything), and we haven't yet gotten to the bottom of it. Solving that underlying issue would also be good!



Some references:

* https://github.com/sciencehistory/scihist_digicoll/issues/2684
* https://github.com/sciencehistory/scihist_digicoll/issues/2684#issuecomment-2486426237
