### PR TITLE
Rake task to recreate all m4a combined audio derivs

### DIFF
--- a/lib/tasks/data_fixes/recreate_m4a_combined_audio_derivatives.rake
+++ b/lib/tasks/data_fixes/recreate_m4a_combined_audio_derivatives.rake
@@ -10,7 +10,7 @@ namespace :scihist do
 
   task :recreate_m4a_combined_audio_derivatives => :environment do
 
-    progress_bar = ProgressBar.create(total: Work.where("json_attributes -> 'genre' ?  'Oral histories'").count, format: "%a %t: |%B| %R/s %c/%u %p%% %e")
+    progress_bar = ProgressBar.create(total: Work.where("json_attributes -> 'genre' ?  'Oral histories'").count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
 
     # Add these jobs to the special_jobs queue
     # where they can be picked up (only) by special_worker dynos


### PR DESCRIPTION
Ref #3215 
Variation on ref #1682 - just to recreate derivatives. Ignores recent derivatives, just so we can run it several times in a row.
- [x] Test in staging before we merge