### PR TITLE
Add schema.org metadata for Video as microdata 

### DIFF
--- a/app/components/work_image_show_component.html.erb
+++ b/app/components/work_image_show_component.html.erb
@@ -23,7 +23,7 @@
             wrapping_component: TranscriptionTabsComponent.new(work: work, members: members_for_transcription_tabs),
             should_wrap: has_transcription_or_translation?) do %>
 
-        <div class="work-description">
+        <div class="work-description" itemprop="description">
           <%= DescriptionDisplayFormatter.new(work.description).format  %>
         </div>
 

--- a/app/components/work_oh_audio_show_component.html.erb
+++ b/app/components/work_oh_audio_show_component.html.erb
@@ -99,7 +99,7 @@
                 <ul>
                   <% DateDisplayFormatter.new(work.date_of_work).display_dates.each do |interval| %>
                     <li>
-                      <span itemprop="date_created">
+                      <span itemprop="dateCreated">
                         <%= interval %>
                       </span>
                     </li>

--- a/app/components/work_title_and_dates_component.html.erb
+++ b/app/components/work_title_and_dates_component.html.erb
@@ -5,7 +5,7 @@
     </div>
   <% end %>
 
-  <h1>
+  <h1 itemprop="name">
     <%= title %>
     <%= publication_badge(work) %>
     <% if can?(:update, work) %>

--- a/app/components/work_title_and_dates_component.html.erb
+++ b/app/components/work_title_and_dates_component.html.erb
@@ -33,7 +33,7 @@
         <ul>
           <% DateDisplayFormatter.new(date_of_work).display_dates.each do |interval| %>
             <li>
-              <span itemprop="date_created">
+              <span itemprop="dateCreated">
                 <%= interval %>
               </span>
             </li>

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -11,13 +11,21 @@
     https://linkilo.co/blog/are-video-transcripts-a-seo-ranking-factor/ %>
 
 <div class="video-show-page-layout work-show" itemscope itemtype="http://schema.org/VideoObject" class="row">
+  <%# uploadDate REQUIRED by google for VideoObject, don't know why %>
+  <%= tag.meta itemprop: "uploadDate", content: work.published_at.iso8601 %>
 
-  <% attributes = WorkSocialShareAttributes.new(work, view_context: self) %>
+  <% if video_asset&.file_metadata&.has_key?("duration_seconds") %>
+    <%=
+        # schema.org 'duration' requires ISO8601 duration which looks like `PTnHnMnS`
 
-  <%= tag.meta itemprop: "name", content: attributes.simple_title %>
-  <%= tag.meta itemprop: "description", content: attributes.short_plain_description %>
-  <%= tag.meta itemprop: "duration", content: "P1H12M13S" %>
-  <%= tag.meta itemprop: "thumbnailUrl", content: attributes.share_media_url %>
+        seconds = video_asset.file_metadata["duration_seconds"]
+        tag.meta itemprop: "duration",
+          content: ActiveSupport::Duration.build(
+                      seconds
+                    ).iso8601(precision: (seconds % 1 == 0 ? 0 : 3))
+    %>
+  <% end %>
+  <%= tag.meta itemprop: "thumbnailUrl", content: WorkSocialShareAttributes.new(work, view_context: view_context).share_media_url %>
 
 
   <div class="show-title">
@@ -145,7 +153,7 @@
   <% end %>
 
   <div class="show-metadata">
-    <div class="work-description">
+    <div class="work-description" itemprop="description">
       <%= DescriptionDisplayFormatter.new(work.description).format  %>
     </div>
 

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -6,7 +6,19 @@
   <%= render "works/meta_tags", work: work  %>
 
 <% end %>
-<div class="video-show-page-layout work-show" itemscope itemtype="http://schema.org/CreativeWork" class="row">
+
+<%# try to include microdata for schema.org video object, including marking up transcript text
+    https://linkilo.co/blog/are-video-transcripts-a-seo-ranking-factor/ %>
+
+<div class="video-show-page-layout work-show" itemscope itemtype="http://schema.org/VideoObject" class="row">
+
+  <% attributes = WorkSocialShareAttributes.new(work, view_context: self) %>
+
+  <%= tag.meta itemprop: "name", content: attributes.simple_title %>
+  <%= tag.meta itemprop: "description", content: attributes.short_plain_description %>
+  <%= tag.meta itemprop: "duration", content: "P1H12M13S" %>
+  <%= tag.meta itemprop: "thumbnailUrl", content: attributes.share_media_url %>
+
 
   <div class="show-title">
     <%= render WorkTitleAndDatesComponent.new(work) %>
@@ -88,6 +100,8 @@
                 >supports HTML5 video</a
               >
             </p>
+
+
           <% end %>
         </div>
       <% else %> <%# no video file available %>
@@ -122,7 +136,8 @@
           </button>
         </div>
 
-        <div class="show-video-transcript-content" data-transcript-content-target>
+
+        <div class="show-video-transcript-content" data-transcript-content-target itemprop="transcript">
           <%= render OralHistory::VttTranscriptComponent.new(OralHistoryContent::OhmsXml::VttTranscript.new(vtt_transcript_str)) %>
         </div>
       </div>

--- a/spec/factories/asset_factory.rb
+++ b/spec/factories/asset_factory.rb
@@ -155,6 +155,14 @@ FactoryBot.define do
         faked_height { nil }
         faked_width { nil }
 
+        faked_duration_seconds { 5.02 }
+        faked_bitrate { 8002 }
+        faked_audio_bitrate { 8000 }
+        faked_audio_sample_rate { 44100 }
+        faked_video_bitrate { 8000 }
+
+
+
         transient do
           faked_thumbnail {
             create(:stored_uploaded_file,


### PR DESCRIPTION
Especially including the `transcript` property, hoping it will help google index the transcript -- although the fact that it's initially hidden on page and requires a 'show' button to show does not give me much optimism, certainly doesn't hurt. 

Note for "rich results" as a result of your markup (what most people use it for)  you really want a link directly to the video as `contentUrl`, but we currently use a time-limited URL for video, so don't provide this -- unclear if we can actually get a "rich result" in google results. (Unclear if Google really lets people do this much anymore anyway). 

Also includes some fixup of schema.org microdata for generic non-video items, which we had some half-hearted gestures towards but they had some mistakes. 

References:
* https://developers.google.com/search/docs/appearance/structured-data/video?visit_id=638864809809254119-1037114800&hl=en&rd=1
* https://linkilo.co/blog/are-video-transcripts-a-seo-ranking-factor/
* found schema.org probably makes no difference for relevancy, which indeed google says it won't: https://strategiq.co/hub/video-schema-transcripts-search-rankings/ 
* google may not even allow video rich snippets much: https://boldcontentvideo.com/2014/08/12/google-reduces-video-rich-snippets/

Tools to test parsing of schema.org microdata:
* https://validator.schema.org/
* https://search.google.com/test/rich-results
