### PR TITLE
Admin note for collections

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -161,6 +161,7 @@ class Admin::CollectionsController < AdminController
                 :representative_attributes => {},
                 :funding_credit_attributes => {},
                 :related_link_attributes => {},
+                :admin_note_attributes => true,
                 :external_id_attributes => true
         ).tap do |hash|
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -44,6 +44,7 @@ class Collection < Kithe::Collection
   validates :department, presence: {}, inclusion: { in: DEPARTMENTS, allow_blank: true }
 
   attr_json :funding_credit, FundingCredit.to_type
+  attr_json :admin_note, :text, array: true, default: -> { [] }
 
   # Override the default ActiveRecord one to create a new Asset if it didn't exist already.
   # The default AR didn't work quite right because of STI and other reasons, but this works

--- a/app/views/admin/collections/_form.html.erb
+++ b/app/views/admin/collections/_form.html.erb
@@ -125,5 +125,10 @@
     %>
     <hr/>
 
+    <%= f.repeatable_attr_input(:admin_note, build: :at_least_one) do |input_name, value| %>
+      <div class="mb-3">
+        <%= f.input_field :admin_note, name: input_name, value: value, as: :text, class: "form-control", rows: 4 %>
+      </div>
+    <% end %>
   </div>
 <% end %>

--- a/spec/factories/collection_factory.rb
+++ b/spec/factories/collection_factory.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
         }
       ]
     }
+    admin_note { ['admin note', 'second admin note']}
     department { "Archives" }
     published { true }
 


### PR DESCRIPTION
Ref #3292

Issue says: "We understand this will only be accessible upon editing a collection." but I wonder if it might be better to add it on the collection show page (e.g. https://digital.sciencehistory.org/collections/gcb1zm0 ).