### PR TITLE
Safer check for leaf_representative content type

### DIFF
--- a/app/components/work_show_info_component.html.erb
+++ b/app/components/work_show_info_component.html.erb
@@ -195,7 +195,7 @@
     <% related_or_more_like_this_works.each do |work| %>
       <li class="related-work">
         <div class="related-work-thumb">
-          <%= link_to work_path(work.friendlier_id), class: ("img-wrapper-video-icon" if work.leaf_representative.content_type.start_with?("video/")) do %>
+          <%= link_to work_path(work.friendlier_id), class: ("img-wrapper-video-icon" if work.leaf_representative&.content_type&.start_with?("video/")) do %>
             <%= render ThumbComponent.new(work.leaf_representative, thumb_size: :standard, lazy: true) %>
           <% end %>
         </div>


### PR DESCRIPTION
In dev I had some works that came up as related works but didn't HAVE leaf_representative. So this would raise, in a way that was confusing to me. Ought not to happen in prod, but you never know, any kind of data that can be wrong will be. I realie this may be obviated by future PR, which may also need this safety check.
