### PR TITLE
Look at thumb not asset for height/width for aspect ratio

### DIFF
--- a/app/components/thumb_component.rb
+++ b/app/components/thumb_component.rb
@@ -159,7 +159,7 @@ class ThumbComponent < ApplicationComponent
     # thumb we're actually displaying for width and height
     thumb = asset&.file("thumb_#{thumb_size}")
 
-    if asset.width && asset.height
+    if thumb.width && thumb.height
       # width / height as string is supported
       return "aspect-ratio: #{thumb.width} / #{thumb.height}"
     elsif lazy?


### PR DESCRIPTION
Normally the same, but when the asset is a PDF, the asset itself doesn't have a height/width, but it's thumb derivative (that we are about to display) does!  One part of the logic already was using `thumb`, it was just an error that the other part wasn't.

Makes it able to put aspect ratio in CSS for PDF thumbs when it couldn't before, avoiding (correct) error message, closing #3032.

I don't think it's worth adding a PDF test case, but maybe I'm wrong?
