### PR TITLE
img2pdf 0.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,16 +11,4 @@
 # used for installs. https://www.codementor.io/@inanc/how-to-run-python-and-ruby-on-heroku-with-multiple-buildpacks-kgy6g3b1e
 
 
-
-# img2pdf==0.4.4
-#
-# We need an img2pdf with a fix for jp2 alpha channels that is not yet included
-# in a release.
-#
-# https://gitlab.mister-muffin.de/josch/img2pdf/issues/173
-# https://gitlab.mister-muffin.de/josch/img2pdf/commit/acc25a49265effbbffa36e053ae2a3aa633eddbf
-#
-# When that fix is included in a release, sometime after 0.4.4, we can go back to ordinary
-# pip install.
-#
-img2pdf @ git+https://gitlab.mister-muffin.de/josch/img2pdf.git@09064e8
+img2pdf==0.6.1


### PR DESCRIPTION
Background:
- [issue with lots of detail including ways to test img2pdf](https://github.com/sciencehistory/scihist_digicoll/issues/2288) 
- [PR solving the issue](https://github.com/sciencehistory/scihist_digicoll/pull/2294)

The bug is described in AssetGraphicOnlyPdfCreator:
```
img2pdf can't handle input with an alpha channel (eg for transparency), if you
somehow wind up with one, you'll currently get a TTY::Command::ExitError raised:
`This function must not be called on images with alpha`
```
We want to update to to img2pdf 0.6.1 , in hopes that this bug is fixed.

Before merging this:
- [x] Make sure 0.6.1 can handle JP2 input with an "alpha" channel (see the issue above for examples to test against).
- [x] Make sure system_env_spec passes
- [x] Make sure the issue referenced below is addressed in 0.6.1

https://gitlab.mister-muffin.de/josch/img2pdf/issues/173
https://gitlab.mister-muffin.de/josch/img2pdf/commit/acc25a49265effbbffa36e053ae2a3aa633eddbf




