### PR TITLE
Background Job to create "chunk" records for Oral History RAG

### DIFF
--- a/app/jobs/oh_transcript_chunker_job.rb
+++ b/app/jobs/oh_transcript_chunker_job.rb
@@ -18,7 +18,7 @@ class OhTranscriptChunkerJob < ApplicationJob
       raise RuntimeError.new("We only know how to process legacy OHMS xml at present, can't process OralHistoryContent #{oral_history_content.id}")
     end
 
-    OralHistory::OhmsLegacyTranscriptChunker.new(oral_history_content: oral_history_content).create_db_records
+    OralHistory::OhmsLegacyTranscriptChunker.new(oral_history_content: oral_history_content, allow_embedding_wait_seconds: 10).create_db_records
   end
 
 end


### PR DESCRIPTION
It is _not_ yet wired up to automatically create them, say, when a new OHMS is uploaded or whatever. 

But a bg job that can be used manually-programmatically when you want to bulk create a bunch of chunks, as we do from time to time in this prototype period. 

That is super straightforward, just a job wrapper -- but the PR also includes some logic for rescueing when OpenAI API returns 429 rate limit exceeded, and waiting and retrying up to a maximum wait specified (default 0, you have to opt in).  Also logs some stuff. 

When i did this on staging for the OHMS batch, I _did_ get some rate limit exceeded, which messed up our import. -- wasn't logging enough to be sure what would fix it, so at least this is logging now. If it doesn't work, we're not behind where we were. 

(Also got an email that after using it enough we had been bumped up to a higher rate limit automatically, so might not happen again). 

- A BG job to do OH chunking/embedding
- OhmsLegacyTranscriptChunker can wait and retry on Openai rate limit exceeded
