### PR TITLE
Video.js custom theme to make control bar bigger and with the components and order we want

### DIFF
--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -22,7 +22,8 @@
 
           <%= content_tag("video",
                   id: "work-video-player",
-                  class: "video-js vjs-fluid vjs-big-play-centered vjs-theme-scihist",
+                  # normalise-time-controls: https://github.com/videojs/video.js/pull/8833
+                  class: "video-js vjs-fluid vjs-big-play-centered vjs-theme-scihist vjs-normalise-time-controls",
                   playsinline: true, # https://developer.apple.com/documentation/webkit/delivering-video-content-for-safari#Enable-Inline-Video-Playback
                   controls: true,
                   preload: "metadata",
@@ -32,6 +33,30 @@
                   data: {
                     setup: {
                       controlBar: {
+                        # custom children list to move volume to right, and remove remaining time.
+                        # Started from:
+                        # https://github.com/videojs/video.js/blob/09eb7150453bb2cbd96e638be3e115590ae98578/src/js/control-bar/control-bar.js#L56-L76
+                        children: [
+                          'playToggle',
+                          'skipBackward',
+                          'skipForward',
+                          'currentTimeDisplay',
+                          'timeDivider',
+                          'durationDisplay',
+                          'progressControl',
+                          'liveDisplay',
+                          'seekToLive',
+                          #'remainingTimeDisplay',
+                          'customControlSpacer',
+                          'volumePanel',
+                          'playbackRateMenuButton',
+                          'chaptersButton',
+                          'descriptionsButton',
+                          'subsCapsButton',
+                          'audioTrackButton',
+                          'pictureInPictureToggle',
+                          'fullscreenToggle'
+                        ],
                         skipButtons: {
                           # seconds. only 5, 10, and 30 are supported by video.js
                           forward: 30,
@@ -39,7 +64,8 @@
                         },
                         volumePanel: {
                           inline: false
-                        }
+                        },
+                        durationDisplay: true
                       },
                       aspectRatio: "#{video_asset.width}:#{video_asset.height}"
                     }.to_json

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -36,6 +36,9 @@
                           # seconds. only 5, 10, and 30 are supported by video.js
                           forward: 30,
                           backward: 10
+                        },
+                        volumePanel: {
+                          inline: false
                         }
                       },
                       aspectRatio: "#{video_asset.width}:#{video_asset.height}"

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -4,8 +4,8 @@
 
 <% content_for :head do %>
   <%= render "works/meta_tags", work: work  %>
-<% end %>
 
+<% end %>
 <div class="video-show-page-layout work-show" itemscope itemtype="http://schema.org/CreativeWork" class="row">
 
   <div class="show-title">
@@ -22,7 +22,7 @@
 
           <%= content_tag("video",
                   id: "work-video-player",
-                  class: "video-js vjs-fluid vjs-big-play-centered",
+                  class: "video-js vjs-fluid vjs-big-play-centered vjs-theme-scihist",
                   playsinline: true, # https://developer.apple.com/documentation/webkit/delivering-video-content-for-safari#Enable-Inline-Video-Playback
                   controls: true,
                   preload: "metadata",

--- a/app/frontend/javascript/video_player.js
+++ b/app/frontend/javascript/video_player.js
@@ -1,9 +1,5 @@
 import videojs from 'video.js';
 
-// Get video.js styles too, vite will spit them out for us
-import 'video.js/dist/video-js.css';
-
-
 // if we have a video player, look for extra track empty captions safari loads
 // from HLS manifests that do not declare no captions, and remove them.
 //
@@ -30,3 +26,6 @@ if (navigator.vendor?.includes("Apple")) {
     });
   }
 }
+
+// css is imported through our CSS pipelines, with custom theming, in video_js.scss
+

--- a/app/frontend/stylesheets/local/video_js.scss
+++ b/app/frontend/stylesheets/local/video_js.scss
@@ -1,3 +1,7 @@
+// video.js styles from the video.js node-modules package, how to do this may change
+// in sass upgrades....
+@import 'video.js/dist/video-js.css';
+
 // The video.js player can play audio-only, even from an audio tag --
 // but by default with a big static poster image etc. This is a custom
 // style for a more standard audio controls only control bar.
@@ -110,4 +114,95 @@
         display: none;
       }
     }
+}
+
+
+// Custom theme making controls larger, and putting "scrubber" bar on
+// top, full-width.
+//
+// Inspired in part by ramp theme, https://github.com/samvera-labs/ramp/blob/23aae5c5aa9e7c95d1c94cba5cf870daf76df1aa/src/components/MediaPlayer/VideoJS/videojs-theme.scss
+//
+// Which was itself based on video.js "city" theme. https://github.com/videojs/themes/blob/master/city/index.css
+
+.vjs-theme-scihist {
+  .vjs-control-bar {
+    font-size: 120%;
+    height: 4em;
+    padding-top: 1em;
+    display: flex;
+  }
+
+  .vjs-control {
+    width: 3.5em; // instead of 4em, with bigger font-size don't need it
+  }
+
+  // move scrubber up on top
+  .vjs-progress-control {
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    width: 100%;
+    font-size: 200%;
+  }
+
+  .vjs-progress-control .vjs-progress-holder {
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    width: 100%;
+    margin: 0;
+  }
+
+  // How high should it be? Yes this is an odd way to do it, worked
+  // best of what I tried.
+  .vjs-progress-control, .vjs-progress-holder, .vjs-play-progress {
+    height: 0.5em;
+  }
+
+  // Keep scurbber from getting bigger on hover, distracting and unneeded
+  // when it's on top
+  .vjs-progress-control:hover .vjs-progress-holder {
+    font-size: unset;
+  }
+
+  // This is the big circle current time indicator itself, this tweak
+  // aligns it properly vertically with our fatter bar. Should be a better way?
+  .vjs-play-progress::before {
+    top: 0.1em;
+  }
+
+  // Custom theme color
+  .vjs-play-progress {
+    background-color: #78712e;
+  }
+
+  // Make font bigger in time display
+  .vjs-control-bar .vjs-time-control {
+    width: auto;
+    font-size: 120%;
+    line-height: 2.7em; // not sure, but works
+    flex-grow: 2; // take up extra space
+    text-align: left;
+  }
+
+  // Fix subtitles for control bar
+
+  // 1.5 em is differnece in size of our custom control bar (4em + 1 em padding == 5em, plus 0.5em progress controls == 5.5em?), and
+  // default videojs control bar (3em), negative. - 2.5em.
+  //
+  // Moves text tracks out of way of control bar. Class below will reset it to not be out of the way when control bar is not
+  // visible, using same technique as default video.js.
+  // See https://github.com/videojs/video.js/discussions/9050 and https://github.com/videojs/video.js/blob/09eb7150453bb2cbd96e638be3e115590ae98578/src/css/components/_text-track.scss#L2-L20
+
+  .vjs-text-track-display {
+    transform: translateY(-2.5em);
+  }
+
+  // Move captions down when controls aren't being shown
+  &.vjs-controls-disabled .vjs-text-track-display,
+  &.vjs-user-inactive.vjs-playing .vjs-text-track-display {
+    transform: translateY(0);
+  }
 }

--- a/app/frontend/stylesheets/local/video_js.scss
+++ b/app/frontend/stylesheets/local/video_js.scss
@@ -219,6 +219,23 @@
     background-color: white;
     background-color: rgba(255, 255, 255, 0.95);
     color: black;
+
+     // make it a bit closer, since it's over scrubber we moved up
+    top: -2.8em;
+  }
+  .vjs-mouse-display { // the little line that hovers over progress bar
+    background-color: white !important;
+  }
+
+  // put it above our new higher controlbar to avoid overlap
+  .vjs-volume-vertical {
+    bottom: 9em;
+  }
+
+  // Place popup menus above and on top of progress control
+  .vjs-menu-button-popup .vjs-menu {
+    bottom: 1.5em;
+    z-index: 1;
   }
 
   // Fix subtitles for control bar

--- a/app/frontend/stylesheets/local/video_js.scss
+++ b/app/frontend/stylesheets/local/video_js.scss
@@ -207,6 +207,20 @@
     padding-right: 0;
   }
 
+  // The elapsed time tooltip over grabber, not needed as we show elapsed
+  // time in toolbar, plus it gets in the way of current hover time
+  .vjs-play-progress .vjs-time-tooltip {
+    display:none !important;
+  }
+
+  // the mouse position hover time tooltip, display black on white instead please,
+  // uses styling that was on the elapsed time tooltip
+  .vjs-mouse-display .vjs-time-tooltip {
+    background-color: white;
+    background-color: rgba(255, 255, 255, 0.95);
+    color: black;
+  }
+
   // Fix subtitles for control bar
 
   // 1.5 em is differnece in size of our custom control bar (4em + 1 em padding == 5em, plus 0.5em progress controls == 5.5em?), and

--- a/app/frontend/stylesheets/local/video_js.scss
+++ b/app/frontend/stylesheets/local/video_js.scss
@@ -181,10 +181,30 @@
   // Make font bigger in time display
   .vjs-control-bar .vjs-time-control {
     width: auto;
+    min-width: 0.5em; // not sure why min-width makes em shrink to fit properly
     font-size: 120%;
     line-height: 2.7em; // not sure, but works
-    flex-grow: 2; // take up extra space
-    text-align: left;
+  }
+
+  // volume take up extra space to it's left, to give us two groups
+  // this works, oddly enough.
+  .vjs-volume-panel {
+    margin-left: auto;
+    width: 3.5em !important;
+  }
+
+  // Remove padding around time-divider, why the heck is it there so huge?
+  .vjs-time-divider {
+    padding: 0 0.25em;
+    flex-grow: 0;
+  }
+  .vjs-duration {
+    padding: 0;
+    flex-grow: 0;
+  }
+  .vjs-current-time {
+    padding-left: 0.25em;
+    padding-right: 0;
   }
 
   // Fix subtitles for control bar
@@ -204,5 +224,16 @@
   &.vjs-controls-disabled .vjs-text-track-display,
   &.vjs-user-inactive.vjs-playing .vjs-text-track-display {
     transform: translateY(0);
+  }
+}
+
+// on smaller screens, we can't fit in duration, just hide it. We can use
+// CSS container queries to actually do it in terms of size of video!
+.show-video {
+  container-type: size;
+}
+@container (max-width: 25rem) {
+  .vjs-theme-scihist .vjs-duration, .vjs-theme-scihist .vjs-time-divider {
+    display: none !important;
   }
 }


### PR DESCRIPTION
- make video.js volume vertical instead of inline bar, much less confusing
- custom video.js theme making controls bigger, while keeping subtitles out of way
- customize video.js controlbar to show elapsed time, and move volume to right side
- hide elapsed time tooltip, restyle mouse hover tooltip
- get menus out of way of progress bar
