### PR TITLE
Create an ENV switch to skip the `scihist:solr_cloud:sync_configset` release task on heroku

### DIFF
--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -11,10 +11,10 @@ namespace :scihist do
         $stderr.puts "\n!!! WARNING, no ENV['DATABASE_URL'], not running rake db:migrate as part of heroku release !!!\n\n"
       end
 
-      if ENV['SOLR_URL']
+      if ENV['SOLR_URL'] && ENV['SKIP_SYNC_SOLR_CONFIGSET'] != 'true'
         Rake::Task["scihist:solr_cloud:sync_configset"].invoke
       else
-        $stderr.puts "\n!!! WARNING, no ENV['SOLR_URL'], not running rake scihist:solr_cloud:sync_configset as part of heroku release !!!\n\n"
+        $stderr.puts "\n\nWARNING: no ENV['SOLR_URL'] or ENV['SKIP_SYNC_SOLR_CONFIGSET'] is set to 'true'.\n\nNot running rake scihist:solr_cloud:sync_configset as part of heroku release.\n\n"
       end
     end
 


### PR DESCRIPTION
Ref #3063 
@jrochkind  noted this afternoon:
`we could certainly just add a env SUPPRESS_SOLR_CONFIG_PUSH or something.`
Great idea. Helpful in Catch-22 situations when you cannot release the next version of SOLR to Heroku, because the release phase involves pushing the config to SearchStax.... but there's a version mismatch. ♻️