### PR TITLE
Edit description of HLS derivatives

### DIFF
--- a/infrastructure/aws-mediaconvert/aws-mediaconvert-preset-scihist-hls-extra-low.json
+++ b/infrastructure/aws-mediaconvert/aws-mediaconvert-preset-scihist-hls-extra-low.json
@@ -1,7 +1,7 @@
 {
   "Description": "240h, 500 kbps",
   "Category": "HLS",
-  "Name": "scihist-hls-extra-low-with-normalization",
+  "Name": "scihist-hls-extra-low",
   "Settings": {
     "VideoDescription": {
       "ScalingBehavior": "DEFAULT",

--- a/infrastructure/aws-mediaconvert/aws-mediaconvert-preset-scihist-hls-high.json
+++ b/infrastructure/aws-mediaconvert/aws-mediaconvert-preset-scihist-hls-high.json
@@ -1,7 +1,7 @@
 {
   "Description": "1080h, 3000 kbps",
   "Category": "HLS",
-  "Name": "scihist-hls-high-with-normalization",
+  "Name": "scihist-hls-high",
   "Settings": {
     "VideoDescription": {
       "ScalingBehavior": "DEFAULT",

--- a/infrastructure/aws-mediaconvert/aws-mediaconvert-preset-scihist-hls-low.json
+++ b/infrastructure/aws-mediaconvert/aws-mediaconvert-preset-scihist-hls-low.json
@@ -1,7 +1,7 @@
 {
   "Description": "480h, 1500 kbps",
   "Category": "HLS",
-  "Name": "scihist-hls-low-with-normalization",
+  "Name": "scihist-hls-low",
   "Settings": {
     "VideoDescription": {
       "ScalingBehavior": "DEFAULT",

--- a/infrastructure/aws-mediaconvert/aws-mediaconvert-preset-scihist-hls-medium.json
+++ b/infrastructure/aws-mediaconvert/aws-mediaconvert-preset-scihist-hls-medium.json
@@ -1,7 +1,7 @@
 {
   "Description": "720h, 2500 kbps",
   "Category": "HLS",
-  "Name": "scihist-hls-medium-with-normalization",
+  "Name": "scihist-hls-medium",
   "Settings": {
     "VideoDescription": {
       "ScalingBehavior": "DEFAULT",


### PR DESCRIPTION
These changes don't actually affect anything about how AWS creates derivatives - we are just documenting the new settings in the code and signing off on a 17% increase in the price.

#3230 

# About the change
## Comparing jobs:

### Old encoding job example
https://us-east-1.console.aws.amazon.com/mediaconvert/home?region=us-east-1#/jobs/summary/1768255347053-tqeppr

### New encoding job example
https://us-east-1.console.aws.amazon.com/mediaconvert/home?region=us-east-1#/jobs/details/1769618444577-nsksfw

### Normalization details can be found at:
Jobs -> Job Summary -> Details -> Output Groups -> [either deriv] -> Audio 1 -> Advanced

# Pricing
My reading of the MediaConvert [pricing documentation](https://aws.amazon.com/mediaconvert/pricing/) is that normalizing the audio in these derivatives will add 17% to the cost of creating derivatives in MediaConvert:

## Professional tier
The per-minute rate offered under the Professional tier varies based on the resolution, frame rate, quality setting, and codec of the output. Each combination of these attributes creates the multiplier used to calculate normalized output minutes. The Professional tier also offers a number of optional add-on features including [...] Audio Normalization,[...], each available for an additional charge.

The multiplier listed for `Audio Normalization` is 0.17x .

## Costs over the past 6 months

[AWS](https://us-east-1.console.aws.amazon.com/costmanagement/home?region=us-east-1#/cost-explorer?chartStyle=STACK&costAggregate=unBlendedCost&endDate=2026-01-31&excludeForecasting=false&filter=%5B%7B%22dimension%22:%7B%22id%22:%22Service%22,%22displayValue%22:%22Service%22%7D,%22operator%22:%22INCLUDES%22,%22values%22:%5B%7B%22value%22:%22AWS%20Elemental%20MediaConvert%22,%22displayValue%22:%22Elemental%20MediaConvert%22%7D%5D%7D%5D&futureRelativeRange=CUSTOM&granularity=Monthly&groupBy=%5B%22Service%22%5D&historicalRelativeRange=LAST_6_MONTHS&isDefault=true&reportMode=STANDARD&reportName=New%20cost%20and%20usage%20report&showOnlyUncategorized=false&showOnlyUntagged=false&startDate=2025-08-01&usageAggregate=undefined&useNormalizedUnits=false) says our MediaConvert derivatives are currently costing us $12.33 per month on average.

Assuming we digitize at roughly the same rate, the _additional_ monthly cost of adding normalization should be under $3.
