### PR TITLE
update from Blacklight 8.7.0 to 8.11.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem 'scout_apm'
 # NOTE ALSO: We are using `blacklight-frontend` JS NPM package, updating blacklight
 # version may require an update with yarn to `blacklight-frontend`, has to be
 # checked manually.
-gem "blacklight", "~> 8.7.0"
+gem "blacklight", "~> 8.11.0"
 gem "blacklight_range_limit", "~> 9.0.0" # version no longer sync'd with blacklight, not sure how we tell what version works with what version of BL
 
 # for some code to deal with transcoding video, via AWS MediaConvert

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,7 +151,7 @@ GEM
     benchmark (0.4.1)
     bigdecimal (3.2.2)
     bindex (0.8.1)
-    blacklight (8.7.0)
+    blacklight (8.11.0)
       globalid
       i18n (>= 1.7.0)
       jbuilder (~> 2.7)
@@ -850,7 +850,7 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1.0)
   axe-core-rspec (~> 4.3)
   barnes
-  blacklight (~> 8.7.0)
+  blacklight (~> 8.11.0)
   blacklight_range_limit (~> 9.0.0)
   bootsnap (>= 1.4.4)
   bootstrap4-kaminari-views

--- a/app/frontend/javascript/blacklight_setup.js
+++ b/app/frontend/javascript/blacklight_setup.js
@@ -25,41 +25,17 @@ import BlacklightRangeLimit from "blacklight-range-limit";
 BlacklightRangeLimit.init({onLoadHandler: Blacklight.onLoad });
 
 
-// Patch in some blacklight modal fixes
+// Patch in any needed blacklight modal fixes
 
 if (Blacklight.Modal.target()) {
 
-  // Disable scrollbar on body when modal is open
-  // https://github.com/projectblacklight/blacklight/pull
-
-  Blacklight.Modal.target().addEventListener("show.blacklight.blacklight-modal", (event) => {
-    // Turn off body scrolling
-    Blacklight.Modal.originalBodyOverflow = document.body.style['overflow'];
-    Blacklight.Modal.originalBodyPaddingRight = document.body.style['padding-right'];
-    document.body.style["overflow"] = "hidden"
-    document.body.style["padding-right"] = "0px"
-  });
-
-  Blacklight.Modal.target().addEventListener("hide.blacklight.blacklight-modal", (event) => {
-    // Turn body scrolling back to what it was
-    document.body.style["overflow"] = Blacklight.Modal.originalBodyOverflow;
-    document.body.style["padding-right"] = Blacklight.Modal.originalBodyPaddingRight;
-    Blacklight.Modal.originalBodyOverflow = undefined;
-    Blacklight.Modal.originalBodyPaddingRight = undefined;
-  });
-
-
-  // Make click on background overlay close modal
-
-  Blacklight.Modal.target().addEventListener("click", (event) => {
-    if (event.target.matches(Blacklight.Modal.modalSelector)) {
-      Blacklight.Modal.hide();
-    }
-  });
-
   // Make sure we catch html modal's own close (eg escape key), to trigger blacklight
   // hide cleanup, including restoration of scroll behavior!
+  //
+  // https://github.com/projectblacklight/blacklight/pull/3694
+  //
   // https://github.com/sciencehistory/scihist_digicoll/issues/3049
+  //
   Blacklight.Modal.target().addEventListener("cancel", (event) => {
     // we can stop default behavior, we're going to close the dialog ourselves
     event.preventDefault();

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@popperjs/core": "^2.11.8",
     "@rails/ujs": "^ 7.1.3-4",
     "@shopify/draggable": "^1.0.0-beta.8",
-    "blacklight-frontend": "^8.7.0",
+    "blacklight-frontend": "^8.11.0",
     "blacklight-range-limit": "9.0.0",
     "bootstrap": "^ 5.0.0",
     "domready": "^1.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -382,10 +382,10 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-blacklight-frontend@^8.7.0:
-  version "8.7.0"
-  resolved "https://registry.yarnpkg.com/blacklight-frontend/-/blacklight-frontend-8.7.0.tgz#4ef0d5c984ea41addf42914dd37157f7eee3f3f5"
-  integrity sha512-iDPNfD+QQo5+ZoLLl4uRXtgzvPFup4JnzAa1MnxdP+7cxkHm24cidJ+c/9UBZjk9mrOOnFdlMfWZnbX+zG+mkQ==
+blacklight-frontend@^8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/blacklight-frontend/-/blacklight-frontend-8.11.0.tgz#bf0da92b29472d640c88170e1e39179e48d5da07"
+  integrity sha512-ibtWYn9gUKJzcuQyBnUtGr1AASRl05iGwBmCibXdnZk13+96hzHLsOKbTOKq585eqN2QPc9axkO837TM5erDUA==
   dependencies:
     bootstrap ">=4.3.1 <6.0.0"
 


### PR DESCRIPTION
- update blacklight from 8.7.0 to 8.11.0
- Remove previous blacklight modal fixes that are now included upstream

closes #3048 