### PR TITLE
DZI manifest file location is now tracked by a Shrine uploaded file

### DIFF
--- a/app/jobs/delete_dzi_job.rb
+++ b/app/jobs/delete_dzi_job.rb
@@ -1,5 +1,5 @@
 class DeleteDziJob < ApplicationJob
-  def perform(dzi_file_id)
-    DziFiles.delete(dzi_file_id)
+  def perform(dzi_file_id, storage_key)
+    DziFiles.delete(dzi_file_id, storage_key: storage_key)
   end
 end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -56,6 +56,12 @@ class Asset < Kithe::Asset
   attr_json :hls_playlist_file_data, ActiveModel::Type::Value.new
   include VideoHlsUploader::Attachment(:hls_playlist_file, store: :video_derivatives, column_serializer: nil)
 
+  # And similar for storing the DZI manifest file -- DZI tiles filess are also stored adjacent,
+  # but not pointed to by shrine file, just this one.
+  attr_json :dzi_manifest_file_data, ActiveModel::Type::Value.new
+  include GenericActiveRecordUploader::Attachment(:dzi_manifest_file, store: :dzi_storage, column_serializer: nil)
+
+
   before_promotion :store_exiftool
   before_promotion :invalidate_audio_missing_metadata, if: ->(asset) { asset.content_type&.start_with?("audio/") }
   before_promotion :invalidate_corrupt_tiff, if: ->(asset) { asset.content_type == "image/tiff" }

--- a/spec/factories/asset_factory.rb
+++ b/spec/factories/asset_factory.rb
@@ -63,6 +63,12 @@ FactoryBot.define do
       end
     end
 
+    trait :fake_dzi do
+      after(:build) do |asset, evaluator|
+        asset.dzi_manifest_file_attacher.set(Shrine::UploadedFile.new(id: "faked", storage: DziFiles::DEFAULT_SHRINE_STORAGE_KEY.to_s))
+      end
+    end
+
     # While it still uses a real file, it skips all of the (slow) standard metadata extraction
     # and derivative generation, instead just SETTING the metadata and derivatives to fixed
     # values (which may not be actually right, but that doesn't matter for many tests).

--- a/spec/jobs/ensure_correct_derivatives_storage_job_spec.rb
+++ b/spec/jobs/ensure_correct_derivatives_storage_job_spec.rb
@@ -7,7 +7,7 @@ describe "EnsureCorrectDerivativesStorageJob" do
     let(:sample_file_location) {  Rails.root + "spec/test_support/images/20x20.png" }
     let(:asset) do
       # create one with no derivatives
-      a = create(:asset_with_faked_file,
+      a = create(:asset_with_faked_file, :fake_dzi,
         derivative_storage_type: "restricted",
         faked_derivatives: {})
 
@@ -43,7 +43,7 @@ describe "EnsureCorrectDerivativesStorageJob" do
 
     it "Deletes DZI files when ensuring restricted" do
       expect(Shrine.storages[:dzi_storage]).to receive(:delete_prefixed).with(
-        asset.dzi_file.dzi_uploaded_file.id.sub(/\.dzi$/, "_files/")
+        asset.dzi_manifest_file.id.sub(/\.dzi$/, "_files/")
       )
       job.perform_now
     end

--- a/spec/services/pdf_to_page_images_spec.rb
+++ b/spec/services/pdf_to_page_images_spec.rb
@@ -109,9 +109,9 @@ describe PdfToPageImages do
     end
 
     describe "on_existing_dup" do
-      let!(:duplicate) { create(:asset, :inline_promoted_file, file: File.open(pdf_path), parent: work, extracted_pdf_source_info: { page_index: 1 }) }
+      let!(:duplicate) { create(:asset, :fake_dzi, :inline_promoted_file, file: File.open(pdf_path), parent: work, extracted_pdf_source_info: { page_index: 1 }) }
       let!(:original_file_id) { duplicate.file.id }
-      let!(:original_dzi_id) { duplicate.dzi_file.dzi_uploaded_file.id }
+      let!(:original_dzi_id) { duplicate.dzi_manifest_file.id }
       let!(:original_derivatives_json) { duplicate.file_derivatives.as_json }
 
       it ":abort uses existing without update" do
@@ -140,7 +140,7 @@ describe PdfToPageImages do
 
         # it should have new derivatives and dzi created, all inline!
         expect(asset.dzi_file&.present?).to eq true
-        expect(asset.dzi_file.dzi_uploaded_file.id).not_to eq original_dzi_id
+        expect(asset.dzi_file.dzi_manifest_file.id).not_to eq original_dzi_id
 
         expect(asset.file_derivatives).to be_present
         expect(asset.file_derivatives.as_json).not_to eq original_derivatives_json


### PR DESCRIPTION
Stored in an attr_json, an implementation we previously were using and verified.

Before this change, the DZI file location was assumed based on current asset fingerprint checksum. That meant that it automatically changed when the asset changed -- good. But we had no way to move it to a new location _without_ changing the asset fingerprint. And since we are delivering them with cache-forever headers, when we have an improvement to the generation algorithm and want to regenerate them -- we need to move them to a new location.

Persisting current location in the db lets us change the location on demand, although of course we have to generate them at a different location, but we can change the logic for picking a location -- and the old location can still be remembered in db, to work until it's replaced, and to be deleted.
