### PR TITLE
Swap out old unmaintained webvtt gem for more maintained one

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -189,7 +189,7 @@ gem "warning", "~> 1.2" # managing ruby warning output
 
 gem "rack-attack", "~> 6.6" # throttling excessive requests
 
-gem "webvtt", "< 2" # https://github.com/jronallo/webvtt
+gem "webvtt-ruby", "< 2" # https://github.com/opencoconut/webvtt-ruby
 
 # MS Word .docx for some OH transcript handling
 # Appears entirely unmaintained and has some bugfixes we need in unreleased master

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -436,7 +436,6 @@ GEM
     matrix (0.4.2)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
     minitar (1.0.2)
     minitest (5.25.5)
     mono_logger (1.1.2)
@@ -462,9 +461,6 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.8)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.18.8-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-gnu)
@@ -821,7 +817,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    webvtt (0.0.3)
+    webvtt-ruby (0.4.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yell (2.2.2)
@@ -830,7 +826,6 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
-  ruby
   x86_64-linux
 
 DEPENDENCIES
@@ -928,7 +923,7 @@ DEPENDENCIES
   warning (~> 1.2)
   web-console (>= 4.1.0)
   webmock (~> 3.5)
-  webvtt (< 2)
+  webvtt-ruby (< 2)
 
 RUBY VERSION
    ruby 3.3.8p144

--- a/app/models/oral_history_content/ohms_xml/vtt_transcript.rb
+++ b/app/models/oral_history_content/ohms_xml/vtt_transcript.rb
@@ -41,8 +41,7 @@ class OralHistoryContent
           # extra doesn't hurt
           src = src + "\n"
 
-          # original gem is sometimes picking up empty cues, which is annoying
-          Webvtt::File.new(src).cues.collect { |webvtt_cue| Cue.new(webvtt_cue) }
+          WebVTT.from_blob(src).cues.collect { |webvtt_cue| Cue.new(webvtt_cue) }
         end
       end
 
@@ -110,19 +109,13 @@ class OralHistoryContent
         # parse start str into number of seconds as float
         # times can be hh:mm:ss.ff or mm:ss.ff
         def start_sec_f
-          @start_sec_f ||= begin
-            self.start =~ /(?:(\d+):)?(\d+):(\d\d)(\.\d+)?/
-            ($1.to_i * 60 * 60) + ($2.to_i * 60) + $3.to_i + $4.to_f
-          end
+          self.start.to_f
         end
 
         #  parase end str into number of seconds as float
         #  times can be hh:mm:ss.ff or mm:ss.ff
         def end_sec_f
-          @end_sec_f ||= begin
-            self.end =~ /(?:(\d+):)?(\d+):(\d\d)(\.\d\d\d)?/
-            ($1.to_i * 60 * 60) + ($2.to_i * 60) + $3.to_i + $4.to_f
-          end
+          self.end.to_f
         end
 
         # split text inside a cue into paragraphs.

--- a/spec/models/oral_history_content/vtt_transcript_spec.rb
+++ b/spec/models/oral_history_content/vtt_transcript_spec.rb
@@ -39,18 +39,18 @@ describe OralHistoryContent::OhmsXml::VttTranscript do
     expect(cues.length).to eq 4
 
     first_cue = cues[0]
-    expect(first_cue.start).to eq "00:00:00.000"
+    expect(first_cue.start.to_s).to eq "00:00:00.000"
     expect(first_cue.start_sec_f).to eq 0.0
-    expect(first_cue.end).to eq "00:00:02.000"
+    expect(first_cue.end.to_s).to eq "00:00:02.000"
     expect(first_cue.end_sec_f).to eq 2.0
     expect(first_cue.paragraphs.length).to eq 1
     expect(first_cue.paragraphs[0].speaker_name).to eq "Esme Johnson"
     expect(first_cue.paragraphs[0].raw_html).to eq "It’s a <i>blue</i> <script>apple</script> tree!"
 
     second_cue = cues[1]
-    expect(second_cue.start).to eq "00:00:02.400"
+    expect(second_cue.start.to_s).to eq "00:00:02.400"
     expect(second_cue.start_sec_f).to eq 2.4
-    expect(second_cue.end).to eq "00:00:04.000"
+    expect(second_cue.end.to_s).to eq "00:00:04.000"
     expect(second_cue.end_sec_f).to eq 4.0
 
     expect(second_cue.paragraphs.length).to eq 3


### PR DESCRIPTION
Old and unmaintained (sorry, peer librarian jaron): https://github.com/jronallo/webvtt

Somewhat more maintained and with more functionality: https://github.com/opencoconut/webvtt-ruby

Ended up being very easy to swap out -- we are using only basic functionality, and were already using a wrapper class to cover for lack of functionalkty in @jaron/webvtt, so made it even more trivial.
