### PR TITLE
Fixity report as a hash

### DIFF
--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -96,7 +96,7 @@ class Admin::AssetsController < AdminController
   end
 
   def fixity_report
-    @fixity_report = FixityReport.new()
+    @fixity_report = FixityReport.new.report_hash
   end
 
   def display_attach_form

--- a/app/models/fixity_report.rb
+++ b/app/models/fixity_report.rb
@@ -10,188 +10,75 @@ class FixityReport
   # Assets older than EXPECTED_FRESH_IN_DAYS should not be stale, or it's a problem.
   EXPECTED_FRESH_IN_DAYS = 1
 
-  # All assets, including collection thumbnail assets.
-  def asset_count
-    @asset_count ||= Asset.count
-  end
-
-  def not_recent_count
-    @not_recent_count ||= Asset.where("#{recent_asset_sql} = false").count
-  end
-
-  def not_recent_not_stored_count
-    @not_recent_not_stored_count ||= Asset.where("#{recent_asset_sql} = false").where(not_stored_file_sql).count
-  end
-
-  # All assets with stored files.
-  def stored_files
-    @stored_files ||= Asset.where(stored_file_sql).count
-  end
-
-  # Assets with a file that have been checked in the past week.
-  def recent_checks
-     @recent_checks ||= check_count_having([
-       stored_file_sql, "#{stale_checks_sql} = false"
-     ])
-  end
-
-  # Assets with no stored files, which obviously can't
-  # be checked for fixity.
-  # Note: asset_stats reports these as null.
-  # Note: this could also be count_asset_stats ({stored_file: [false, nil]}).
-  def no_stored_files
-    @no_stored_files ||= asset_count - stored_files
-  end
-
-  # Assets with a file stored on them, but which haven't
-  # had a fixity check yet.
-  def no_checks
-    @no_checks ||= check_count_having([
-      stored_file_sql,
-      "fixity_checks.count = 0"
-    ])
-  end
-
-  # Assets with a file and at least one fixity check.
-  def with_checks
-    @with_checks ||= stored_files - no_checks
-  end
-
-  # Assets with a file that *have* checks, but have not been checked for the past week.
-  # Note: assets with no checks yet show up as nil, so stale_checks + recent_checks != with_checks
-  def stale_checks
-    @stale_checks ||= check_count_having([
-      stored_file_sql, "#{stale_checks_sql}"
-    ])
-  end
-
-  def recent_count
-    @recent_count ||= Asset.where(recent_asset_sql).count
-  end
-
-  def earliest_check_date
-    @earliest_check_date ||= FixityCheck.minimum(:created_at).in_time_zone
-  end
-
-  def latest_check_date
-    @latest_check_date ||= FixityCheck.maximum(:created_at).in_time_zone
-  end
-
-  # Assets with files, that were ingested less than a week ago.
-  # def recent_files
-  #   @recent_files ||= check_count_having([
-  #     stored_file_sql, recent_asset_sql
-  #   ])
-  # end
-
-  # Assets with files, that have no checks
-  # or stale checks.
-  # Because this is a left join,
-  # :stale_check could be true
-  #     (because the checks are stale),
-  # or nil
-  #     (because there are no checks yet.)
-  def no_checks_or_stale_checks
-    @no_checks_or_stale_checks ||= check_count_having([
-      stored_file_sql,
-      "(#{stale_checks_sql}) OR (#{stale_checks_sql} is NULL)"
-    ])
-  end
-
-  # See discussion of stale_check above.
-  # Is this method name way too long?
-  # Maybe, but the concept is kind of complex.
-  def not_recent_with_no_checks_or_stale_checks
-    @not_recent_with_no_checks_or_stale_checks ||= check_count_having([
-      stored_file_sql,
-      "#{recent_asset_sql} = false",
-      "(#{stale_checks_sql}) OR (#{stale_checks_sql} is NULL)"
-    ])
-  end
-
-
-  # an ActiveRecord relation corresponding to #not_recent_with_no_checks_or_stale_checks, but
-  # returning a relation you can get actual assets from, not just count.
-  def need_checks_assets_relation
-    build_query([
-      stored_file_sql,
-      "#{recent_asset_sql} = false",
-      "(#{stale_checks_sql}) OR (#{stale_checks_sql} is NULL)"
-    ], count_only: false)
-  end
-
-
-
-
-  # Of the assets that have fixity checks, which has the OLDEST most recent
-  # check, and what is it?
-  #
-  # We return an OpenStruct with `asset` and `timestamp` for the asset with
-  # the oldest most recent fixity check. Can both be null if there are no fixity
-  # checks.
-  #
-  # This is some tricky SQL, but we think we got it right.
-  def stalest_current_fixity_check
-    @stalast_current_fixity_check ||= begin
-      # We think this does what we want in SQL...
-      (pk, timestamp) = Asset.left_outer_joins(:fixity_checks).group(:id).
-                          having(stored_file_sql).
-                          order(Arel.sql "max(fixity_checks.created_at)").
-                          limit(1).
-                          maximum("fixity_checks.created_at").first.to_a
-
-      OpenStruct.new(asset: (Asset.find(pk) if pk), timestamp: timestamp&.in_time_zone)
-    end
-  end
-
-
-  # Any assets whose most recent check has failed.
-  # This query might get slow if we
-  # accumulate a lot of failed checks.
-  # This method contacts the DB twice,
-  # once to get the asset ids, and once
-  # to load the assets into memory. Oh well.
-  def bad_assets
-    @bad_assets ||= begin
-      sql = """
-        SELECT bad.asset_id FROM fixity_checks bad
-        WHERE bad.passed = 'f'
-        AND NOT EXISTS (
-          SELECT FROM fixity_checks good
-          WHERE good.asset_id = bad.asset_id
-          AND good.passed = 't'
-          AND good.created_at > bad.created_at )
-      """
-      results = ActiveRecord::Base.connection.execute(sql)
-      asset_ids = results.to_a.map {|row| row['asset_id']}
-      Asset.find(asset_ids)
-    end
-  end
-
-  private
-
   # We store video originals in 'video_store' and everything else in 'store'.
-  def not_stored_file_sql
-    "(file_data ->> 'storage' NOT IN ('store', 'video_store') or file_data ->> 'storage' is NULL)"
-  end
+  NOT_STORED_FILE_SQL = "(file_data ->> 'storage' NOT IN ('store', 'video_store') or file_data ->> 'storage' is NULL)"
+  STORED_FILE_SQL     = "(file_data ->> 'storage' IN ('store','video_store'))"
+  STALE_CHECKS_SQL    = "(max(fixity_checks.created_at) < (NOW() - INTERVAL '#{STALE_IN_DAYS} days'))"
+  RECENT_ASSET_SQL    = "(kithe_models.created_at > (NOW() - INTERVAL '#{EXPECTED_FRESH_IN_DAYS} days'))"
+  REPORT_CACHE_KEY = "scihist:fixity_report"
+  HOW_LONG_TO_CACHE_REPORT = 1.days
 
-  def stored_file_sql
-    "(file_data ->> 'storage' IN ('store','video_store'))"
-  end
+  def report_hash
+    rep = {}
+    rep[:asset_count]      = Asset.count
+    rep[:recent_count]     = Asset.count(RECENT_ASSET_SQL)
+    rep[:not_recent_count] = Asset.count("#{RECENT_ASSET_SQL} = false")
+    rep[:stored_files]     = Asset.count(STORED_FILE_SQL)
+    rep[:no_checks]     = check_count_having([STORED_FILE_SQL, "fixity_checks.count = 0"])
+    rep[:recent_checks] = check_count_having([ STORED_FILE_SQL, "#{STALE_CHECKS_SQL} = false" ])
+    rep[:stale_checks]  = check_count_having([ STORED_FILE_SQL, STALE_CHECKS_SQL ])
+    rep[:no_stored_files] = rep[:asset_count]  - rep[:stored_files]
+    rep[:with_checks]     = rep[:stored_files] - rep[:no_checks]
+    rep[:not_recent_not_stored_count] = Asset.where("#{RECENT_ASSET_SQL} = false").count(NOT_STORED_FILE_SQL)
 
-  def stale_checks_sql
-    "(max(fixity_checks.created_at) < (NOW() - INTERVAL '#{STALE_IN_DAYS} days'))"
-  end
+    rep[:earliest_check_date] = FixityCheck.minimum(:created_at).in_time_zone
+    rep[:latest_check_date]   = FixityCheck.maximum(:created_at).in_time_zone
 
-  def recent_asset_sql
-    "(kithe_models.created_at > (NOW() - INTERVAL '#{EXPECTED_FRESH_IN_DAYS} days'))"
+
+    # Note the left join.
+    # STALE_CHECKS_SQL could be true
+    #   (because the checks are stale),
+    # or nil
+    #   (because there are no checks yet.)
+    rep[:no_checks_or_stale_checks]  = check_count_having([
+      STORED_FILE_SQL,
+      "(#{STALE_CHECKS_SQL}) OR (#{STALE_CHECKS_SQL} is NULL)"
+    ])
+
+    rep[:not_recent_with_no_checks_or_stale_checks] = check_count_having([
+      STORED_FILE_SQL,
+      "#{RECENT_ASSET_SQL} = false",
+      "(#{STALE_CHECKS_SQL}) OR (#{STALE_CHECKS_SQL} is NULL)"
+    ])
+
+
+    # Stalest:
+    (pk, timestamp) = Asset.left_outer_joins(:fixity_checks).group(:id).
+                        having(STORED_FILE_SQL).
+                        order(Arel.sql "max(fixity_checks.created_at)").
+                        limit(1).
+                        maximum("fixity_checks.created_at").first.to_a
+    rep[:stalest_current_fixity_check_asset_id] = pk
+    rep[:stalest_current_fixity_check_timestamp] = timestamp&.in_time_zone
+
+    # Any assets whose most recent check has failed.
+    # This query will get slow if we
+    # accumulate a lot of failed checks.
+    rep[:bad_asset_ids]    = ActiveRecord::Base.connection.execute("""
+      SELECT bad.asset_id FROM fixity_checks bad
+      WHERE bad.passed = 'f'
+      AND NOT EXISTS (
+        SELECT FROM fixity_checks good
+        WHERE good.asset_id = bad.asset_id
+        AND good.passed = 't'
+        AND good.created_at > bad.created_at )
+    """).to_a.map {|row| row['asset_id']}
+
+    rep[:timestamp] = Time.current.to_s
+    rep
   end
 
   def check_count_having(conditions)
-    build_query(conditions, count_only: true)
-  end
-
-  def build_query(conditions, count_only:false)
     subquery = Asset.
       select("kithe_models.id").
       left_outer_joins(:fixity_checks).
@@ -199,12 +86,6 @@ class FixityReport
     conditions.each do |h|
       subquery = subquery.having(h)
     end
-    relation = Asset.where(id: subquery)
-
-    if count_only
-      relation.count
-    else
-      relation
-    end
+    Asset.where(id: subquery).count
   end
 end

--- a/app/views/admin/assets/fixity_report.html.erb
+++ b/app/views/admin/assets/fixity_report.html.erb
@@ -130,32 +130,32 @@
 
 
       <tr>
-        <td>Stored (attached file)</td>
+        <td>Fully ingested (attached file)</td>
         <td><%= number_with_delimiter(@fixity_report[:stored_files])%></td>
       </tr>
 
       <tr>
-        <td>Stored, no checks</td>
+        <td>Fully ingested, no checks</td>
         <td><%= number_with_delimiter(@fixity_report[:no_checks]) %></td>
       </tr>
 
       <tr>
-        <td>Stored, at least one check</td>
+        <td>Fully ingested, at least one check</td>
         <td><%= number_with_delimiter(@fixity_report[:with_checks]) %></td>
       </tr>
 
       <tr>
-        <td>Stored, checked in the past <%= FixityReport::STALE_IN_DAYS %> days</td>
+        <td>Fully ingested, checked in the past <%= FixityReport::STALE_IN_DAYS %> days</td>
         <td><%= number_with_delimiter(@fixity_report[:recent_checks]) %></td>
       </tr>
 
       <tr>
-        <td>Stored, stale checks (have not been checked for <%= FixityReport::STALE_IN_DAYS %> days, or ever)</td>
+        <td>Fully ingested, stale checks (have not been checked for <%= FixityReport::STALE_IN_DAYS %> days, or ever)</td>
         <td><%= number_with_delimiter(@fixity_report[:no_checks_or_stale_checks]) %></td>
       </tr>
 
       <tr>
-        <td>Stored asset with stalest fixity check</td>
+        <td>Fully ingested asset with stalest fixity check</td>
         <td>
             <% if @fixity_report[:stalest_current_fixity_check_asset_id] %>
               <%= link_to l(@fixity_report[:stalest_current_fixity_check_timestamp], format: :admin), admin_asset_path(Asset.find(@fixity_report[:stalest_current_fixity_check_asset_id] )) %>

--- a/app/views/admin/assets/fixity_report.html.erb
+++ b/app/views/admin/assets/fixity_report.html.erb
@@ -161,6 +161,7 @@
               <%= link_to l(@fixity_report[:stalest_current_fixity_check_timestamp], format: :admin), admin_asset_path(Asset.find(@fixity_report[:stalest_current_fixity_check_asset_id] )) %>
             <% end %>
         </td>
+      </tr>
       <tr>
         <td>Oldest fixity check on record</td>
         <td><%= @fixity_report[:earliest_check_date] ? l(@fixity_report[:earliest_check_date], format: :admin) : "NONE!" %></td>

--- a/app/views/admin/assets/fixity_report.html.erb
+++ b/app/views/admin/assets/fixity_report.html.erb
@@ -3,16 +3,16 @@
 <div class="container">
   <div class="row">
     <div class="col-md">
-      <% if @fixity_report.bad_assets.blank? && @fixity_report.not_recent_with_no_checks_or_stale_checks == 0 %>
+      <% if @fixity_report[:bad_asset_ids].blank? && @fixity_report[:not_recent_with_no_checks_or_stale_checks] == 0 %>
         <p class="h2 alert alert-success"><i class="fa fa fa-thumbs-up" aria-hidden="true"></i> Fixity health good.</p>
       <% else %>
         <p class="h2 alert alert-danger"><i class="fa fa fa-thumbs-down" aria-hidden="true"></i> There are fixity health problems!</p>
         <ul>
-          <% unless @fixity_report.bad_assets.blank? %>
-            <li><%= pluralize @fixity_report.bad_assets.count, 'asset' %> currently failing fixity check</li>
+          <% unless @fixity_report[:bad_asset_ids].blank? %>
+            <li><%= pluralize @fixity_report[:bad_asset_ids].count, 'asset' %> currently failing fixity check</li>
           <% end %>
-          <% unless @fixity_report.not_recent_with_no_checks_or_stale_checks == 0 %>
-            <li><%= pluralize @fixity_report.not_recent_with_no_checks_or_stale_checks, 'asset' %> expected to have fresh fixity checks, but missing fresh fixity checks</li>
+          <% unless @fixity_report[:not_recent_with_no_checks_or_stale_checks] == 0 %>
+            <li><%= pluralize @fixity_report[:not_recent_with_no_checks_or_stale_checks], 'asset' %> expected to have fresh fixity checks, but missing fresh fixity checks</li>
           <% end %>
         </ul>
       <% end %>
@@ -21,7 +21,7 @@
     <div class="col-md alert alert-info">
       <ul>
         <li>We intend to schedule checks such that every file is checked at least once every <%= pluralize FixityReport::STALE_IN_DAYS, 'day' %>.</li>
-        <li>Fixity checks run <b>nightly</b> and will check 1/<%= FixityReport::STALE_IN_DAYS %> of our total assets (~<%= @fixity_report.asset_count / FixityReport::STALE_IN_DAYS %> assets) each night, choosing the assets with missing or most stale checks to run checks on.</li>
+        <li>Fixity checks run <b>nightly</b> and will check 1/<%= FixityReport::STALE_IN_DAYS %> of our total assets (~<%= @fixity_report[:asset_count] / FixityReport::STALE_IN_DAYS %> assets) each night, choosing the assets with missing or most stale checks to run checks on.</li>
         <li>Can only run fixity checks on assets that are <i>fully ingested</i> and have attached files.</li>
         <li>For assets created within last <%= pluralize FixityReport::EXPECTED_FRESH_IN_DAYS, 'day' %>, we tolerate missing fixity checks, as they may not have run yet.</li>
       </ul>
@@ -31,13 +31,12 @@
 
 <div class="mt-5">
   <h2 class="border-bottom">Assets Currently Failing Fixity</h2>
-  <%# never fear, bad_assets is memoized %>
-  <% if @fixity_report.bad_assets.present? %>
+  <% if @fixity_report[:bad_asset_ids].present? %>
       <p class="text-danger">
-        <i class="fa fa fa-thumbs-down" aria-hidden="true"></i> <%= pluralize(@fixity_report.bad_assets.count, 'failure') %>
+        <i class="fa fa fa-thumbs-down" aria-hidden="true"></i> <%= pluralize(@fixity_report[:bad_asset_ids].count, 'failure') %>
       </p>
       <ul class="list-unstyled alert alert-danger">
-        <% @fixity_report.bad_assets.each do |asset| %>
+        <% Asset.find(@fixity_report[:bad_asset_ids]).each do |asset| %>
             <li >
               <i class="fa fa-times" aria-hidden="true" ></i>
               <%= link_to(asset.title, admin_asset_path(asset)) %>
@@ -67,13 +66,13 @@
       <tbody>
         <tr>
           <td>Total</td>
-          <td colspan="2"><%= number_with_delimiter @fixity_report.not_recent_count %></td>
+          <td colspan="2"><%= number_with_delimiter @fixity_report[:not_recent_count] %></td>
         </tr>
 
         <tr>
           <td>Not yet fully ingested</td>
-          <td><%= number_with_delimiter @fixity_report.not_recent_not_stored_count %></td>
-          <% if (@fixity_report.not_recent_not_stored_count > 0) %>
+          <td><%= number_with_delimiter @fixity_report[:not_recent_not_stored_count] %></td>
+          <% if (@fixity_report[:not_recent_not_stored_count] > 0) %>
             <td class="bg-warning">
               <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
               Expect 0. Are these stuck in ingest process?
@@ -85,8 +84,8 @@
 
         <tr>
           <td>Fully ingested without <em>fresh</em> (within past <%= pluralize FixityReport::STALE_IN_DAYS, 'day' %>) fixity check</td>
-          <td><%= number_with_delimiter(@fixity_report.not_recent_with_no_checks_or_stale_checks) %></td>
-          <% if @fixity_report.not_recent_with_no_checks_or_stale_checks == 0 %>
+          <td><%= number_with_delimiter(@fixity_report[:not_recent_with_no_checks_or_stale_checks]) %></td>
+          <% if @fixity_report[:not_recent_with_no_checks_or_stale_checks] == 0 %>
             <td class="bg-success text-white">
               <i class="fa fa fa-thumbs-up" aria-hidden="true"></i> Good
             </td>
@@ -96,12 +95,6 @@
             </td>
           <% end %>
         </tr>
-
-        <tr>
-
-
-
-
       </tbody>
     </tr>
   </table>
@@ -118,68 +111,64 @@
       </tr>
     </thead>
     <tbody>
-        <tr>
-          <td>Total assets</td>
-          <td><%= number_with_delimiter(@fixity_report.asset_count) %></td>
-        </tr>
+      <tr>
+        <td>Total assets</td>
+        <td><%= number_with_delimiter(@fixity_report[:asset_count]) %></td>
+      </tr>
 
-        <tr>
-          <td>Created in the last <%= pluralize FixityReport::EXPECTED_FRESH_IN_DAYS, 'day' %></td>
-          <td><%= number_with_delimiter @fixity_report.recent_count %></td>
-        </tr>
+      <tr>
+        <td>Created in the last <%= pluralize FixityReport::EXPECTED_FRESH_IN_DAYS, 'day' %></td>
+        <td><%= number_with_delimiter @fixity_report[:recent_count] %></td>
+      </tr>
 
-        <tr>
-          <td>Not yet fully ingested (no attached file)<br>
-            <i>These should be temporary, pending ingest, and can't be fixity checked yet.</i>
-          </td>
-          <td><%=  number_with_delimiter(@fixity_report.no_stored_files) %></td>
-        </tr>
-
-
-        <tr>
-          <td>Fully ingested (attached file)</td>
-          <td><%= number_with_delimiter(@fixity_report.stored_files) %></td>
-        </tr>
-
-        <tr>
-          <td>Fully ingested, no checks</td>
-          <td><%= number_with_delimiter(@fixity_report.no_checks) %></td>
-        </tr>
-
-        <tr>
-          <td>Fully ingested, at least one check</td>
-          <td><%= number_with_delimiter(@fixity_report.with_checks) %></td>
-        </tr>
-
-        <tr>
-          <td>Fully ingested, checked in the past <%= FixityReport::STALE_IN_DAYS %> days</td>
-          <td><%= number_with_delimiter(@fixity_report.recent_checks) %></td>
-        </tr>
-
-        <tr>
-          <td>Fully ingested, stale checks (have not been checked for <%= FixityReport::STALE_IN_DAYS %> days, or ever)</td>
-          <td><%= number_with_delimiter(@fixity_report.no_checks_or_stale_checks) %></td>
-        </tr>
-
-        <tr>
-          <td>Fully-ingested Asset with oldest most-recent fixity check</td>
-          <td>
-              <% if @fixity_report.stalest_current_fixity_check.timestamp && @fixity_report.stalest_current_fixity_check.asset %>
-                <%= link_to l(@fixity_report.stalest_current_fixity_check.timestamp, format: :admin), admin_asset_path(@fixity_report.stalest_current_fixity_check.asset) %>
-              <% end %>
-          </td>
-
-        <tr>
-          <td>Oldest fixity check on record</td>
-          <td><%= @fixity_report.earliest_check_date ? l(@fixity_report.earliest_check_date, format: :admin) : "NONE!" %></td>
-        </tr>
-
-        <tr>
-          <td>Most recent fixity check on record</td>
-          <td><%= @fixity_report.latest_check_date ? l(@fixity_report.latest_check_date, format: :admin) : "NONE!" %></td>
-        </tr>
+      <tr>
+        <td>Not yet fully ingested (no attached file)<br>
+          <i>These should be temporary, pending ingest, and can't be fixity checked yet.</i>
+        </td>
+        <td><%=  number_with_delimiter(@fixity_report[:no_stored_files]) %></td>
+      </tr>
 
 
+      <tr>
+        <td>Stored (attached file)</td>
+        <td><%= number_with_delimiter(@fixity_report[:stored_files])%></td>
+      </tr>
+
+      <tr>
+        <td>Stored, no checks</td>
+        <td><%= number_with_delimiter(@fixity_report[:no_checks]) %></td>
+      </tr>
+
+      <tr>
+        <td>Stored, at least one check</td>
+        <td><%= number_with_delimiter(@fixity_report[:with_checks]) %></td>
+      </tr>
+
+      <tr>
+        <td>Stored, checked in the past <%= FixityReport::STALE_IN_DAYS %> days</td>
+        <td><%= number_with_delimiter(@fixity_report[:recent_checks]) %></td>
+      </tr>
+
+      <tr>
+        <td>Stored, stale checks (have not been checked for <%= FixityReport::STALE_IN_DAYS %> days, or ever)</td>
+        <td><%= number_with_delimiter(@fixity_report[:no_checks_or_stale_checks]) %></td>
+      </tr>
+
+      <tr>
+        <td>Stored asset with stalest fixity check</td>
+        <td>
+            <% if @fixity_report[:stalest_current_fixity_check_asset_id] %>
+              <%= link_to l(@fixity_report[:stalest_current_fixity_check_timestamp], format: :admin), admin_asset_path(Asset.find(@fixity_report[:stalest_current_fixity_check_asset_id] )) %>
+            <% end %>
+        </td>
+      <tr>
+        <td>Oldest fixity check on record</td>
+        <td><%= @fixity_report[:earliest_check_date] ? l(@fixity_report[:earliest_check_date], format: :admin) : "NONE!" %></td>
+      </tr>
+      <tr>
+        <td>Most recent fixity check on record</td>
+        <td><%= @fixity_report[:latest_check_date] ? l(@fixity_report[:latest_check_date], format: :admin) : "NONE!" %></td>
+      </tr>
     </tbody>
   </table>
 </div>

--- a/spec/models/fixity_report_spec.rb
+++ b/spec/models/fixity_report_spec.rb
@@ -36,7 +36,7 @@ describe FixityReport do
     end
   end
 
-  let(:report) { FixityReport.new }
+  let(:report) { FixityReport.new.report_hash }
 
   it "correctly counts the assets and fixity checks" do
     # OK we have 3 assets, with the a bunch of fixity checks attached to them.
@@ -48,27 +48,27 @@ describe FixityReport do
     expect(recent_asset_with_file_2.fixity_checks.map{ |fc| fc.passed?}).to eq [true,  true, true,  true, false, true]
 
     # The report counts our 5 assets.
-    expect(report.asset_count).to eq 5
+    expect(report[:asset_count]).to eq 5
 
     # old_asset, recent_asset_with_file_1 and recent_asset_with_file_2 failed their checks at some point in the past.
     # But the only one that should be reported as currently
     # failing is recent_asset_with_file_1, since its most recent check has failed.
-    expect(report.bad_assets).to match_array([recent_asset_with_file_1])
+    expect(report[:bad_asset_ids]).to match_array([recent_asset_with_file_1.id])
 
     # All assets except recent_asset_no_file have files
-    expect(report.stored_files).to eq 4
+    expect(report[:stored_files]).to eq 4
 
     # recent_asset_no_file has no stored file.
-    expect(report.no_stored_files).to eq 1
+    expect(report[:no_stored_files]).to eq 1
 
     # Assets old_asset, recent_asset_with_file_1 and recent_asset_with_file_2 have checks.
-    expect(report.with_checks).to eq 3
+    expect(report[:with_checks]).to eq 3
 
     # old_asset, recent_asset_with_file_1 and recent_asset_with_file_2 have recent checks
-    expect(report.recent_checks).to eq 3
+    expect(report[:recent_checks]).to eq 3
 
     # All the items with checks have recent ones.
-    expect(report.stale_checks).to eq 0
+    expect(report[:stale_checks]).to eq 0
 
     # All assets except old_asset are less than a week old.
     # Asset recent_asset_no_file doesn't have a file yet so we don't
@@ -77,16 +77,16 @@ describe FixityReport do
     #expect(report.recent_files).to eq 3
 
     # All assets with checks have recent checks, but recent_asset_no_checks still needs to be checked.
-    expect(report.no_checks_or_stale_checks).to eq 1
+    expect(report[:no_checks_or_stale_checks]).to eq 1
 
     # old_asset was ingested more than a day ago
-    expect(report.not_recent_count).to eq 1
+    expect(report[:not_recent_count]).to eq 1
 
     # all but old_asset: recent_asset_no_checks, recent_asset_with_file_1, recent_asset_with_file_2, recent_asset_no_file
-    expect(report.recent_count).to eq 4
+    expect(report[:recent_count]).to eq 4
 
     # Asset old_asset is not recent, but it's been checked this week.
-    expect(report.not_recent_with_no_checks_or_stale_checks).to eq 0
+    expect(report[:not_recent_with_no_checks_or_stale_checks]).to eq 0
   end
 
   describe "stale checks" do
@@ -109,54 +109,56 @@ describe FixityReport do
 
       # In this scenario:
       # All assets with fixity checks have their most recent check passing.
-      expect(report.bad_assets).to match_array([])
+
+      expect(report[:bad_asset_ids]).to match_array([])
 
       # Still 4 assets.
-      expect(report.asset_count).to eq 5
+      expect(report[:asset_count]).to eq 5
 
       # Four have stored files: recent_asset_no_checks, old_asset, recent_asset_with_file_1 and recent_asset_with_file_2.
-      expect(report.stored_files).to eq 4
+      expect(report[:stored_files]).to eq 4
 
       #recent_asset_no_checks has no file.
-      expect(report.no_stored_files).to eq 1
+      expect(report[:no_stored_files]).to eq 1
 
       # recent_asset_no_checks has no checks
-      expect(report.no_checks).to eq 1
+      expect(report[:no_checks]).to eq 1
 
       # 3 have checks
-      expect(report.with_checks).to eq 3
+      expect(report[:with_checks]).to eq 3
 
       # recent_asset_with_file_2 is now the only one with recent checks:
-      expect(report.recent_checks).to eq 1
+      expect(report[:recent_checks]).to eq 1
 
       # old_asset and recent_asset_with_file_1 have stale checks now
-      expect(report.stale_checks).to eq 2
+      expect(report[:stale_checks]).to eq 2
 
       # recent_asset_no_checks, recent_asset_with_file_1 and recent_asset_with_file_2 are recent assets with files.
       #expect(report.recent_files).to eq 3
 
       # recent_asset_no_checks (no checks yet) old_asset (checks stale) and recent_asset_with_file_1 (checks also stale) need to get checked.
-      expect(report.no_checks_or_stale_checks).to eq 3
+      expect(report[:no_checks_or_stale_checks]).to eq 3
 
       # old_asset is only one ingested more than a day ago
-      expect(report.not_recent_count).to eq 1
+      expect(report[:not_recent_count]).to eq 1
 
       # all but old_asset: recent_asset_no_checks, recent_asset_with_file_1, recent_asset_with_file_2, recent_asset_no_file
-      expect(report.recent_count).to eq 4
+      expect(report[:recent_count]).to eq 4
 
       # Don't have any at present
-      expect(report.not_recent_not_stored_count).to eq(0)
+      expect(report[:not_recent_not_stored_count]).to eq(0)
 
       # old_asset was ingested more than a day ago but it hasn't been checked for over a week.
       # Sound the alarm!
-      expect(report.not_recent_with_no_checks_or_stale_checks).to eq 1
+      expect(report[:not_recent_with_no_checks_or_stale_checks]).to eq 1
 
       # and can we fetch the actual assets that correspond, with this other method?
       found = []
-      report.need_checks_assets_relation.each do |asset|
+      FixityReport.new.need_checks_assets_relation.each do |asset|
         found << asset
       end
       expect(found.length).to eq 1
+
     end
   end
 
@@ -165,8 +167,9 @@ describe FixityReport do
     let!(:old_asset_no_file) { create(:asset, created_at: Time.now() - 10000000)}
     let!(:recent_asset_file) { create(:asset_image_with_correct_sha512) }
 
+
     it "correctly reports" do
-      expect(report.not_recent_not_stored_count).to eq(1)
+      expect(report[:not_recent_not_stored_count]).to eq(1)
     end
   end
 
@@ -184,9 +187,10 @@ describe FixityReport do
         ])
     }
 
+
     it "finds" do
-      expect(report.stalest_current_fixity_check.asset).to eq(asset_with_oldest_current)
-      expect(report.stalest_current_fixity_check.timestamp).to eq(oldest_current)
+      expect(report[:stalest_current_fixity_check_asset_id]).to eq(asset_with_oldest_current.id)
+      expect(report[:stalest_current_fixity_check_timestamp]).to eq(oldest_current)
     end
   end
 end


### PR DESCRIPTION
This is one of a series of refactors to simplify and speed up our fixity code.

Ref https://github.com/sciencehistory/scihist_digicoll/issues/2787

The GitHub diff looks a lot more complicated than it should; you may want to abandon the side-by-side comparison in this case.

In this PR:

- We create a new method in `fixity_report.rb` called `report_hash`, which returns a hash containing all the data needed to display a fixity report on the front page.
- `fixity_report.rb` also makes better use of class constants. Much more readable.
- Instead of defining a series of one-line methods on FixityReport, we just add key-value pairs to the hash.
  - For instance, instead of `@fixity_report.asset_count` we have `@fixity_report[:asset_count]`.
- Instead of storing AR objects in the hash, we just store their IDs and find them at display time. So instead of `@fixity_report.bad_assets` we use  `Asset.find(@fixity_report[:bad_asset_ids])`.

