### PR TITLE
Fix createdAt metadata for missing published_at

### DIFF
--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -12,7 +12,7 @@
 
 <div class="video-show-page-layout work-show" itemscope itemtype="http://schema.org/VideoObject" class="row">
   <%# uploadDate REQUIRED by google for VideoObject, don't know why %>
-  <%= tag.meta itemprop: "uploadDate", content: work.published_at.iso8601 %>
+  <%= tag.meta itemprop: "uploadDate", content: work.published_at&.iso8601 %>
 
   <% if video_asset&.file_metadata&.has_key?("duration_seconds") %>
     <%=


### PR DESCRIPTION
Possibly for when staff was looking at an unpublished work page?  We were getting `NoMethodError: undefined method `iso8601' for nil`. Easy to fix.

Ref #3003 
