### PR TITLE
switch to Claude Sonnet 4.6

### DIFF
--- a/app/services/oral_history/claude_interactor.rb
+++ b/app/services/oral_history/claude_interactor.rb
@@ -8,8 +8,8 @@ module OralHistory
   # Does not do a continuous conversation, user gets one isolated question. Returns
   # answer as JSON.
   class ClaudeInteractor
-    # claude sonnet 4.5
-    MODEL_ID = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+    # claude sonnet 4.6
+    MODEL_ID = "global.anthropic.claude-sonnet-4-6"
 
     ANSWER_UNAVAILABLE_TEXT = "This tool was unable to answer this question using the resources available."
 


### PR DESCRIPTION
Getting this in this straightforward way now, to have it in place for any user tests. 

I would like to actually parameterize this and record which model was used in the db, so we know when looking at historical data (or if we ever wanted to a/b test etc) -- but get this in first to make sure it's present for user-testing. 
