### PR TITLE
Fix SQL performance on vector similar search limited to N max hits per interview

### DIFF
--- a/app/services/oral_history/chunk_fetcher.rb
+++ b/app/services/oral_history/chunk_fetcher.rb
@@ -66,15 +66,20 @@ module OralHistory
     #     pre-loading to avoid n+1 fetch problem.
     def fetch_chunks
       relation = if max_per_interview
-        wrap_relation_for_max_per_interview(base_relation: base_relation, max_per_interview: max_per_interview, inner_limit: oversample_factor * top_k)
+        wrap_relation_for_max_per_interview(
+          base_relation: base_relation,
+          max_per_interview: max_per_interview,
+          inner_limit: oversample_factor * max_per_interview * top_k
+        )
       else
         base_relation
       end
 
-      relation.limit(top_k).strict_loading
+      # Preload work, so we can get title or other metadata we might want.
+      relation.limit(top_k).includes(oral_history_content: :work).strict_loading
     end
 
-    # Without limit count, we'll add that later.
+    # Without limit count or includes pre-fetch, we'll add those later.
     def base_relation
       relation = OralHistoryChunk
 
@@ -103,9 +108,6 @@ module OralHistory
       # Add our nearnest neighbor embedding query!
       relation = relation.neighbors_for_embedding(question_embedding)
 
-      # Preload work, so we can get title or other metadata we might want.
-      relation = relation.includes(oral_history_content: :work)
-
       # exclude specific chunks?
       if exclude_oral_history_chunk_ids.present?
         relation = relation.where.not(id: exclude_oral_history_chunk_ids)
@@ -119,58 +121,53 @@ module OralHistory
       relation
     end
 
+
     # We need to take base_scope and use it as a Postgres CTE (Common Table Expression)
     # to select from, but adding on a ROW_NUMBER window function, that let's us limit
     # to top max_per_interview
     #
-    # Kinda tricky. Got from google and talking to LLMs.
+    # Kinda tricky, especially to do with good index usage. Got solution from google and talking
+    # to LLMs, including having them look at pg explain/analyze output.
     #
-    # @return [ActiveRecord::Relation] that's been wrapped with a CTE to enforce max_per_interview limits.
+    # @param base_relation [ActiveRecord::Relation] original relation, it can have joins and conditions.
+    #   It MUST have already had vector distance ordering applied to it with `neighbor` gem.
+    #
+    # @param max_per_interview [Integer] maximum results to include per interview (oral_history_content_id)
+    #
+    # @param inner_limit [Integer] how many to OVER-FETCH in inner limit, to have enough even after
+    #    applying max-per-interview.
+    #
+    # @return [ActiveRecord::Relation] that's been in a query to enforce max_per_interview limits. It does
+    #   not have an overall limit set, caller should do that if desired, otherwise will be effectively
+    #   limited by inner_limit.
     def wrap_relation_for_max_per_interview(base_relation:, max_per_interview:, inner_limit:)
-      # We are creating a SQL of this form:
-      #
-      #     WITH ranked_chunks AS (
-      #     SELECT
-      #             chunks.*,
-      #             chunks.embedding <=> ? as distance,
-      #             ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY chunks.embedding <=> ?) as doc_rank
-      #           FROM chunks
-      #           ORDER BY chunks.embedding <=> ?
-      #           LIMIT <big limit to get enough to choose from>
-      #     )
-      #         SELECT *
-      #         FROM ranked_chunks
-      #         WHERE doc_rank <= <max_per_interview>
-      #         ORDER BY distance
-      #         LIMIT <actual limit>
-      #
-      # Where the thing inside teh ranked_chunks CTE is the original neighbor query (base_relation),
-      # with the ROW_NUMBER and a limit added to it
-
-      base_relation = base_relation.dup # cause we're gonna mutate it, avoid confusion.
-
-      # add a 'select' using semi-private select_values API
-      # Not sure what neighbor's type erialization is doing we couldn't get right ourselves, but it works.
-      base_relation.select_values += [
-        ActiveRecord::Base.sanitize_sql([
-          "ROW_NUMBER() OVER (PARTITION BY oral_history_content_id ORDER BY oral_history_chunks.embedding <=> ?) as doc_rank",
-          Neighbor::Type::Vector.new.serialize(question_embedding)
-        ])
-      ]
-
       # In the inner CTE, have to fetch oversampled, so we can wind up with
-      # hopefully enough in outer. Leaving inner unlimited would be peformance,
-      # cause of how indexing works it doesn't need to calculate them all.
+      # hopefully enough in outer. Leaving inner unlimited would be peformance problem,
+      # cause of how indexing works it doesn't need to calculate them all if limited.
       base_relation = base_relation.limit(inner_limit)
 
-      # copy the order from inner scope, where neighbor gem set it to be vector distance asc
-      # We leave the real limit for the caller to set
-      OralHistoryChunk.with(ranked_chunks: base_relation).
-        select("*").
-        from("ranked_chunks").
-        where("doc_rank <= ?", max_per_interview).
-        order("neighbor_distance").
-        includes(oral_history_content: :work)
+      # Now we have another CTE that assigns doc_rank within partitioned
+      # interviews, from base. Raw SQL is just way easier here.
+      partitoned_ranked_cte = Arel.sql(<<~SQL.squish)
+        SELECT base.*,
+          ROW_NUMBER() OVER (
+            PARTITION BY oral_history_content_id
+            ORDER BY neighbor_distance
+          ) AS doc_rank
+        FROM base
+      SQL
+
+      # A wrapper SQL that incorporates both those CTE's, limiting to
+      # doc_rank of how many we want per-interview, and overall making sure to
+      # again order by vector neighbor_distance that must already have been included
+      # in the base relation.
+      base_relation.klass
+        .select("*") # just pass through from underlying CTE queries.
+        .with(base: base_relation)
+        .with(partitioned_ranked: partitoned_ranked_cte)
+        .from("partitioned_ranked")
+        .where("doc_rank <= ?", max_per_interview)
+        .order(Arel.sql("neighbor_distance"))
     end
   end
 end


### PR DESCRIPTION
When we want to search for "top X chunks by vector similarity, limited to N per inteview" -- we decided we wanted to try to do this in SQL for efficiency. (This may have been unnecessary or undesirable, I am now realizing, but for now sticking with it). 

It was confusing to figure out an SQL query to do this, ended up needing aggregates and ROW_NUMBER function and such.  I got ChatGPT to help me find a working one -- but it turns out the approach it gave me was both over-complicated, and didn't let the PG query planner succesfully use our vector HNSW index, so it was not performant!

* I noticed it was slow, and got postgres explain and analyze output. 
   * Useful Rails feature, `any_activerecord_relation.explain` or `any_activerecord_relation.explain(:analyze)` gives you postgres output from console
   * Buit with our 3072-element vectors, these, since they include original query, are filled up with that vector. Wrote a little ruby function to replace the vector with a placeholder, and remove spacer dashes and spaces. 
   *         def clean_explain(str)
	           str.gsub(/\[(\-?\d+\.\d+(e-\d\d)?,)+(\-?\d+\.\d+(e-\d\d)?)\]/, "[embedding]").
		                gsub(/ {10,}/, " ").gsub(/\-{10,}/, '')
              end
  * Then the explain output is still a bit confusing, but ChatGPT or Clade are GREAT at explaining it and telling you if you have a performance problem or if it's using indexes!
* So then some back and forth with ChatGPT and Claude, who kept suggesting over-complicated solutions or solutions that didn't actually work, to figure out the pattern that would work, and be simpler, and use the index properly!

It's actually simpler than what we had before, using more Common Table Expression (CTE) labelled sub-queries.  And confirmed it uses our indexes. 

It can still take up to a second on staging, not sure why, which seems too long.... but an improvement for now.  

We may ultimately end up doing this filtering in memory in the app, just over-fetch what you want, and limit to top-N-per-interview in ruby instead -- becuase we may end up wanting to do other things that can't be done in SQL too, like re-ranking for better relevancy etc. 

But doesn't hurt! 