### PR TITLE
add enable_extension pg_catalog.plpgsql to db/schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,6 +12,7 @@
 
 ActiveRecord::Schema[8.0].define(version: 2025_12_01_161421) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"
 
   # Custom types defined in this database.


### PR DESCRIPTION
I think Rails started wanting ot put this in schema.rb as a result of a *postgres* version bump rather than a Rails one, but regardless, it really wants to put this in there now, let's put it in in it's own separate commit so it stops being in the way in migration commits.
