### PR TITLE
Delete any whisper transcribed passages beginning with a © symbol

### DIFF
--- a/app/services/openai_audio_transcribe.rb
+++ b/app/services/openai_audio_transcribe.rb
@@ -26,8 +26,9 @@ class OpenaiAudioTranscribe
   # https://arxiv.org/html/2501.11378v1
   # https://github.com/DSP-AGH/ICASSP2025_Whisper_Hallucination
   REMOVE_TEXT = [
+    # copyright symbol at beginning of line followed by anything
     # \p{Zs} is unicode separator space (not newline)
-    /\p{Zs}*(© )?transcript Emily Beynon/
+    /\p{Zs}*©.*/
   ]
 
   attr_reader :use_prompt, :create_audio_derivative_if_needed

--- a/spec/services/openai_audio_transcribe_spec.rb
+++ b/spec/services/openai_audio_transcribe_spec.rb
@@ -73,7 +73,7 @@ describe OpenaiAudioTranscribe do
         © transcript Emily Beynon
 
         00:03.000 --> 00:05.000
-        This one keeps © transcript Emily Beynon some words
+        This one keeps some words © transcript Emily Beynon more stuff
         EOS
       end
 


### PR DESCRIPTION
More expansive version of #3026, which only deleted a particular known name after copyright. We saw other weird ones with copyright symbol too. The copyright **symbol** is not expected as legit transcription ever, so let's just trim it all.
