### PR TITLE
Clean up transcript CSS to support highlighting current paragraph

### DIFF
--- a/app/components/oral_history/footnote_reference_component.html.erb
+++ b/app/components/oral_history/footnote_reference_component.html.erb
@@ -2,7 +2,7 @@
     data-toggle="ohms-reference"
     data-bs-content="<%= escaped_footnote_text %>"
     <% if footnote_is_html %> data-bs-html="true" <% end %>
-    data-bs-custom-class="ohms-footnote-popover"
+    data-bs-custom-class="transcript-footnote-popover"
     data-bs-trigger="hover focus"
     aria-label="footnote <%= number %>"
     data-role="ohms-navbar-aware-internal-link"

--- a/app/components/oral_history/legacy_transcript_component.rb
+++ b/app/components/oral_history/legacy_transcript_component.rb
@@ -52,7 +52,10 @@ module OralHistory
       paragraph_html_arr = paragraphs.collect do |p_arr|
         content_tag("p", class: "ohms-transcript-paragraph") do
           safe_join(p_arr.collect do |line|
-            content_tag("span", format_ohms_line(line), class: "ohms-transcript-line", id: "ohms_line_#{line[:line_num]}")
+            content_tag("span", format_ohms_line(line),
+              class: "ohms-transcript-line",
+                id: "ohms_line_#{line[:line_num]}",
+                "data-searchable-transcript-line" => true)
           end)
         end
       end

--- a/app/components/oral_history/legacy_transcript_component.rb
+++ b/app/components/oral_history/legacy_transcript_component.rb
@@ -98,7 +98,7 @@ module OralHistory
       # catch speaker prefix, adapted from standard PHP OHMS viewer
       if ohms_line_str =~ /\A[[:space:]]*([A-Z\-.\' ]+:) (.*)\Z/
         ohms_line_str = safe_join([
-          content_tag("span", $1, class: "ohms-speaker"),
+          content_tag("span", $1, class: "transcript-speaker"),
           " ",
           $2
         ])

--- a/app/components/oral_history/legacy_transcript_component.rb
+++ b/app/components/oral_history/legacy_transcript_component.rb
@@ -50,13 +50,15 @@ module OralHistory
       paragraphs << current_paragraph
 
       paragraph_html_arr = paragraphs.collect do |p_arr|
-        content_tag("p", class: "ohms-transcript-paragraph") do
-          safe_join(p_arr.collect do |line|
-            content_tag("span", format_ohms_line(line),
-              class: "ohms-transcript-line",
-                id: "ohms_line_#{line[:line_num]}",
-                "data-searchable-transcript-line" => true)
-          end)
+        content_tag("div", class: "ohms-transcript-paragraph-wrapper") do
+          content_tag("p", class: "ohms-transcript-paragraph") do
+            safe_join(p_arr.collect do |line|
+              content_tag("span", format_ohms_line(line),
+                class: "ohms-transcript-line",
+                  id: "ohms_line_#{line[:line_num]}",
+                  "data-searchable-transcript-line" => true)
+            end)
+          end
         end
       end
 

--- a/app/components/oral_history/vtt_transcript_component.html.erb
+++ b/app/components/oral_history/vtt_transcript_component.html.erb
@@ -1,23 +1,25 @@
 <div class="ohms-transcript-container">
   <% display_paragraphs do |start_seconds, speaker, html_text| %>
-    <p class="ohms-transcript-paragraph" data-searchable-transcript-line="true">
-      <% if start_seconds %>
-        <%=  content_tag(
-                "a",
-                format_ohms_timestamp(start_seconds),
-                href: "#t=#{start_seconds}",
-                class: "ohms-transcript-timestamp default-link-style",
-                data: { "ohms_timestamp_s" => start_seconds}
-              )
-        %>
-      <% end %>
+      <div class="ohms-transcript-paragraph-wrapper">
+        <p class="ohms-transcript-paragraph" data-searchable-transcript-line="true">
+          <% if start_seconds %>
+            <%=  content_tag(
+                    "a",
+                    format_ohms_timestamp(start_seconds),
+                    href: "#t=#{start_seconds}",
+                    class: "ohms-transcript-timestamp default-link-style",
+                    data: { "ohms_timestamp_s" => start_seconds}
+                  )
+            %>
+          <% end %>
 
-      <% if speaker %>
-        <span class="transcript-speaker"><%= speaker %></span>:
-      <% end %>
+          <% if speaker %>
+            <span class="transcript-speaker"><%= speaker %></span>:
+          <% end %>
 
-      <%= html_text %>
-    </p>
+          <%= html_text %>
+        </p>
+    </div>
   <% end %>
 </div>
 

--- a/app/components/oral_history/vtt_transcript_component.html.erb
+++ b/app/components/oral_history/vtt_transcript_component.html.erb
@@ -14,7 +14,7 @@
       <% end %>
 
       <% if speaker %>
-        <span class="ohms-speaker"><%= speaker %></span>:
+        <span class="transcript-speaker"><%= speaker %></span>:
       <% end %>
 
       <%= html_text %>

--- a/app/components/oral_history/vtt_transcript_component.html.erb
+++ b/app/components/oral_history/vtt_transcript_component.html.erb
@@ -1,7 +1,6 @@
 <div class="ohms-transcript-container">
   <% display_paragraphs do |start_seconds, speaker, html_text| %>
-    <%# need ohms-transcript-line class for compat with legacy transcript search JS %>
-    <p class="ohms-transcript-paragraph ohms-transcript-line">
+    <p class="ohms-transcript-paragraph" data-searchable-transcript-line="true">
       <% if start_seconds %>
         <%=  content_tag(
                 "a",

--- a/app/frontend/javascript/audio/ohms_search.js
+++ b/app/frontend/javascript/audio/ohms_search.js
@@ -120,7 +120,7 @@ Search.regexpStrForSearch = function(query) {
 // Returns array of 'result' objects, how do we standardize what that is?
 // context, tab id, id.
 //
-// looks through all objects that are .ohms-transcript-line,
+// looks through all objects that are in a *[data-searchable-transcript-line] container.
 // that works for our DOM. Should we add a data- hook?
 //
 // Highlights every hit, results a list of result objects.
@@ -139,7 +139,7 @@ Search.searchTranscript = function(query) {
   // 3: after match
   var find_re = new RegExp("((?:\\S*\\s+\\S*){0,1})(" + query + ")((?:\\s*\\S+\\s*){0,4})", "gi")
 
-  return $(".ohms-transcript-line").map(function() {
+  return $("*[data-searchable-transcript-line]").map(function() {
     var line = $(this);
 
     var lineId = this.id;

--- a/app/frontend/stylesheets/local/oh_audio.scss
+++ b/app/frontend/stylesheets/local/oh_audio.scss
@@ -225,6 +225,11 @@
     text-transform: uppercase;
   }
 
+  #ohTranscript.tab-pane {
+    // Compensate for extra padding for highlighting
+    margin: -0.5rem -0.25rem;
+  }
+
 
   .tab-pane.downloads {
     margin-bottom: 2rem;
@@ -233,6 +238,7 @@
       margin-top: 0;
     }
   }
+
 
   .downloads-pdf {
     border-top: 3px solid $table-border-color;
@@ -343,15 +349,33 @@
 // make room for and position the timecode links
 // This is more or less how standard OHMS viewer does it.
 .ohms-transcript-container {
-  position: relative;
-  padding-left: 5.5em;
-  max-width: calc(5.5em + #{$max-readable-width});
+  // hack to disable margin collapsing
+  display: flex;
+  flex-direction: column;
 
   .ohms-transcript-paragraph {
+    position: relative;
+    padding-left: 5.5em;
+    max-width: calc(5.5em + #{$max-readable-width});
+
     .ohms-transcript-timestamp {
       font-family: $brand-sans-serif;
       position: absolute;
       left: 0;
+    }
+  }
+
+  // To allow bg color highlighting of a paragraph without the edges of
+  // the highlight touching text, we have to wrap in a container with some
+  // padding and margin. Perhaps we could have done this with just padding,
+  // was hard to get this all to line up right, had to compensate in some
+  // wrappers.
+  .ohms-transcript-paragraph-wrapper {
+    margin: (0.25 * $paragraph-spacer) 0;
+    padding: (0.25 * $paragraph-spacer);
+
+    .ohms-transcript-paragraph {
+      margin-bottom: 0;
     }
   }
 }

--- a/app/frontend/stylesheets/local/oh_audio.scss
+++ b/app/frontend/stylesheets/local/oh_audio.scss
@@ -324,7 +324,7 @@
   padding-right: .1em;
 }
 
-.ohms-speaker {
+.transcript-speaker {
   font-weight: 800;
   @extend %special-label;
   //color: $shi-red;

--- a/app/frontend/stylesheets/local/oh_audio.scss
+++ b/app/frontend/stylesheets/local/oh_audio.scss
@@ -330,6 +330,16 @@
   //color: $shi-red;
 }
 
+.transcript-footnote-popover {
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
+
+  a {
+    // Make it look like a link, not sure why it wasn't looking like any kind
+    // of link otherwise
+    @extend .text-link;
+  }
+}
+
 // make room for and position the timecode links
 // This is more or less how standard OHMS viewer does it.
 .ohms-transcript-container {
@@ -342,16 +352,6 @@
       font-family: $brand-sans-serif;
       position: absolute;
       left: 0;
-    }
-  }
-
-  .ohms-footnote-popover {
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
-
-    a {
-      // Make it look like a link, not sure why it wasn't looking like any kind
-      // of link otherwise
-      @extend .text-link;
     }
   }
 }

--- a/app/frontend/stylesheets/local/show-layout.scss
+++ b/app/frontend/stylesheets/local/show-layout.scss
@@ -250,7 +250,8 @@ $max-image-column-breakpoint: ($max-image_column * 2) + $main_gutter_width + 90p
      }
     .show-video-transcript-content {
       overflow-y: scroll;
-       padding: 1rem;
+      // leaving room for margin and padding for highlighted paragraphs
+      padding: ($paragraph-spacer * 0.5) ($paragraph-spacer * 0.75);
     }
   }
 }

--- a/spec/components/oral_history/legacy_transcript_component_spec.rb
+++ b/spec/components/oral_history/legacy_transcript_component_spec.rb
@@ -21,7 +21,7 @@ describe OralHistory::LegacyTranscriptComponent, type: :component do
     # plus one because we have added one for the 0 timestamp
     expect(parsed.css("a.ohms-transcript-timestamp").count).to eq(ohms_xml.legacy_transcript.sync_timecodes.count + 1)
 
-    first_line = parsed.css("div.ohms-transcript-container > p.ohms-transcript-paragraph > span.ohms-transcript-line").first
+    first_line = parsed.css("div.ohms-transcript-container p.ohms-transcript-paragraph > span.ohms-transcript-line").first
 
     expect(first_line.to_html).to eq(
       %Q{<span class="ohms-transcript-line" id="ohms_line_1" data-searchable-transcript-line="true"><a href="#t=0" class="ohms-transcript-timestamp" data-ohms-timestamp-s="0">00:00:00</a><span class="transcript-speaker">BROCK:</span> This is an oral history interview with Ron Duarte taking place on 13 June \n</span>}

--- a/spec/components/oral_history/legacy_transcript_component_spec.rb
+++ b/spec/components/oral_history/legacy_transcript_component_spec.rb
@@ -22,8 +22,9 @@ describe OralHistory::LegacyTranscriptComponent, type: :component do
     expect(parsed.css("a.ohms-transcript-timestamp").count).to eq(ohms_xml.legacy_transcript.sync_timecodes.count + 1)
 
     first_line = parsed.css("div.ohms-transcript-container > p.ohms-transcript-paragraph > span.ohms-transcript-line").first
+
     expect(first_line.to_html).to eq(
-      %Q{<span class="ohms-transcript-line" id="ohms_line_1"><a href="#t=0" class="ohms-transcript-timestamp" data-ohms-timestamp-s="0">00:00:00</a><span class="ohms-speaker">BROCK:</span> This is an oral history interview with Ron Duarte taking place on 13 June \n</span>}
+      %Q{<span class="ohms-transcript-line" id="ohms_line_1" data-searchable-transcript-line="true"><a href="#t=0" class="ohms-transcript-timestamp" data-ohms-timestamp-s="0">00:00:00</a><span class="transcript-speaker">BROCK:</span> This is an oral history interview with Ron Duarte taking place on 13 June \n</span>}
     )
   end
 

--- a/spec/components/oral_history/vtt_transcript_component_spec.rb
+++ b/spec/components/oral_history/vtt_transcript_component_spec.rb
@@ -9,11 +9,11 @@ describe OralHistory::VttTranscriptComponent, type: :component do
   it "renders html as expected" do
     parsed = render_inline(vtt_transcript_component)
 
-    paragraphs = parsed.css(".ohms-transcript-container p.ohms-transcript-paragraph.ohms-transcript-line")
+    paragraphs = parsed.css(".ohms-transcript-container p.ohms-transcript-paragraph")
     expect(paragraphs.length).to eq 8
 
     # Don't use same speaker name in multiple paragraphs in a row
-    expect(paragraphs.collect { |p| p.css("span.ohms-speaker")&.text }).to eq [
+    expect(paragraphs.collect { |p| p.css("span.transcript-speaker")&.text }).to eq [
       "SCHNEIDER", "NAME OF INTERVIEWEE", "SCHNEIDER", "NAME OF INTERVIEWEE", "", "", "SCHNEIDER", "NAME OF INTERVIEWEE"
     ]
 
@@ -55,7 +55,7 @@ describe OralHistory::VttTranscriptComponent, type: :component do
     it "scrubs output" do
       parsed = render_inline(vtt_transcript_component)
 
-      paragraphs = parsed.css(".ohms-transcript-container p.ohms-transcript-paragraph.ohms-transcript-line")
+      paragraphs = parsed.css(".ohms-transcript-container p.ohms-transcript-paragraph")
 
       expect(paragraphs.length).to eq 4
 


### PR DESCRIPTION
Cleaned up some classes to be simpler, but then added a wrapper to transcript paragraph that includes whitespace so that we can use bg color to highlight a paragraph with a bit of spacing between edges of color and text. Had to reduce margins in some parents to compensate for extra whitespace there, including a bit hacky negative margin in tabbed OH. 

- change .ohms-speaker to .transcript-speaker to re-use in split CSS for VTT
- audio search uses data attribute not class for target
- move footnotes CSS to support split between vtt and legacy ohms transcript formatting
- Add transcript wrapper with whitespace to support highlighting current paragraph
