### PR TITLE
Remove empty CC tracks Safari adds for HLS manifests without closed caption metadata

### DIFF
--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -23,6 +23,7 @@
           <%= content_tag("video",
                   id: "work-video-player",
                   class: "video-js vjs-fluid vjs-big-play-centered",
+                  playsinline: true, # https://developer.apple.com/documentation/webkit/delivering-video-content-for-safari#Enable-Inline-Video-Playback
                   controls: true,
                   preload: "metadata",
                   poster: poster_src,

--- a/app/frontend/javascript/video_player.js
+++ b/app/frontend/javascript/video_player.js
@@ -4,3 +4,29 @@ import videojs from 'video.js';
 import 'video.js/dist/video-js.css';
 
 
+// if we have a video player, look for extra track empty captions safari loads
+// from HLS manifests that do not declare no captions, and remove them.
+//
+// See:
+//   * https://github.com/videojs/video.js/issues/2808
+//   * https://developer.apple.com/library/archive/qa/qa1801/_index.html
+//
+// And in ramp project (not sure why they aren't doing it on desktop Safari, we
+// do need it there):
+//   * https://github.com/samvera-labs/ramp/blob/23aae5c5aa9e7c95d1c94cba5cf870daf76df1aa/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js#L571-L597
+if (navigator.vendor?.includes("Apple")) {
+  const videoPlayerEl = document.querySelector("#work-video-player")
+  if (videoPlayerEl) {
+    const textTracks = videojs(videoPlayerEl).textTracks();
+
+    textTracks.on('addtrack', function() {
+      for (let i = 0; i < textTracks.length; i++) {
+        // empty language and label are ones safari adds for HLS manifest without CLOSED_CAPTION=none,
+        // we don't want em.
+        if (textTracks[i].language === '' && textTracks[i].label === '') {
+          textTracks.removeTrack(textTracks[i]);
+        }
+      }
+    });
+  }
+}


### PR DESCRIPTION
This is very odd and annoying -- we probably should be creating our HLS manifests with this metadata, but oddly AWS MediaConvert charges extra to do so! We could try to post-process the file to add it... or we can just remove teh weird tracks with no label specified, which seems to be what everyone else does.

  * https://github.com/videojs/video.js/issues/2808
  * https://developer.apple.com/library/archive/qa/qa1801/_index.html
  * https://github.com/samvera-labs/ramp/blob/23aae5c5aa9e7c95d1c94cba5cf870daf76df1aa/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js#L571-L597
