### PR TITLE
Add docValues to Solr id and model pk fields

### DIFF
--- a/app/models/search_builder/all_search_result_ids_builder.rb
+++ b/app/models/search_builder/all_search_result_ids_builder.rb
@@ -13,13 +13,16 @@ class SearchBuilder
 
       # This method runs on all searches, but we exit early unless we actually want this.
       return unless scope.context[:all_search_result_ids] == 'true'
-  
+
       solr_parameters.delete_if do |k, v|
         k.start_with?('facet')   || k.end_with?("facet.limit") ||
-        k.start_with?("hl")      || 
-        k.start_with?("stats")  
+        k.start_with?("hl")      ||
+        k.start_with?("stats")
       end
 
+      # It's important for performance that ALL fields in `fl` (in this case just one)
+      # have `docValues=true` in solr schema, to avoid major stored field performance hit
+      # in this query that could have thousands of results.
       solr_parameters.merge!({fl:"model_pk_ssi", rows: '10000000', hl: 'false', facet: 'false'})
     end
   end

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -245,8 +245,7 @@
     -->
     <field name="_version_" type="long" indexed="true" stored="true"/>
 
-
-    <field name="id" type="string" stored="true" indexed="true" multiValued="false" required="true"/>
+    <field name="id" type="string" stored="true" docValues="true" useDocValuesAsStored="true" indexed="true" multiValued="false" required="true"/>
     <field name="timestamp" type="pdate" indexed="true" stored="true" default="NOW" multiValued="false"/>
 
     <!-- this was dynamic typed *_ssi, but we override specifically to add docValues, so we can

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -252,7 +252,7 @@
          do queries including it without triggering stored field loading.  So it doesn't really
          match *_ssi anymore, sorry, but we don't wanna change the name. This holds actual UUID
          pk.  -->
-    <field name="model_pk_ssi" type="string" docValues="true" useDocValuesAsStored="true" stored="true" indexed="true" multiValued="false"/>
+    <field name="model_pk_ssi" type="string" docValues="true" useDocValuesAsStored="true" stored="false" indexed="true" multiValued="false"/>
 
 
     <field name="lat" type="pdouble" stored="true" indexed="true" multiValued="false"/>

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -245,8 +245,16 @@
     -->
     <field name="_version_" type="long" indexed="true" stored="true"/>
 
+
     <field name="id" type="string" stored="true" indexed="true" multiValued="false" required="true"/>
     <field name="timestamp" type="pdate" indexed="true" stored="true" default="NOW" multiValued="false"/>
+
+    <!-- this was dynamic typed *_ssi, but we override specifically to add docValues, so we can
+         do queries including it without triggering stored field loading.  So it doesn't really
+         match *_ssi anymore, sorry, but we don't wanna change the name. This holds actual UUID
+         pk.  -->
+    <field name="model_pk_ssi" type="string" docValues="true" useDocValuesAsStored="true" stored="true" indexed="true" multiValued="false"/>
+
 
     <field name="lat" type="pdouble" stored="true" indexed="true" multiValued="false"/>
     <field name="lng" type="pdouble" stored="true" indexed="true" multiValued="false"/>
@@ -272,7 +280,7 @@
     <!-- Three full text fields (containing oral history transcripts, transcriptions, translations, OCR text, and the like).
 
       stored=true is necessary for highlighting.
-      
+
       We've gone back and forth about whether to use length normalization for these fields.
       (see omitNorms at https://solr.apache.org/guide/solr/latest/indexing-guide/fields.html).
       The consensus is it doesn't make that big of a difference in practice, so we're going
@@ -284,7 +292,7 @@
       https://lucene.apache.org/solr/guide/8_0/highlighting.html#Highlighting-SchemaOptionsandPerformanceConsiderations
 
     -->
-    
+
     <!-- Full text search for works entirely in English -->
     <field name="searchable_fulltext_en" type="text_en" stored="true" indexed="true" multiValued="true" omitNorms="false" storeOffsetsWithPositions="true"/>
 


### PR DESCRIPTION
Fixes #3120

**don't merge until you are ready to do the downtime with cleanup outlined below**

it turns out that our large full text stored fields really add a performance penalty to fetching documents -- *even if* your solr `fl` field list doesn't include the large stored fields.  This isn't necessarily a big deal for our normal UX searches with 25 records a page -- but in "add search to cart" function, we were trying to pull thousands of docs out of solr. 

It turns out that if *all* your fields in the `fl` fieldlist have docValues so Solr can use this instead of the actual "stored field" disk representation -- you can avoid the penalty. 

The relevant query here has only ONE field in `fl`, `model_pk_ssi` -- so just have to make sure it has docValues, and we're good!  As long as we're at it, give our pk `id` field docValues too, because we might want ot use it in similar ways (it actually holds our `friendlier_id`). 

Thanks to @mgibney for the hint!

## Deploy

When changing docValues you need ot completely erase and rebuild your solr index, you can't do it with an in-place reindex. 

There are ways to do this iwthout downtime by juggling multiple solr collections/cores in and out, but we'll just do it with 10-15 minutes of downtime instead and avoid the headache. 

1. [ ] maintenance mode on
2. [ ] merge and deploy to heroku with these changes
3. [ ] delete "collection" in solr admin dashboard
4. [ ] `heroku run -r production rake scihist:solr_cloud:create_collection scihist:solr:reindex`
    -  (indexing is going slow these days, this full reindex could take up to 7-8 minutes)
5. [ ] maintenance mode off 
