### PR TITLE
OralHistory Availability Scopes

### DIFF
--- a/app/models/oral_history_content.rb
+++ b/app/models/oral_history_content.rb
@@ -113,6 +113,19 @@ class OralHistoryContent < ApplicationRecord
     distinct
   }
 
+  # Have to write the confusing opposite of above
+  # Everything that either doesn't have request mode OFF, OR has a published non-portrait
+  # member. GAH.
+  scope :all_except_fully_embargoed, -> {
+    where.not(available_by_request_mode: ["off", nil]).
+      joins(work: :members).
+      or(
+        OralHistoryContent.joins(work: :members).
+        where(members: {  published: true } ).
+        where.not(members: { role: "portrait" })
+      ).distinct
+  }
+
   after_commit :after_commit_update_work_index_if_needed
 
   # Sets IO to be combined_audio_m4a, writing directly to "store" storage,

--- a/spec/models/oral_history_content_spec.rb
+++ b/spec/models/oral_history_content_spec.rb
@@ -220,5 +220,16 @@ describe OralHistoryContent do
       expect(results).not_to include(ohms_oh.oral_history_content)
       expect(results).not_to include(immediate_oh.oral_history_content)
     end
+
+    it "fetches all except fully embargoed" do
+      results = OralHistoryContent.all_except_fully_embargoed.to_a
+
+      expect(results).to include(needs_approval_oh.oral_history_content)
+      expect(results).to include(upon_request_oh.oral_history_content)
+      expect(results).to include(ohms_oh.oral_history_content)
+      expect(results).to include(immediate_oh.oral_history_content)
+
+      expect(results).not_to include(private_oh.oral_history_content)
+    end
   end
 end


### PR DESCRIPTION
scopes to generate SQL to fetch various categories of Oral History on availabilty, for use in OH AI #3178 

This is just scopes and tests for scopes. 

Trickier than it should be becuase of our legacy OH modeling decisions, including need to guess functional aspects from 'shape' of the OH data.

It is unfortunate that:

* no request func turned on, with a public PDF, means a public oral history
* request func turned on with non-public PDFs means requestable
* no request func turned on with non-public PDFs means completely private and unavailable

 But at least we can sequester it mostly into these scopes and a separate PR with good tests! 