### PR TITLE
update to latest puma 7.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -443,7 +443,7 @@ GEM
       timeout
     net-smtp (0.5.1)
       net-protocol
-    nio4r (2.7.4)
+    nio4r (2.7.5)
     nokogiri (1.18.10-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-gnu)
@@ -532,7 +532,7 @@ GEM
       date
       stringio
     public_suffix (6.0.2)
-    puma (7.0.4)
+    puma (7.1.0)
       nio4r (~> 2.0)
     qa (5.15.0)
       activerecord-import


### PR DESCRIPTION
As puma 7.0.0 was released recently, it pays to keep up with updates fixing regressions etc. Just ran `bundle update puma` and committed Gemfile.lock.
