### PR TITLE
Edit works attached to dq item

### DIFF
--- a/app/controllers/admin/digitization_queue_items_controller.rb
+++ b/app/controllers/admin/digitization_queue_items_controller.rb
@@ -131,7 +131,7 @@ class Admin::DigitizationQueueItemsController < AdminController
   def import_attached_works_from_cart
     @admin_digitization_queue_item.work_ids = current_user.works_in_cart.pluck(:id)
     @admin_digitization_queue_item.save!
-    redirect_to @admin_digitization_queue_item, notice: 'imported!'
+    redirect_to @admin_digitization_queue_item, notice: "#{current_user.works_in_cart.count} works from your cart have been attached."
   end
 
 

--- a/app/views/admin/digitization_queue_items/show.html.erb
+++ b/app/views/admin/digitization_queue_items/show.html.erb
@@ -102,7 +102,7 @@
       <%= link_to "Create new attached work", new_admin_work_path(digitization_queue_item: @admin_digitization_queue_item.id), class: "btn btn-primary mb-1" %>
       <%= link_to "Batch create attached works", admin_batch_create_path(digitization_queue_item: @admin_digitization_queue_item.id), class: "btn btn-outline-secondary" %>
       <%= link_to "Export to cart ...", admin_export_attached_works_to_cart_path(id: @admin_digitization_queue_item.id), class: "btn btn-outline-secondary",  data: { confirm: "Add #{ @admin_digitization_queue_item.works.count } attached works to your cart?" } %>
-      <%= link_to "Attach from cart ...", admin_import_attached_works_from_cart_path(id: @admin_digitization_queue_item.id), class: "btn btn-outline-secondary",  data: { confirm: "This will disconnect any currently attached works and replace them with the #{ current_user.works_in_cart.count } works currently in your cart. Are you sure?" } %>
+      <%= link_to "Attach from cart ...", admin_import_attached_works_from_cart_path(id: @admin_digitization_queue_item.id), class: "btn btn-outline-secondary",  data: { confirm: "This will detach #{ @admin_digitization_queue_item.works.count } works, and replace them with the #{ current_user.works_in_cart.count } works currently in your cart. Are you sure?" } %>
     </p>
 
     <h2>Comments</h2>

--- a/app/views/admin/digitization_queue_items/show.html.erb
+++ b/app/views/admin/digitization_queue_items/show.html.erb
@@ -101,6 +101,8 @@
     <p>
       <%= link_to "Create new attached work", new_admin_work_path(digitization_queue_item: @admin_digitization_queue_item.id), class: "btn btn-primary mb-1" %>
       <%= link_to "Batch create attached works", admin_batch_create_path(digitization_queue_item: @admin_digitization_queue_item.id), class: "btn btn-outline-secondary" %>
+      <%= link_to "Export to cart ...", admin_export_attached_works_to_cart_path(id: @admin_digitization_queue_item.id), class: "btn btn-outline-secondary",  data: { confirm: "Add #{ @admin_digitization_queue_item.works.count } attached works to your cart?" } %>
+      <%= link_to "Attach from cart ...", admin_import_attached_works_from_cart_path(id: @admin_digitization_queue_item.id), class: "btn btn-outline-secondary",  data: { confirm: "This will disconnect any currently attached works and replace them with the #{ current_user.works_in_cart.count } works currently in your cart. Are you sure?" } %>
     </p>
 
     <h2>Comments</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -369,6 +369,10 @@ Rails.application.routes.draw do
       as: "delete_digitization_queue_item_comment"
 
 
+    get "digitization_queue_items/:id/export_attached_works_to_cart", to: "digitization_queue_items#export_attached_works_to_cart", as: "export_attached_works_to_cart"
+
+    get "digitization_queue_items/:id/import_attached_works_from_cart", to: "digitization_queue_items#import_attached_works_from_cart", as: "import_attached_works_from_cart"
+
     #Cart:
     resources :cart_items, param: :work_friendlier_id, only: [:index, :update, :destroy] do
       collection do


### PR DESCRIPTION
Ref #3076
This PR proposes a way to edit the list of works associated with a digitization queue item:

* Clear your cart
* Export the works from the DQ item to the cart
* Add or delete works from the cart until it contains the works you want on the DQ
* Replace the works in the DQ with the contents of your cart.

The UI is clunky for now.