### PR TITLE
Add Solr query results and filter caches

### DIFF
--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -342,8 +342,12 @@
        autowarmCount="0"/>
 
 
-    <!-- as of Oct 2025 with 14K docs, caching a result set with entire corpus is around 4Kb
-         so 1 meg is 250 cached items as a floor (more since most items are not the entire corpus)
+    <!-- as of Oct 2025 with 14K docs, filter and query result caches look like they may be around 3-7K
+         per entry. filterCaches look SMALLER, but not sure if that's true. This is just approximate.
+         So caches should get around 150-300 entries per megabyte.
+
+         As our corpus gets larger, space for each cache entry will increase, holding fewer entries
+         per megabyte.
     -->
 
     <filterCache class="solr.CaffeineCache"


### PR DESCRIPTION
Let's add a Solr queryResultsCache and filterCache.  I think this could actually help our Solr performance quite a bit, it is fairly standard to have these in a Solr deployment, not sure why we didn't.  https://solr.apache.org/guide/solr/latest/configuration-guide/caches-warming.html

**We will not deploy this until our document cache deployment is fully understood and stable, so as not to change more than one cache/RAM/solr thing at a time!**

As far as we know, the `maxRamMB` is more or less accurate for these caches, so I've used it (rather than `size` count) to set max size -- 3MB for filter cache, and 2MB for query result cache. 5MB is ~1% of our Solr JVM heap, so we believe should be easily accomadatable. 

Experiments in staging show that query result cache is around 4-7Kb per item, so 2MB is around 300-500 queries, and filter cache is around 2-3Kb per item, so 3MB is also around 1000-1500 filters.  (we also could be wrong about these estimates, but should give at least order of magnitude!)

We have autowarm set to 500, so probably usually most of the cache. 

## More on how they work/are expected to work

The **queryResultsCache** caches exact full queries (caches whole query even if you only asked for limited `rows`).  So if you do a query and paginate through it -- subsequent paginations will be a cache hit if first page hit is still in there. 

It's important for this ordinary use alone, if significant of our queries are sequential pagination queries within short enough time to get cache hits. Since we don't limit bots from paginating through un-facet-limited un-query-term-ed results, we think this could be a lot of our queries and this could help. 

The **filterCache** is in a sense lower level, because it caches individual `fq` clauses, individual limits, that can be shared between queries. So for instance, the `published:true` limit that is in most of our solr queries can be cached once by the filter cache, and re-used on nearly every other query.   When searching within a collection, the limit to stay within that collection is also a `fq` that could be cached and re-used, increasing collection search performance when there are cache hits. 

### An example with a collection

Many of our current Solr timeouts are collection results. Often without a query or facet limit -- makes sense, since these are the ones we don't restrict bots from accessing, so it's gonna be a lot of our searches. How will a collection search be effected by caches?

The entire exact search (limited ot certain collection, published true, any additinoal query terms or facets) will be stored as 1 entry in the query result cache. So if the bots continue paging through result set while that hit is still in cache, it will be very fast.  While some items will have been stored in filter cache too, the filter cache won't be used on subseqauent hits of *exact same query*, because it gets complete results from query cache. 

But also the limit `collection: $myCollection` is also stored in the filter cache separately -- and shared by any activity in that collection, even with different facet limits or query terms.   Collection limits may have an even higher chance of staying fresh in our cache -- since they are shared by more searches, since our filter cache is larger, and since there are theoretically more finite list of possible limits (although the number of unique subjects and creators we have for facet limits may make that not so true -- or make us want to increase filter cache further). 

But if a hit _is_ found in the filter cache, it will speed up the search somewhat, as pieces of the search won't have to be re-done, but not as much as if it had been in the query cache, as other parts of the query will still have to be executed fresh. 