### PR TITLE
Reindex a parent work if an asset has it's WebVTT content or audio_asr_enabled flag changed

### DIFF
--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -93,6 +93,14 @@ describe Asset do
         expect(WebMock).to have_requested(:post, solr_update_url_regex)
       end
 
+      it "re-indexes on WebVTT change" do
+        asset.file_attacher.add_persisted_derivatives(
+          {Asset::ASR_WEBVTT_DERIVATIVE_KEY => StringIO.new("WEBVTT\n\nTest")}
+        )
+
+        expect(WebMock).to have_requested(:post, solr_update_url_regex)
+      end
+
       it "does not re-index when relevant attributes did not change" do
         asset.title = "new one"
         asset.save!


### PR DESCRIPTION
May have new or removed or changed VTT transcript content to be indexed.

We had an existing method of using ActiveRecord hooks to automatically trigger this parent work reindexes on asset changes. So I just extended it using the existing pattern. I don't necessarily love this pattern as it has been working out, but not the time to rethink it now.

After merging and deploying, a bulk reindex to ensure we're starting from consistency is a good idea.

Ref mega-issue #3003 
