### PR TITLE
Rack prefers :unprocessable_content arg to :unprocessable_entity

### DIFF
--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -65,7 +65,7 @@ class Admin::AssetsController < AdminController
         format.json { render :show, status: :ok, location: @asset }
       else
         format.html { render :edit }
-        format.json { render json: @asset.errors, status: :unprocessable_entity }
+        format.json { render json: @asset.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -72,7 +72,7 @@ class Admin::CollectionsController < AdminController
         format.json { render :show, status: :created, location: @collection }
       else
         format.html { render :new }
-        format.json { render json: @collection.errors, status: :unprocessable_entity }
+        format.json { render json: @collection.errors, status: :unprocessable_content }
       end
     end
   end
@@ -87,7 +87,7 @@ class Admin::CollectionsController < AdminController
         format.json { render :show, status: :ok, location: @collection }
       else
         format.html { render :edit }
-        format.json { render json: @collection.errors, status: :unprocessable_entity }
+        format.json { render json: @collection.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/admin/digitization_queue_items_controller.rb
+++ b/app/controllers/admin/digitization_queue_items_controller.rb
@@ -36,7 +36,7 @@ class Admin::DigitizationQueueItemsController < AdminController
         format.json { render :show, status: :created, location: admin_digitization_queue_items_url(@admin_digitization_queue_item) }
       else
         format.html { render :new }
-        format.json { render json: @admin_digitization_queue_item.errors, status: :unprocessable_entity }
+        format.json { render json: @admin_digitization_queue_item.errors, status: :unprocessable_content }
       end
     end
   end
@@ -68,7 +68,7 @@ class Admin::DigitizationQueueItemsController < AdminController
         format.json { render json: { notice: notice } }
       else
         format.html { render :edit }
-        format.json { render json: @admin_digitization_queue_item.errors, status: :unprocessable_entity }
+        format.json { render json: @admin_digitization_queue_item.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/admin/interviewee_biographies_controller.rb
+++ b/app/controllers/admin/interviewee_biographies_controller.rb
@@ -30,7 +30,7 @@ class Admin::IntervieweeBiographiesController < AdminController
         format.json { render :edit, status: :created, location: @interviewee_biography }
       else
         format.html { render :new }
-        format.json { render json: @interviewee_biography.errors, status: :unprocessable_entity }
+        format.json { render json: @interviewee_biography.errors, status: :unprocessable_content }
       end
     end
 
@@ -50,7 +50,7 @@ class Admin::IntervieweeBiographiesController < AdminController
         @interviewee_biography.oral_history_content&.collect(&:work)&.each(&:update_index)
       else
         format.html { render :edit }
-        format.json { render json: @interviewee_biography.errors, status: :unprocessable_entity }
+        format.json { render json: @interviewee_biography.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/admin/interviewer_profiles_controller.rb
+++ b/app/controllers/admin/interviewer_profiles_controller.rb
@@ -33,7 +33,7 @@ class Admin::InterviewerProfilesController < AdminController
         format.json { render :show, status: :created, location: @interviewer_profile }
       else
         format.html { render :new }
-        format.json { render json: @interviewer_profile.errors, status: :unprocessable_entity }
+        format.json { render json: @interviewer_profile.errors, status: :unprocessable_content }
       end
     end
   end
@@ -47,7 +47,7 @@ class Admin::InterviewerProfilesController < AdminController
         format.json { render :show, status: :ok, location: @interviewer_profile }
       else
         format.html { render :edit }
-        format.json { render json: @interviewer_profile.errors, status: :unprocessable_entity }
+        format.json { render json: @interviewer_profile.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -39,7 +39,7 @@ class Admin::UsersController < AdminController
         format.json { render :show, status: :created, location: @user }
       else
         format.html { render :new }
-        format.json { render json: @user.errors, status: :unprocessable_entity }
+        format.json { render json: @user.errors, status: :unprocessable_content }
       end
     end
   end
@@ -53,7 +53,7 @@ class Admin::UsersController < AdminController
         format.json { render :show, status: :ok, location: @user }
       else
         format.html { render :edit }
-        format.json { render json: @user.errors, status: :unprocessable_entity }
+        format.json { render json: @user.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -114,7 +114,7 @@ class Admin::WorksController < AdminController
         format.json { render :show, status: :created, location: @work }
       else
         format.html { render :edit }
-        format.json { render json: @work.errors, status: :unprocessable_entity }
+        format.json { render json: @work.errors, status: :unprocessable_content }
       end
     end
   end
@@ -136,7 +136,7 @@ class Admin::WorksController < AdminController
         format.json { render :show, status: :ok, location: @work }
       else
         format.html { render :edit }
-        format.json { render json: @work.errors, status: :unprocessable_entity }
+        format.json { render json: @work.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -721,9 +721,9 @@ class CatalogController < ApplicationController
 
 
   # Suppress noisy UnpermittedParameters errors, caused in practice by a bot.
-  # Respond instead with :unprocessable_entity.
+  # Respond instead with :unprocessable_content.
   def handle_unpermitted_params
-    return render plain: "Error: unpermitted parameters.", status: :unprocessable_entity
+    return render plain: "Error: unpermitted parameters.", status: :unprocessable_content
   end
 
 end

--- a/spec/controllers/collection_show_controller_spec.rb
+++ b/spec/controllers/collection_show_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
         collection_id:   collection.friendlier_id,
         "facet.page" =>  { goat: 'goat' }
       }
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
     end
 
     it "doesn't throw an error when facet.page is an array" do
@@ -54,7 +54,7 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
         collection_id:   collection.friendlier_id,
         "facet.page" =>  ['x', 'y']
       }
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
     end
   end
 
@@ -121,11 +121,11 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
 
       let(:random_order) { (0..containers.length - 1).to_a.shuffle }
 
-      let(:containers) do  
+      let(:containers) do
         [
           { "box"=> "1",  "folder"=> "1"  },
           { "box"=> "1" },
-          
+
           { "box"=> "2",   "folder"=> "1"  },
           { "box"=> "2",   "folder"=> "2"  },
 
@@ -139,7 +139,7 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
       let(:titles) do
         containers.map do |pc|
           "#{pc.try('box', 'none')},#{pc.try('folder', 'none')}"
-        end   
+        end
       end
 
       let!(:works) do


### PR DESCRIPTION
This started producing deprecation warnings when I tried upgrading other dependencies. Not sure exactly why the deprecation warnings just started showing up as this seems to have been deprecated since rack 3.1, which we were already on: https://github.com/rack/rack/commit/64ad26e3381da2ce1853638a2c4ea241c2ad3729. See also: https://github.com/rack/rack/pull/2137

But Rails seems to be dealing with it too: https://github.com/rails/rails/blob/c6272da25fa823d26f8469ffef3a9dc7a1225d2c/actionpack/lib/action_dispatch/http/response.rb#L51

Easy enough for us to change, all tests still pass (verified that with an unrecognized symbol they fail), let's do this first before further dependency upgrades.
