### PR TITLE
update to puma 7.0.0.pre1 with keep-alive long-tail fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ gem "aws-sdk-cloudfront", "~> 1.91"
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
 # Use Puma as the app server
-gem 'puma', '~> 6.4'
+gem 'puma', '>= 7.0.0.pre1', '< 8'
 
 # resque+redis being used for activejob.
 # resque-pool currently does not support resque 2.0 alas.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -540,7 +540,7 @@ GEM
       date
       stringio
     public_suffix (6.0.2)
-    puma (6.6.0)
+    puma (7.0.0.pre1)
       nio4r (~> 2.0)
     qa (5.15.0)
       activerecord-import
@@ -896,7 +896,7 @@ DEPENDENCIES
   prawn-html (< 2)
   prawn-svg (< 2)
   pry-byebug
-  puma (~> 6.4)
+  puma (>= 7.0.0.pre1, < 8)
   qa (~> 5.2, >= 5.14.0)
   rack (>= 3.0)
   rack-attack (~> 6.6)


### PR DESCRIPTION
Heroku will be updating to their router 2.0 with persistent http connections to app. This fix is needed to avoid performance regression when they do so. https://github.com/puma/puma/pull/3678

Normally I wouldn't update to a pre-release puma version, but seems the best option here -- and actually there don't seem to be any major changes in the 7.0.0.pre1 *except* this! https://github.com/puma/puma/releases/tag/v7.0.0.pre1

Fixes #3065
