### PR TITLE
Properly escape title_or_id to match any category of external_id (collections)

### DIFF
--- a/spec/controllers/admin/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin/admin_collections_controller_spec.rb
@@ -23,4 +23,27 @@ RSpec.describe Admin::CollectionsController, :logged_in_user, type: :controller 
       end
     end
   end
+
+  context "sql escaping" do
+    render_views
+    let(:quotey_string) { " \\\''''  Bellen's \"lecture\" \\\'''' " }
+    let(:rows) { response.parsed_body.css '.table.admin-list tbody tr' }
+
+    context "sql escaping for title" do
+      let!(:collection) { create(:collection, title: quotey_string) }
+      it "matches title" do
+        get :index, params:{"title_or_id"=> quotey_string }
+        expect(rows.length).to eq 1
+      end
+    end
+    context "sql escaping" do
+      let!(:collection) { create(:collection, external_id: [
+        Work::ExternalId.new( {"value"=>quotey_string,   "category"=>"accn"} ),
+      ]) }
+      it "matches external_id" do
+        get :index, params:{"title_or_id"=> quotey_string }
+        expect(rows.length).to eq 1
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes the same problem as ref #3038 (single quotes, backslashes etc. entered the title_or_id search box trigger DB errors), but on the collections page.

Note: we are also adding search by UUID, since the code is parallel.