### PR TITLE
move pstore require to inside rake task itself

### DIFF
--- a/lib/tasks/scihist.rake
+++ b/lib/tasks/scihist.rake
@@ -155,11 +155,11 @@ namespace :scihist do
   end
 
   namespace :derivatives do
-    require 'pstore'
-
     desc "Dump all paths from storage (s3) to a PSTORE file for analysis"
 
     task :dump_paths => :environment do
+      require 'pstore'
+
       ENV["DESTINATION"] ||= "./tmp/derivative_paths.pstore"
 
 
@@ -188,6 +188,8 @@ namespace :scihist do
 
     desc "check all derivative references exist as files on storage from DB produced by :dump"
     task :check_paths => :environment do
+      require 'pstore'
+
       ENV["SOURCE"] ||= "./tmp/derivative_paths.pstore"
 
       missing_count = 0


### PR DESCRIPTION
Was getting a deprecation warning just on loading the rake file, even if not running the tasks that used pstore

```
/Users/jrochkind/code/scihist_digicoll/lib/tasks/scihist.rake:158: warning: /Users/jrochkind/.rubies/ruby-3.4.5/lib/ruby/3.4.0/pstore.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```

Now will only get them if actually running the rake tasks -- which also means they'll BREAK on ruby 3.5 unless we add the dependency... but I dont' think we even USE these rake tasks anymore, if we need them again we can fix it then, I don't want to add a dependency for legacy rake tasks we don't use!

scihist:derivatives:dump_paths
scihist:derivatives:check_paths

I think actually used long ago for original implementation of this app from sufia. 
