### PR TITLE
Normalize and compress audio for oral histories

### DIFF
--- a/app/services/combined_audio_derivative_creator.rb
+++ b/app/services/combined_audio_derivative_creator.rb
@@ -120,12 +120,10 @@ class CombinedAudioDerivativeCreator
     # see https://www.reddit.com/r/ffmpeg/comments/15kiucp/ffmpeg_how_to_add_dialog_normalization_to_ac3_file/
     # see https://ffmpeg.org/ffmpeg-all.html#speechnorm
 
-    # For podcast-like spoken word, a very standard target is:
-    #  Integrated loudness (I): −16 LUFS (stereo) or −19 LUFS (mono)
-    #  True peak (TP): −1.5 dBTP (conservative, avoids codec overs)
-    #  Loudness range (LRA): ~7 LU (keeps dynamics controlled for speech)
-
-
+    #  Target loudness
+    #  Integrated loudness (I):  −19 LUFS (mono)
+    #  True peak (TP):           −1.5 dBTP (conservative, avoids codec overs)
+    #  Loudness range (LRA):      ~7 LU (keeps dynamics controlled for speech)
     filtergraph = "concat=n=#{components.count}:v=0:a=1, speechnorm, loudnorm=I=-19:TP=-1.5:LRA=7:print_format=summary[aout]"
 
     # Finally, some output options:


### PR DESCRIPTION
Context for this PR:

We’re doing a round of improvements on the processing for the combined audio derivatives (so e.g. in the [Choudhry interview](https://digital.sciencehistory.org/works/nt2ydj8#prevq=oral+history&tab=ohDownloads) that would be the Complete Interview Audio File as opposed to the 5 Separate Audio Segments. )

We definitely want to _normalize_ the audio (so, e.g. if the interviewer mistakenly records Segments 1 and 2 at a really soft level and the rest of the segments really loud, everything gets brought down or up to a comparable level before we stitch the audio together).

We’re also thinking of _compressing_ the audio as well. This means that if e.g. the interviewer and interviewee are a different distance from the microphone (resulting in one person’s speech being soft and another’s being loud) it will soften the loud bits and louden the soft bits.

We could test this out on an OH that you know to have some big audio-level discrepancies. We could also test the formula on e.g. a taped interview with loud buzzes and bumps due to subpar audio equipment.

Just to see if it makes everything easier to listen to.


Ref #3215

Targets:
- Integrated loudness (I):  -19 LUFS
- True peak (TP):           −1.5 dBTP
- Loudness range (LRA):      ~7 LU

This PR also has `ffmpeg` do a bit of audio compression, ensuring that the loud and soft parts within the file are brought closer to each other (within roughly 7 loudness units), in addition to the entire file being raised / lowered to  about -16 LUFS.

# Results

`ffmpeg -i combined_audio.m4a  -filter:a ebur128=framelog=verbose -f null -`

## Before:
```
Integrated loudness:
I:         -23.1 LUFS
Threshold: -34.4 LUFS

Loudness range:
LRA:        12.5 LU
Threshold: -44.4 LUFS
LRA low:   -32.3 LUFS
LRA high:  -19.7 LUFS
```

## After:
```
Integrated loudness:
  I:         -21.9 LUFS
  Threshold: -32.6 LUFS

Loudness range:
  LRA:         7.2 LU
  Threshold: -42.6 LUFS
  LRA low:   -26.5 LUFS
  LRA high:  -19.3 LUFS
```