### PR TITLE
Create mechanism for second special_jobs_two queue/workers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -10,6 +10,8 @@ worker: bundle exec resque-pool
 #     2. Regular worker dynos will NEVER execute jobs from the special_jobs queue.
 # See config/resque-pool-special-worker.yml for more details.
 special_worker: bundle exec resque-pool --config  config/resque-pool-special-worker.yml
+# A second one when we need two queues of special work!
+special_worker_two: bundle exec resque-pool --config  config/resque-pool-special-worker_two.yml
 
 # https://devcenter.heroku.com/articles/release-phase
 release: bundle exec rake scihist:heroku:on_release

--- a/config/resque-pool-special-worker-two.yml
+++ b/config/resque-pool-special-worker-two.yml
@@ -1,0 +1,10 @@
+# See also Procfile .
+
+# Most of our redis config is in resque-pool.yml,
+# but we use this queue for big jobs
+# (like creating a bunch of derivatives in parallel).
+production:
+  "special_jobs_two": <%= ENC['SPECIAL_JOB_TWO_WORKER_COUNT'] || 2 %>
+
+development:
+  "*": 0


### PR DESCRIPTION
With setup to use it for DeleteDziJob created as offshot of FixDerivColorsJob

We're running into AWS rate limits, which don't make a lot of sense to us (our use of prefixes should make this a non-issue at our scale), but hopefully this will help.

We can scale DeleteDZI  workers independently, which we think may really triggering the AWS api rate limit (although it doesn't make a lot of sense, some of our assumptions about what's going on are def wrong)

Then we can also process all the new DZI separately, and have the queue of ones to delete as a record of ones NEEDING deletion (which orgphan catcher would catch too). 

Thought about loging them too, in case somehow the queue gets corrupted -- but that was a pain to do, not going to worry about it (secure that the orphan checker can find and delete dzi's if needed, seems to be working). 

But my idea is I can keep just retrying from taht special_worker2 queue until I figure out how to get em deleted depite rate limit!
