### PR TITLE
Claude OH AI: Place introduction instructions after findings instructions

### DIFF
--- a/app/views/claude_interactor/system_instructions.text.erb
+++ b/app/views/claude_interactor/system_instructions.text.erb
@@ -5,7 +5,6 @@ You are a research assistant specializing in oral history analysis. Your role is
 Output a single valid JSON object with this structure (no code fences, preambles, or external text.)
 
 {
-  "introduction": "<introduction>",
   "findings": [
     {
       "answer": "<claim, fact, or piece of information>",
@@ -20,6 +19,7 @@ Output a single valid JSON object with this structure (no code fences, preambles
       ]
     }
   ],
+  "introduction": "<introduction>",
   "answer_unavailable": true | false
 }
 
@@ -35,24 +35,23 @@ Output a single valid JSON object with this structure (no code fences, preambles
 
 
 
-## Introduction (2-7 sentences)
-
-- Provide a brief, factual overview that directly addresses the question.
-- Briefly summarize the findings found in the oral histories.
-- Note any significant gaps or patterns in the available information.
-- Do NOT add interpretation, broader context, or extrapolation beyond what's in the transcripts. The conclusions are about what was found in transcripts, not about what exists in the world.
-- **For quantitative or exhaustive questions** ("how many," "list," "which," "who," "all"), the first sentence must state you're providing examples, not complete counts or exhaustive lists.
-
-
-
 ## Findings
 
-- Each finding should contain ONE specific claim, fact, or piece of information
+- Each finding should contain a specific claim, fact, or piece of information
 - **Keep findings concise** - Focus on the main point, without related but extraneous detials. Omit supporting details, specific statistics, or elaborations unless they're essential to understanding the claim. The quote can have more details.
 - Be specific and concrete—include names, dates, locations, and other details when available
 - Quote directly when the exact wording is helpful, but paraphrase for clarity when appropriate
 - Each finding needs at least one citation.
-- If a claim draws from multiple sources, cite all: [Interview ID1, ¶X; Interview ID2, ¶Y]
+- If a claim draws from multiple sources, cite each of them.
+
+
+## Introduction (2-7 sentences)
+
+- Provide a brief, factual overview summarizes the findings found in the oral histories.
+- Written after findings are complete, but will be dislayed to users at top.
+- Note any significant gaps or patterns in the available information.
+- Do NOT add interpretation, broader context, or extrapolation beyond what's in the transcripts. The conclusions are about what was found in transcripts, not about what exists in the world.
+- **For quantitative or exhaustive questions** ("how many," "list," "which," "who," "all"), the first sentence must state you're providing examples, not complete counts or exhaustive lists.
 
 
 


### PR DESCRIPTION
With a few other tweaks. Since intro is meant to summarize findings, this may make things easier on Claude? Came up when I was exploring stremaing, that could make things more reliable or slightly faster. Shoudln't hurt anyway.

----

**Decided not to do this!** 

It made the intro significantly different actually!  It _did_ make it in some ways better and more specific and less vague, but also a lot longer -- and we aren't sure we want it longer. 

This wasn't actually a change we wanted, just something i was trying -- learning that with these LLM instructions every change has intended as well as unintended effects.  It's good enough, nobody asked for this, stop futzing with it. 

If in the future we want better intro's that are still concise and it's actually asked for, we can actually make it a task. 

## Examples so you see what i mean

### before

> The passages consulted offer several perspectives from chemical engineers on how they define their discipline and its origins as a distinct field. Interviewees discuss chemical engineering's relationship to chemistry, its roots in industrial processes, its identity as an American invention, and the tensions that arose as it separated from chemistry. These examples may not represent a complete list of relevant discussions in the collection, and additional relevant information may exist in other passages not examined here.

### after

> The passages consulted reveal rich and varied perspectives on how chemical engineers define their discipline and reflect on its origins. A recurring theme is the contested boundary between chemistry and engineering: multiple interviewees describe chemical engineering as emerging from an uneasy hybrid of the two fields, with its identity disputed by both chemists and engineers in its early decades. Several interviewees trace the discipline's origins to the large-scale petroleum and process industries, and to the development of 'unit operations' as a unifying framework—particularly at MIT after the chemistry-chemical engineering split in 1920. Others emphasize the discipline's breadth and adaptability, while some express concern that it has become too narrow or conservative. The passages consulted represent examples from the collection; additional relevant perspectives may exist in other interviews not examined here.