### PR TITLE
Set specific window size for headless chrome in specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -58,6 +58,11 @@ RSpec.configure do |config|
     version = Capybara::Selenium::Driver.load_selenium
     options_key = Capybara::Selenium::Driver::CAPS_VERSION.satisfied_by?(version) ? :capabilities : :options
     browser_options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+      # Not sure what default chrome headless window size is, but we want to make sure
+      # it's big enough for "non-collapse" responsive size, for our specs, but still
+      # kinda small seems good for testing?
+      opts.add_argument "--window-size=820,540"
+
       # These are defaults from capybara
       # https://github.com/teamcapybara/capybara/blob/0480f90168a40780d1398c75031a255c1819dce8/lib/capybara/registrations/drivers.rb#L31-L39
 


### PR DESCRIPTION
In some cases the window was too small, such that eg facet sidebar would collapse into hidden disclosure, which would cause some of our tests to fail. I don't know what determines default window size or why it seemed to change unpredictably -- for instance, upgrading some dependencies that shoudln't be related, in a different PR, seemed to trigger this. But it's confusing when it does get triggered, and seems better to just explicitly set the window size so it's always the same.

Still small (there may be test benefits to a small window, making sure things work at small window size?), but big enough to NOT have collapsed sidebar etc.
