### PR TITLE
Add fetchpriority=high to our hero/poster image

### DIFF
--- a/app/components/member_image_component.rb
+++ b/app/components/member_image_component.rb
@@ -33,7 +33,7 @@
 # we don't want to show people the placeholder, this is just a fail-safe to avoid
 # showing non-public content in case of other errors.
 class MemberImageComponent < ApplicationComponent
-  attr_reader :size, :lazy, :member, :image_label, :work_download_options
+  attr_reader :size, :lazy, :member, :image_label, :work_download_options, :fetchpriority
 
   delegate :can?, to: :helpers
 
@@ -60,13 +60,16 @@ class MemberImageComponent < ApplicationComponent
   #
   #  @param work_download_options [Array<DownloadOption>] sometimes we want to show them, sometimes we
   #     don't, and they are expensive, so pass them in if you want them.
-  def initialize(member, size: :standard, lazy: false, image_label: nil, work_download_options: nil)
+  #
+  #  @param fetchpriority [String] pass `high` or `low` fetchpriority to underlying img tag
+  def initialize(member, size: :standard, lazy: false, image_label: nil, work_download_options: nil, fetchpriority:nil)
     @lazy = !!lazy
     @size = size
     @member = member
 
     @image_label = image_label
     @work_download_options = work_download_options
+    @fetchpriority = fetchpriority
   end
 
   def call
@@ -77,7 +80,7 @@ class MemberImageComponent < ApplicationComponent
     content_tag("div", class: "member-image-presentation") do
       private_label +
       content_tag("a", **thumb_link_attributes) do
-        render ThumbComponent.new(representative_asset, thumb_size: size, lazy: lazy, alt_text_override: "")
+        render ThumbComponent.new(representative_asset, thumb_size: size, lazy: lazy, alt_text_override: "", fetchpriority: fetchpriority)
       end +
 
       content_tag("div", class: "action-item-bar") do

--- a/app/components/thumb_component.rb
+++ b/app/components/thumb_component.rb
@@ -31,7 +31,7 @@
 # ThumbComponent does NOT do any access control, it will display whatever you give it, if it can,
 # even if not published with no logged in user. Access control should be done by caller.
 class ThumbComponent < ApplicationComponent
-  attr_accessor :placeholder_img_url, :thumb_size, :asset
+  attr_accessor :placeholder_img_url, :thumb_size, :asset, :fetchpriority
 
   delegate :needs_border?, to: :helpers
 
@@ -54,17 +54,21 @@ class ThumbComponent < ApplicationComponent
   # @param recent_items [Boolean] The ThumbComponents used in the recent_itmes section of the homepage
   # function slightly differently: they are intended to be visible on screenreaders, so we
   # are allowing an alt text for them.
+  #
+  # @param fetchpriority [String] `high` or `low` for fetchpriority attribute on img tag.
   def initialize(asset,
     thumb_size: :standard,
     placeholder_img_url: nil,
     lazy: false,
-    alt_text_override: nil)
+    alt_text_override: nil,
+    fetchpriority: nil)
 
     @asset = asset
     @placeholder_img_url = placeholder_img_url
     @thumb_size = thumb_size.to_sym
     @lazy = lazy
     @alt_text_override = alt_text_override
+    @fetchpriority = fetchpriority
 
     unless ALLOWED_THUMB_SIZES.include? thumb_size
       raise ArgumentError.new("thumb_size must be in #{ALLOWED_THUMB_SIZES}, but was '#{thumb_size}'")
@@ -94,7 +98,7 @@ class ThumbComponent < ApplicationComponent
       # well while just letting people call ThumbComponent from different places
       helpers.fa_file_audio_class_solid
     else
-      tag "img", alt: "", src: placeholder_img_url, width: "100%";
+      tag "img", alt: "", src: placeholder_img_url, width: "100%"
     end
   end
 
@@ -146,6 +150,10 @@ class ThumbComponent < ApplicationComponent
 
     if needs_border?(asset)
       img_attributes[:class] = "bordered"
+    end
+
+    if fetchpriority.present?
+      img_attributes[:fetchpriority] = fetchpriority
     end
 
     img_attributes.merge!(style: aspect_ratio_style_tag)

--- a/app/components/work_image_show_component.html.erb
+++ b/app/components/work_image_show_component.html.erb
@@ -12,7 +12,7 @@
 
   <div class="show-hero">
     <%# note the large hero one gets work_download_options %>
-    <%= render MemberImageComponent.new(representative_member, size: :large, work_download_options: work_download_options) %>
+    <%= render MemberImageComponent.new(representative_member, size: :large, work_download_options: work_download_options, fetchpriority: "high") %>
     <%= render "works/rights_and_social", work: work %>
 
     <%= render WorkDownloadLinksComponent.new(work, download_options: work_download_options) %>

--- a/spec/components/member_image_component_spec.rb
+++ b/spec/components/member_image_component_spec.rb
@@ -28,6 +28,13 @@ describe MemberImageComponent, type: :component do
         expect(poster_link["tabindex"]).to eq "-1"
         expect(poster_link["aria-hidden"]).to eq "true"
       end
+
+      describe "with fetchpriority:high" do
+        let(:presenter) { MemberImageComponent.new(member, fetchpriority: :high) }
+        it "includes attribute on img tag" do
+          expect(wrapper_div.at_css(".thumb img[fetchpriority=high]")).to be_present
+        end
+      end
     end
 
     describe "with whole-work download options passed in" do

--- a/spec/components/thumb_component_spec.rb
+++ b/spec/components/thumb_component_spec.rb
@@ -99,6 +99,15 @@ describe ThumbComponent, type: :component do
       expect(img_tag["style"]).to eq "aspect-ratio: #{argument.width} / #{argument.height}"
     end
 
+    describe "fetchpriority" do
+      let(:instance) { ThumbComponent.new(argument, thumb_size: thumb_size, fetchpriority: "high") }
+
+      it "is included as argument" do
+        img_tag = rendered.at_css("img")
+        expect(img_tag[:fetchpriority]).to eq "high"
+      end
+    end
+
     describe "with no aspect ratio available" do
       let(:argument) do
         build(:asset_with_faked_file).tap do |asset|


### PR DESCRIPTION
Per Google PageSpeed recommendations, ref #3088 

Our hero image is "largest contentful paint" (LCP), getting it loaded quicker is better for our PageSpeed. Not sure this change makes detectable difference in our PageSpeed score on it's own, and not sure how much it matters to user (page layout should not jump around when hero image is loaded) -- but does cross a thing off the PageSpeed recommendations, and I don't think hurts. 

- ThumbComponent supports fetchpriority
- fetchpriority high on large hero image
