### PR TITLE
store ENV['SOURCE_OPTION'] with current git sha of project in OralHistory::AiConversation

### DIFF
--- a/app/models/oral_history/ai_conversation.rb
+++ b/app/models/oral_history/ai_conversation.rb
@@ -18,6 +18,12 @@ class OralHistory::AiConversation < ApplicationRecord
 
   enum :status, { queued: "queued", in_process: "in_process", success: "success", error: "error" }, prefix: :status
 
+  before_save do
+    # record git SHA of the current codebase, to give us a chance to know what logic
+    # generated this, for comparison.
+    self.project_source_version ||= ENV['SOURCE_VERSION']
+  end
+
   # Actually talk to Claude based on question preserved here, and record answer and metadata as
   # we go. This could take 10+ seconds, so is usually done in a background job.
   #

--- a/db/migrate/20251215162911_add_project_source_version_to_ai_conversation.rb
+++ b/db/migrate/20251215162911_add_project_source_version_to_ai_conversation.rb
@@ -1,0 +1,5 @@
+class AddProjectSourceVersionToAiConversation < ActiveRecord::Migration[8.0]
+  def change
+    add_column :oral_history_ai_conversations, :project_source_version, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_12_01_161421) do
+ActiveRecord::Schema[8.0].define(version: 2025_12_15_162911) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "vector"
 
@@ -243,6 +243,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_01_161421) do
     t.datetime "request_sent_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "project_source_version"
   end
 
   create_table "oral_history_chunks", force: :cascade do |t|

--- a/spec/models/oral_history/ai_conversation_spec.rb
+++ b/spec/models/oral_history/ai_conversation_spec.rb
@@ -41,6 +41,22 @@ RSpec.describe OralHistory::AiConversation, type: :model do
       expect(conversation.answer_json).to eq json_return
     end
 
+    describe "with SOURCE_VERSION" do
+      let(:source_version) { "mock_git_sha" }
+
+      before do
+        allow(OralHistoryChunk).to receive(:get_openai_embedding).and_return(OralHistoryChunk::FAKE_EMBEDDING)
+
+        allow(ENV).to receive(:[]).and_call_original # for other ENV
+        allow(ENV).to receive(:[]).with("SOURCE_VERSION").and_return(source_version)
+      end
+
+      it "is recorded" do
+        conversation.exec_and_record_interaction
+        expect(conversation.project_source_version).to eq source_version
+      end
+    end
+
     describe "with response error" do
       let(:json_return) { "illegal not a hash" }
       let(:conversation) { OralHistory::AiConversation.build(question: question, question_embedding: OralHistoryChunk::FAKE_EMBEDDING) }


### PR DESCRIPTION
ENV['SOURCE_OPTION'] being added from a buildpack via https://github.com/sciencehistory/scihist_digicoll/pull/3188

This gives us enough information to _theoretically_ reconstruct what version of hte AI-interacting code was in use at the time, to compare answers from different versions.

In fact, you'd need the list of all project SHA's to do that, knowing where in the list AI logic changed to divide into eras; but, I mean, we do have that in git. There's some more work to actually segment AiConversations based on that, but we store now now the SHA that is enough to reconstruct it historically with more wok, good enough for now.

Ref AI project #3178 
