### PR TITLE
Only ask SOLR for the id of similar works

### DIFF
--- a/app/services/more_like_this_getter.rb
+++ b/app/services/more_like_this_getter.rb
@@ -77,6 +77,7 @@ class MoreLikeThisGetter
       "q"         => "id:#{@work.friendlier_id}",
       "fq"        => "{!term f=published_bsi}true",
       "mlt.fl"    => 'more_like_this_keywords_tsimv',
+      "fl"        => 'id',
       "rows"      => @limit
     }
   end


### PR DESCRIPTION
Ref #3167
Simple change.
Should make the work page load more quickly in certain cases (e.g. oral history pages with a lot of transcript data in the SOLR document. ([example](https://digital.sciencehistory.org/works/1ydxpkn): before: 744,506 chars returned from SOLR; after: only 329 chars.)