### PR TITLE
Change query and filter cache to use size instead of maxRamMB

### DIFF
--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -343,23 +343,27 @@
 
 
     <!-- as of Oct 2025 with 14K docs, filter and query result caches look like they may be around 3-7K
-         per entry. filterCaches look SMALLER, but not sure if that's true. This is just approximate.
-         So caches should get around 150-300 entries per megabyte.
+         per entry maybe? hard to say.
+
+         We want around ~3MB for filterCache and ~2MB for queryResultCache, but we don't really trust
+         the maxRamMB parameter, it's been looking weird, so we use size guessing.
 
          As our corpus gets larger, space for each cache entry will increase, holding fewer entries
          per megabyte.
 
-         autowarmCount choices are guesses, more investigation is possible.
+         autowarmCount choices are also guesses, more investigation is possible.
     -->
 
     <filterCache class="solr.CaffeineCache"
-             maxRamMB="3"
-             autowarmCount="60%"
+             size="300"
+             initialSize="300"
+             autowarmCount="40%"
              async="true" />
 
      <queryResultCache class="solr.CaffeineCache"
-             maxRamMB="2"
-             autowarmCount="30%"
+             size="100"
+             initialSize="100"
+             autowarmCount="20%"
              async="true" />
 
   </query>


### PR DESCRIPTION
WE don't trust maxRamMB. It's weird. And statistics showing negative RAM and such. We'll estimate based on size. And lower our estimates a bit. And also lower autoWarm.

We're worried something about caches may have been worsening worst case performances, want to ameliorate.
