### PR TITLE
limit on inner CTE for max-per-interview chunk fetch is actually applied now.

### DIFF
--- a/app/services/oral_history/chunk_fetcher.rb
+++ b/app/services/oral_history/chunk_fetcher.rb
@@ -161,7 +161,7 @@ module OralHistory
       # In the inner CTE, have to fetch oversampled, so we can wind up with
       # hopefully enough in outer. Leaving inner unlimited would be peformance,
       # cause of how indexing works it doesn't need to calculate them all.
-      base_relation.limit(inner_limit)
+      base_relation = base_relation.limit(inner_limit)
 
       # copy the order from inner scope, where neighbor gem set it to be vector distance asc
       # We leave the real limit for the caller to set


### PR DESCRIPTION
Wasn't being applied before, cause it is not a mutating operation. Resulting in pathological performance.

Fixing this... doesn't seem to resolve performance problems?  This max-per-interview query is still taking 1-3 seconds when it should be sub-second. But this is what we intended, so fixing this bug and then continuing to try to understand query. 
