### PR TITLE
Simple OH AI conversation feedback

### DIFF
--- a/app/components/oral_history/ai_conversation_display_component.html.erb
+++ b/app/components/oral_history/ai_conversation_display_component.html.erb
@@ -50,7 +50,7 @@
 
       <div class="feedback-btn mt-5">
         <%= link_to "Give us feedback on this answer",
-              feedback_oral_history_ai_conversation_path,
+              feedback_oral_history_ai_conversation_path(ai_conversation.external_id),
               class: "default-link-style btn btn-brand-alt",
               data: { blacklight_modal: "trigger" } %>
       </div>

--- a/app/components/oral_history/ai_conversation_display_component.html.erb
+++ b/app/components/oral_history/ai_conversation_display_component.html.erb
@@ -47,6 +47,13 @@
           </li>
         <% end %>
       </ul>
+
+      <div class="feedback-btn mt-5">
+        <%= link_to "Give us feedback on this answer",
+              feedback_oral_history_ai_conversation_path,
+              class: "default-link-style btn btn-brand-alt",
+              data: { blacklight_modal: "trigger" } %>
+      </div>
     </div>
   <% end %>
 

--- a/app/components/oral_history/ai_conversation_display_component.html.erb
+++ b/app/components/oral_history/ai_conversation_display_component.html.erb
@@ -67,6 +67,22 @@
     <details class="ai-conversation-help admin-debug-info mt-5">
       <summary class="text-link">Admin Debug Info</summary>
 
+      <% if ai_conversation.feedbacks.present? %>
+        <h3 class="h5">User Feedback</h3>
+
+        <% ai_conversation.feedbacks.each do |feedback| %>
+          <details class="mt-2">
+            <summary>
+              <span class="fw-bold"><%= feedback.user.name.presence || feedback.user.email %></span>, <%= l(feedback.created_at, format: :admin_compact) %>
+            </summary>
+            <div class="ms-5">
+              <span class="text-danger"><%= "★" * feedback.rating %></span> <%= "• " * (5 - feedback.rating) %>
+              <%= simple_format(feedback.comment) %>
+            </div>
+          </details>
+        <% end %>
+      <% end %>
+
       <dl class="mt-2">
         <dt>estimated cost</dt>
         <dd>

--- a/app/controllers/admin/oh_ai_conversation_controller.rb
+++ b/app/controllers/admin/oh_ai_conversation_controller.rb
@@ -7,6 +7,10 @@ class Admin::OhAiConversationController < AdminController
       relation = relation.where("question ILIKE ?", "%#{params[:q]}%")
     end
 
+    if params[:feedbacks] == "1"
+      relation = relation.joins(:feedbacks).where.not(feedbacks: { id: nil }).distinct
+    end
+
     @ai_conversations = relation.all
   end
 end

--- a/app/controllers/oral_history_conversation_feedback_controller.rb
+++ b/app/controllers/oral_history_conversation_feedback_controller.rb
@@ -1,0 +1,18 @@
+class OralHistoryConversationFeedbackController < ApplicationController
+  before_action do
+    # for now let anyone who can engage in conversations rate any conversation,
+    # we don't record who issued which.
+    #authorize! :create, OralHistory::AiConversation
+  end
+
+  # displayed in modal
+  def new
+
+  end
+
+  # response displayed in modal
+  def create
+
+  end
+
+end

--- a/app/controllers/oral_history_conversation_feedback_controller.rb
+++ b/app/controllers/oral_history_conversation_feedback_controller.rb
@@ -5,6 +5,8 @@ class OralHistoryConversationFeedbackController < ApplicationController
     authorize! :create, OralHistory::AiConversation
   end
 
+  before_action :set_ai_conversation
+
   # displayed in modal
   def new
 
@@ -12,7 +14,25 @@ class OralHistoryConversationFeedbackController < ApplicationController
 
   # response displayed in modal
   def create
-
+    OralHistory::AiConversationFeedback.create!(
+      feedback_params.merge(
+        user: current_user,
+        oral_history_ai_conversation: @ai_conversation,
+      )
+    )
   end
 
+  private
+
+  def set_ai_conversation
+    # will raise NotFound leading to 404 if not found
+    @ai_conversation = OralHistory::AiConversation.find_by_external_id!(params[:id])
+  end
+
+  def feedback_params
+    params.require(:feedback).permit(:rating, :comment).tap do |hash|
+      hash.delete(:comment) if hash[:comment].blank?
+      hash.delete(:rating) if hash[:rating].to_i.zero?
+    end
+  end
 end

--- a/app/controllers/oral_history_conversation_feedback_controller.rb
+++ b/app/controllers/oral_history_conversation_feedback_controller.rb
@@ -2,7 +2,7 @@ class OralHistoryConversationFeedbackController < ApplicationController
   before_action do
     # for now let anyone who can engage in conversations rate any conversation,
     # we don't record who issued which.
-    #authorize! :create, OralHistory::AiConversation
+    authorize! :create, OralHistory::AiConversation
   end
 
   # displayed in modal

--- a/app/controllers/oral_history_conversation_feedback_controller.rb
+++ b/app/controllers/oral_history_conversation_feedback_controller.rb
@@ -17,7 +17,7 @@ class OralHistoryConversationFeedbackController < ApplicationController
     OralHistory::AiConversationFeedback.create!(
       feedback_params.merge(
         user: current_user,
-        oral_history_ai_conversation: @ai_conversation,
+        ai_conversation: @ai_conversation,
       )
     )
   end

--- a/app/frontend/stylesheets/local/range_input_as_star_rating.scss
+++ b/app/frontend/stylesheets/local/range_input_as_star_rating.scss
@@ -1,0 +1,77 @@
+// Turn a range input into star ratings using mostly CSS (a simple onclick necessary
+// in HTML) from
+//
+// https://codepen.io/stoumann/pen/yLbYOdz
+
+input[type=range].star-rating {
+  --dir: right;
+  --fill: #d7272e; // gold;
+  --fillbg: #dddddc; //rgba(100, 100, 100, 0.15);
+  --heart: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 21.328l-1.453-1.313q-2.484-2.25-3.609-3.328t-2.508-2.672-1.898-2.883-0.516-2.648q0-2.297 1.57-3.891t3.914-1.594q2.719 0 4.5 2.109 1.781-2.109 4.5-2.109 2.344 0 3.914 1.594t1.57 3.891q0 1.828-1.219 3.797t-2.648 3.422-4.664 4.359z"/></svg>');
+  --star: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 17.25l-6.188 3.75 1.641-7.031-5.438-4.734 7.172-0.609 2.813-6.609 2.813 6.609 7.172 0.609-5.438 4.734 1.641 7.031z"/></svg>');
+  --stars: 5;
+  --starsize: 3rem;
+  --symbol: var(--star);
+  --value: 1;
+  --w: calc(var(--stars) * var(--starsize));
+  --x: calc(100% * (var(--value) / var(--stars)));
+  block-size: var(--starsize);
+  inline-size: var(--w);
+  position: relative;
+  touch-action: manipulation;
+  -webkit-appearance: none;
+}
+[dir="rtl"] input[type=range].star-rating {
+  --dir: left;
+}
+input[type=range].star-rating::-moz-range-track {
+  background: linear-gradient(to var(--dir), var(--fill) 0 var(--x), var(--fillbg) 0 var(--x));
+  block-size: 100%;
+  mask: repeat left center/var(--starsize) var(--symbol);
+}
+input[type=range].star-rating::-webkit-slider-runnable-track {
+  background: linear-gradient(to var(--dir), var(--fill) 0 var(--x), var(--fillbg) 0 var(--x));
+  block-size: 100%;
+  mask: repeat left center/var(--starsize) var(--symbol);
+  -webkit-mask: repeat left center/var(--starsize) var(--symbol);
+}
+input[type=range].star-rating::-moz-range-thumb {
+  height: var(--starsize);
+  opacity: 0;
+  width: var(--starsize);
+}
+input[type=range].star-rating::-webkit-slider-thumb {
+  height: var(--starsize);
+  opacity: 0;
+  width: var(--starsize);
+  -webkit-appearance: none;
+}
+input[type=range].star-rating, input[type=range].star-rating-label {
+  display: block;
+  font-family: ui-sans-serif, system-ui, sans-serif;
+}
+input[type=range].star-rating-label {
+  margin-block-end: 1rem;
+}
+
+/* NO JS */
+input[type=range].star-rating--nojs::-moz-range-track {
+  background: var(--fillbg);
+}
+input[type=range].star-rating--nojs::-moz-range-progress {
+  background: var(--fill);
+  block-size: 100%;
+  mask: repeat left center/var(--starsize) var(--star);
+}
+input[type=range].star-rating--nojs::-webkit-slider-runnable-track {
+  background: var(--fillbg);
+}
+input[type=range].star-rating--nojs::-webkit-slider-thumb {
+  background-color: var(--fill);
+  box-shadow: calc(0rem - var(--w)) 0 0 var(--w) var(--fill);
+  opacity: 1;
+  width: 1px;
+}
+[dir="rtl"] input[type=range].star-rating--nojs::-webkit-slider-thumb {
+  box-shadow: var(--w) 0 0 var(--w) var(--fill);
+}

--- a/app/models/oral_history/ai_conversation.rb
+++ b/app/models/oral_history/ai_conversation.rb
@@ -16,6 +16,8 @@ class OralHistory::AiConversation < ApplicationRecord
 
   self.filter_attributes += [:question_embedding] # it's just too long
 
+  has_many :ai_coversation_feedback, dependent: :delete_all
+
   enum :status, { queued: "queued", in_process: "in_process", success: "success", error: "error" }, prefix: :status
 
   before_save do

--- a/app/models/oral_history/ai_conversation.rb
+++ b/app/models/oral_history/ai_conversation.rb
@@ -16,7 +16,10 @@ class OralHistory::AiConversation < ApplicationRecord
 
   self.filter_attributes += [:question_embedding] # it's just too long
 
-  has_many :ai_coversation_feedback, dependent: :delete_all
+  has_many :feedbacks,
+    dependent: :delete_all,
+    class_name: "OralHistory::AiConversationFeedback",
+    foreign_key: :oral_history_ai_conversation_id
 
   enum :status, { queued: "queued", in_process: "in_process", success: "success", error: "error" }, prefix: :status
 

--- a/app/models/oral_history/ai_conversation_feedback.rb
+++ b/app/models/oral_history/ai_conversation_feedback.rb
@@ -1,0 +1,3 @@
+class OralHistory::AiConversationFeedback < ApplicationRecord
+  belongs_to :ai_conversation
+end

--- a/app/models/oral_history/ai_conversation_feedback.rb
+++ b/app/models/oral_history/ai_conversation_feedback.rb
@@ -1,3 +1,4 @@
 class OralHistory::AiConversationFeedback < ApplicationRecord
-  belongs_to :ai_conversation
+  belongs_to :oral_history_ai_conversation, class_name: "OralHistory::AiConversation"
+  belongs_to :user
 end

--- a/app/models/oral_history/ai_conversation_feedback.rb
+++ b/app/models/oral_history/ai_conversation_feedback.rb
@@ -1,4 +1,9 @@
 class OralHistory::AiConversationFeedback < ApplicationRecord
-  belongs_to :oral_history_ai_conversation, class_name: "OralHistory::AiConversation"
+  self.table_name = "oral_history_ai_conversation_feedbacks"
+
+  belongs_to :ai_conversation,
+    class_name: "OralHistory::AiConversation",
+    foreign_key: :oral_history_ai_conversation_id
+
   belongs_to :user
 end

--- a/app/policies/access_policy.rb
+++ b/app/policies/access_policy.rb
@@ -5,11 +5,11 @@ class AccessPolicy
   include AccessGranted::Policy
   # :publish and :admin are only defined in our code.
   # as is :access_staff_viewer_functions.
-  # 
+  #
   # The :admin, :editor and :staff_viewer roles are cumulative:
   # e.g. if the :staff_viewer role can do something, so can :editor and :admin.
   #
-  # If you edit this file, please also update 
+  # If you edit this file, please also update
   # spec/policies/access_policy_spec.rb
   def configure
     role :admin, proc { |user| has_admin_permissions?(user) } do
@@ -27,6 +27,9 @@ class AccessPolicy
         comment.user_id == user.id
       end
       can :access_staff_functions
+
+      # Can be removed once #3326 is merged, covering it.
+      can :create, OralHistory::AiConversation
     end
 
     role :public do
@@ -55,11 +58,11 @@ class AccessPolicy
   def has_admin_permissions?(user)
     user&.admin_user?
   end
-  
+
   def has_editor_permissions?(user)
     user&.admin_user? || user&.editor_user?
   end
-  
+
   def has_staff_viewer_permissions?(user)
     user&.admin_user? || user&.editor_user? || user&.staff_viewer_user?
   end

--- a/app/views/admin/oh_ai_conversation/index.html.erb
+++ b/app/views/admin/oh_ai_conversation/index.html.erb
@@ -2,8 +2,8 @@
 
 <%= link_to "Ask New Question", new_oral_history_ai_conversation_path, class: "btn btn-brand-main" %>
 
-<%= form_with(url: admin_oh_ai_conversations_path, method: :get) do |f| %>
-  <div class="input-group mb-4 mt-5">
+<%= simple_form_for("", url: admin_oh_ai_conversations_path, method: :get) do |f| %>
+  <div class="input-group mb-2 mt-5">
     <div class="input-group-prepend">
       <%= f.label :q, "Questions containing", class: "input-group-text" %>
     </div>
@@ -13,8 +13,15 @@
     <div class="input-group-append">
       <%= f.submit value: "Search", class: "input-group-text btn btn-brand-dark" %>
     </div>
-
   </div>
+
+  <%= f.input "feedbacks", as: :boolean,
+        label: "Only show questions with feedback",
+        input_html: {
+                      checked: (params[:feedbacks] == "1"),
+                      onchange: "this.form.submit()"
+                    }
+   %>
 <% end %>
 
 <div class="mt-5 mb-3">

--- a/app/views/admin/oh_ai_conversation/index.html.erb
+++ b/app/views/admin/oh_ai_conversation/index.html.erb
@@ -29,6 +29,7 @@
       <th scope="col">Created at</th>
       <th scope="col">Question</th>
       <th scope="col">Answer</th>
+      <th scope="col">Feedback</th>
     </tr>
   </thead>
   <% @ai_conversations.each do |ai_conversation| %>
@@ -46,6 +47,11 @@
         <%= truncate(ai_conversation.answer_json&.dig("introduction") || ai_conversation.answer_json&.dig("narrative"), length: 140, separator: /\b/).presence ||
               ai_conversation.error_info&.slice("exception_class", "message").presence
         %>
+      </td>
+      <td>
+        <% ai_conversation.feedbacks.each do |feedback| %>
+          <div><span class="text-danger"><%= "★" * feedback.rating %></span> <%= "• " * (5 - feedback.rating) %></div>
+        <% end %>
       </td>
     </tr>
   <% end %>

--- a/app/views/oral_history_conversation_feedback/create.html.erb
+++ b/app/views/oral_history_conversation_feedback/create.html.erb
@@ -1,0 +1,19 @@
+
+<div data-blacklight-modal="container">
+  <%= simple_form_for :feedback, url: feedback_oral_history_ai_conversation_path, method: :post, data: { blacklight_modal: "preserve"} do |f| %>
+
+    <div class="modal-header">
+      <h1 class="modal-title">Feedback on answer</h1>
+      <button type="button" class="blacklight-modal-close btn-close" data-bl-dismiss="modal" aria-label="Close"></button>
+    </div>
+
+    <div class="modal-body">
+      Thank you for your feedback.
+    </div>
+
+    <div class="modal-footer">
+      <button type="button" class="btn btn-secondary" data-bl-dismiss="modal">OK</button>
+    </div>
+  <% end %>
+</div>
+

--- a/app/views/oral_history_conversation_feedback/new.html.erb
+++ b/app/views/oral_history_conversation_feedback/new.html.erb
@@ -11,6 +11,11 @@
 
 
     <div class="modal-body max-readable-width-block">
+
+      <p>
+        <span class="fw-bold">From:</span> <%= current_user.email %>
+      </p>
+
       <%= f.input "rating", as: :range, required: false,
           label: "How useful was the answer to you?",
           default: 1,

--- a/app/views/oral_history_conversation_feedback/new.html.erb
+++ b/app/views/oral_history_conversation_feedback/new.html.erb
@@ -1,0 +1,40 @@
+
+<div data-blacklight-modal="container">
+  <%= simple_form_for :feedback, url: feedback_oral_history_ai_conversation_path, method: :post, data: { blacklight_modal: "preserve"} do |f| %>
+
+    <div class="modal-header">
+      <h1 class="modal-title">Feedback on answer</h1>
+      <button type="button" class="blacklight-modal-close btn-close" data-bl-dismiss="modal" aria-label="Close"></button>
+    </div>
+
+
+
+
+    <div class="modal-body max-readable-width-block">
+      <%= f.input "rating", as: :range, required: false,
+          label: "How useful was the answer to you?",
+          default: 1,
+          input_html: {
+            class: 'star-rating',
+            min: 1,
+            max: 5,
+            step: 1,
+            style: "--value:0",
+            value: 0,
+            oninput:"this.style.setProperty('--value', `${this.valueAsNumber}`)" } %>
+
+      <%= f.input "comment", as: :text,
+          label: "Any other comments or feedback?",
+          required: false,
+          input_html: {
+            rows: 3
+          } %>
+    </div>
+
+
+    <div class="modal-footer">
+      <button type="submit" class="btn btn-secondary">Send</button>
+    </div>
+  <% end %>
+</div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,9 @@ Rails.application.routes.draw do
     # /oral_histories/ask
     resources :oral_history_ai_conversation, only: [:show, :create, :new], path: :ask do
       member do
+        get 'feedback', to: "oral_history_conversation_feedback#new"
+        post 'feedback', to: "oral_history_conversation_feedback#create"
+
         get 'refresh'
       end
     end

--- a/db/migrate/20260416175054_create_oral_history_ai_conversation_feedbacks.rb
+++ b/db/migrate/20260416175054_create_oral_history_ai_conversation_feedbacks.rb
@@ -1,0 +1,12 @@
+class CreateOralHistoryAiConversationFeedbacks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :oral_history_ai_conversation_feedbacks do |t|
+      t.integer :rating
+      t.text :comment
+      t.references :oral_history_ai_conversation, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_24_170634) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_16_175054) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"
@@ -244,6 +244,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_24_170634) do
     t.index ["work_id"], name: "index_oral_history_access_requests_on_work_id"
   end
 
+  create_table "oral_history_ai_conversation_feedbacks", force: :cascade do |t|
+    t.text "comment"
+    t.datetime "created_at", null: false
+    t.bigint "oral_history_ai_conversation_id", null: false
+    t.integer "rating"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["oral_history_ai_conversation_id"], name: "idx_on_oral_history_ai_conversation_id_33d8a144e0"
+    t.index ["user_id"], name: "index_oral_history_ai_conversation_feedbacks_on_user_id"
+  end
+
   create_table "oral_history_ai_conversations", force: :cascade do |t|
     t.string "status", default: "queued", null: false
     t.uuid "external_id", default: -> { "gen_random_uuid()" }, null: false
@@ -362,6 +373,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_24_170634) do
   add_foreign_key "on_demand_derivatives", "kithe_models", column: "work_id"
   add_foreign_key "oral_history_access_requests", "kithe_models", column: "work_id"
   add_foreign_key "oral_history_access_requests", "oral_history_requester_emails"
+  add_foreign_key "oral_history_ai_conversation_feedbacks", "oral_history_ai_conversations"
+  add_foreign_key "oral_history_ai_conversation_feedbacks", "users"
   add_foreign_key "oral_history_chunks", "oral_history_content"
   add_foreign_key "oral_history_content", "kithe_models", column: "work_id"
   add_foreign_key "queue_item_comments", "digitization_queue_items"


### PR DESCRIPTION
Happens in a modal, cause we already had Blacklight modal re-usable func to hang on. (Might be better in page, but we'd have to write JS... at some point we should just start using rails stimulus/turbo). 

Use some fancy CSS found on google (not AI for a change) to turn an html range input into 1-5 star selection.  Use unicode star character on dashboards. 

Existing feedback shows up in "Admin Debug Info" on a question; and admin dashboard listing asked questions shows stars and lets you filter for just questions with feedback. 

If staff wants to go add "extra" feedback, they can go to the question and click the button again, or for the first time. User is attached to feedback. 
