### PR TITLE
Store sha hash in the backup file and in the s3 metadata

### DIFF
--- a/lib/tasks/copy_database_to_s3.rake
+++ b/lib/tasks/copy_database_to_s3.rake
@@ -43,7 +43,6 @@ namespace :scihist do
     dump_command = [
       'echo', "\"-- GIT SHA:\"",                 '&&',
       'echo', "\"-- #{ENV['SOURCE_VERSION']}\"", '&&',
-
       # --clean means "include DROP commands at the top of the file."
       'pg_dump', '--no-password', '--no-owner', '--no-acl', '--clean', ENV['DATABASE_URL']
     ].join(" ")
@@ -61,7 +60,7 @@ namespace :scihist do
     result = aws_object.upload_file(temp_file_2.path,
         content_type: "application/gzip",
         storage_class: "STANDARD_IA",
-        metadata: { "backup_time" => Time.now.utc.to_s, "git_sha_hash" => git_sha }
+        metadata: { "backup_time" => Time.now.utc.to_s, "git_sha_hash" => ENV['SOURCE_VERSION'] }
         )
 
     raise "Upload failed" unless result


### PR DESCRIPTION
Ref #723 

Assumes you've run 
```
heroku buildpacks:add https://github.com/ianpurvis/heroku-buildpack-version
```
This is tricky to get right the first time but I've tested the changes enough in staging.

Deploy sequence
- [x] Add  buildpack in staging and production
- [x] Deploy
- [x] Leave to run overnight
- [x] Double-check no errors and sha hash in backup file
- [x] Updated [buildpack documentation](https://sciencehistory.atlassian.net/wiki/spaces/HDC/pages/1915748368/Heroku+Operational+Components+Overview#Buildpacks)