### PR TITLE
allow basic_internal type users access to ai conversations

### DIFF
--- a/app/controllers/oral_history_ai_conversation_controller.rb
+++ b/app/controllers/oral_history_ai_conversation_controller.rb
@@ -1,24 +1,15 @@
 class OralHistoryAiConversationController < ApplicationController
-  # for now ALL require staff login, eventually we will gate so you can
-  # only see your own questions
-  before_action :authorize_access
-
-  # For now, admin controllers allow anyone who is logged in
-  def authorize_access
-    unless can? :access_staff_functions
-      # raise the error from `access_granted` to be consistent.
-      raise AccessGranted::AccessDenied.new("Only logged-in staff can access this feature")
-    end
-  end
-
   # empty question form
   def new
+    authorize! :create, OralHistory::AiConversation
     # for now maybe we're not showing counts at all actually.
     #@immediate_or_automatic_count = OralHistory::CategoryWithChunksCount.new(category: :immediate_or_automatic).fetch_count
     #@all_count = OralHistory::CategoryWithChunksCount.new(category: :all).fetch_count
   end
 
   def create
+    authorize! :create, OralHistory::AiConversation
+
     #search_params = params.slice(:access_limit,).to_unsafe_h
     # convert include_restricted presence/absence to an access limit restriction. Misisng
     # access limit means everything.
@@ -32,6 +23,7 @@ class OralHistoryAiConversationController < ApplicationController
   # See your question and possibly answer if it's complete!
   def show
     @conversation = OralHistory::AiConversation.find_by_external_id(params.require(:id))
+    authorize! :read, @conversation
   end
 
   # hacky way to deliver partial HTML for our thing that should prob be

--- a/app/frontend/stylesheets/local/homepage.scss
+++ b/app/frontend/stylesheets/local/homepage.scss
@@ -205,6 +205,21 @@
       }
     }
 
+    .homepage-ai-link {
+      background-color: $shi-maroon;
+      color: $shi-yellow;
+
+      a {
+        color: white;
+        text-decoration: underline;
+      }
+
+      padding: 1rem;
+
+      font-size: 1.25rem;
+      text-align: center;
+    }
+
     .featured-topics {
         background-color: $shi-dark-gray;
 

--- a/app/policies/access_policy.rb
+++ b/app/policies/access_policy.rb
@@ -27,15 +27,14 @@ class AccessPolicy
         comment.user_id == user.id
       end
       can :access_staff_functions
-
-      # Can be removed once #3326 is merged, covering it.
-      can :create, OralHistory::AiConversation
     end
 
     role :basic_internal, proc { |user| has_basic_internal_permissions?(user) } do
       # right now we let them read all conversations, we aren't yet restricting to only see own
-      can :read, OralHistory::AiConversation
-      can :create, OralHistory::AiConversation
+      if ScihistDigicoll::Env.lookup("feature_ai_for_basic_internal")
+        can :read, OralHistory::AiConversation
+        can :create, OralHistory::AiConversation
+      end
 
       # We have to look at associated work/oh, can bebit expensive in bulk, beware
       # basic_internal read published AND automatic-approval requestable.

--- a/app/policies/access_policy.rb
+++ b/app/policies/access_policy.rb
@@ -32,6 +32,12 @@ class AccessPolicy
       can :create, OralHistory::AiConversation
     end
 
+    role :basic_internal, proc { |user| has_basic_internal_permissions?(user) } do
+      # right now we let them read all conversations, we aren't yet restricting to only see own
+      can :read, OralHistory::AiConversation
+      can :create, OralHistory::AiConversation
+    end
+
     role :public do
       can :read, Kithe::Model do |mod, user|
         # mod could be any of Kithe::Model, Collection, Work, Asset,
@@ -55,16 +61,22 @@ class AccessPolicy
 
   private
 
+  # They are all hieararchical, admin has ALL permissions, editor has all but admin, etc.
+
   def has_admin_permissions?(user)
     user&.admin_user?
   end
 
   def has_editor_permissions?(user)
-    user&.admin_user? || user&.editor_user?
+    user&.editor_user? || has_admin_permissions?(user)
   end
 
   def has_staff_viewer_permissions?(user)
-    user&.admin_user? || user&.editor_user? || user&.staff_viewer_user?
+    user&.admin_user? || has_editor_permissions?(user)
   end
 
+  # Anyone with a @sciencehistory.org login!
+  def has_basic_internal_permissions?(user)
+    user&.basic_internal_user? || has_staff_viewer_permissions?(user)
+  end
 end

--- a/app/policies/access_policy.rb
+++ b/app/policies/access_policy.rb
@@ -34,16 +34,16 @@ class AccessPolicy
       if ScihistDigicoll::Env.lookup("feature_ai_for_basic_internal")
         can :read, OralHistory::AiConversation
         can :create, OralHistory::AiConversation
-      end
 
-      # We have to look at associated work/oh, can bebit expensive in bulk, beware
-      # basic_internal read published AND automatic-approval requestable.
-      can :read, Asset do |asset, user|
-        asset.published? ||
-          (
-            asset.oh_available_by_request? &&
-            asset.work.oral_history_content.available_by_request_automatic?
-          )
+        # We have to look at associated work/oh, can bebit expensive in bulk, beware
+        # basic_internal read published AND automatic-approval requestable.
+        can :read, Asset do |asset, user|
+          asset.published? ||
+            (
+              asset.oh_available_by_request? &&
+              asset.work.oral_history_content.available_by_request_automatic?
+            )
+        end
       end
     end
 
@@ -81,7 +81,7 @@ class AccessPolicy
   end
 
   def has_staff_viewer_permissions?(user)
-    user&.admin_user? || has_editor_permissions?(user)
+    user&.staff_viewer_user? || has_editor_permissions?(user)
   end
 
   # Anyone with a @sciencehistory.org login!

--- a/app/policies/access_policy.rb
+++ b/app/policies/access_policy.rb
@@ -27,6 +27,9 @@ class AccessPolicy
         comment.user_id == user.id
       end
       can :access_staff_functions
+
+      # Better than basic_internal, these guys can read all assets unpublished too.
+      can :read, Asset
     end
 
     role :basic_internal, proc { |user| has_basic_internal_permissions?(user) } do
@@ -34,16 +37,17 @@ class AccessPolicy
       if ScihistDigicoll::Env.lookup("feature_ai_for_basic_internal")
         can :read, OralHistory::AiConversation
         can :create, OralHistory::AiConversation
+      end
 
-        # We have to look at associated work/oh, can bebit expensive in bulk, beware
-        # basic_internal read published AND automatic-approval requestable.
-        can :read, Asset do |asset, user|
-          asset.published? ||
-            (
-              asset.oh_available_by_request? &&
-              asset.work.oral_history_content.available_by_request_automatic?
-            )
-        end
+      # We have to look at associated work/oh, can bebit expensive in bulk, beware
+      # basic_internal read published AND automatic-approval requestable.
+      can :read, Asset do |asset, user|
+        # basic_internal can read "automatic request" oral history PDFs too even if unpublished.
+        asset.published? ||
+          (
+            asset.oh_available_by_request? &&
+            asset.parent.oral_history_content.available_by_request_automatic?
+          )
       end
     end
 

--- a/app/policies/access_policy.rb
+++ b/app/policies/access_policy.rb
@@ -30,6 +30,10 @@ class AccessPolicy
 
       # Better than basic_internal, these guys can read all assets unpublished too.
       can :read, Asset
+
+      # redundant once feature-flag is removed in basic_internal
+      can :read, OralHistory::AiConversation
+      can :create, OralHistory::AiConversation
     end
 
     role :basic_internal, proc { |user| has_basic_internal_permissions?(user) } do

--- a/app/policies/access_policy.rb
+++ b/app/policies/access_policy.rb
@@ -36,6 +36,16 @@ class AccessPolicy
       # right now we let them read all conversations, we aren't yet restricting to only see own
       can :read, OralHistory::AiConversation
       can :create, OralHistory::AiConversation
+
+      # We have to look at associated work/oh, can bebit expensive in bulk, beware
+      # basic_internal read published AND automatic-approval requestable.
+      can :read, Asset do |asset, user|
+        asset.published? ||
+          (
+            asset.oh_available_by_request? &&
+            asset.work.oral_history_content.available_by_request_automatic?
+          )
+      end
     end
 
     role :public do

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -9,6 +9,15 @@ we want the full width of the screen, no margins or padding. %>
 
 
 <%= render 'homepage/hero_image_and_search_form' %>
+
+<% if can? :create, OralHistory::AiConversation %>
+  <div class="homepage-ai-link">
+    <i class="fa fa-flask" aria-hidden="true"></i>
+    BETA:
+    <%= link_to "Oral History AI-assisted search", new_oral_history_ai_conversation_path %>
+  </div>
+<% end %>
+
 <%= render 'homepage/recent_items' %>
 <%= render 'homepage/featured_topics' %>
 <%= render 'homepage/collections' %>

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -768,5 +768,7 @@ module ScihistDigicoll
     define_key "feature_search_inside_work", default: true, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM
 
     define_key "disable_downloads", default: false, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM
+
+    define_key "feature_ai_for_basic_internal", default: false, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM
   end
 end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -11,5 +11,8 @@ FactoryBot.define do
     factory :staff_viewer_user do
       user_type { "staff_viewer" }
     end
+    factory :basic_internal_user do
+      user_type { "basic_internal" }
+    end
   end
 end

--- a/spec/policies/access_policy_spec.rb
+++ b/spec/policies/access_policy_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe "access policies:" do
   let!(:published_asset) { create(:asset_with_faked_file) }
   let!(:unpublished_asset) { create(:asset_with_faked_file, published: false) }
-  
+
   let!(:collection) { create(:collection) }
 
   let(:comment_you_can_delete) { Admin::QueueItemComment.new(user: user)}
@@ -144,6 +144,32 @@ describe "access policies:" do
     end
     it "can't delete a QueueItemComment by someone else" do
       expect(policy.can?(:destroy, coment_you_can_t_delete)).to be false
+    end
+
+    describe "oral histories" do
+      describe "automatically requestable" do
+        let(:asset) {
+          build(:asset, published: false, oh_available_by_request: true,
+            parent: build(:oral_history_work,  :available_by_request, available_by_request_mode: :automatic)
+          )
+        }
+
+        it "can be read" do
+          expect(policy.can?(:read, asset)).to be true
+        end
+      end
+
+      describe "manually requestable" do
+        let(:asset) {
+          build(:asset, oh_available_by_request: true,
+            parent: build(:oral_history_work,  :available_by_request, available_by_request_mode: :manual)
+          )
+        }
+
+        it "cannot be read" do
+          expect(policy.can?(:read, asset)).to be false
+        end
+      end
     end
   end
 

--- a/spec/policies/access_policy_spec.rb
+++ b/spec/policies/access_policy_spec.rb
@@ -103,7 +103,7 @@ describe "access policies:" do
   end
 
   describe 'staff_viewer' do
-    let(:user) { FactoryBot.create(:staff_viewer_user, email: "staff_viewer@b.c") }
+    let(:user) { FactoryBot.create(:staff_viewer_user) }
     let(:policy) { AccessPolicy.new(user) }
 
     it "is a staff_viewer user" do
@@ -145,6 +145,11 @@ describe "access policies:" do
     it "can't delete a QueueItemComment by someone else" do
       expect(policy.can?(:destroy, coment_you_can_t_delete)).to be false
     end
+  end
+
+  describe "basic_internal user" do
+    let(:user) { FactoryBot.create(:basic_internal_user) }
+    let(:policy) { AccessPolicy.new(user) }
 
     describe "oral histories" do
       describe "automatically requestable" do
@@ -161,7 +166,7 @@ describe "access policies:" do
 
       describe "manually requestable" do
         let(:asset) {
-          build(:asset, oh_available_by_request: true,
+          build(:asset, published: false, oh_available_by_request: true,
             parent: build(:oral_history_work,  :available_by_request, available_by_request_mode: :manual_review)
           )
         }

--- a/spec/policies/access_policy_spec.rb
+++ b/spec/policies/access_policy_spec.rb
@@ -162,7 +162,7 @@ describe "access policies:" do
       describe "manually requestable" do
         let(:asset) {
           build(:asset, oh_available_by_request: true,
-            parent: build(:oral_history_work,  :available_by_request, available_by_request_mode: :manual)
+            parent: build(:oral_history_work,  :available_by_request, available_by_request_mode: :manual_review)
           )
         }
 


### PR DESCRIPTION
Ref #3320

- let basic_internal users create and see individual AI conversations
- simple homepage link to OH AI conversation if user is logged in

re #3399

- [x] Still need to actually fix access_policy access so non-elevated-permission users have access to PDFs that for external users require a request to be made with automatic approval. 

For now feature flag `FEATURE_AI_FOR_BASIC_INTERNAL=true` to enable -- so we can go ahead and merge. 