### PR TITLE
lowering the document cache to 256

### DIFF
--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -336,8 +336,8 @@
 -->
   <query>
     <documentCache class="solr.CaffeineCache"
-       size="512"
-       initialSize="512"
+       size="256"
+       initialSize="256"
        autowarmCount="0"/>
   </query>
 


### PR DESCRIPTION
Ref #3124 
Based on observing production for an hour or so, we think 512 is probably too many documents, so we're bringing it down to 256.