### PR TITLE
set claude temperature to 0 for deterministic results

### DIFF
--- a/app/services/oral_history/claude_interactor.rb
+++ b/app/services/oral_history/claude_interactor.rb
@@ -76,7 +76,10 @@ module OralHistory
       response = AWS_BEDROCK_CLIENT.converse(
         model_id: MODEL_ID,
         system: [{ text: render_system_instructions }],
-        messages: [{ role: 'user', content: [{ text: render_user_prompt(chunks) }] }]
+        messages: [{ role: 'user', content: [{ text: render_user_prompt(chunks) }] }],
+        inference_config: {
+          temperature: 0.0
+        }
       )
 
       conversation_record&.add_timing("LLM response received")


### PR DESCRIPTION
In addition to now being deterministic (same exact answer for same question every time), it should now follow instructions better? 

I think deterministic will make our stakeholders more comfortable. Makes testing/comparing changes easier for sure. 

Why would anyone ever want non-0 temperature?  When I asked claude, 

> Great question! There are actually many legitimate use cases for non-zero temperature. Your RAG citation system is a special case where determinism is paramount, but most LLM applications benefit from some randomness… Creative Writing… Generating Multiple Diverse Options… Conversational AI / Chatbots, Making a chatbot feel more natural and human-like… Overcoming "Analysis Paralysis",  When the model is too conservative or gets stuck… Avoiding Repetitive Patterns, If you're generating a long document or having a long conversation, temp=0.0 can lead to repetitive structure… Personality and Tone Variation¬  When "Correctness" is Subjective… 

> Your RAG citation system needs temp=0.0 because:
> ✅ Reproducibility is critical (research)
> ✅ Correctness is objective (citations)
> ✅ Consistency is a feature, not a bug
> ✅ No creativity needed (extract facts)
> ✅ Structured output (JSON)
> ✅ Academic/scholarly context


> Temperature represents a fundamental tradeoff:
>
> Low temp: Exploit what the model "knows" works best
> High temp: Explore possibilities the model is less sure about
>
> Both are valuable! It depends entirely on your goal.
> Your goal: Extract facts accurately → Low temp
> Other goals: Generate creative content → High temp
