### PR TITLE
Create extracted_pdf_text_json derivative for PDF on ingest

### DIFF
--- a/app/uploaders/asset_uploader.rb
+++ b/app/uploaders/asset_uploader.rb
@@ -120,6 +120,32 @@ class AssetUploader < Kithe::AssetUploader
   end
 
 
+  # These are only meant and probably useful for for Oral History transcript PDFs.
+  # This will also get misclenaeous other PDFs and Oral History "Front Matter" PDFs
+  # which we don't need -- but it's pretty cheap to calculate, and it's just so much
+  # easier to do it on ingest, with every PDF, not reliant on attributes of PDF that
+  # could change.
+  #
+  # Does not OCR only extracts actual text, so at worst might be mostly blank pages.
+  #
+  # We save the pdf_md5 fingerprint and the git sha (source_version) for technical
+  # provenance and debugging.
+  Attacher.define_derivative("extracted_pdf_text_json", content_type: "application/pdf") do |original_file, attacher:, add_metadata:|
+    json = OralHistory::ExtractPdfText.new(pdf_file_path: original_file.path).extract_pdf_text
+
+    add_metadata.merge!(
+      original_filename: "extracted_pdf_text.json",
+      mime_type: "application/json",
+      source: {
+        pdf_md5: attacher.file&.md5,
+        source_version: ENV['SOURCE_VERSION']
+      }
+    )
+
+    StringIO.new(JSON.dump(json))
+  end
+
+
   # For FLAC originals, we create a mono m4a derivative.
   # Typically this deriv is only 5% of the size of the original FLAC,
   # while still fine for listening, at least for for oral histories.

--- a/lib/tasks/data_fixes/enqueue_pdf_extracted_text_derivatives.rake
+++ b/lib/tasks/data_fixes/enqueue_pdf_extracted_text_derivatives.rake
@@ -1,0 +1,20 @@
+namespace :scihist do
+  namespace :data_fixes do
+
+    desc """
+      Enqueue jobs in 'special_jobs' to make extracted_pdf_text_json derivative for all PDF assets
+    """
+    task :enqueue_pdf_extacted_text_derivatives => [:environment] do
+      scope = Asset.where("file_data -> 'metadata' ->> 'mime_type' = 'application/pdf'")
+
+      progress_bar = ProgressBar.create(total: scope.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+
+
+      scope.find_each do |asset|
+        Kithe::CreateDerivativesJob.set(queue: "special_jobs").
+          perform_later(asset, only: :extracted_pdf_text_json, lazy: true)
+        progress_bar.increment
+      end
+    end
+  end
+end

--- a/spec/models/asset/derivatives_spec.rb
+++ b/spec/models/asset/derivatives_spec.rb
@@ -18,7 +18,8 @@ describe "derivative creation" do
       expect(pdf_asset.file_derivatives.keys.sort).
         to contain_exactly(:thumb_large,:thumb_large_2X,
           :thumb_mini, :thumb_mini_2X,
-          :thumb_standard, :thumb_standard_2X
+          :thumb_standard, :thumb_standard_2X,
+          :extracted_pdf_text_json
         )
       expect(pdf_asset.file_derivatives[:thumb_mini].metadata['width']).to eq(54)
       expect(pdf_asset.file_derivatives[:thumb_large_2X].metadata['width']).to eq(1050)


### PR DESCRIPTION
Using the ExtractPdfText service (which calls python helper), to extract a JSON representation of text from the PDF, that is fairly "structural".  (This is the first step to generating "transcript paragraphs" from it using the `ExtractedPdfTextParagraphSplitter`, that has a lot more heuristics to try to make a good transcript). 

We only actually want this for PDF transcripts.  But it's just so much easier to create it on PDF ingest, then to try to manage kepeing it for all PDFs with `:transcript` role, a thing that can change after ingest.  We just let shrine's derivative handling handle the life-cycle of the thing, including deleting it if PDF is deleted, etc.  For other kinds of PDFs (oral history "front matter"; the very occasional other PDF), it will b eignored, and will sometimes be just empty -- it does not do any OCR, it relies on there actually being PDF text to extract. But that's fine -- it is pretty quick/cheap to create, no big deal. 

Since it's a derivative, it's stored as a "file" -- just our dumped JSON, `application/json` mime-type set, no problem. 

Also includes a rake task to add them to existing PDFs. 

- [x] After deploy, run rake task to queue jobs in `special_jobs` queues to add derivatives. `heroku run rake scihist:datafixes:enqueue_pdf_extacted_text_derivatives -r production`. 
  - Create some `special_jobs` workers to process. With 2-4 workers, should process in well under 10 minutes, this is pretty quick. 


There may be other places we could simplify using this new derivative, like for PDF indexing? Not sure, for a future time. 