### PR TITLE
Add link rel=preconnect for performance for certain additional origin domains

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,11 @@
     <!-- Internet Explorer use the highest version available -->
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
+    <!-- try to improve performance of typekit fonts noted as perf hit
+        https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/ -->
+    <link rel="preconnect" href="https://use.typekit.net" crossorigin>
+    <link rel="preconnect" href="https://p.typekit.net" crossorigin>
+
     <%= render 'layouts/google_analytics_4' %>
 
     <title><%= render_page_title %></title>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,6 +33,12 @@
     <link rel="preconnect" href="https://use.typekit.net" crossorigin>
     <link rel="preconnect" href="https://p.typekit.net" crossorigin>
 
+    <!-- and preconnect our derivatives cloudfront if we've got it, thumbnails will
+      come from here -->
+    <% if ScihistDigicoll::Env.lookup(:s3_bucket_derivatives_host) %>
+      <link rel="preconnect" href="https://<%= ScihistDigicoll::Env.lookup(:s3_bucket_derivatives_host) %>" crossorigin>
+    <% end %>
+
     <%= render 'layouts/google_analytics_4' %>
 
     <title><%= render_page_title %></title>


### PR DESCRIPTION
Does seem to imrpove our PageSpeed score, makes sense.  Ref #3088

 https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/ 

- link rel=preconnect on typekit font domains to try to improve perf of custom adobe font use, per lighthouse report. Typekit default load is kind of a performance problem, but this at least helps as a first step. 
- link rel=preconnect cloudfront hostname for derivatives (thumanils) if present for performance, since we'll be loading lots of thumbs from there later in page, this does seem to ehlp. 

Actually this by itself has pretty limited effect on PageSpeed scores, but it does check off one thing PageSpeed is telling us to do, and i don't think should hurt. May have synergy with other changes. 
