### PR TITLE
Facets indexed to solr should be unicode normalized NFC

### DIFF
--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -279,6 +279,15 @@ class WorkIndexer < Kithe::Indexer
         context.add_output("text_no_boost_tesim", *standard_text)
       end
     end
+
+    # Unicode normalize all facets -- should display identically, but matters for facet
+    # search/suggest func that does byte-per-byte searching. Solr does no unicode normalization
+    # or 'analysis'  at all on "string" fields, we've got to do it.
+    each_record do |_rec, context|
+      context.output_hash.keys.grep(/_facet$/).each do |facet_key|
+        context.output_hash[facet_key].each { |value| value.unicode_normalize!(:nfc) }
+      end
+    end
   end
 
   # Iterate over all members of a work, collecting a string from each one that is published.

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -68,6 +68,15 @@ describe WorkIndexer do
     end
   end
 
+  describe "un-normalized unicode in a facet value" do
+    let(:work) { create(:work, subject: ["café".unicode_normalize(:nfd)]) }
+    let(:output_hash)   { WorkIndexer.new.map_record(work) }
+
+    it "gets normalized as NFC" do
+      expect(output_hash["subject_facet"]).to eq ["café".unicode_normalize(:nfc)]
+    end
+  end
+
   describe "oral history" do
     let(:work) { create(:oral_history_work, :published, format: ['text']) }
 


### PR DESCRIPTION
NFC normalization should not effect how text looks on screen -- but when we start using facet search/suggest feature, it can matter, as solr does not do any unicode normalization or analysis of 'string' fields we use for facetting, but needs to be a byte-by-byte match when using the facet filtering features the new UX feature has. Ref #3062.

So we will normalize NFC in our indexer before we send to solr.  Doesn't hurt to do immediately. Then in another PR, we can also ensure query is NFC normalized, so it can match.

Most of the stuff in our DB is probably NFC normalized already? But it can depend on exactly what a staff user entered/pasted into text entry for metadata entry!

- [ ] reindex after deploy