### PR TITLE
Add a sizes attribute to the homepage hero image tag

### DIFF
--- a/app/components/home_page_hero_image_component.html.erb
+++ b/app/components/home_page_hero_image_component.html.erb
@@ -6,6 +6,13 @@
       [path_1000, "1000w"], # scaled to 1000 width
       [path_2000, "2000w"], # scaled to 2000 width
     ],
+
+
+    # This max-width: 992 value is the 'lg' breakpoint in Bootstrap.
+    # See also homepage.scss.
+    # See also https://github.com/sciencehistory/scihist_digicoll/issues/2647
+    sizes: "(max-width: 992) 50vw, 100vw",
+
     'aria-labelledby' => 'homeHeroCaption'
   ) %>
   <figcaption id="homeHeroCaption">

--- a/app/frontend/stylesheets/local/homepage.scss
+++ b/app/frontend/stylesheets/local/homepage.scss
@@ -24,6 +24,17 @@
           // for small screens at collapsed size
           max-height: 20rem;
           object-fit: cover;
+          /*
+            Note:
+
+            The Bootstrap breakpoint of 992 pixels,
+            referenced below as media-breakpoint-up('lg')
+            is also hard-wired in the template:
+            /app/components/home_page_hero_image_component.html.erb
+
+            See https://github.com/sciencehistory/scihist_digicoll/issues/2647 for context.
+
+          */
           @include media-breakpoint-up('lg') {
             max-height: revert;
             object-fit: revert; // cause apparently sometimes it's off by 1 pixel!


### PR DESCRIPTION
Ref #2647

This appears to work nicely, but i had to hardcode the breakpoint value in the template. Not a huge deal, as long as it's well documented.