### PR TITLE
Google Arts and Culture download creator job, with spec

### DIFF
--- a/app/jobs/google_arts_and_culture_download_creator_job.rb
+++ b/app/jobs/google_arts_and_culture_download_creator_job.rb
@@ -1,0 +1,71 @@
+class GoogleArtsAndCultureDownloadCreatorJob < ApplicationJob
+
+
+  # Requests all files needed for a google arts and culture export,
+  # downloads them, compresses them, and adds them to a bucket on s3.
+  def perform(user: user, user_notes: nil)
+    @user = user
+    @user_notes = user_notes
+    return if @user.works_in_cart == []  || exporter.scope.count == 0
+    begin
+      logger.info("#{self.class}: Preparing download for #{@user.name}.")
+      add_metadata_and_files_to_zip
+      upload_to_s3
+    rescue StandardError => e
+      download.log_error(e)
+      raise
+    end
+  ensure
+     files_to_close.compact.each { |f| f.close; f.unlink }
+  end
+
+
+  # Adds all the necessary files to tmp_zipfile
+  def add_metadata_and_files_to_zip
+    Zip::File.open(tmp_zipfile.path, create: true) do |zipfile|
+      add_to_zip_file(name:'metadata.csv', file_to_add: exporter.metadata_csv_tempfile, destination_zipfile: zipfile)
+      exporter.file_hash.each do |name, uploaded_file_obj|
+        add_to_zip_file(name:name, file_to_add: uploaded_file_obj.download, destination_zipfile: zipfile)
+        download.log_work_added!
+      end
+    end
+    tmp_zipfile.close
+  end
+
+
+  def files_to_close
+    @files_to_close ||= []
+  end
+
+  # Create or return an object that preserves a record of this download.
+  def download
+    @download ||= @user.google_arts_and_culture_downloads.create!({
+      user_notes: @user_notes,
+      progress: 0,
+      progress_total: exporter.file_hash.count
+    })
+  end
+
+  def upload_to_s3
+    File.open(tmp_zipfile.path, "r") { |io| download.put_file io }
+    @download.update!({status: 'success'})
+  end
+
+  def tmp_zipfile
+    @tmp_zipfile ||= Tempfile.new(["files", ".zip"]).tap { |t| t.binmode }
+  end
+
+  def exporter
+    @exporter ||= GoogleArtsAndCulture::Exporter.new(scope)
+  end
+
+  def scope
+    @scope = @user.works_in_cart
+  end
+
+  def add_to_zip_file(name:, file_to_add:, destination_zipfile:)
+    entry = ::Zip::Entry.new(destination_zipfile.name, name, compression_method: ::Zip::Entry::STORED)
+    destination_zipfile.add(entry, file_to_add)
+    files_to_close << file_to_add
+  end
+end

--- a/app/models/google_arts_and_culture_download.rb
+++ b/app/models/google_arts_and_culture_download.rb
@@ -1,5 +1,5 @@
-# Represents a zip file containing files and metadata meant to be downloaded from S3 and then exported into Google Arts and Culture.
 
+# Represents a zip file containing files and metadata meant to be downloaded from S3 and then exported into Google Arts and Culture.
 class GoogleArtsAndCultureDownload < ApplicationRecord
   SHRINE_STORAGE_KEY = :google_arts_and_culture
   enum :status, %w{in_progress uploading success error}.collect {|v| [v, v]}.to_h.freeze
@@ -54,4 +54,5 @@ class GoogleArtsAndCultureDownload < ApplicationRecord
     Rails.logger.info e.message
     update!({status: 'error', error_info: e.message})
   end
+  
 end

--- a/spec/jobs/google_arts_and_culture_download_creator_job_spec.rb
+++ b/spec/jobs/google_arts_and_culture_download_creator_job_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+describe GoogleArtsAndCultureDownloadCreatorJob do
+
+  let(:user) {FactoryBot.create(:admin_user)}
+
+  let(:work_1) { FactoryBot.build(:public_work, :with_assets)}
+  let(:work_2) { FactoryBot.build(:public_work, :with_assets)}
+  let(:work_3) { FactoryBot.build(:public_work, :with_assets)}
+
+  let(:work_4) { FactoryBot.build(:public_work)}
+  let(:work_5) { FactoryBot.build(:public_work)}
+  let(:work_6) { FactoryBot.build(:public_work)}
+
+
+  let(:job) { GoogleArtsAndCultureDownloadCreatorJob.new(user:user, user_notes: "some notes") }
+
+  let(:error_class) { StandardError }
+
+
+  before do
+    user.works_in_cart = [work_1, work_2, work_3, work_4, work_5, work_6]
+  end
+
+  it "creates an export" do
+    expect(user.google_arts_and_culture_downloads.count).to eq 0
+    job.perform_now
+    expect(user.google_arts_and_culture_downloads.count).to eq 1
+    download = user.google_arts_and_culture_downloads.first
+    expect(download.status).to eq "success"
+    expect(download.progress).to eq 6
+    expect(download.progress_total).to eq 6
+    expect(download.user_notes).to eq "some notes"
+  end
+
+  it "fails quietly if cart is empty without creating a download." do
+    user.update!({works_in_cart: []})
+    expect(user.google_arts_and_culture_downloads.count).to eq 0
+    job.perform_now
+    expect(user.google_arts_and_culture_downloads.count).to eq 0
+  end
+
+
+  describe "with an error" do
+    before do
+      expect(job).to receive(:add_metadata_and_files_to_zip).and_raise(error_class)
+    end
+    it "finishes in error state, and raises original" do
+      expect(user.google_arts_and_culture_downloads.count).to eq 0
+      expect {
+        job.perform_now
+      }.to raise_error(error_class)
+      expect(user.google_arts_and_culture_downloads.count).to eq 1
+      download = user.google_arts_and_culture_downloads.first
+      expect(download.status).to eq "error"
+      expect(download.progress).to eq 0
+      expect(download.progress_total).to eq 6
+      expect(download.user_notes).to eq "some notes"
+      expect(download.error_info).to eq ("StandardError")
+    end
+  end
+end


### PR DESCRIPTION
Ref https://github.com/sciencehistory/scihist_digicoll/issues/2903

A job to create a GAC download object, along with its test. Uses files and metadata from the exporter classes, so this is very simple.

All this job does is zip up the exporter's files, update the download object with progress info so the user can follow along, and upload the resulting zip file to s3 so a user can download it.

So far there's no code to actually run this job.
