### PR TITLE
Fix blacklight responsive display of facet sidebar

### DIFF
--- a/app/frontend/stylesheets/local/search_results.scss
+++ b/app/frontend/stylesheets/local/search_results.scss
@@ -1,5 +1,11 @@
+
+
 // override sufia facet widget styles to be more brand-like, and generally neater
 .facets {
+  // disable border Blacklight default is trying to put in at small sizes,
+  // we have already taken care of it differently.
+  --bl-facets-smallish-border: none;
+
   .facets-header {
     // To try to make top line of search results all line up, we hackily try to make
     // this have the exact same line-height in pixels as .page_links. hack to try to improve on BL.
@@ -11,6 +17,13 @@
       font-weight: 600;
       text-align: center;
     }
+  }
+
+  // We don't collapse our facets until bootstrap `sm` but Blacklight
+  // wants to display them at medium, and the way blacklight does by hiding
+  // with a `.d-sm-none` means this seems the best way to fix, a bit annoying.
+  .facet-toggle-button {
+    @extend .d-md-none;
   }
 
   .card-header {


### PR DESCRIPTION
We have customized the facet sidebar extensively, as it used to be very bad in Blacklight default. Some past blacklight upgrades seem to have interacted poorly with our customizations. We fix:

1. An extra border was being added to the facet area in bootstrap sm and md sizes, which was unneeded in our design.

2. we don't collapse facet sidebar until bootstrap 'sm' size, but Blacklight was making the "show facets" button visible at 'md' size when they were already shown, unnecessary, confusing, and bad layout.

## before
<img width="677" height="111" alt="Screenshot 2025-07-17 at 10 29 46 AM" src="https://github.com/user-attachments/assets/40be6beb-3e47-4e88-be78-1d0e1cd605ce" />

<img width="263" height="236" alt="Screenshot 2025-07-17 at 10 29 36 AM" src="https://github.com/user-attachments/assets/973d58a0-a926-4f43-970d-b0f0eb1bd728" />


## after

<img width="261" height="188" alt="Screenshot 2025-07-17 at 10 35 42 AM" src="https://github.com/user-attachments/assets/d06709b6-5bb7-48c6-b319-85d558adbf81" />
<img width="666" height="82" alt="Screenshot 2025-07-17 at 10 31 25 AM" src="https://github.com/user-attachments/assets/2e243c89-d755-4f27-bfbb-603e2a2989ee" />
