### PR TITLE
more like this limit in cache key

### DIFF
--- a/app/services/more_like_this_getter.rb
+++ b/app/services/more_like_this_getter.rb
@@ -128,7 +128,7 @@ class MoreLikeThisGetter
   end
 
   def cache_key
-    "scihist:more_like_this:#{@work.friendlier_id}"
+    "scihist:more_like_this:#{@work.friendlier_id}:#{@limit}"
   end
 
   # Caching these should save trips to our flaky solr provider.

--- a/spec/services/more_like_this_getter_spec.rb
+++ b/spec/services/more_like_this_getter_spec.rb
@@ -11,7 +11,7 @@ describe MoreLikeThisGetter,  solr: true, indexable_callbacks: true, queue_adapt
   let(:limit) { nil }
   let(:getter) {MoreLikeThisGetter.new(work_to_match, limit: limit)}
   let(:work_to_match)   { create(:public_work, subject: shared_subject, description: shared_description)  }
-  let(:work_to_match_cache_key) {"scihist:more_like_this:#{work_to_match.friendlier_id}"}
+  let(:work_to_match_cache_key) {"scihist:more_like_this:#{work_to_match.friendlier_id}:#{limit || MoreLikeThisGetter::DEFAULT_LIMIT}"}
 
   let(:five_public_works) { [
       create(:public_work, subject: shared_subject, description: shared_description),


### PR DESCRIPTION
If you retrieve a cache for a different limit than you need right now, that's a bug. This fixes it. 

Prep for #2866 
