### PR TITLE
fix legacy OHMS footnotes section display

### DIFF
--- a/app/components/oral_history/footnotes_section_component.html.erb
+++ b/app/components/oral_history/footnotes_section_component.html.erb
@@ -2,6 +2,6 @@
 <div class="mx-1 my-2"><strong>NOTES</strong></div>
 <div class="footnote-list mx-1 mb-5">
     <% footnote_array.each_with_index.map do |footnote_text, i| %>
-        <= render FootnoteComponent.new(footnote_reference: i+1, footnote_text, footnote_text) %>
+        <%= render OralHistory::FootnoteComponent.new(footnote_reference: i+1, footnote_text: footnote_text) %>
     <% end %>
 </div>

--- a/spec/components/oral_history/legacy_transcript_component_spec.rb
+++ b/spec/components/oral_history/legacy_transcript_component_spec.rb
@@ -46,6 +46,9 @@ describe OralHistory::LegacyTranscriptComponent, type: :component do
     expect(line_with_first_footnote).to include "[1]"
 
     expect(parsed.css(".footnote").count).to eq 2
+
+    expect(parsed.css(".footnote-list .footnote-page-bottom-container").count).to eq 2
+    expect(parsed.css(".footnote-list .footnote-page-bottom-container").text). to include("U.S. Patent 2,281,576, issued 5 May 1942")
   end
 
   # Footnotes and footnote references are expected


### PR DESCRIPTION
Had typos such that it didn't display, with no tests to catch. Added tests too.

Fixes #3207
