### PR TITLE
image helper needs_border? forgot an asset can have a Collection parent, or maybe no parent to be safe

### DIFF
--- a/app/helpers/image_helper.rb
+++ b/app/helpers/image_helper.rb
@@ -56,6 +56,6 @@ module ImageHelper
   #
   # We like the border blending into bg for physical object photos
   def needs_border?(asset)
-    asset.file_metadata[AssetUploader::WHITE_EDGE_DETECT_KEY] && !asset.parent.format.include?("physical_object")
+    asset.file_metadata[AssetUploader::WHITE_EDGE_DETECT_KEY] && !(asset.parent.respond_to?(:format) && asset.parent.format.include?("physical_object"))
   end
 end


### PR DESCRIPTION
Fixes #3107
