### PR TITLE
Update gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -191,9 +191,7 @@ gem "rack-attack", "~> 6.6" # throttling excessive requests
 gem "webvtt-ruby", "< 2" # https://github.com/opencoconut/webvtt-ruby
 
 # MS Word .docx for some OH transcript handling
-# Appears entirely unmaintained and has some bugfixes we need in unreleased master
-# We will lock to SHA for safety.
-gem "docx", github: "ruby-docx/docx", ref: "c5bcb57"
+gem "docx", "< 1.0"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/ruby-docx/docx.git
-  revision: c5bcb57b3d21fead105f1c7af8d3881dd31674cc
-  ref: c5bcb57
-  specs:
-    docx (0.8.0)
-      nokogiri (~> 1.13, >= 1.13.0)
-      rubyzip (~> 2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -255,6 +246,9 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.6.2)
+    docx (0.10.0)
+      nokogiri (~> 1.13, >= 1.13.0)
+      rubyzip (>= 2.0, < 4)
     domain_name (0.6.20240107)
     dot-properties (0.1.4)
       bundler (>= 2.2.33)
@@ -360,7 +354,7 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     jmespath (1.6.2)
-    json (2.15.1)
+    json (2.13.2)
     jwt (2.10.2)
       base64
     kaminari (1.2.2)
@@ -531,6 +525,7 @@ GEM
       prawn (>= 0.11.1, < 3)
       rexml (>= 3.3.9, < 4)
     prettyprint (0.2.0)
+    prism (1.4.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -707,9 +702,11 @@ GEM
     scout_apm (5.7.1)
       parser
     securerandom (0.4.1)
-    selenium-webdriver (4.35.0)
+    selenium-webdriver (4.36.0)
       base64 (~> 0.2)
+      json (<= 2.13.2)
       logger (~> 1.4)
+      prism (~> 1.0, < 1.5)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
@@ -866,7 +863,7 @@ DEPENDENCIES
   db-query-matchers (< 2.0)
   device_detector (~> 1.0)
   devise (~> 4.5)
-  docx!
+  docx (< 1.0)
   equivalent-xml
   factory_bot_rails
   faraday (~> 2.0)


### PR DESCRIPTION
- bundle update
- for some reason json wasn't updated by bundle update, required adding to gemfile temporarily to get Gemfile.lock to update
- update samvera active_encode to 2.0, no backwards incompat changes should effect us
- back to docx release instead of unreleased from github; it got a release that included bugfixes and features we needed, and now allows rubyzip 3.x -- move to rubyzip 3.x in subsequent PR as it ends up requiring some fiddling. 
