### PR TITLE
Properly escape title_or_id to match any category of external_id (works)

### DIFF
--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -710,7 +710,8 @@ class Admin::WorksController < AdminController
       if params[:title_or_id].present?
         match_ilike = Work.sanitize_sql_like params[:title_or_id]
         match_uuid = Work.type_for_attribute(:id).cast(params[:title_or_id])
-        match_any_external_id = "[{ \"value\" : #{params[:title_or_id].to_json} }]"
+        match_any_external_id = [{ "value" => params[:title_or_id] }].to_json
+
         scope = scope.where(
           [
             "title ILIKE ?",

--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -708,30 +708,17 @@ class Admin::WorksController < AdminController
     def build_search(params)
       scope = Work.all
       if params[:title_or_id].present?
-
-        # 1) to match titles and friendlier IDs, use sanitize_sql_like
-        sanitized_search_phrase = Work.sanitize_sql_like params[:title_or_id]
-
-
-        # 2) to simplify escaping in the jsonb expression for external_id matching,
-        # we're also removing single and double quotes from
-        # the string we use to match external_id,
-        # on the assumption that Sierra bib IDs, ArchivesSpace IDs, etc.
-        # will not contain either quote character.
-        external_id_search_phrase = sanitized_search_phrase.delete("\"'")
-
-        # this expression should match any element of the external_id jsonb array,
-        # as long as its value is external_id_search_phrase, regardless of the value of 'category'.
-        jsonb_match_value = "'[{\"value\": \"#{external_id_search_phrase}\"}]'::jsonb"
-
-        # this condition attempts to match external_id against jsonb_match_value:
-        matches_external_id = "json_attributes -> 'external_id' @> #{jsonb_match_value}"
-
-
-        scope = scope.where("(title ILIKE ? OR friendlier_id ILIKE ? OR #{matches_external_id} OR id = ?)",
-          "%#{sanitized_search_phrase}%",
-          "%#{sanitized_search_phrase}%",
-          Work.type_for_attribute(:id).cast(params[:title_or_id])
+        match_ilike = Work.sanitize_sql_like params[:title_or_id]
+        match_uuid = Work.type_for_attribute(:id).cast(params[:title_or_id])
+        match_any_external_id = "[{ \"value\" : #{params[:title_or_id].to_json} }]"
+        scope = scope.where(
+          [
+            "title ILIKE ?",
+            "friendlier_id ILIKE ?",
+            "id = ?",
+            "json_attributes -> 'external_id' @> ?::jsonb",
+          ].join(" OR "),
+          match_ilike, match_ilike, match_uuid, match_any_external_id
         )
       end
 
@@ -773,3 +760,4 @@ class Admin::WorksController < AdminController
       scope.includes(:leaf_representative).page(params[:page]).per(20)
     end
 end
+

--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -708,18 +708,18 @@ class Admin::WorksController < AdminController
     def build_search(params)
       scope = Work.all
       if params[:title_or_id].present?
-        match_ilike = Work.sanitize_sql_like params[:title_or_id]
-        match_uuid = Work.type_for_attribute(:id).cast(params[:title_or_id])
-        match_any_external_id = [{ "value" => params[:title_or_id] }].to_json
-
         scope = scope.where(
           [
-            "title ILIKE ?",
-            "friendlier_id ILIKE ?",
-            "id = ?",
-            "json_attributes -> 'external_id' @> ?::jsonb",
+            "title ILIKE :match_ilike",
+            "friendlier_id ILIKE :match_ilike",
+            "id = :match_uuid",
+            "json_attributes -> 'external_id' @> :match_any_external_id::jsonb",
           ].join(" OR "),
-          match_ilike, match_ilike, match_uuid, match_any_external_id
+          {
+            match_ilike: Work.sanitize_sql_like(params[:title_or_id]),
+            match_uuid:  Work.type_for_attribute(:id).cast(params[:title_or_id]),
+            match_any_external_id: [{ "value" => params[:title_or_id] }].to_json
+          }
         )
       end
 

--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -718,7 +718,7 @@ class Admin::WorksController < AdminController
           {
             match_ilike: Work.sanitize_sql_like(params[:title_or_id]),
             match_uuid:  Work.type_for_attribute(:id).cast(params[:title_or_id]),
-            match_any_external_id: [{ "value" => params[:title_or_id] }].to_json
+            match_any_external_id: [{ value: params[:title_or_id] }].to_json
           }
         )
       end

--- a/spec/controllers/admin/works_controller_spec.rb
+++ b/spec/controllers/admin/works_controller_spec.rb
@@ -449,12 +449,28 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
         context "sql escaping" do
           let(:quotey_title) { " \\\''''  Bellen's \"lecture\" \\\'''' " }
           let!(:works) { [ create(:work, title: quotey_title) ] }
-          it "escapes SQL properly" do
+          it "matches title correctly despite quotes" do
             get :index, params:{"title_or_id"=> quotey_title }
             rows = response.parsed_body.css('.table.admin-list tbody tr')
             expect(rows.length).to eq 1
           end
         end
+
+        context "sql escaping" do
+          let(:quotey_title) { " \\\''''  Bellen's \"lecture\" \\\'''' " }
+          let!(:works) { [
+            create(:work, external_id: [ Work::ExternalId.new({"value"=>quotey_title, "category"=>"interview"}) ]),
+          ] }
+          it "matches external_id correctly despite quotes" do
+            get :index, params:{"title_or_id"=> quotey_title }
+            rows = response.parsed_body.css('.table.admin-list tbody tr')
+            expect(rows.length).to eq 1
+          end
+        end
+
+
+
+
 
         # object bib item accn aspace interview
         context "filtering by external_id" do


### PR DESCRIPTION
Ref #3038

Much better fix for band-aid fix ref #3038 , which which fixed the bug but dodged the real problem by simply removing escape characters from the search string.

The key was to figure out
 - exactly what to pass to the ActiveRecord escaping;
 - exactly what to pass to `to_json'.