### PR TITLE
move rspec-rails dependency out of bundler `test` group, into default group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -208,8 +208,11 @@ group :development do
   gem 'listen', '~> 3.3'
 end
 
+# rspec-rails is NOt in group :test, so we can run `rspec system_env_spec` on heroku,
+# where dev/test aren't installed.
+gem 'rspec-rails', '~> 8.0'
+
 group :test do
-  gem 'rspec-rails', '~> 8.0'
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'

--- a/system_env_spec/README.md
+++ b/system_env_spec/README.md
@@ -14,21 +14,9 @@ Just run:
 
 ## On heroku
 
-App needs to be installed to heroku first. By default, Heroku does not install gems in `development` or `test` group, but we need them here.
+We have `rspec-rails` gem dependency in default gem group so it is installed in "production" too (ie heroku), to make it possible to simply run:
 
-First, tell the app you want to install `rspec` on the next deploy:
-
-    heroku config:set BUNDLE_WITHOUT=" "
-
-This sets `BUNDLE_WITHOUT` to be a space (by default, the variable doesn't exist; empty string is ignored by heroku, need one space!). Although this restarts the dyno, it doesn't actually trigger a deploy.
-
-Next, trigger a deploy.  Use a null commit if you have to, and deploy it to Heroku. On deploy, `rspec` will be installed.
-
- Finally, `heroku run "rspec system_env_spec"`
-
-When you are done, remember to unset the heroku config again:
-
-    heroku config:unset BUNDLE_WITHOUT
+    heroku run "rspec system_env_spec"
 
 ## Note on versions of CLI dependencies
 


### PR DESCRIPTION
We need it installed on heroku, so we can run `rspec system_env_spec` on heroku; heroku does not install development/test groups. We had tried weird workarounds before where we'd temproarily install development and test bundle gem groups on heroku, but they were too error prone and started giving us trouble. This is simplest.

Closes #3034 by making it unnecessary.

Have confirmed working on staging to run `heroku run rspec system_env_spec`
