### PR TITLE
Note presence of photoshop (or similar) embedded thumbnail metadata in characterization metadata

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -324,6 +324,21 @@ class Asset < Kithe::Asset
     end
   end
 
+  # "Embedded preview" means pretty much
+  # the same thing as "Photoshop thumbnail", but to
+  # reduce confusion with represenative thumbnails
+  # we're calling it by a different name.
+  #
+  # Images with an embedded preview always have more than one exiftool key ending in ':ImageWidth'.
+  #
+  # Details:
+  #   https://sciencehistory.atlassian.net/wiki/spaces/HDC/pages/2775351299/TIFF+files+in+the+digital+collections
+  def contains_embedded_preview?
+    return false if self.exiftool_result.nil?
+    image_width_keys = self.exiftool_result.keys.select {|k| k.end_with?(':ImageWidth') }
+    (more_than_one_layer_or_page? == false) && image_width_keys.present? && image_width_keys.count > 1
+  end
+
   def corrected_webvtt?
     file_derivatives[CORRECTED_WEBVTT_DERIVATIVE_KEY.to_sym].present?
   end
@@ -494,6 +509,7 @@ class Asset < Kithe::Asset
   # See https://sciencehistory.atlassian.net/wiki/spaces/HDC/pages/2775351299/TIFF+files+in+the+digital+collections
   # See https://github.com/sciencehistory/scihist_digicoll/issues/2939
   def more_than_one_layer_or_page?
+    return false if self.exiftool_result.nil?
     layer_or_page_keys = [
       'Photoshop:LayerCount',
       'EXIF:PageNumber'

--- a/app/views/admin/assets/show.html.erb
+++ b/app/views/admin/assets/show.html.erb
@@ -320,11 +320,10 @@
         </dd>
       <% end %>
 
-      <%if @asset&.exiftool_result&.keys&.select {|k| k.end_with?(':ImageWidth') }&.count > 1 %>
+      <%if @asset.contains_embedded_preview? %>
         <dt class="col-sm-4">Embedded preview</dt>
-        <dd class="col-sm-8">Preview is present</dd>
+        <dd class="col-sm-8">Present</dd>
       <% end %>
-
 
       <% if @exiftool_result.pdf_version.present? %>
         <dt class="col-sm-4">PDF Version</dt>


### PR DESCRIPTION
Ref #2953 

[Thumbnail typology in the digital collections: a lengthy treatise](https://sciencehistory.atlassian.net/wiki/spaces/HDC/pages/2775351299/TIFF+files+in+the+digital+collections)

It turns out the EXIF metadata Kithe is already extracting allows us to detect the presence or absence of these pretty easily. I added a method on the asset model, alongside other related code.

I'm labeling the thumbnail an "embedded preview" to distinguish it from a thumbnail asset.
Test with the following files:
- TIFF [without a thumbnail](https://staging-digital.sciencehistory.org/admin/asset_files/xutqqax)
- TIFF [with a thumbnail](https://staging-digital.sciencehistory.org/admin/asset_files/uke4442)
