### PR TITLE
Set `hl.weightMatches` to `false`

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -234,7 +234,7 @@ class CatalogController < ApplicationController
       # Trey Pendragon suggested turning this off. Thanks, Trey!
       # "Currently, this setting slows down the unified highlighter a lot when many fields are highlighted"
       # https://solr.apache.org/guide/solr/latest/query-guide/highlighting.html
-      "hl.weightMatches" => "false"
+      "hl.weightMatches" => "false",
 
       "hl.bs.type" => "WORD",
       "hl.fragsize" => "140",

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -229,6 +229,13 @@ class CatalogController < ApplicationController
       # The change did not substantially impair the quality of the snippets returned,
       # and made searches much faster.
       "hl.maxAnalyzedChars" => "250000",
+
+
+      # Trey Pendragon suggested turning this off. Thanks, Trey!
+      # "Currently, this setting slows down the unified highlighter a lot when many fields are highlighted"
+      # https://solr.apache.org/guide/solr/latest/query-guide/highlighting.html
+      "hl.weightMatches" => "false"
+
       "hl.bs.type" => "WORD",
       "hl.fragsize" => "140",
       "hl.fragsizeIsMinimum" => "true"

--- a/spec/system/catalog_search_spec.rb
+++ b/spec/system/catalog_search_spec.rb
@@ -208,18 +208,7 @@ describe CatalogController, solr: true, indexable_callbacks: true do
       visit search_catalog_path(search_field: "all_fields", q: '"I graduated from Bristol High School"')
       expect(page).to have_selector("#document_#{published_work.friendlier_id}")
       within("#document_#{published_work.friendlier_id}") do
-        # byebug
-        # expect(page).to have_selector(".scihist-results-list-item-highlights em", text: "I graduated from Bristol High School")
-
-        # expect(page).to have_selector(".scihist-results-list-item-highlights em", text: "I")
-        # expect(page).to have_selector(".scihist-results-list-item-highlights em", text: "graduated")
-        # expect(page).to have_selector(".scihist-results-list-item-highlights em", text: "from")
-        # expect(page).to have_selector(".scihist-results-list-item-highlights em", text: "Bristol")
-        # expect(page).to have_selector(".scihist-results-list-item-highlights em", text: "High")
-        # expect(page).to have_selector(".scihist-results-list-item-highlights em", text: "School")
-
-         "I graduated from Bristol High School".split.each {|word| expect(page).to have_selector(".scihist-results-list-item-highlights em", text: word) }
-
+        "I graduated from Bristol High School".split.each {|word| expect(page).to have_selector(".scihist-results-list-item-highlights em", text: word) }
         expect(page).not_to have_selector(".scihist-results-list-item-description")
         expect(page).not_to have_content(published_work.description)
       end

--- a/spec/system/catalog_search_spec.rb
+++ b/spec/system/catalog_search_spec.rb
@@ -208,7 +208,17 @@ describe CatalogController, solr: true, indexable_callbacks: true do
       visit search_catalog_path(search_field: "all_fields", q: '"I graduated from Bristol High School"')
       expect(page).to have_selector("#document_#{published_work.friendlier_id}")
       within("#document_#{published_work.friendlier_id}") do
-        expect(page).to have_selector(".scihist-results-list-item-highlights em", text: "I graduated from Bristol High School")
+        # byebug
+        # expect(page).to have_selector(".scihist-results-list-item-highlights em", text: "I graduated from Bristol High School")
+
+        # expect(page).to have_selector(".scihist-results-list-item-highlights em", text: "I")
+        # expect(page).to have_selector(".scihist-results-list-item-highlights em", text: "graduated")
+        # expect(page).to have_selector(".scihist-results-list-item-highlights em", text: "from")
+        # expect(page).to have_selector(".scihist-results-list-item-highlights em", text: "Bristol")
+        # expect(page).to have_selector(".scihist-results-list-item-highlights em", text: "High")
+        # expect(page).to have_selector(".scihist-results-list-item-highlights em", text: "School")
+
+         "I graduated from Bristol High School".split.each {|word| expect(page).to have_selector(".scihist-results-list-item-highlights em", text: word) }
 
         expect(page).not_to have_selector(".scihist-results-list-item-description")
         expect(page).not_to have_content(published_work.description)


### PR DESCRIPTION
Ref #3075
Produces a noticeable improvement in highlighting speed.
Suggested by Trey Pendragon on the Code4Lib #solr channel.
Tested in staging, a bit.