### PR TITLE
Adjust OH AI UX handling of access levels

### DIFF
--- a/app/components/oral_history/ai_conversation_citation_component.html.erb
+++ b/app/components/oral_history/ai_conversation_citation_component.html.erb
@@ -11,6 +11,10 @@
 
 
     <span data-shi-slot="footnote-badges">
+      <% unless citation_item.oral_history_content.has_ohms_transcript? %>
+        <span class="badge text-body bg-warning border border-warning-subtle ms-2">PDF-only</span>
+      <% end %>
+
       <% if citation_item.oral_history_content.available_by_request_manual_review? %>
           <span class="badge bg-danger-subtle border border-danger-subtle text-body ms-2">Restricted</span>
       <% end %>

--- a/app/components/oral_history/ai_conversation_citation_component.html.erb
+++ b/app/components/oral_history/ai_conversation_citation_component.html.erb
@@ -11,17 +11,8 @@
 
 
     <span data-shi-slot="footnote-badges">
-      <% if citation_item.oral_history_content.has_ohms_transcript? %>
-        <span class="badge bg-info text-body border border-info-subtle ms-2">Synchronized Audio</span>
-      <% end %>
-
-      <% case citation_item.oral_history_content.available_by_request_mode %>
-        <% when "off" %>
-          <span class="badge bg-success-subtle text-body border border-success-subtle ms-2">Immediate</span>
-        <% when "automatic" %>
-          <span class="badge bg-warning border border-warning-subtle text-body ms-2">Upon request</span>
-        <% when "manual_review" %>
-          <span class="badge bg-danger-subtle border border-danger-subtle text-body ms-2">With approval</span>
+      <% if citation_item.oral_history_content.available_by_request_manual_review? %>
+          <span class="badge bg-danger-subtle border border-danger-subtle text-body ms-2">Restricted</span>
       <% end %>
     </span>
   </h4>

--- a/app/components/oral_history/ai_conversation_citation_component.rb
+++ b/app/components/oral_history/ai_conversation_citation_component.rb
@@ -10,9 +10,12 @@ module OralHistory
       # If OHMS, we link directly to work page with anchor to take to specific paragraph
       if citation_item.work.oral_history_content.has_ohms_transcript?
         work_path(citation_item.work.friendlier_id, anchor: "p=#{citation_item.paragraph_start}")
+      elsif citation_item.work.oral_history_content.available_by_request_manual_review?
+        # they will need to request, just go to Work page
+        work_path(citation_item.work.friendlier_id)
       else
-        # otherwise, for now, to PDF -- will need to be logged in staff to see many of these,
-        # for now this demo is only for staff. May need to rethink if ever for other audience.
+        # otherwise, for now wit only staff viewers,  if it's not approval required, we
+        # we let them see it, and go right , to PDF. May need to rethink if ever for other audience.
         view_transcript_pdf_path(citation_item.work)
       end
     end

--- a/app/components/oral_history/ai_conversation_citation_component.rb
+++ b/app/components/oral_history/ai_conversation_citation_component.rb
@@ -11,8 +11,8 @@ module OralHistory
       if citation_item.work.oral_history_content.has_ohms_transcript?
         work_path(citation_item.work.friendlier_id, anchor: "p=#{citation_item.paragraph_start}")
       elsif citation_item.work.oral_history_content.available_by_request_manual_review?
-        # they will need to request, just go to Work page
-        work_path(citation_item.work.friendlier_id)
+        # they will need to request, just go to Work page, and trigger open request form
+        work_path(citation_item.work.friendlier_id, anchor: "modal-auto-open=oh-request-trigger")
       else
         # otherwise, for now wit only staff viewers,  if it's not approval required, we
         # we let them see it, and go right , to PDF. May need to rethink if ever for other audience.

--- a/app/components/work_file_list_show_component.html.erb
+++ b/app/components/work_file_list_show_component.html.erb
@@ -51,6 +51,7 @@
             <%= link_to request_button_name,
               oral_history_request_form_path(@work.friendlier_id),
               class: "btn btn-brand-main mb-2",
+              id: "oh-request-trigger",
               data: {
                 blacklight_modal: "trigger"
               }

--- a/app/controllers/oral_history_ai_conversation_controller.rb
+++ b/app/controllers/oral_history_ai_conversation_controller.rb
@@ -13,14 +13,16 @@ class OralHistoryAiConversationController < ApplicationController
 
   # empty question form
   def new
-    @immediate_ohms_only_count = OralHistory::CategoryWithChunksCount.new(category: :immediate_ohms_only).fetch_count
-    @immediate_only_count = OralHistory::CategoryWithChunksCount.new(category: :immediate_only).fetch_count
-    @immediate_or_automatic_count = OralHistory::CategoryWithChunksCount.new(category: :immediate_or_automatic).fetch_count
-    @all_count = OralHistory::CategoryWithChunksCount.new(category: :all).fetch_count
+    # for now maybe we're not showing counts at all actually.
+    #@immediate_or_automatic_count = OralHistory::CategoryWithChunksCount.new(category: :immediate_or_automatic).fetch_count
+    #@all_count = OralHistory::CategoryWithChunksCount.new(category: :all).fetch_count
   end
 
   def create
-    search_params = params.slice(:access_limit).to_unsafe_h
+    #search_params = params.slice(:access_limit,).to_unsafe_h
+    # convert include_restricted presence/absence to an access limit restriction. Misisng
+    # access limit means everything.
+    search_params = { "access_limit" => (params["include_restricted"] == "1" ? nil : 'immediate_or_automatic')}
 
     conversation = OralHistoryAiConversationJob.launch(session_id: session.id, question: params.require(:q), search_params: search_params)
 

--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -91,4 +91,4 @@ import "../javascript/transcript_toggle.js"
 import "../javascript/admin/extent_converter.js"
 import "../javascript/oh_ai_footnote_popover.js"
 import "../javascript/ai_conversation.js"
-
+import "../javascript/modal_auto_open.js"

--- a/app/frontend/javascript/modal_auto_open.js
+++ b/app/frontend/javascript/modal_auto_open.js
@@ -1,0 +1,20 @@
+import domready from 'domready';
+
+// Let's you put in fragment #modal-auto-open=$id
+//
+// and if id is on that page with a modal trigger, will trigger it on page load.
+//
+// Motivated by linking to OH page with an auto open of request button.
+
+domready(function() {
+  // remove initial "#" from fragmentIdentifier, then parse like query.
+  const hashParams = new URLSearchParams(window.location.hash.slice(1));
+
+  const id = hashParams.get("modal-auto-open");
+  if (id) {
+    const element = document.querySelector(`#${id}`);
+    if (element) {
+      element.click();
+    }
+  }
+});

--- a/app/views/oral_history_ai_conversation/new.html.erb
+++ b/app/views/oral_history_ai_conversation/new.html.erb
@@ -39,7 +39,12 @@
     </div>
 
     <div>
-      <%= f.input :access_limit, as: :radio_buttons, required: false,
+      <%= f.input :include_restricted, as: :boolean, input_html: { checked: true },
+              label: "Include restricted-access oral history transcripts",
+              hint: "Restricted-access transcripts require a request and approval proces to access complete transcripts"
+      %>
+
+      <%# f.input :access_limit, as: :radio_buttons, required: false,
             collection: [
               ['immediate_ohms_only', "Only those with synchronized audio (OHMS) — #{@immediate_ohms_only_count}"],
               ['immediate_only', "Only those fully public (do not require request) — #{@immediate_only_count}"],

--- a/app/views/oral_history_ai_conversation/show.html.erb
+++ b/app/views/oral_history_ai_conversation/show.html.erb
@@ -14,24 +14,21 @@
     <% end %>
   </p>
 
-  <div class="alert alert-warning mb-4 mt-4">
+  <div class="alert alert-warning mb-0 mt-4">
     <span class="fw-bold">Q:</span> <%=  @conversation.question %>
   </div>
 
 
-  <%# have to match the DOM of the Blacklight search results filters. Fragile? Maybe. %>
-  <div id="appliedParams" class="constraints-container">
-    <span class="applied-filter">
-      <span class="constraint-value btn btn-outline-secondary">
-          <span class="filter-name">Including</span>
-          <span class="filter-value">
-            <%= @conversation.search_params&.dig("access_limit").presence ? t(@conversation.search_params["access_limit"], scope: "oral_history.access_limit") : "All" %>
-          </span>
-      </span>
-    </span>
-  </div>
 
-  <div class="d-flex justify-content-end mb-3">
+  <% if label = t(@conversation.search_params&.dig("access_limit"), scope: "oral_history.access_limit_feedback", default: nil) %>
+    <div class="d-flex justify-content-end">
+      <div class="pt-1 pb-1 ps-2 pe-2 bg-light border border-top-0 rounded-bottom d-inline-block">
+        <%= label %>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="d-flex justify-content-end mb-3 mt-4">
     <span class="ai-conversation-date text-muted" data-iso8601="<%= @conversation.request_sent_at&.iso8601 %>">
         Prepared <%= l(@conversation.request_sent_at&.to_date || @conversation.created_at.to_date, format: :long) %>
     </span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,8 +94,12 @@ en:
     sign_in_link_label: "Access Science History Institute Requests"
     access_limit:
       immediate_ohms_only: "Only with synchronized audio"
-      immediate_only: "Only fully public"
-      immediate_or_automatic: "Fully public or with automatically approved request"
+      immediate_only: "Only fully public without request" # these names need work if we are to use them.
+      immediate_or_automatic: "Fully public"
+    access_limit_feedback:
+      immediate_ohms_only: "Synchronized audio"
+      immediate_only: "Fully public withotu requests" # these names need work if we are to use them.
+      immediate_or_automatic: "Only fully public transcripts"
 
   user:
     user_type:

--- a/spec/controllers/oral_history_ai_conversation_controller_spec.rb
+++ b/spec/controllers/oral_history_ai_conversation_controller_spec.rb
@@ -32,6 +32,28 @@ describe OralHistoryAiConversationController, :logged_in_user, type: :controller
         }.to raise_error(ActionController::ParameterMissing).and change(OralHistory::AiConversation, :count).by(0)
       end
     end
+
+    describe "with include restricted" do
+      it "has no access restrictions" do
+        expect {
+          get :create, params: { q: question, include_restricted: "1" }
+        }.to change(OralHistory::AiConversation, :count).by(1)
+
+        last_conversation = OralHistory::AiConversation.last
+        expect(last_conversation.search_params['access_limit']).to be_blank
+      end
+    end
+
+    describe "without include restricted" do
+      it "has access restrictions only avoiding needs_approval" do
+        expect {
+          get :create, params: { q: question, include_restricted: "0" }
+        }.to change(OralHistory::AiConversation, :count).by(1)
+
+        last_conversation = OralHistory::AiConversation.last
+        expect(last_conversation.search_params['access_limit']).to eq "immediate_or_automatic"
+      end
+    end
   end
 
   describe "#show" do


### PR DESCRIPTION
Dealing with #3399

Still need to actually fix access_policy access so non-elevated-permission users have access to PDFs that for external users require a request to be made with automatic approval.  Will need to be done on as of yet unmerged #3326 

- change OI AI conversation form to only have two restriction/access choices.
- fix constraint echo for new OH restriction search choices
- in AI results display, tag 'restricted' transcripts. 
  -  try tagging non-OHMS transcripts "PDF-only" to get you ready for the annoyance -- the number of pdf-only transcripst we have will go down if we accomplish our other goals, and this may no longer be necessary. 
- When linking out from AI answer, items requiring approval link to work page, with request form auto oepn. 
