### PR TITLE
Video tag uses VTT captions if available

### DIFF
--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -47,6 +47,9 @@
             <%= tag "source", src: video_src_url, type: video_asset.content_type %>
           <% end %>
 
+          <% if auto_caption_track_url %>
+            <%= tag "track", src: auto_caption_track_url, label: "Auto-captions", kind: "captions" %>
+          <% end %>
 
           <p class="vjs-no-js">
             To view this video please enable JavaScript, and consider upgrading to a

--- a/app/components/work_video_show_component.rb
+++ b/app/components/work_video_show_component.rb
@@ -29,6 +29,18 @@ class WorkVideoShowComponent < ApplicationComponent
     video_asset.file_url(expires_in: 5.days.to_i)
   end
 
+  def auto_caption_track_url
+    unless defined? @auto_caption_track_url
+      @auto_caption_track_url = if video_asset.corrected_webvtt?
+        download_derivative_path(video_asset, Asset::CORRECTED_WEBVTT_DERIVATIVE_KEY, disposition: :inline)
+      elsif video_asset.asr_webvtt?
+        download_derivative_path(video_asset, Asset::ASR_WEBVTT_DERIVATIVE_KEY, disposition: :inline)
+      end
+    end
+
+    @auto_caption_track_url
+  end
+
   # the representative, if it's visible to current user, otherwise nil!
   def video_asset
     return @video_asset if defined?(@video_asset)

--- a/spec/factories/asset_factory.rb
+++ b/spec/factories/asset_factory.rb
@@ -167,6 +167,23 @@ FactoryBot.define do
         }
       end
 
+      trait :asr_vtt do
+        after(:build) do |asset|
+          asset.file_attacher.merge_derivatives({
+            Asset::ASR_WEBVTT_DERIVATIVE_KEY => build(:stored_uploaded_file, file: StringIO.new("foo"), filename: "vtt.vtt", content_type: "text/vtt")
+          })
+        end
+      end
+
+      trait :corrected_vtt do
+        after(:build) do |asset|
+          asset.file_attacher.merge_derivatives({
+            Asset::ASR_WEBVTT_DERIVATIVE_KEY => build(:stored_uploaded_file, file: StringIO.new("WEBVTT\n\noriginal"), filename: "vtt.vtt", content_type: "text/vtt"),
+            Asset::CORRECTED_WEBVTT_DERIVATIVE_KEY => build(:stored_uploaded_file, file: StringIO.new("WEBVTT\n\ncorrected"), filename: "vtt.vtt", content_type: "text/vtt")
+          })
+        end
+      end
+
       trait :mp3 do
         faked_file { File.open((Rails.root + "spec/test_support/audio/5-seconds-of-silence.mp3")) }
         faked_content_type { "audio/mpeg" }


### PR DESCRIPTION
On top of #2979, supply those VTT, if they exist, to `<video>` tag for video.js to offer em as a caption option. 

How simple is that?

Only does something if vtt tracks are present, so in production won't be visible change at present. 