### PR TITLE
Improve bulk solr indexing memory usage/performance

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -304,8 +304,9 @@ class Asset < Kithe::Asset
   # fetch shrine attachment return as string
   def asr_webvtt_str
     if asr_webvtt?
+      # rewindable false may improve performance and save some RAM, avoiding cached copy
       stringio = StringIO.new
-      file_derivatives[ASR_WEBVTT_DERIVATIVE_KEY.to_sym].stream(stringio)
+      file_derivatives[ASR_WEBVTT_DERIVATIVE_KEY.to_sym].stream(stringio, rewindable: false)
       stringio.string
     end
   end
@@ -317,7 +318,8 @@ class Asset < Kithe::Asset
   def corrected_webvtt_str
     if corrected_webvtt?
       stringio = StringIO.new
-      file_derivatives[CORRECTED_WEBVTT_DERIVATIVE_KEY.to_sym].stream(stringio)
+      # rewindable false may improve performance and save some RAM, avoiding cached copy
+      file_derivatives[CORRECTED_WEBVTT_DERIVATIVE_KEY.to_sym].stream(stringio, rewindable: false)
       stringio.string
     end
   end

--- a/lib/tasks/scihist.rake
+++ b/lib/tasks/scihist.rake
@@ -127,8 +127,9 @@ namespace :scihist do
           Work.strict_loading.for_batch_indexing,
           Collection.strict_loading.includes(:contains_contained_by)
         ].each do |scope|
+          # use util to try to minimize RAM use.
           # limiting batch size to 100 seems to have good effect on limiting RAM use
-          scope.find_each(batch_size: 100) do |model|
+          ScihistDigicoll::Util.find_each(scope, batch_size: 100) do |model|
             progress_bar.title = "#{model.class.name}:#{model.friendlier_id}" if progress_bar
             model.update_index
             progress_bar.increment if progress_bar

--- a/lib/tasks/scihist.rake
+++ b/lib/tasks/scihist.rake
@@ -129,7 +129,7 @@ namespace :scihist do
         ].each do |scope|
           # use util to try to minimize RAM use.
           # limiting batch size to 100 seems to have good effect on limiting RAM use
-          ScihistDigicoll::Util.find_each(scope, batch_size: 100) do |model|
+          ScihistDigicoll::Util.find_each(scope, batch_size: 50) do |model|
             progress_bar.title = "#{model.class.name}:#{model.friendlier_id}" if progress_bar
             model.update_index
             progress_bar.increment if progress_bar

--- a/lib/tasks/scihist.rake
+++ b/lib/tasks/scihist.rake
@@ -108,7 +108,7 @@ namespace :scihist do
       # for collection, so have to in two parts.
 
       Kithe.indexable_settings.writer_settings.merge!(
-        "solr_writer.thread_pool" => 1,
+        "solr_writer.thread_pool" => 2,
         "solr_writer.http_timeout" => 8
       )
 

--- a/lib/tasks/scihist.rake
+++ b/lib/tasks/scihist.rake
@@ -124,8 +124,8 @@ namespace :scihist do
         # a bit, but not too bad.
 
         [
-          Work.strict_loading.for_batch_indexing,
-          Collection.strict_loading.includes(:contains_contained_by)
+          Work.strict_loading.readonly.for_batch_indexing,
+          Collection.strict_loading.readonly.includes(:contains_contained_by)
         ].each do |scope|
           # use util to try to minimize RAM use.
           # limiting batch size to 100 seems to have good effect on limiting RAM use


### PR DESCRIPTION
Some tweaks to improve Solr indexing performance, primarily via reducing memory usage. Thanks to @eddierubeiz for noticing the R14 memory errors (which mean memory swapping is happening) were a large component of our perf problems. 

- When fetching models for solr index, re-use existing util method which optimizes for reduced RAM use
- Reduce fetch batch size to 50, seems to help with RAM with no real hit on throughput
- Use shrine feature to avoid rewind cache when fetching transcript derivatives, hoping to improve memory and performance
- Add one more traject writer thread for reindexing, helps with performance a bit, in case indexing is happening faster than 1 writer thread can handle
- add ActiveRecord .readonly just cause why not

These changes reduce memory consumption, but not quite enough to avoid R14 erorrs in standard-1x, we still get some. We do NOT get R14's with standard-2x -- although oddly this does not seem to actually improve overall time much?  

performane-m or performance-l are both a lot faster (I guess becuase of better dedicated CPU time?), and will give you faster indexing. -m seems as good as -l, although all of them vary from run to run. 

Sample findings on staging solr with these changes

|dyno size|R14 errors?|speed|
|:-----|:-----|:-----|
|standard-1x|yes|46-54 rps, 4:22 — 5:09|
|standard-2x|no|46-51 rps, 4:37-5:09|
|performance-m|no|69 rps 3:24|
|performance-l| no  |65.31/s 03:38|
