### PR TITLE
Fix sql escaping in admin works controller

### DIFF
--- a/spec/controllers/admin/works_controller_spec.rb
+++ b/spec/controllers/admin/works_controller_spec.rb
@@ -411,7 +411,8 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
         let!(:works) { [
           create(:work, title: "work_a"),
           create(:work, title: "work_b")
-          ] }
+        ] }
+
         it "sorts correctly by title" do
           get :index, params: { sort_field: :title, sort_order: :asc }
           rows = response.parsed_body.css('.table.admin-list tbody tr')
@@ -443,6 +444,16 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
           get :index, params: { work_format: "" }
           rows = response.parsed_body.css('.table.admin-list tbody tr')
           expect(rows.length).to eq 2
+        end
+
+        context "sql escaping" do
+          let(:quotey_title) { " \\\''''  Bellen's \"lecture\" \\\'''' " }
+          let!(:works) { [ create(:work, title: quotey_title) ] }
+          it "escapes SQL properly" do
+            get :index, params:{"title_or_id"=> quotey_title }
+            rows = response.parsed_body.css('.table.admin-list tbody tr')
+            expect(rows.length).to eq 1
+          end
         end
 
         # object bib item accn aspace interview


### PR DESCRIPTION
Ref #3035 - thanks for reporting @archivistsarah !

# Context
The search string is correctly escaped for matching against the title and friendlier_id, but escaping it to use in the `external_id` jsonb code is difficult, because we are writing SQL that's meant to match the external_id regardless of its `category` 

# An extra assumption
In searching for works by `external_id`, (which contains e.g. Sierra bib numbers, aspace identifiers, and other external IDs) I'm stripping single and double quotes out of the search phrase before searching. I feel like this is reasonable enough, though I'm flagging @Gabz73 @JAuerbach26 @archivistsarah just in case.

I intend to  self-merge and deploy, as this is a bug.