### PR TITLE
update bundler to latest 2.6.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -898,4 +898,4 @@ RUBY VERSION
    ruby 3.3.8p144
 
 BUNDLED WITH
-   2.5.22
+   2.6.8


### PR DESCRIPTION
May eliminate those annoying 'stringio' warnings
