### PR TITLE
Rake task to fill in legacy DZI manifest location in json_attributes location

### DIFF
--- a/lib/tasks/data_fixes/fill_in_legacy_dzi_manifest_location.rake
+++ b/lib/tasks/data_fixes/fill_in_legacy_dzi_manifest_location.rake
@@ -1,0 +1,34 @@
+namespace :scihist do
+  namespace :data_fixes do
+    task :fill_in_legacy_dzi_manifest_location => :environment do
+      scope = Asset.where("file_data -> 'metadata' ->> 'mime_type' like 'image/%'")
+
+      if ENV['ASSET_ID']
+        scope = scope.where(friendlier_id: ENV['ASSET_ID'])
+      end
+
+      progress_bar = ProgressBar.create(total: scope.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+
+      scope.find_in_batches(batch_size: 100) do |batch|
+        Asset.transaction do
+          batch.each do |asset|
+            Kithe::Indexable.index_with(batching: true) do
+              legacy_manifest_location = "#{asset.id}/md5_#{asset.md5}.dzi"
+
+              if asset.json_attributes["dzi_manifest_file_data"].blank?
+                asset.json_attributes["dzi_manifest_file_data"] = {
+                  "id" => legacy_manifest_location,
+                  "storage" => "dzi_storage"
+                }
+
+                asset.save!
+              end
+
+              progress_bar.increment
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Where #2962 will find it.

So we can merge and run this FIRST, to prep database and minimize any unfound DZI's.

- [x] heroku run rake scihist:data_fixes:fill_in_legacy_dzi_manifest_location -r staging
  -  on staging this will result in many that point to non-actually-exsitng DZI since we don't sync all DZI media  -- but that's exactly what will happen after syncing prod to staging after implementing this in prod, so that's an appropriate thing! 
- [ ] heroku run rake scihist:data_fixes:fill_in_legacy_dzi_manifest_location -r production

