### PR TITLE
OralHistoryChunk needs to use postgres halfvec type instead of vector

### DIFF
--- a/db/migrate/20260121211717_embedding_vector_to_halfvec.rb
+++ b/db/migrate/20260121211717_embedding_vector_to_halfvec.rb
@@ -1,0 +1,34 @@
+class EmbeddingVectorToHalfvec < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction! # for concurrent index creation
+                           #
+  def change
+    reversible do |direction|
+
+      direction.up do
+        remove_index :oral_history_chunks, :embedding, if_exists: true
+
+        change_column :oral_history_chunks,
+                    :embedding,
+                    :halfvec,
+                    limit: 3072,
+                    using: "embedding::halfvec"
+
+        add_index :oral_history_chunks,
+            :embedding,
+            using: :hnsw,
+            opclass: :halfvec_cosine_ops,
+            algorithm: :concurrently
+
+      end
+
+      direction.down do
+        remove_index :oral_history_chunks, :embedding, if_exists: true
+
+        change_column :oral_history_chunks,
+                    :embedding,
+                    :vector,
+                    limit: 3072
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_13_195648) do
+ActiveRecord::Schema[8.0].define(version: 2026_01_21_211717) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"
@@ -250,7 +250,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_13_195648) do
   end
 
   create_table "oral_history_chunks", force: :cascade do |t|
-    t.vector "embedding", limit: 3072, null: false
+    t.halfvec "embedding", limit: 3072, null: false
     t.bigint "oral_history_content_id", null: false
     t.integer "start_paragraph_number", null: false
     t.integer "end_paragraph_number", null: false
@@ -259,7 +259,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_13_195648) do
     t.jsonb "other_metadata", default: {}
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index "((embedding)::halfvec(3072)) halfvec_cosine_ops", name: "idx_on_embedding_halfvec_3072_halfvec_cosine_ops_4742ee9fb6", using: :hnsw
+    t.index ["embedding"], name: "index_oral_history_chunks_on_embedding", opclass: :halfvec_cosine_ops, using: :hnsw
     t.index ["oral_history_content_id"], name: "index_oral_history_chunks_on_oral_history_content_id"
   end
 


### PR DESCRIPTION
For our 3072-dimensional embedding vector, to index it we need to use postgres halfvec instead of vector. Previously we thought we could do a halfvec index with a vector column to get indexing -- but EXPLAIN showed index was not being used.  (And queries were very slow). So we try this.

Tested on staging. Solves performance problem with first query we do -- performance problem is still there with second one, that applies `max_per_interview` with a nested query. So this helps half the problem, will need to keep investigating for second half.  

But we're down to 2-3s for fetching it looks like in some samples, instead of sometimes as long as 8-10 before. 
