### PR TITLE
Remove memcached, dalli and references to it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,7 +97,6 @@ gem "resque-heroku-signals" # gah, weirdly needed for graceful shutdown on herok
 gem "http", "~> 5.2" # for http client access
 
 # using memcached for Rails.cache in production, requires dalli
-gem "dalli", "~> 3.2"
 
 gem 'honeybadger', '~> 5.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,7 +233,6 @@ GEM
     css_parser (1.21.1)
       addressable
     csv (3.3.4)
-    dalli (3.2.8)
     database_cleaner (2.1.0)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.2.1)
@@ -436,6 +435,7 @@ GEM
     matrix (0.4.2)
     method_source (1.1.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.9)
     minitar (1.0.2)
     minitest (5.25.5)
     mono_logger (1.1.2)
@@ -461,6 +461,9 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
+    nokogiri (1.18.8)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.18.8-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-gnu)
@@ -826,6 +829,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
+  ruby
   x86_64-linux
 
 DEPENDENCIES
@@ -854,7 +858,6 @@ DEPENDENCIES
   content_disposition (~> 1.0)
   csl-styles (~> 2.0)
   csv (~> 3.3.0)
-  dalli (~> 3.2)
   database_cleaner (~> 2.0)
   db-query-matchers (< 2.0)
   device_detector (~> 1.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,15 +77,14 @@ Rails.application.configure do
   if ScihistDigicoll::Env.lookup(:ephemeral_redis_cache_store_url)
     # On heroku we use a Redis instance named ephemeral_redis for our cache.
     # (see https://github.com/sciencehistory/scihist_digicoll/pull/2994).
-    #
-    # We tune the timeouts for ephemeral_redis to give up really quickly -- we don't want the server
-    # waiting too long on a slow memcached, especially with rack-attack accessing
-    # it on every request and more-like-this accessing it everytime a work page is shown.
-    # It's just a cache; give up if it's slow!
-
-    # (Note that we use another Redis instance (noeviction_redis) for our active job queue; do not confuse them.)
     # Note that additional settings pertaining to the cache itself (e.g. expiration policy) can be set
     # within Heroku's addon.
+    #
+    # We tune the timeouts for ephemeral_redis to give up quickly: we don't want the server
+    # waiting too long on a slow cache, especially with rack-attack accessing
+    # it on every request and more-like-this accessing it on every work page request.
+    #
+    # (Note that we use another Redis instance (noeviction_redis) for our active job queue; do not confuse them.)
     config.cache_store = :redis_cache_store, {
       url: ScihistDigicoll::Env.lookup(:ephemeral_redis_cache_store_url),
 
@@ -100,53 +99,6 @@ Rails.application.configure do
       read_timeout:    ScihistDigicoll::Env.lookup(:ephemeral_redis_read_timeout   ),
       write_timeout:   ScihistDigicoll::Env.lookup(:ephemeral_redis_write_timeout  ),
     }
-  else
-    ##################################################
-    ##################################################
-    ### BEGIN OBSOLETE MEMCACHED CODE
-    ### REMOVE ALL THIS MEMCACHED CODE WHEN WE ARE READY TO STOP USING MEMCACHED.
-    ###
-    # On heroku we try to set up either memcachier or memcachedcloud, in that order,
-    # depending on what env variables are defined.
-    #
-    # We tune the timeouts to give up really quickly -- we don't want the server
-    # waiting too long on a slow memcached, especially with rack-attack accessing
-    # it on every request. It's just a cache; give up if it's slow!
-    #
-    # https://github.com/petergoldstein/dalli/blob/5588d98f79eb04a9abcaeeff3263e08f93468b30/lib/dalli/protocol/connection_manager.rb
-    #
-    # We use configuration including 'pool' suggested by memcachier docs, which requires
-    # connection_pool gem to be available to work.
-    #
-    require 'connection_pool'  # needed for dalli pool_size to work
-
-    mem_cache_store_config = {
-      :socket_timeout => (ENV["MEMCACHE_TIMEOUT"] || 0.15).to_f,       # default is maybe 1 second?
-      :socket_failure_delay => 0.08,                                   # retry failures with fairly quick 80ms delay
-      :failover => true,                                              # don't think it matters unless provider gives us more than one hostname
-      # Rails 7.1+ uses :pool with sub-hash instead of individual pool_size and pool_timeout
-      :pool => {
-        :size => ENV.fetch("RAILS_MAX_THREADS") { 5 },              # should match puma, suggested by memcachier docs
-        :timeout => (ENV["MEMCACHE_TIMEOUT"] || 0.15).to_f          # don't wait too long for a connection from pool either
-      }
-    }
-
-    if ENV["MEMCACHIER_SERVERS"]
-      # https://devcenter.heroku.com/articles/memcachier#ruby-puma-webserver
-      config.cache_store = :mem_cache_store, ENV["MEMCACHIER_SERVERS"].split(","), mem_cache_store_config.merge({
-        :username => ENV["MEMCACHIER_USERNAME"],
-        :password => ENV["MEMCACHIER_PASSWORD"]
-      })
-    elsif ENV["MEMCACHEDCLOUD_SERVERS"]
-      # https://devcenter.heroku.com/articles/memcachedcloud#using-memcached-from-ruby
-      config.cache_store = :mem_cache_store, ENV["MEMCACHEDCLOUD_SERVERS"].split(','), mem_cache_store_config.merge({
-        :username => ENV["MEMCACHEDCLOUD_USERNAME"],
-        :password => ENV["MEMCACHEDCLOUD_PASSWORD"]
-      })
-    end
-    ### END OBSOLETE MEMCACHED CODE
-    ##################################################
-    ##################################################
   end
 
   # Use a real queuing backend for Active Job (and separate queues per environment)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -54,8 +54,8 @@ end
 # We also do reverse IP lookup on the less frequent ALERTS.
 #
 # To do this, we need to store and consult some state about the last time(s)
-# we logged, which we do in the cache that rack-attackc is already using
-# (probably the Rails.cache which is probably a memcached)
+# we logged, which we do in the cache that rack-attack is already using
+# (probably the Redis-based Rails.cache)
 #
 # The implementation of all of this is currently kind of squirrely and hard
 # to follow, sorry.


### PR DESCRIPTION
The new ephemeral redis is doing fine as a cache in production, so we're going to remove the old memcache code.
Ref #3015