### PR TITLE
use : instead of / to delimit parts of cache key for more_like_this cache items

### DIFF
--- a/app/services/more_like_this_getter.rb
+++ b/app/services/more_like_this_getter.rb
@@ -88,7 +88,7 @@ class MoreLikeThisGetter
   # standard blacklight config, except it won't retry failed queries.
   def solr_connection
     # If we don't get a response from SOLR right away,
-    # we just want to show the page without the more_like_this content. 
+    # we just want to show the page without the more_like_this content.
     #
     # Note the existence of Scihist::BlacklightSolrRepository, which we are
     # consciously not using as the solr repo in this method. Its only purpose
@@ -129,7 +129,7 @@ class MoreLikeThisGetter
   end
 
   def cache_key
-    "more_like_this/#{@work.friendlier_id}"
+    "scihist:more_like_this:#{@work.friendlier_id}"
   end
 
   # Caching these should save trips to our flaky solr provider.

--- a/spec/services/more_like_this_getter_spec.rb
+++ b/spec/services/more_like_this_getter_spec.rb
@@ -9,7 +9,7 @@ describe MoreLikeThisGetter,  solr: true, indexable_callbacks: true, queue_adapt
   let(:other_getter) {MoreLikeThisGetter.new(work_to_match)}
   let(:getter_of_two_works) {MoreLikeThisGetter.new(work_to_match, max_number_of_works: 2)}
   let(:work_to_match)   { create(:public_work, subject: "aaa", description: "aaa")  }
-  let(:work_to_match_cache_key) {"more_like_this/#{work_to_match.friendlier_id}"}
+  let(:work_to_match_cache_key) {"scihist:more_like_this:#{work_to_match.friendlier_id}"}
 
   let(:five_public_works) { [
       create(:public_work, subject: "aaa", description: "aaa"),
@@ -18,7 +18,7 @@ describe MoreLikeThisGetter,  solr: true, indexable_callbacks: true, queue_adapt
       create(:public_work, subject: "aaa", description: "aaa"),
       create(:public_work, subject: "aaa", description: "aaa"),
     ]
-  } 
+  }
   let(:five_private_works) { [
       create(:private_work, subject: "aaa", description: "aaa"),
       create(:private_work, subject: "aaa", description: "aaa"),
@@ -56,7 +56,7 @@ describe MoreLikeThisGetter,  solr: true, indexable_callbacks: true, queue_adapt
     context "setting turned on" do
       before do
         allow(ScihistDigicoll::Env).to receive(:lookup).with(:cache_more_like_this).and_return(true)
-      end 
+      end
       after do
         allow(ScihistDigicoll::Env).to receive(:lookup).and_call_original
       end


### PR DESCRIPTION
Turns out : is more standard, and will let some tools show you as groups more easily, including redis admin panel.

For instance, look at this redis admiin panel, how it groups the rack-attack keys in groups with total counts, but the more-like-this keys are all just flat. 

<img width="602" height="532" alt="Screenshot 2025-07-28 at 3 31 09 PM" src="https://github.com/user-attachments/assets/31122713-e03e-42cd-bbaa-2c439cbd9c3a" />

(Although it does use `/` for that last part, that it doesn't actually want grouped I guess, or maybe that was my custom config that should have been different!)

Turns out `:` is more standard, see also how Rails `rate_limit` [uses join(":") here, a colon](https://github.com/rails/rails/blob/3235827585d87661942c91bc81f64f56d710f0b2/actionpack/lib/action_controller/metal/rate_limiting.rb#L62). 

So we'll use a colon too. 

This will mean after deploy, every cache check will be a miss for a while, as it wont' find the old ones. And we'll have double the content stored in our cache until the old ones expire (a week) -- but we have plenty of room in cache no big deal. (If we had to we could write a script to list redis keys and manually remove the ones of the old format, but doesn't seem worth it). 

We'll put a `scihist` prefix in front of it all too, to help us realize it's from local code not a gem, perhaps.  