### PR TITLE
Fix retrival of HLS playlist from ActiveEncode gem api, from MediaConvert

### DIFF
--- a/app/models/active_encode_status.rb
+++ b/app/models/active_encode_status.rb
@@ -22,9 +22,10 @@ class ActiveEncodeStatus < ApplicationRecord
   def refresh_from_aws
     active_encode_result = ActiveEncode::Base.find(self.active_encode_id)
 
-    # active_encode let's us recognize the master playlist just cause
-    # it has no height/width set? OK, fine.
-    master_playlist = active_encode_result.output.find { |o| o.height.nil? }
+    # active_encode makes it difficult to recognize master playlist, the label
+    # matching our base name currently should do it. Other ones that aren't mater
+    # might be #{OUTPUT_BASE_NAME}_low.m3u8 or #{OUTPUT_BASE_NAME}_high.m3u8 etc.
+    master_playlist = active_encode_result.output.find { |o| o.label == "#{CreateHlsMediaconvertJobService::OUTPUT_BASE_NAME}.m3u8" }
 
     # update updated_at even if no other state changes, to record the refresh
     update!(

--- a/app/services/create_hls_mediaconvert_job_service.rb
+++ b/app/services/create_hls_mediaconvert_job_service.rb
@@ -35,6 +35,7 @@ class CreateHlsMediaconvertJobService
     HlsPresetInfo.new(preset_name: "scihist-hls-high", name_modifier: "_high", pixel_height: 1080, bitrate: 4_400_000),
   ].sort_by(&:bitrate).freeze
 
+  OUTPUT_BASE_NAME = "hls"
 
   OUTPUT_SHRINE_STORAGE_KEY = :video_derivatives
 
@@ -120,7 +121,7 @@ class CreateHlsMediaconvertJobService
 
       unique_number = SecureRandom.hex
 
-      path = "/hls/#{asset.id}/#{unique_number}/hls"
+      path = "/hls/#{asset.id}/#{unique_number}/#{OUTPUT_BASE_NAME}"
 
       if output_storage.prefix.present?
         path = "/#{output_storage.prefix.to_s}#{path}"

--- a/spec/models/active_encode_status_spec.rb
+++ b/spec/models/active_encode_status_spec.rb
@@ -14,12 +14,14 @@ RSpec.describe ActiveEncodeStatus, type: :model do
           s3_url = "s3://#{File.join('faked-output-bucket', Shrine.storages[:video_derivatives].prefix.to_s, 'somewhere/hls.m3u8')}"
 
           output.id = "fake"
+          output.label = "hls.m3u8"
           output.url = s3_url
         end,
         ActiveEncode::Output.new.tap do |output|
           s3_url = "s3://#{File.join('faked-output-bucket', Shrine.storages[:video_derivatives].prefix.to_s, 'wrong/hls_low.m3u8')}"
 
           output.id = "fake"
+          output.label = "hls_low.m3u8"
           output.url = s3_url
           output.height = 420
         end


### PR DESCRIPTION
We use the ActiveEncode gem api to get back the status of the AWS MediaConvert async job.  When it's complete, we need to retrieve the URL to the created HLS playlist.

Either MediaConvert or the ActiveEncode API makes it hard to determine which of the outputs it lists is the main HLS playlist, vs subsidiary child playlists. We had been recognizing it based on it not having a `height` filled out -- but for whatever reason, it started having a height filled out recently.

Switch to recogizing it by it's name, just `hls.m3u8`, not `hls_low.m3u8`, or `hls_high.m3u8`, etc.

Fixes https://github.com/sciencehistory/scihist_digicoll/issues/3202 where our app is failing to retrieve master HLS url from output and store in our model. Tested in staging to demonstrate the fix. 

- [x]  After this code is deployed, run #refresh_from_aws on two assets from two assets in #3202, and ensure that both assets have their `hls_playlist_file` present subsequent. 