### PR TITLE
remove gem activerecord-postgres_enum, not needed since Rails 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -158,9 +158,6 @@ gem 'sitemap_generator', '~> 6.0' # google sitemap generation
 
 gem 'sane_patch', '< 2.0' # time-limited monkey patches
 
-gem 'activerecord-postgres_enum', '~> 2.0' # can record postgres enums in schema.rb dump
-
-
 # For autoscaling on heroku via hirefire.io service, but hopefully won't cause any problems
 # when running not on heroku.
 #

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,9 +61,6 @@ GEM
       timeout (>= 0.4.0)
     activerecord-import (2.2.0)
       activerecord (>= 4.2)
-    activerecord-postgres_enum (2.1.0)
-      activerecord (>= 5.2)
-      pg
     activestorage (8.0.3)
       actionpack (= 8.0.3)
       activejob (= 8.0.3)
@@ -278,7 +275,6 @@ GEM
       faraday (~> 2.0)
     faster_s3_url (1.2.0)
     fastimage (2.4.0)
-    ffi (1.17.2)
     ffi (1.17.2-arm64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
     ffi-compiler (1.3.2)
@@ -499,7 +495,6 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
-    pg (1.6.2)
     pg (1.6.2-arm64-darwin)
     pg (1.6.2-x86_64-linux)
     pp (0.6.3)
@@ -815,7 +810,6 @@ PLATFORMS
 DEPENDENCIES
   access-granted (~> 1.0)
   active_encode (~> 2.0)
-  activerecord-postgres_enum (~> 2.0)
   alba (~> 3.1)
   attr_json (~> 2.3)
   aws-sdk-cloudfront (~> 1.91)

--- a/db/migrate/20200810180533_add_available_by_request_mode_to_oral_history_content.rb
+++ b/db/migrate/20200810180533_add_available_by_request_mode_to_oral_history_content.rb
@@ -2,6 +2,6 @@ class AddAvailableByRequestModeToOralHistoryContent < ActiveRecord::Migration[6.
   def change
     create_enum :available_by_request_mode_type, %w[off automatic manual_review]
 
-    add_column :oral_history_content, :available_by_request_mode, :available_by_request_mode_type, null: false, default: "off"
+    add_column :oral_history_content, :available_by_request_mode, :enum, enum_type: :available_by_request_mode_type, null: false, default: "off"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,11 +14,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_08_171351) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_enum :available_by_request_mode_type, [
-    "off",
-    "automatic",
-    "manual_review",
-  ], force: :cascade
+  # Custom types defined in this database.
+  # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "available_by_request_mode_type", ["off", "automatic", "manual_review"]
 
   create_function :kithe_models_friendlier_id_gen, sql_definition: <<-'SQL'
       CREATE OR REPLACE FUNCTION public.kithe_models_friendlier_id_gen(min_value bigint, max_value bigint)


### PR DESCRIPTION
Gem for recording postgres enum types in schema.rb.  not needed since Rails 7.  That it was still there was resulting in double inclusion of the enum type in a dumped schema.rb, which we were assiduously avoiding committing, but it was annoying. Looks like this fixes it.

Slightly differnet form of statement in schema.rb, fixed now. Slightly different best practice in migration that uses it, fixed there too.
