### PR TITLE
Highlight current video transcript line

### DIFF
--- a/app/components/oral_history/vtt_transcript_component.html.erb
+++ b/app/components/oral_history/vtt_transcript_component.html.erb
@@ -8,7 +8,9 @@
                     format_ohms_timestamp(start_seconds),
                     href: "#t=#{start_seconds}",
                     class: "ohms-transcript-timestamp default-link-style",
-                    data: { "ohms_timestamp_s" => start_seconds}
+                      # must be formatted exactly the same in JS transcript highlighter
+                      # code that searches for it.
+                    data: { "ohms_timestamp_s" => "%.3f" % start_seconds.round(3)}
                   )
             %>
           <% end %>

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -119,7 +119,7 @@
           </button>
         </div>
 
-        <div class="show-video-transcript-content">
+        <div class="show-video-transcript-content" data-transcript-content-target>
           <%= render OralHistory::VttTranscriptComponent.new(OralHistoryContent::OhmsXml::VttTranscript.new(vtt_transcript_str)) %>
         </div>
       </div>

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -78,7 +78,7 @@
             <% end %>
 
             <% if auto_caption_track_url %>
-              <%= tag "track", src: auto_caption_track_url, label: "Auto-captions", kind: "captions" %>
+              <%= tag "track", id: "scihistAutoCaptions", src: auto_caption_track_url, label: "Auto-captions", kind: "captions" %>
             <% end %>
 
             <p class="vjs-no-js">

--- a/app/frontend/javascript/video_player.js
+++ b/app/frontend/javascript/video_player.js
@@ -1,5 +1,9 @@
 import videojs from 'video.js';
 
+// css is imported through our CSS pipelines, with custom theming, in video_js.scss
+
+const videoPlayerEl = document.querySelector("#work-video-player")
+
 // if we have a video player, look for extra track empty captions safari loads
 // from HLS manifests that do not declare no captions, and remove them.
 //
@@ -10,22 +14,19 @@ import videojs from 'video.js';
 // And in ramp project (not sure why they aren't doing it on desktop Safari, we
 // do need it there):
 //   * https://github.com/samvera-labs/ramp/blob/23aae5c5aa9e7c95d1c94cba5cf870daf76df1aa/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js#L571-L597
-if (navigator.vendor?.includes("Apple")) {
-  const videoPlayerEl = document.querySelector("#work-video-player")
-  if (videoPlayerEl) {
-    const textTracks = videojs(videoPlayerEl).textTracks();
+if (videoPlayerEl && navigator.vendor?.includes("Apple")) {
+  const textTracks = videojs(videoPlayerEl).textTracks();
 
-    textTracks.on('addtrack', function() {
-      for (let i = 0; i < textTracks.length; i++) {
-        // empty language and label are ones safari adds for HLS manifest without CLOSED_CAPTION=none,
-        // we don't want em.
-        if (textTracks[i].language === '' && textTracks[i].label === '') {
-          textTracks.removeTrack(textTracks[i]);
-        }
+  textTracks.on('addtrack', function() {
+    for (let i = 0; i < textTracks.length; i++) {
+      // empty language and label are ones safari adds for HLS manifest without CLOSED_CAPTION=none,
+      // we don't want em.
+      if (textTracks[i].language === '' && textTracks[i].label === '') {
+        textTracks.removeTrack(textTracks[i]);
       }
-    });
-  }
+    }
+  });
 }
 
-// css is imported through our CSS pipelines, with custom theming, in video_js.scss
+
 

--- a/app/frontend/javascript/video_player.js
+++ b/app/frontend/javascript/video_player.js
@@ -130,6 +130,12 @@ if (videoPlayerEl) {
       //scrollToEl = scrollToEl.previousElementSibling || scrollToEl;
 
       container.scrollTo(0, scrollToEl.offsetTop);
+
+      // on small screen with really big lines, maybe it's still not visible,
+      // we need to skip the previous line and just put this on top
+      if (!elementFullyVisibleWithin(line, constainer)) {
+        conatainer.scrollTo(0, line.offsetTop);
+      }
     }
 
     function elementFullyVisibleWithin(element, container) {

--- a/app/frontend/javascript/video_player.js
+++ b/app/frontend/javascript/video_player.js
@@ -78,6 +78,8 @@ if (videoPlayerEl) {
       })
     }
 
+    const vjsPlayer = this;
+
     function removeTranscriptHighlights() {
       document.querySelectorAll(`.${highlightCssClass}`).forEach( (el) => el.classList.remove(highlightCssClass))
     }
@@ -88,7 +90,15 @@ if (videoPlayerEl) {
       }
 
       // Odd JS way to turn it to a standard array so we can interate
-      const activeCuesArr = Array.prototype.slice.call(activeCues, 0)
+      let activeCuesArr = Array.prototype.slice.call(activeCues, 0)
+
+      // Sometimes there's more than one because end time for one cue is start time for the other,
+      // we dont' need to show the one that's about to end.
+      if (activeCuesArr.length > 1) {
+        activeCuesArr = activeCuesArr.filter( cue => {
+          vjsPlayer.currentTime() <= (cue.endTime - 0.25)
+        });
+      }
 
       let firstHighlightedEl = undefined;
 

--- a/app/frontend/javascript/video_player.js
+++ b/app/frontend/javascript/video_player.js
@@ -103,9 +103,9 @@ if (videoPlayerEl) {
       let firstHighlightedEl = undefined;
 
       activeCuesArr.forEach( (cue) => {
-        // in HTML attribute, we rounded to one digit after decimal point... hope it's the same
-        // rounding algorithm? TODO we need to test, or change algorithm.
-        document.querySelectorAll(`*[data-ohms-timestamp-s="${cue.startTime.toFixed(1)}"]`).forEach( (el) => {
+        // when outputting seconds float in vtt_transcript_component.html.erb, it must be output
+        // with exact same number of decimal places including trailing zeroes as here.
+        document.querySelectorAll(`*[data-ohms-timestamp-s="${cue.startTime.toFixed(3)}"]`).forEach( (el) => {
           firstHighlightedEl = firstHighlightedEl || el;
 
           el.closest(".ohms-transcript-paragraph-wrapper")?.classList?.add(highlightCssClass);

--- a/app/frontend/stylesheets/local/oh_audio.scss
+++ b/app/frontend/stylesheets/local/oh_audio.scss
@@ -367,12 +367,11 @@
 
   // To allow bg color highlighting of a paragraph without the edges of
   // the highlight touching text, we have to wrap in a container with some
-  // padding and margin. Perhaps we could have done this with just padding,
-  // was hard to get this all to line up right, had to compensate in some
-  // wrappers.
+  // padding and margin. Plus some negative margin to go to edge on
+  // video show page. Hard to get this all right, applies to oral history too.
   .ohms-transcript-paragraph-wrapper {
-    margin: (0.25 * $paragraph-spacer) 0;
-    padding: (0.25 * $paragraph-spacer);
+    margin: (0.25 * $paragraph-spacer) (-0.75 * $paragraph-spacer);
+    padding: (0.25 * $paragraph-spacer) $paragraph-spacer;
 
     .ohms-transcript-paragraph {
       margin-bottom: 0;

--- a/app/frontend/stylesheets/local/oh_audio.scss
+++ b/app/frontend/stylesheets/local/oh_audio.scss
@@ -380,6 +380,15 @@
   }
 }
 
+.transcript-highlighted {
+  // shi-gray-1
+  background-color: #efeeed;
+
+  .ohms-transcript-timestamp {
+    font-weight: bold;
+  }
+}
+
 .ohms-index-container {
   max-width: $max-readable-width;
   padding-bottom: 1.5rem;

--- a/app/frontend/stylesheets/local/show-layout.scss
+++ b/app/frontend/stylesheets/local/show-layout.scss
@@ -249,6 +249,7 @@ $max-image-column-breakpoint: ($max-image_column * 2) + $main_gutter_width + 90p
       background-color: $shi-gray-3;
      }
     .show-video-transcript-content {
+      position: relative; // for scrolling target
       overflow-y: scroll;
       // leaving room for margin and padding for highlighted paragraphs
       padding: ($paragraph-spacer * 0.5) ($paragraph-spacer * 0.75);

--- a/app/frontend/stylesheets/local/show-layout.scss
+++ b/app/frontend/stylesheets/local/show-layout.scss
@@ -168,6 +168,13 @@ $max-image-column-breakpoint: ($max-image_column * 2) + $main_gutter_width + 90p
 .video-show-page-layout {
   display: grid;
 
+  // .ohms-transcript-paragraph-wrapper {
+  //   margin-left: -0.75em;
+  //   margin-right: -0.75rem;
+  //   padding-left: 1rem;
+  //   padding-right: 1rem;
+  // }
+
   // At very small screen, single column, and re-arrange transcript
   // to be right below video, which requires us elminating one container
   grid-template-columns: 1fr;

--- a/spec/components/oral_history/vtt_transcript_component_spec.rb
+++ b/spec/components/oral_history/vtt_transcript_component_spec.rb
@@ -23,7 +23,7 @@ describe OralHistory::VttTranscriptComponent, type: :component do
     ]
 
     expect(paragraphs.collect { |p| p.at_css("a.ohms-transcript-timestamp").try(:[], 'data-ohms-timestamp-s') }).to eq [
-      "3603.0", "3618.0", "3631.0", "3638.0", nil, nil, "3674.0", "3682.0"
+      "3603.000", "3618.000", "3631.000", "3638.000", nil, nil, "3674.000", "3682.000"
     ]
   end
 

--- a/spec/components/work_video_show_component_spec.rb
+++ b/spec/components/work_video_show_component_spec.rb
@@ -107,6 +107,7 @@ describe WorkVideoShowComponent, type: :component do
         expect(track_element["src"]).to eq download_derivative_path(asset, Asset::ASR_WEBVTT_DERIVATIVE_KEY, disposition: :inline)
         expect(track_element["label"]).to eq "Auto-captions"
         expect(track_element["kind"]).to eq "captions"
+        expect(track_element["id"]).to eq "scihistAutoCaptions" # used by JS
       end
 
       it "includes on-page transcript toggle" do

--- a/spec/system/work_show_spec.rb
+++ b/spec/system/work_show_spec.rb
@@ -236,7 +236,7 @@ describe "Public work show page", type: :system, js: false do
 
         click_on "Show transcript"
         expect(page).to have_selector("#show-video-transcript-collapse h2", text: "Transcript")
-        expect(page).to have_selector("#show-video-transcript-collapse a[data-ohms-timestamp-s='0.0']")
+        expect(page).to have_selector("#show-video-transcript-collapse a[data-ohms-timestamp-s='0.000']")
       end
     end
   end


### PR DESCRIPTION
And scroll to it, if needed. If mouse is over transcript area, don't scroll, since you figure the user is working there -- this UX copied from youtube, but youtube also highlights current line on hover, which maybe makes it more obvious...

- factor out check for video element so we can re-use
- id on video track so we can refer to it in js
- highlight current video transcript line
- Scroll to currently highlighted transcript line. With highlight in general fixed for safari
- avoid weird double-highlight
- make sure output of decimal timestamp matches in js and html template
- make highlight go end to end

Ref #3003
