### PR TITLE
update to browse_everything 3.0.0.alpha.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,7 +122,7 @@ gem "traject", ">= 3.5" # to include support for HTTP basic auth in Solr url
 
 gem 'simple_form', "~> 5.0"
 
-gem "browse-everything", "~> 1.5"
+gem "browse-everything", ">= 2.0.0.alpha.1", "< 3"
 gem "qa", "~> 5.2", ">= 5.14.0"
 gem "shrine", "~> 3.3" #, path: "../shrine"
 # shrine-compat endpoint to get uppy to direct upload to S3 with resumable multi-part upload

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,16 +164,13 @@ GEM
     bot_challenge_page (0.11.0)
       http (~> 5.2)
       rails (>= 7.1, < 8.1)
-    browse-everything (1.6.0)
+    browse-everything (2.0.0.alpha.1)
       addressable (~> 2.5)
       aws-sdk-s3
-      dropbox_api (>= 0.1.20)
       faraday (~> 2.0)
       google-apis-drive_v3
       googleauth (>= 0.6.6, < 2.0)
       rails (>= 4.2, < 8.1)
-      ruby-box
-      signet (~> 0.8)
     browser (6.2.0)
     builder (3.3.0)
     byebug (12.0.0)
@@ -255,9 +252,6 @@ GEM
     down (5.4.2)
       addressable (~> 2.8)
     drb (2.2.3)
-    dropbox_api (0.1.21)
-      faraday (< 3.0)
-      oauth2 (~> 1.1)
     dry-cli (1.3.0)
     dumb_delegator (1.1.0)
     equivalent-xml (0.6.0)
@@ -354,8 +348,8 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     jmespath (1.6.2)
-    json (2.15.0)
-    jwt (2.10.2)
+    json (2.13.2)
+    jwt (3.1.2)
       base64
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -463,12 +457,14 @@ GEM
       faraday (< 3)
       faraday-follow_redirects (>= 0.3.0, < 2)
       rexml
-    oauth2 (1.4.11)
-      faraday (>= 0.17.3, < 3.0)
-      jwt (>= 1.0, < 3.0)
-      multi_json (~> 1.3)
+    oauth2 (2.0.17)
+      faraday (>= 0.17.3, < 4.0)
+      jwt (>= 1.0, < 4.0)
+      logger (~> 1.2)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0, >= 2.0.3)
+      version_gem (~> 1.1, >= 1.1.9)
     observer (0.1.2)
     oga (3.4)
       ast
@@ -525,6 +521,7 @@ GEM
       prawn (>= 0.11.1, < 3)
       rexml (>= 3.3.9, < 4)
     prettyprint (0.2.0)
+    prism (1.4.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -673,11 +670,6 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.6)
-    ruby-box (1.15.0)
-      addressable
-      json
-      multipart-post
-      oauth2
     ruby-ll (2.1.4)
       ansi
       ast
@@ -688,7 +680,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    rubyzip (3.1.1)
+    rubyzip (3.2.0)
     sane_patch (1.0.0)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -701,9 +693,11 @@ GEM
     scout_apm (5.7.1)
       parser
     securerandom (0.4.1)
-    selenium-webdriver (4.35.0)
+    selenium-webdriver (4.36.0)
       base64 (~> 0.2)
+      json (<= 2.13.2)
       logger (~> 1.4)
+      prism (~> 1.0, < 1.5)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
@@ -734,6 +728,9 @@ GEM
     sitemap_generator (6.3.0)
       builder (~> 3.0)
     slop (4.10.1)
+    snaky_hash (2.0.3)
+      hashie (>= 0.1.0, < 6)
+      version_gem (>= 1.1.8, < 3)
     solr_wrapper (4.2.0)
       faraday (>= 1.0, < 3)
       faraday-follow_redirects
@@ -786,6 +783,7 @@ GEM
       roda (>= 2.27, < 4)
     uri (1.0.4)
     useragent (0.16.11)
+    version_gem (1.1.9)
     view_component (4.0.2)
       activesupport (>= 7.1.0, < 8.1)
       concurrent-ruby (~> 1)
@@ -849,7 +847,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   bootstrap4-kaminari-views
   bot_challenge_page (>= 0.10.0, < 2)
-  browse-everything (~> 1.5)
+  browse-everything (>= 2.0.0.alpha.1, < 3)
   browser (~> 6.0)
   capybara (>= 2.15)
   capybara-screenshot


### PR DESCRIPTION
which allows us to update to oauth2 2.x and get off unmaintained oauth2 1.x. 

Closes #2902

Tested Azure scihist sso login, all good. 
