### PR TITLE
update npm picomatch to 2.3.2 and 4.0.4

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -721,14 +721,14 @@ picocolors@^1.1.1:
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 picomatch@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
-  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 pkcs7@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
In response to dependabot notice https://github.com/sciencehistory/scihist_digicoll/security/dependabot/183

It was an indirect dependency -- and our dependency tree included a depdendency on a different major version of picomatch too -- and the dependabot notice was a bit confused bout what was going on. 

Also yarn 1 which we use doesn't do great at updating indirect dependencies. 

I manualy edited the yarn.lock to remove the block that looked like:

    picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
      version "2.3.1"

Then ran `yarn install`, and re-filled it the same thing with 2.3.2, which should resolve the alert. 

oh and then same thing for the separate pickmatch 4.x line in yarn.lock. 

It's taken me a while to figure out how to deal wiht this in yarn 1!  We should prob move to something else one of these days, perhaps not even yarn, now that we're on vite. 
