### PR TITLE
Controller and view for GAC downloads

### DIFF
--- a/app/controllers/admin/cart_items_controller.rb
+++ b/app/controllers/admin/cart_items_controller.rb
@@ -103,36 +103,4 @@ class Admin::CartItemsController < AdminController
     end
   end
 
-
-  def google_arts_and_culture_export
-    files_to_close = []
-    tmp_zipfile = Tempfile.new(["files", ".zip"]).tap { |t| t.binmode }
-
-    exporter = GoogleArtsAndCulture::Exporter.new(current_user.works_in_cart)
-
-    Zip::File.open(tmp_zipfile.path, create: true) do |zipfile|
-
-      # Metadata
-      metadata_csv_tempfile = exporter.metadata_csv_tempfile
-      entry = ::Zip::Entry.new(zipfile.name, 'metadata.csv', compression_method: ::Zip::Entry::STORED)
-      zipfile.add(entry, metadata_csv_tempfile)
-      files_to_close << metadata_csv_tempfile
-
-      # Files
-      exporter.file_hash.each do |file_name, uploaded_file_obj|
-        downloaded_file = uploaded_file_obj.download
-        entry = ::Zip::Entry.new(zipfile.name, file_name, compression_method: ::Zip::Entry::STORED)
-        zipfile.add(entry, downloaded_file)
-        files_to_close << downloaded_file
-      end
-    end
-
-    send_file tmp_zipfile.path, filename: "google-arts-and-culture-export-#{Date.today.to_s}.zip"
-
-  ensure
-    (files_to_close || []).compact.each do |f|
-      f.close
-      f.unlink
-    end
-  end
 end

--- a/app/controllers/admin/google_arts_and_culture_downloads_controller.rb
+++ b/app/controllers/admin/google_arts_and_culture_downloads_controller.rb
@@ -1,0 +1,60 @@
+class Admin::GoogleArtsAndCultureDownloadsController < AdminController
+  before_action :authenticate_user!
+
+  def index
+    @google_arts_and_culture_downloads = GoogleArtsAndCultureDownload.all
+      .includes(:user)
+      .page(params[:page]).per(20)
+      .order(created_at: :desc)
+  end
+
+  # Post to this method to load a bunch of works into the cart
+  def load_into_cart
+    scope = eligible_scope
+
+    cs = params.dig('load_into_cart', 'created_at_start_date' )
+    ms = params.dig('load_into_cart', 'modified_at_start_date')
+    ce = params.dig('load_into_cart', 'created_at_end_date'   )
+    me = params.dig('load_into_cart', 'modified_at_end_date'  )
+
+    scope = scope.where('DATE(created_at) >= ?', cs.to_date ) if cs.present?
+    scope = scope.where('DATE(updated_at) >= ?', ms.to_date ) if ms.present?
+    scope = scope.where('DATE(created_at) <= ?', ce.to_date ) if ce.present?
+    scope = scope.where('DATE(updated_at) <= ?', me.to_date ) if me.present?
+
+    all_ids = scope.pluck('id')
+    CartItem.transaction do
+      all_ids.each_slice(500) do |ids|
+        CartItem.upsert_all( ids.map { |id| { user_id: current_user.id, work_id: id } } ,  unique_by: [:user_id, :work_id])
+      end
+    end
+    redirect_to admin_google_arts_and_culture_downloads_path, notice: "Added #{scope.count} works to your cart."
+  end
+
+
+  def export_cart
+    user_notes = params.dig('export_cart', 'user_notes')
+    GoogleArtsAndCultureDownloadCreatorJob.perform_later(user: current_user, user_notes: user_notes)
+    redirect_to admin_google_arts_and_culture_downloads_path, notice: "Currently preparing a new download based on the works. Reload this page to see progress."
+  end
+
+
+  def eligible_scope
+    @eligible_scope ||= begin
+
+      museum_scope = Work.where(published: true).
+      where("json_attributes -> 'department' ?| array[:depts  ]", depts:   ['Museum'] ).
+      where("json_attributes -> 'format'     ?| array[:formats]", formats: ['physical_object'] ).
+      where("json_attributes -> 'rights'     ?| array[:rights ]", rights:  ['https://creativecommons.org/licenses/by/4.0/'] )
+
+      library_scope = Work.where(published: true).
+      where("json_attributes -> 'department' ?| array[:depts  ]", depts:   ['Library'] ).
+      where("json_attributes -> 'format'     ?| array[:formats]", formats: ['image'] ).
+      where("json_attributes -> 'rights'     ?| array[:rights ]", rights:  ['http://creativecommons.org/publicdomain/mark/1.0/'] )
+
+      museum_scope.or(library_scope)
+    end
+  end
+  helper_method :eligible_scope
+
+end

--- a/app/controllers/admin/google_arts_and_culture_downloads_controller.rb
+++ b/app/controllers/admin/google_arts_and_culture_downloads_controller.rb
@@ -34,6 +34,11 @@ class Admin::GoogleArtsAndCultureDownloadsController < AdminController
 
   def export_cart
     user_notes = params.dig('export_cart', 'user_notes')
+    unless current_user.works_in_cart.where(published:true).present?
+      redirect_to admin_google_arts_and_culture_downloads_path, notice: "Add at least one published work to your cart first."
+      return
+    end
+
     GoogleArtsAndCultureDownloadCreatorJob.perform_later(user: current_user, user_notes: user_notes)
     redirect_to admin_google_arts_and_culture_downloads_path, notice: "Currently preparing a new download based on the works. Reload this page to see progress."
   end

--- a/app/controllers/admin/google_arts_and_culture_downloads_controller.rb
+++ b/app/controllers/admin/google_arts_and_culture_downloads_controller.rb
@@ -10,7 +10,7 @@ class Admin::GoogleArtsAndCultureDownloadsController < AdminController
 
   # Post to this method to load a bunch of works into the cart
   def load_into_cart
-    scope = eligible_scope
+    scope = GoogleArtsAndCulture::Exporter.eligible_scope
 
     cs = params.dig('load_into_cart', 'created_at_start_date' )
     ms = params.dig('load_into_cart', 'modified_at_start_date')
@@ -37,24 +37,4 @@ class Admin::GoogleArtsAndCultureDownloadsController < AdminController
     GoogleArtsAndCultureDownloadCreatorJob.perform_later(user: current_user, user_notes: user_notes)
     redirect_to admin_google_arts_and_culture_downloads_path, notice: "Currently preparing a new download based on the works. Reload this page to see progress."
   end
-
-
-  def eligible_scope
-    @eligible_scope ||= begin
-
-      museum_scope = Work.where(published: true).
-      where("json_attributes -> 'department' ?| array[:depts  ]", depts:   ['Museum'] ).
-      where("json_attributes -> 'format'     ?| array[:formats]", formats: ['physical_object'] ).
-      where("json_attributes -> 'rights'     ?| array[:rights ]", rights:  ['https://creativecommons.org/licenses/by/4.0/'] )
-
-      library_scope = Work.where(published: true).
-      where("json_attributes -> 'department' ?| array[:depts  ]", depts:   ['Library'] ).
-      where("json_attributes -> 'format'     ?| array[:formats]", formats: ['image'] ).
-      where("json_attributes -> 'rights'     ?| array[:rights ]", rights:  ['http://creativecommons.org/publicdomain/mark/1.0/'] )
-
-      museum_scope.or(library_scope)
-    end
-  end
-  helper_method :eligible_scope
-
 end

--- a/app/jobs/google_arts_and_culture_download_creator_job.rb
+++ b/app/jobs/google_arts_and_culture_download_creator_job.rb
@@ -48,7 +48,6 @@ class GoogleArtsAndCultureDownloadCreatorJob < ApplicationJob
 
   def upload_to_s3
     File.open(tmp_zipfile.path, "r") { |io| download.put_file io }
-    @download.update!({status: 'success'})
   end
 
   def tmp_zipfile

--- a/app/models/google_arts_and_culture_download.rb
+++ b/app/models/google_arts_and_culture_download.rb
@@ -4,6 +4,7 @@ class GoogleArtsAndCultureDownload < ApplicationRecord
   SHRINE_STORAGE_KEY = :google_arts_and_culture
   enum :status, %w{in_progress uploading success error}.collect {|v| [v, v]}.to_h.freeze
   belongs_to :user
+  before_destroy :delete_file
 
   def works_added
     @works_added ||= 0
@@ -19,17 +20,15 @@ class GoogleArtsAndCultureDownload < ApplicationRecord
   end
 
   def uploaded_file
-    @uploaded_file ||= Shrine::UploadedFile.new(
+    @uploaded_file ||= Shrine::UploadedFile.new({
       "id" => file_key,
       "storage" => SHRINE_STORAGE_KEY,
       "metadata" => {
-        "mime_type" => 'application/zip'
+        "mime_type" => 'application/zip',
+        "created_at" => Time.current.utc.iso8601.to_s,
+        "created_by" => user.name
       }
-    )
-  end
-
-  def file_exists?
-    uploaded_file.exists?
+    })
   end
 
   def file_url
@@ -48,6 +47,11 @@ class GoogleArtsAndCultureDownload < ApplicationRecord
       log_error(e)
       raise
     end
+    update!({file_data: uploaded_file.as_json, status: 'success'})
+  end
+
+  def delete_file
+    uploaded_file.delete
   end
 
   def log_error(e)

--- a/app/serializers/google_arts_and_culture/asset_serializer.rb
+++ b/app/serializers/google_arts_and_culture/asset_serializer.rb
@@ -32,7 +32,6 @@ module GoogleArtsAndCulture
         friendlier_id:  @asset.parent.friendlier_id, # friendlier_id is just used for works
         subitem_id:     @asset.friendlier_id,
         order_id:       @asset.position || no_value,
-        title:          @asset.title,
       }
 
       @attribute_keys.map do |k|

--- a/app/serializers/google_arts_and_culture/work_serializer.rb
+++ b/app/serializers/google_arts_and_culture/work_serializer.rb
@@ -69,7 +69,6 @@ module GoogleArtsAndCulture
     def work_attribute_methods
       tmp = @attribute_keys.map do |attribute_label|
         new_proc = if self.respond_to? attribute_label
-          #puts "We do respond to #{attribute_label}"
           # If k is defined in this class, use that (e.g. :created)
           Proc.new { self.send attribute_label }
         elsif Work.method_defined? attribute_label

--- a/app/services/google_arts_and_culture/exporter.rb
+++ b/app/services/google_arts_and_culture/exporter.rb
@@ -16,30 +16,21 @@ module GoogleArtsAndCulture
       else
         columns.select { |c| all_attributes.keys.include? c }
       end
+    end
 
+    # Only works within this scope should be exported to Google Arts and Culture.
+    def self.eligible_scope
+      museum_scope = Work.where(published: true).
+      where("json_attributes -> 'department' ?| array[:depts  ]", depts:   ['Museum'] ).
+      where("json_attributes -> 'format'     ?| array[:formats]", formats: ['physical_object'] ).
+      where("json_attributes -> 'rights'     ?| array[:rights ]", rights:  ['https://creativecommons.org/licenses/by/4.0/'] )
 
-      @verbose_mode = false
-      if @verbose_mode
-        message = <<-MESSAGE
-        Starting a Google Arts and Culture export.
-        Class name:
-        #{self.class.name}
+      library_scope = Work.where(published: true).
+      where("json_attributes -> 'department' ?| array[:depts  ]", depts:   ['Library'] ).
+      where("json_attributes -> 'format'     ?| array[:formats]", formats: ['image'] ).
+      where("json_attributes -> 'rights'     ?| array[:rights ]", rights:  ['http://creativecommons.org/publicdomain/mark/1.0/'] )
 
-        Works we are exporting:
-        #{@scope.pluck('friendlier_id').inspect}
-
-        Metadata we are exporting:
-        #{@attribute_keys.inspect}
-
-        Array attributes:
-        #{array_attributes.inspect}
-
-        Count for each array attribute:
-        #{column_counts.inspect}
-MESSAGE
-        Rails.logger.info message
-      end
-
+      museum_scope.or(library_scope)
     end
 
     # Does not close the tempfile.

--- a/app/services/google_arts_and_culture/exporter.rb
+++ b/app/services/google_arts_and_culture/exporter.rb
@@ -8,6 +8,9 @@ module GoogleArtsAndCulture
     def initialize(scope, columns: nil)
       @original_scope = scope
       @scope = scope.where(published: true, type: "Work")
+
+      raise StandardError, "No works in scope." unless @scope.count > 0
+
       @attribute_keys = if columns.nil?
         all_attributes.keys
       else
@@ -15,9 +18,9 @@ module GoogleArtsAndCulture
       end
 
 
-      @verbose_mode = true
+      @verbose_mode = false
       if @verbose_mode
-        Rails.logger.info <<-MESSAGE
+        message = <<-MESSAGE
         Starting a Google Arts and Culture export.
         Class name:
         #{self.class.name}
@@ -34,6 +37,7 @@ module GoogleArtsAndCulture
         Count for each array attribute:
         #{column_counts.inspect}
 MESSAGE
+        Rails.logger.info message
       end
 
     end
@@ -62,11 +66,13 @@ MESSAGE
     # Returns a hash of filenames and downloadable files:
     # file_hash.each { |filename, downloadable_file| [...] }
     def file_hash
-      result = {}
-      @scope.each do |work|
-        result.merge!(WorkSerializer.file_hash(work))
+      @file_hash ||= begin
+        result = {}
+        @scope.each do |work|
+          result.merge!(WorkSerializer.file_hash(work))
+        end
+        result
       end
-      result
     end
 
 

--- a/app/views/admin/cart_items/index.html.erb
+++ b/app/views/admin/cart_items/index.html.erb
@@ -4,7 +4,6 @@
   <p>
     <%= link_to "Batch Edit", batch_update_admin_works_path, class: "btn btn-primary" %>
     <%= link_to "Save a report", report_admin_cart_items_path, class: "btn btn-primary", data: { confirm: "Save a CSV report?"}, method: "post" %>
-    <%= link_to "Google Arts and Culture export", google_arts_and_culture_export_admin_cart_items_path, class: "btn btn-primary", data: { confirm: "Download metadata and files in Google Arts & Culture export format?"}, method: "post" %>
     <%= link_to "Clear Cart", clear_admin_cart_items_path, class: "btn btn-outline-danger", data: { confirm: "Delete all items in cart?"}, method: "delete" %>
   </p>
 

--- a/app/views/admin/google_arts_and_culture_downloads/index.html.erb
+++ b/app/views/admin/google_arts_and_culture_downloads/index.html.erb
@@ -41,7 +41,7 @@
 
 <div class="border p-3 mb-5">
   <h2>2: Prepare a download</h1>
-  <p>The file prepared will contain all the published works in your cart. You can add some bookkeeping notes for later reference, if you want.</p>
+  <p>The download will contain all the published works in your cart. You can add some bookkeeping notes for later reference.</p>
   <%= simple_form_for(:export_cart, url: export_cart_admin_google_arts_and_culture_downloads_path, method: :post) do |f| %>
     <%= f.input :user_notes, required: false, label: "Your notes"  %>
   <%= f.button :submit, value: "Prepare your download", data: { confirm: "Prepare a GAC download containing metadata and files for all the works in your cart? This may take several hours."} %>
@@ -49,7 +49,7 @@
 </div>
 
 <div class="border p-3 mb-5">
-  <h2>3: Download your files and metadata</h2>
+  <h2>3: Download files and metadata</h2>
   <table class="table admin-list">
     <thead>
       <tr>

--- a/app/views/admin/google_arts_and_culture_downloads/index.html.erb
+++ b/app/views/admin/google_arts_and_culture_downloads/index.html.erb
@@ -1,0 +1,85 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Google Arts and Culture Downloads</h1>
+
+<div class="border p-3 mb-5">
+  <h2>1: Load eligible works into your cart</h1>
+  <p>Only works that are eligible for Google Arts and Culture will be added. This will not remove any works from your cart; it only adds them.</p>
+  <%= simple_form_for(:load_into_cart, url: load_into_cart_admin_google_arts_and_culture_downloads_path, method: :post) do |f| %>
+    <div class="row">
+      <div class="col">
+        <%= f.input :created_at_start_date,
+          as: :date, html5: true, required: false,
+          label: "Created on or after" %>
+      </div>
+      <div class="col">
+        <%= f.input :created_at_end_date,
+          as: :date, html5: true, required: false,
+          label: "Created on or before"  %>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col">
+        <%= f.input :modified_at_start_date,
+          as: :date, html5: true, required: false,
+          label: "Modified on or after" %>
+      </div>
+      <div class="col">
+        <%= f.input :modified_at_end_date,
+          as: :date, html5: true, required: false,
+          label: "Modified on or before"  %>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col">
+        <%= f.button :submit, value: "Add works to your cart" %>
+      </div>
+    </div>
+  <% end %>
+</div>
+
+<div class="border p-3 mb-5">
+  <h2>2: Prepare a download</h1>
+  <p>The file prepared will contain all the published works in your cart. You can add some bookkeeping notes for later reference, if you want.</p>
+  <%= simple_form_for(:export_cart, url: export_cart_admin_google_arts_and_culture_downloads_path, method: :post) do |f| %>
+    <%= f.input :user_notes, required: false, label: "Your notes"  %>
+  <%= f.button :submit, value: "Prepare your download", data: { confirm: "Prepare a GAC download containing metadata and files for all the works in your cart? This may take several hours."} %>
+  <% end %>
+</div>
+
+<div class="border p-3 mb-5">
+  <h2>3: Download your files and metadata</h2>
+  <table class="table admin-list">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Started</th>
+        <th>Link to file</th>
+        <th>Requested by</th>
+        <th>Progress</th>
+        <th>Status</th>
+        <th>Notes</th>
+        <th>Error Info</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @google_arts_and_culture_downloads.each do |download| %>
+        <tr>
+          <td><%= download.id %></td>
+          <td><%= l download.created_at %></td>
+          <td><%= link_to('Download', download.file_url) if download.status == 'success' %></td>
+          <td><%= download.user.name %></td>
+          <td><%= download.progress %> of <%= download.progress_total %></td>
+          <td><%= download.status.humanize %></td>
+          <td><%= download.user_notes %></td>
+          <td><%= download.error_info %></td>
+          <td></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= paginate @google_arts_and_culture_downloads, theme: 'twitter-bootstrap-4' %>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -85,6 +85,7 @@
               <li><%= link_to "Interviewer Profiles", admin_interviewer_profiles_path %></li>
               <li><%= link_to "Interviewee Biographies", admin_interviewee_biographies_path %></li>
               <li><%= link_to "OH AI Q&A Log", admin_oh_ai_conversations_path %></li>
+              <li><%= link_to "GAC downloads", admin_google_arts_and_culture_downloads_path %></li>
 
               <li><hr></li>
               <li><%= link_to "Job Queues", admin_resque_server_path %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,8 @@ Rails.application.routes.draw do
     get "works/:id/:derivative_type", to: "on_demand_derivatives#on_demand_status", as: :on_demand_derivative_status
   end
 
+  get "google_arts_and_culture_download_status/:id", to: "google_arts_and_culture#download_status", as: :google_arts_and_culture_download_status
+
   # By-request oral history stuff
   get "works/:work_friendlier_id/request_oral_history", to: "oral_history_requests#new", as: 'oral_history_request_form'
   post "request_oral_history", to: "oral_history_requests#create", as: 'request_oral_history'
@@ -396,7 +398,15 @@ Rails.application.routes.draw do
       collection do
         delete 'clear'
         post 'report'
-        post 'google_arts_and_culture_export'
+        #post 'google_arts_and_culture_export' export_cart
+      end
+    end
+
+    #GAC downloads:
+    resources :google_arts_and_culture_downloads, only: [:index] do
+      collection do
+        post "load_into_cart", to: "google_arts_and_culture_downloads#load_into_cart"
+        post 'export_cart'
       end
     end
 

--- a/spec/controllers/admin/cart_items_controller_spec.rb
+++ b/spec/controllers/admin/cart_items_controller_spec.rb
@@ -42,44 +42,4 @@ RSpec.describe Admin::CartItemsController, :logged_in_user, type: :controller, q
     end
   end
 
-  context "export GAC" do
-    let!(:work_1) do
-      create(
-        :public_work,
-        members: [
-          create(:asset_with_faked_file, faked_content_type: "image/tiff")
-        ]
-      )
-    end
-
-    let!(:work_2) do
-      create(
-        :public_work,
-        members: [
-          create(:asset_with_faked_file, faked_content_type: "image/tiff")
-        ]
-      )
-    end
-
-    let(:scope) { Work.where(id: [work_1.id, work_2.id]) }
-
-    it "builds a zip file that includes a manifest.csv and asset entries" do
-      get :google_arts_and_culture_export
-      expect(response).to have_http_status(:ok)
-      expect(response.headers['Content-Type']).to eq('application/zip') # Or your specific content type
-      expect(response.headers['Content-Disposition']).to include "attachment; filename=\"google-arts-and-culture-export-#{Date.today.to_s}.zip\""
-      entry_names = []
-      zip_io = StringIO.new(response.body)
-      Zip::InputStream.open(zip_io) do |io|
-        while entry = io.get_next_entry
-          entry_names << entry.name
-        end
-      end
-      expect(entry_names[0]).to eq "metadata.csv"
-      expect(entry_names[1]).to match "test_title_.*\.jpg"
-      expect(entry_names[2]).to match "test_title_.*\.jpg"
-    ensure
-      zip_io.close if zip_io
-    end
-  end
 end

--- a/spec/controllers/admin/google_arts_and_culture_downloads_controller_spec.rb
+++ b/spec/controllers/admin/google_arts_and_culture_downloads_controller_spec.rb
@@ -1,0 +1,300 @@
+require 'rails_helper'
+
+RSpec.describe Admin::GoogleArtsAndCultureDownloadsController, :logged_in_user, type: :controller, queue_adapter: :test do
+  let(:default_members) do
+    [
+      create(:asset_with_faked_file, faked_content_type: "image/tiff")
+    ]
+  end
+
+  let(:museum_work_attrs) do
+    {
+      title: "Museum",
+      department: "Museum",
+      format: ['physical_object'],
+      rights: 'https://creativecommons.org/licenses/by/4.0/',
+      created_at: Time.parse("2020-01-01"),
+      updated_at: Time.parse("2021-01-01"),
+      members: default_members
+    }
+  end
+
+  let(:library_work_attrs) do
+    {
+      title: "Library",
+      department: "Library",
+      format: ['image'],
+      rights: 'http://creativecommons.org/publicdomain/mark/1.0/',
+      created_at: Time.parse("2022-01-01"),
+      updated_at: Time.parse("2023-01-01"),
+      members: default_members
+    }
+  end
+
+  let(:archives_work_attrs) do
+    {
+      title: "Archives",
+      department: "Archives",
+      created_at: Time.parse("2022-01-01"),
+      updated_at: Time.parse("2023-01-01"),
+      members: default_members
+    }
+  end
+
+  def create_work(attrs)
+    create(:public_work, **attrs)
+  end
+
+  context "#load_into_cart", :admin_user do
+    let(:cart_titles) { controller.current_user.works_in_cart.pluck(:title).sort }
+    let!(:eligible_museum_work)  { create_work(museum_work_attrs) }
+    let!(:eligible_library_work) { create_work(library_work_attrs) }
+    let!(:archives_work)         { create_work(archives_work_attrs) }
+
+    it "loads all eligible museum and library works into the cart" do
+      expect(controller.current_user.works_in_cart.count).to eq 0
+      get :load_into_cart
+
+      expect(controller.current_user.works_in_cart.count).to eq 2
+      expect(cart_titles).to eq(["Library", "Museum"])
+    end
+
+    it "does not load any works when date filters exclude all eligible works" do
+      get :load_into_cart, params: {
+        "load_into_cart" => {
+          "created_at_start_date" => "2026-04-02",
+          "created_at_end_date" => "2026-04-08",
+          "modified_at_start_date" => "2026-04-08",
+          "modified_at_end_date" => "2026-04-18"
+        }
+      }
+
+      expect(controller.current_user.works_in_cart.count).to eq 0
+    end
+
+    context "when a candidate has the wrong department" do
+      let(:candidate_attrs) do
+        museum_work_attrs.merge(
+          title: "Wrong department",
+          department: "Archives"
+        )
+      end
+
+      let!(:candidate_work) { create_work(candidate_attrs) }
+
+      it "does not add it" do
+        get :load_into_cart
+
+        expect(cart_titles).to eq(["Library", "Museum"])
+      end
+    end
+
+    context "when a museum candidate has the wrong format" do
+      let(:candidate_attrs) do
+        museum_work_attrs.merge(
+          title: "Wrong museum format",
+          format: ['image']
+        )
+      end
+
+      let!(:candidate_work) { create_work(candidate_attrs) }
+
+      it "does not add it" do
+        get :load_into_cart
+
+        expect(cart_titles).to eq(["Library", "Museum"])
+      end
+    end
+
+    context "when a museum candidate has the wrong rights" do
+      let(:candidate_attrs) do
+        museum_work_attrs.merge(
+          title: "Wrong museum rights",
+          rights: 'http://creativecommons.org/publicdomain/mark/1.0/'
+        )
+      end
+
+      let!(:candidate_work) { create_work(candidate_attrs) }
+
+      it "does not add it" do
+        get :load_into_cart
+
+        expect(cart_titles).to eq(["Library", "Museum"])
+      end
+    end
+
+    context "when a library candidate has the wrong format" do
+      let(:candidate_attrs) do
+        library_work_attrs.merge(
+          title: "Wrong library format",
+          format: ['physical_object']
+        )
+      end
+
+      let!(:candidate_work) { create_work(candidate_attrs) }
+
+      it "does not add it" do
+        get :load_into_cart
+
+        expect(cart_titles).to eq(["Library", "Museum"])
+      end
+    end
+
+    context "when a library candidate has the wrong rights" do
+      let(:candidate_attrs) do
+        library_work_attrs.merge(
+          title: "Wrong library rights",
+          rights: 'https://creativecommons.org/licenses/by/4.0/'
+        )
+      end
+
+      let!(:candidate_work) { create_work(candidate_attrs) }
+
+      it "does not add it" do
+        get :load_into_cart
+
+        expect(cart_titles).to eq(["Library", "Museum"])
+      end
+    end
+
+    context "when an otherwise-eligible work falls outside the created_at range" do
+      context "before the start date" do
+        let(:candidate_attrs) do
+          museum_work_attrs.merge(
+            title: "Created too early",
+            created_at: Time.parse("2019-12-31")
+          )
+        end
+
+        let!(:candidate_work) { create_work(candidate_attrs) }
+
+        it "does not add it" do
+          get :load_into_cart, params: {
+            "load_into_cart" => {
+              "created_at_start_date" => "2020-01-01"
+            }
+          }
+
+          expect(cart_titles).to eq(["Library", "Museum"])
+        end
+      end
+
+      context "after the end date" do
+        let(:candidate_attrs) do
+          library_work_attrs.merge(
+            title: "Created too late",
+            created_at: Time.parse("2022-01-02")
+          )
+        end
+
+        let!(:candidate_work) { create_work(candidate_attrs) }
+
+        it "does not add it" do
+          #pp candidate_attrs # library item was created at 2022-01-02
+          get :load_into_cart, params: {
+            "load_into_cart" => {
+              "created_at_end_date" => "2022-01-01"
+            }
+          }
+
+          expect(cart_titles).to eq(["Library", "Museum"])
+        end
+      end
+    end
+
+    context "when an otherwise-eligible work falls outside the modified_at range" do
+      context "before the start date" do
+        let(:candidate_attrs) do
+          museum_work_attrs.merge(
+            title: "Modified too early",
+            updated_at: Time.parse("2020-12-31")
+          )
+        end
+
+        let!(:candidate_work) { create_work(candidate_attrs) }
+
+        it "does not add it" do
+          get :load_into_cart, params: {
+            "load_into_cart" => {
+              "modified_at_start_date" => "2021-01-01"
+            }
+          }
+
+          expect(cart_titles).to eq(["Library", "Museum"])
+        end
+      end
+
+      context "after the end date" do
+        let(:candidate_attrs) do
+          library_work_attrs.merge(
+            title: "Modified too late",
+            updated_at: Time.parse("2023-01-02")
+          )
+        end
+
+        let!(:candidate_work) { create_work(candidate_attrs) }
+
+        it "does not add it" do
+          get :load_into_cart, params: {
+            "load_into_cart" => {
+              "modified_at_end_date" => "2023-01-01"
+            }
+          }
+
+          expect(cart_titles).to eq(["Library", "Museum"])
+        end
+      end
+    end
+
+    context "when ineligible works are within the supplied date ranges" do
+      let!(:wrong_museum_format_work) do
+        create_work(
+          museum_work_attrs.merge(
+            title: "In range wrong museum format",
+            format: ['image'],
+            created_at: Time.parse("2020-06-01"),
+            updated_at: Time.parse("2021-06-01")
+          )
+        )
+      end
+
+      let!(:wrong_library_rights_work) do
+        create_work(
+          library_work_attrs.merge(
+            title: "In range wrong library rights",
+            rights: 'https://creativecommons.org/licenses/by/4.0/',
+            created_at: Time.parse("2022-06-01"),
+            updated_at: Time.parse("2023-06-01")
+          )
+        )
+      end
+
+      it "still excludes them" do
+        get :load_into_cart, params: {
+          "load_into_cart" => {
+            "created_at_start_date" => "2020-01-01",
+            "created_at_end_date" => "2022-12-31",
+            "modified_at_start_date" => "2021-01-01",
+            "modified_at_end_date" => "2023-12-31"
+          }
+        }
+
+        expect(cart_titles).to eq(["Library", "Museum"])
+      end
+    end
+  end
+
+  context "#export_cart" do
+    let(:eligible_museum_work)  { create_work(museum_work_attrs) }
+    let(:eligible_library_work) { create_work(library_work_attrs) }
+    it "starts an export" do
+      controller.current_user.works_in_cart = [eligible_museum_work, eligible_library_work]
+      expect(controller.current_user.works_in_cart.count).to eq 2
+      post :export_cart, params: {export_cart: {user_notes: 'notes'}}
+      expect(GoogleArtsAndCultureDownloadCreatorJob).to have_been_enqueued
+      expect(response).to redirect_to(admin_google_arts_and_culture_downloads_path)
+    end
+
+  end
+
+end

--- a/spec/models/google_arts_and_culture_download_spec.rb
+++ b/spec/models/google_arts_and_culture_download_spec.rb
@@ -5,8 +5,13 @@ describe GoogleArtsAndCultureDownload do
   let(:file) {  Tempfile.new(["files", ".zip"]) }
   it "can put and access file" do
     download.put_file(file)
-    expect(download.file_exists?).to be true
+    shrine_info = download.uploaded_file.as_json
+    expect(shrine_info['id']).to match /google_arts_and_culture_downloads_\d*.zip/
+    expect(shrine_info['storage']).to eq "google_arts_and_culture"
+    expect(shrine_info['metadata']['mime_type']).to eq "application/zip"
+    expect(shrine_info['metadata'].keys.sort).to eq ["created_at", "created_by", "mime_type"]
     expect(download.file_url).to match /public\/google_arts_and_culture_downloads\/google_arts_and_culture_downloads_[\d]+\.zip/
     download.log_work_added!
+    expect(download.works_added).to eq 1
   end
 end

--- a/spec/models/google_arts_and_culture_download_spec.rb
+++ b/spec/models/google_arts_and_culture_download_spec.rb
@@ -5,13 +5,16 @@ describe GoogleArtsAndCultureDownload do
   let(:file) {  Tempfile.new(["files", ".zip"]) }
   it "can put and access file" do
     download.put_file(file)
-    shrine_info = download.uploaded_file.as_json
+
+    shrine_info = download.file_data
     expect(shrine_info['id']).to match /google_arts_and_culture_downloads_\d*.zip/
     expect(shrine_info['storage']).to eq "google_arts_and_culture"
     expect(shrine_info['metadata']['mime_type']).to eq "application/zip"
     expect(shrine_info['metadata'].keys.sort).to eq ["created_at", "created_by", "mime_type"]
     expect(download.file_url).to match /public\/google_arts_and_culture_downloads\/google_arts_and_culture_downloads_[\d]+\.zip/
+
     download.log_work_added!
     expect(download.works_added).to eq 1
+
   end
 end


### PR DESCRIPTION
@archivistsarah  and I demoed this for Clare on Wednesday and Clare approved it.
In particular, Clare confirmed there is no need for us to do regular automatic exports. (If Google allows us access to their storage, we can revisit this.)

### User interface
- A new form that allows you to add any GAC-eligible works by date created or modified to the cart.
- A button to kick off an export of all works in the cart to GAC.
- We can simplify the cart view now, because the UI now lives on the GAC download screen.

### Classes
* A new admin controller and view (with extensive tests, as work filtering is really important here) for managing GAC download workflow.
* I moved GAC-related code out of the cart controller and view.

### Other changes
  * don't include a title for assets
  * basic delete functionality (for now, just from the console)
  * prevent the export of an empty cart (which caused a bug in the past)
  * save file metadata in the database after uploading to s3