### PR TITLE
update puma to 7.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -538,7 +538,7 @@ GEM
       date
       stringio
     public_suffix (6.0.2)
-    puma (7.0.0)
+    puma (7.0.4)
       nio4r (~> 2.0)
     qa (5.15.0)
       activerecord-import


### PR DESCRIPTION
With bugfixes

Seems to be required by heroku -- heroku is unusually not just warning but actually blocking deploy with puma 7.0.0 I think!

```
remote:  !     Your application is using Puma 7.0.0.
remote:  !
remote:  !     This has a known issue with the `PUMA_PERSISTENT_TIMEOUT` environment variable.
remote:  !
remote:  !     This is fixed in Puma 7.0.3+ via https://github.com/puma/puma/pull/3749.
remote:  !     Please upgrade your application to Puma 7.0.3+ by running the following commands:
remote:  !
remote:  !     ```
remote:  !     $ gem install puma
remote:  !     $ bundle update puma
remote:  !     $ git add Gemfile.lock && git commit -m "Upgrade Puma to 7.0.3+"
```