### PR TITLE
Main search form, do not send hidden "search_field" input

### DIFF
--- a/app/views/application/_search_form.html.erb
+++ b/app/views/application/_search_form.html.erb
@@ -11,9 +11,6 @@
 %>
 
 <%= form_tag search_catalog_url, method: :get, class: "search-form", role: "search" do %>
-  <%= hidden_field_tag :search_field, 'all_fields' %>
-
-
   <div class="input-group nav-search-text">
     <%= text_field_tag :q, '', class: "q form-control",
         id: "q",


### PR DESCRIPTION
This will keep the url cleaner, without unnecessary `search_field=all_fields` in it. This was probably copied from Blacklight but is not necessary.

* We don't use multiple search fields
* Even if we did, this would be the default and not necessary
* It keeps BL logic from recognizing a blank query as an 'unfiltered' query, so is complicating our efforts to allow unfiltered queries through bot challenge
