### PR TITLE
Google arts and culture download model

### DIFF
--- a/app/models/google_arts_and_culture_download.rb
+++ b/app/models/google_arts_and_culture_download.rb
@@ -1,22 +1,9 @@
-# Represents one of of our large whole-work derivatives (zip of images, or PDF of images),
-# that are created on-demand.
-#
-# Represents the in_progress/success/error state of creation on demand.
-#
-# An OnDemandDerivative record may exist when the actual derivative no longer exists in storage,
-# because we store them in an S3 with lifecycle rules set to remove not recently used copies,
-# as a sort of cache.
-#
-# You can #put_file, #file_exists?, and #file_url to deal with the attached file. We use Shrine::UploadedFile
-# objects directly, without using Shrine Attachment code.
+# Represents a zip file containing files and metadata meant to be downloaded from S3 and then exported into Google Arts and Culture.
+
 class GoogleArtsAndCultureDownload < ApplicationRecord
-
   SHRINE_STORAGE_KEY = :google_arts_and_culture
-
   enum :status, %w{in_progress uploading success error}.collect {|v| [v, v]}.to_h.freeze
-
   belongs_to :user
-
 
   def works_added
     @works_added ||= 0
@@ -48,7 +35,7 @@ class GoogleArtsAndCultureDownload < ApplicationRecord
   def file_url
     uploaded_file.url(
       public: false,
-      response_content_type: uploaded_file.metadata["mime_type"],
+      response_content_type: 'application/zip',
       response_content_disposition: ContentDisposition.attachment(file_key)
     )
   end
@@ -61,15 +48,10 @@ class GoogleArtsAndCultureDownload < ApplicationRecord
       log_error(e)
       raise
     end
-
-
   end
-
 
   def log_error(e)
     Rails.logger.info e.message
     update!({status: 'error', error_info: e.message})
   end
-
-
 end

--- a/app/models/google_arts_and_culture_download.rb
+++ b/app/models/google_arts_and_culture_download.rb
@@ -1,0 +1,75 @@
+# Represents one of of our large whole-work derivatives (zip of images, or PDF of images),
+# that are created on-demand.
+#
+# Represents the in_progress/success/error state of creation on demand.
+#
+# An OnDemandDerivative record may exist when the actual derivative no longer exists in storage,
+# because we store them in an S3 with lifecycle rules set to remove not recently used copies,
+# as a sort of cache.
+#
+# You can #put_file, #file_exists?, and #file_url to deal with the attached file. We use Shrine::UploadedFile
+# objects directly, without using Shrine Attachment code.
+class GoogleArtsAndCultureDownload < ApplicationRecord
+
+  SHRINE_STORAGE_KEY = :google_arts_and_culture
+
+  enum :status, %w{in_progress uploading success error}.collect {|v| [v, v]}.to_h.freeze
+
+  belongs_to :user
+
+
+  def works_added
+    @works_added ||= 0
+  end
+
+  def log_work_added!
+    @works_added = works_added + 1
+    update!({progress: works_added})
+  end
+
+  def file_key
+    "google_arts_and_culture_downloads_#{id}.zip"
+  end
+
+  def uploaded_file
+    @uploaded_file ||= Shrine::UploadedFile.new(
+      "id" => file_key,
+      "storage" => SHRINE_STORAGE_KEY,
+      "metadata" => {
+        "mime_type" => 'application/zip'
+      }
+    )
+  end
+
+  def file_exists?
+    uploaded_file.exists?
+  end
+
+  def file_url
+    uploaded_file.url(
+      public: false,
+      response_content_type: uploaded_file.metadata["mime_type"],
+      response_content_disposition: ContentDisposition.attachment(file_key)
+    )
+  end
+
+  def put_file(io)
+    update!({status: 'uploading'})
+    begin
+        Shrine.storages[SHRINE_STORAGE_KEY].upload(io, file_key)
+    rescue => e
+      log_error(e)
+      raise
+    end
+
+
+  end
+
+
+  def log_error(e)
+    Rails.logger.info e.message
+    update!({status: 'error', error_info: e.message})
+  end
+
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,7 @@ class User < ApplicationRecord
 
   has_many :cart_items, dependent: :delete_all
   has_many :works_in_cart, through: :cart_items, source: :work
+  has_many :google_arts_and_culture_downloads
 
   # This will correspond to a "role" in the AccessPolicy class.
   # basic_internal is anyone with a @sciencehistory.org login, others are elevated permissions

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -21,5 +21,6 @@ Shrine.storages = {
   restricted_kithe_derivatives: ScihistDigicoll::Env.shrine_restricted_derivatives_storage,
   on_demand_derivatives: ScihistDigicoll::Env.shrine_on_demand_derivatives_storage,
   combined_audio_derivatives: ScihistDigicoll::Env.shrine_combined_audio_derivatives_storage,
-  dzi_storage: ScihistDigicoll::Env.shrine_dzi_storage
+  dzi_storage: ScihistDigicoll::Env.shrine_dzi_storage,
+  google_arts_and_culture: ScihistDigicoll::Env.google_arts_and_culture_storage
 }

--- a/db/migrate/20260324170634_create_google_arts_and_culture_downloads_table.rb
+++ b/db/migrate/20260324170634_create_google_arts_and_culture_downloads_table.rb
@@ -1,0 +1,18 @@
+class CreateGoogleArtsAndCultureDownloadsTable < ActiveRecord::Migration[8.1]
+  def change
+    create_table :google_arts_and_culture_downloads do |t|
+      t.timestamps
+      t.references :user, null: false, type: :bigint, foreign_key: { to_table: :users }
+
+      t.string :status, null: false, default: "in_progress"
+
+      t.text   :error_info
+      t.text   :user_notes
+
+      t.integer :progress
+      t.integer :progress_total
+
+      t.jsonb :file_data
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_10_185449) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_24_170634) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"
@@ -142,6 +142,19 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_10_185449) do
     t.jsonb "data_for_report", default: {}
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "google_arts_and_culture_downloads", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.string "status", default: "in_progress", null: false
+    t.text "error_info"
+    t.text "user_notes"
+    t.integer "progress"
+    t.integer "progress_total"
+    t.jsonb "file_data"
+    t.index ["user_id"], name: "index_google_arts_and_culture_downloads_on_user_id"
   end
 
   create_table "interviewee_biographies", force: :cascade do |t|
@@ -339,6 +352,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_10_185449) do
   end
 
   add_foreign_key "fixity_checks", "kithe_models", column: "asset_id"
+  add_foreign_key "google_arts_and_culture_downloads", "users"
   add_foreign_key "kithe_model_contains", "kithe_models", column: "containee_id"
   add_foreign_key "kithe_model_contains", "kithe_models", column: "container_id"
   add_foreign_key "kithe_models", "digitization_queue_items"

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -293,6 +293,9 @@ module ScihistDigicoll
     define_key :s3_bucket_uploads
     define_key :s3_bucket_on_demand_derivatives
     define_key :s3_bucket_dzi
+    define_key :s3_bucket_public
+
+
 
     # if we are using CloudFront in front of a bucket, we set Cloudfront Distro hostname
     # in variables corresponding to bucket name env, with `_host` on the end. These
@@ -465,7 +468,7 @@ module ScihistDigicoll
     def self.appropriate_shrine_storage(bucket_key:, public: false, mode: lookup!(:storage_mode), prefix: nil,
                                         host: nil, s3_storage_options: {} )
       unless %I{s3_bucket_uploads s3_bucket_originals s3_bucket_originals_video s3_bucket_derivatives
-                s3_bucket_derivatives_video
+                s3_bucket_derivatives_video s3_bucket_public
                 s3_bucket_on_demand_derivatives s3_bucket_dzi}.include?(bucket_key)
         raise ArgumentError.new("Unrecognized bucket_key: #{bucket_key}")
       end
@@ -599,6 +602,13 @@ module ScihistDigicoll
                                       }
                                     }
                                   )
+    end
+
+    def self.google_arts_and_culture_storage
+      @google_arts_and_culture_storage ||=
+        appropriate_shrine_storage(bucket_key: :s3_bucket_public,
+          public: true,
+          prefix: "google_arts_and_culture_downloads")
     end
 
     def self.shrine_combined_audio_derivatives_storage

--- a/spec/models/google_arts_and_culture_download_spec.rb
+++ b/spec/models/google_arts_and_culture_download_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe GoogleArtsAndCultureDownload do
+  let(:download) { create(:admin_user).google_arts_and_culture_downloads.create!({ user_notes: @user_notes, progress: 0, progress_total: 3 }) }
+  let(:file) {  Tempfile.new(["files", ".zip"]) }
+  it "can put and access file" do
+    download.put_file(file)
+    expect(download.file_exists?).to be true
+    expect(download.file_url).to match /public\/google_arts_and_culture_downloads\/google_arts_and_culture_downloads_[\d]+\.zip/
+    download.log_work_added!
+  end
+end


### PR DESCRIPTION
Creates a model (with its migration, as it's an ApplicationRecord) to keep track of downloads to GAC.
Some changes to Shrine setup, as we want to store the download objects in our public bucket.