### PR TITLE
Add arm64-darwin-23 to Gemfile.lock platforms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -825,6 +825,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
For some reason bundler is insisting on adding this to my Gemfile.lock, keeps giving me a change to it, might as well commit it.
