### PR TITLE
Set the oclc assign_fast timeout to two seconds

### DIFF
--- a/config/authorities/assign_fast/oclc_assign_fast.json
+++ b/config/authorities/assign_fast/oclc_assign_fast.json
@@ -1,0 +1,5 @@
+{
+  "search": {
+    "connection": { "timeout":"2"}
+  }
+}


### PR DESCRIPTION
This is now just a configuration file change.
Ref https://github.com/sciencehistory/scihist_digicoll/issues/2770.
I tested this one more time; we will in fact using 2 seconds as the timeout after this PR.