### PR TITLE
Use local system's built-in certificates when connecting to dev_s3 amazon bucket.

### DIFF
--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -487,7 +487,20 @@ module ScihistDigicoll
           prefix:            "#{lookup(:s3_dev_prefix)}/#{shared_bucket_path_prefix}",
           access_key_id:     lookup(:aws_access_key_id),
           secret_access_key: lookup(:aws_secret_access_key),
-          region:            lookup(:aws_region)
+          region:            lookup(:aws_region),
+          # Force a concrete, known-good CA bundle.
+          # Fixes a bug with Ruby 3.4 + OpenSSL 3.5 on macOS in
+          # which:
+          #   SSLContext#cert_store starts out nil;
+          #   somewhere in the AWS SDK / Net::HTTP stack,
+          #     a cert store was being constructed implicitly,
+          #     which triggered CRL expectations,
+          #       leading to an "unable to get certificate CRL" error
+          #       even though the certificate chain was valid.
+          #
+          # See also https://github.com/sciencehistory/scihist_digicoll/issues/3236
+          #
+          ssl_ca_bundle:     OpenSSL::X509::DEFAULT_CERT_FILE
         }.merge(s3_storage_options))
       elsif mode == "production"
         if host.present?


### PR DESCRIPTION
Ref #3236 
Ruby 3.4 + OpenSSL 3.5 on macOS:
`SSLContext#cert_store` started out nil
Somewhere in the AWS SDK / Net::HTTP stack, a cert store was being constructed implicitly.
That implicit store path ended up triggering CRL expectations, leading to the error described in the issue, even though the certificate chain is valid and `openssl s_client` worked fine.

Using `OpenSSL::X509::DEFAULT_CERT_FILE` seems safe to me; this extra option is only used for `dev_s3` in any case.