### PR TITLE
Log requests that have a bot passed cookie as `bot_passed=1`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -271,6 +271,6 @@ gem "barnes"
 gem 'equivalent-xml'
 
 # temporary new bot challenge page
-gem "bot_challenge_page", ">= 0.10.0", "< 2"
+gem "bot_challenge_page", ">= 1.1.0", "< 2"
 
 gem "ruby-openai", "~> 8.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,9 +165,9 @@ GEM
     bootstrap4-kaminari-views (1.0.1)
       kaminari (>= 0.13)
       rails (>= 3.1)
-    bot_challenge_page (0.11.0)
+    bot_challenge_page (1.1.0)
       http (~> 5.2)
-      rails (>= 7.1, < 8.1)
+      rails (>= 7.1, < 8.2)
     browse-everything (2.0.0.alpha.1)
       addressable (~> 2.5)
       aws-sdk-s3
@@ -870,7 +870,7 @@ DEPENDENCIES
   blacklight_range_limit (~> 9.2.0)
   bootsnap (>= 1.4.4)
   bootstrap4-kaminari-views
-  bot_challenge_page (>= 0.10.0, < 2)
+  bot_challenge_page (>= 1.1.0, < 2)
   browse-everything (>= 2.0.0.alpha.1, < 3)
   browser (~> 6.0)
   capybara (>= 2.15)

--- a/config/application.rb
+++ b/config/application.rb
@@ -79,7 +79,8 @@ module ScihistDigicoll
         # wasn't sure if we should use request.remote_ip or request.ip, the
         # difference is not clear, or what it seems, in docs or online info
         ip: controller.request.ip,
-        bot_chlng: controller.request.env["bot_detect.blocked_for_challenge"]
+        bot_chlng: controller.request.env["bot_detect.blocked_for_challenge"],
+        bot_passed: (1 if controller.request.env["bot_detect.after_session_passed"]) # was let through bot challenge with a good session pass
       }.compact
     end
 

--- a/config/initializers/bot_challenge_page.rb
+++ b/config/initializers/bot_challenge_page.rb
@@ -26,4 +26,13 @@ BotChallengePage.configure do |config|
     # But log it in our local DB instead, where we have no quota.
     BotChallengedRequest.save_from_request!(request)
   }
+
+  config.after_session_passed = ->(bot_detect_class) {
+    # used as signal for our logging configuration so we can include this
+    # as a token in our request log line
+    request.env["bot_detect.after_session_passed"] = true
+
+    # But log it in our local DB instead, where we have no quota.
+    BotChallengedRequest.save_from_request!(request)
+  }
 end


### PR DESCRIPTION
Using a new hook feature in new bot_challenge_page gem we had to upgrade to.

Ref #3315

See https://github.com/samvera-labs/bot_challenge_page/pull/20
