### PR TITLE
Fix a css typo, errant colon

### DIFF
--- a/app/frontend/stylesheets/local/show-layout.scss
+++ b/app/frontend/stylesheets/local/show-layout.scss
@@ -196,7 +196,7 @@ $max-image-column-breakpoint: ($max-image_column * 2) + $main_gutter_width + 90p
     margin-bottom: $paragraph-spacer * 2;
   }
 
-  .show-video-transcript: {
+  .show-video-transcript {
     margin-top: $paragraph-spacer;
   }
 


### PR DESCRIPTION
Found by vite processing, although it didn't give us a file/line number:

```
remote:        Build with Vite complete: /tmp/build_23a4a9c2/public/vite
remote:        warnings when minifying css:
remote:        ▲ [WARNING] Expected identifier but found "." [css-syntax-error]
remote:
remote:            <stdin>:19349:2:
remote:              19349 │   .show-video-transcript-margin-top: 1rem;
```
