### PR TITLE
pin connection_pool to 2.x until we update to Rails 8.1, incompatible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,10 @@ gem 'lockbox'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 8.0.0'
 
+# Need to pin connection_pool only UNTIL we update to Rails 8.1.2
+# https://claude.ai/share/bfb7fbc5-cf8b-4548-b7d7-2b82273a0a0e
+gem "connection_pool", "~> 2.4"
+
 # note we use vite-ruby for css and JS, but propshaft delivers some static images and
 # other static assets, as well as produced files from vite.
 gem "propshaft", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,7 +208,7 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     content_disposition (1.0.0)
     crack (1.0.1)
       bigdecimal
@@ -884,6 +884,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   capybara-screenshot
   citeproc-ruby (~> 2.0)
+  connection_pool (~> 2.4)
   content_disposition (~> 1.0)
   csv (~> 3.3.0)
   database_cleaner (~> 2.0)


### PR DESCRIPTION
Diagnosed by Claude: https://claude.ai/share/bfb7fbc5-cf8b-4548-b7d7-2b82273a0a0e
