### PR TITLE
Gzip responses with Rack::Deflator

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -46,8 +46,8 @@ module ScihistDigicoll
       config.log_level = ScihistDigicoll::Env.lookup("rails_log_level")
     end
 
-    # gzip responses if user-agent allows it, on heroku nobody else is going
-    # to do this for us -- lighthouse performance advice.
+    # gzip responses if user-agent allows it, on heroku without a CDN in front of dynamic responses,
+    # nobody else is going to do this for us -- lighthouse performance advice.
     #
     # "before ActionDispatch::Static" seems to be documented advice if our
     # app is delivering static resources direct, which it does in heroku. don't totally understand.
@@ -60,8 +60,6 @@ module ScihistDigicoll
     config.middleware.insert_before ActionDispatch::Static, Rack::Deflater, if: ->(_env, _status, headers, _body) {
       headers[Rack::CONTENT_TYPE]&.start_with?("text/") || headers[Rack::CONTENT_TYPE]&.start_with?("application/json")
     }
-
-
 
     # lograge config. lograge is turned on in production.rb with
     # config.lograge.enabled = true

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,6 +46,23 @@ module ScihistDigicoll
       config.log_level = ScihistDigicoll::Env.lookup("rails_log_level")
     end
 
+    # gzip responses if user-agent allows it, on heroku nobody else is going
+    # to do this for us -- lighthouse performance advice.
+    #
+    # "before ActionDispatch::Static" seems to be documented advice if our
+    # app is delivering static resources direct, which it does in heroku. don't totally understand.
+    #
+    # We are doing htis mainly for HTML, allow for any text/ mime-type, but
+    # exclude, other media is likely to be already compressed and not benefit, if
+    # it winds up going through this pipeline. Def want application/json though,
+    # compression will help there for big ones!
+    #
+    config.middleware.insert_before ActionDispatch::Static, Rack::Deflater, if: ->(_env, _status, headers, _body) {
+      headers[Rack::CONTENT_TYPE]&.start_with?("text/") || headers[Rack::CONTENT_TYPE]&.start_with?("application/json")
+    }
+
+
+
     # lograge config. lograge is turned on in production.rb with
     # config.lograge.enabled = true
     #

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -30,6 +30,9 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 
+  # let's not use gzip compression of responses in test, just slows things down
+  config.middleware.delete Rack::Deflater
+
   # Raise exceptions instead of rendering exception templates.
   # :rescueable is default in Rails 7.1, but we need to fix our tests
   config.action_dispatch.show_exceptions = :none


### PR DESCRIPTION
Google PageSpeed insights really wants the app to deliver gzipped responses.   Ref #3088

On heroku, without a CDN in front of our actual dynamic HTML etc responses -- this means the app itself should gzip on the fly.  That means using the under-documented Rack::Deflator middleware. 

While this increases CPU on our server, the benefits in reducing transfer size of body are real. This seems to be result in noticeable PageSpeed performance score improvements of a few points in both desktop and mobile. 

While it doesn't factor into PageSpeed as it happens later, it's also going ot be especially helpful for our very large single-response JSON "viewer member info"  responses.  For instance Ramelli `/works/4b29b614k/viewer_images_info` json goes from to ~986K full, to ~115K gzipped!!!  Almost worth it just for that, most of our HTML wont' have that much to gain -- especially now that we're delivering many-thumbnail pages incrementally!


Confirmed in staging that it is not gzipping eg https://staging-digital.sciencehistory.org/assets/from_main_website/shi-logo-c79c3f491f4e407533ee0d3c9302c58f2566cba13b2d00ebd275f2c8bea3e706.png , which is good, png and jpg etc already include internal lossless (as well as sometimes lossy) compression, nothing to be gained. 

Confirmed in staging our html and json are now gzipped. 

(Our static css and js was already going through cloudfront and compressed by cloudfront)