### PR TITLE
OralHistoryContent::Paragraph serializable round-trip to JSON

### DIFF
--- a/app/models/oral_history_content/ohms_xml/legacy_transcript.rb
+++ b/app/models/oral_history_content/ohms_xml/legacy_transcript.rb
@@ -249,6 +249,15 @@ class OralHistoryContent
         def speaker_name
           lines.first&.speaker_label&.chomp(":")
         end
+
+        # override to raise just to indicate we haven't done this yet, we could.
+        def as_json(*)
+          raise "Not yet Implemented"
+        end
+
+        def self.from_json(*)
+          raise "Not yet Implemented"
+        end
       end
 
       class Line

--- a/app/models/oral_history_content/paragraph.rb
+++ b/app/models/oral_history_content/paragraph.rb
@@ -5,7 +5,7 @@ class OralHistoryContent
   # Different classes can create these, depending on what format of transcript they are creating
   # from (OHMS, plain text, etc)  in some cases there may be subsets.
   #
-  # Some may create sub-classes specific to their format, but this is a general API for chunkers.
+# There is at least one sub-class as well, OralHistoryContent::OhmsXml::LegacyTranscript::Paragraph
   class Paragraph
     def self.fragment_id(paragraph_index:)
       "oh-t-p#{paragraph_index}"
@@ -122,6 +122,45 @@ class OralHistoryContent
       FullSanitizer.sanitize( s.gsub("<br>", "\n") )
     end
 
+    # object as json-able hash with all instance variables automatically included as keys
+    def as_json
+      instance_variables.to_h do |ivar|
+        [ivar.to_s.delete_prefix("@"), instance_variable_get(ivar)]
+      end
+    end
 
+    # Serialied string version of as_json
+    def to_json(*args)
+      as_json.to_json(*args)
+    end
+
+    # keep track of which new() keyword params are defined, for from_json
+    def self.init_kw_params
+      @init_kw_params ||= self.instance_method(:initialize).parameters.
+        find_all { |type, _| [:keyreq, :key].include?(type) }.
+        collect(&:second).
+        collect(&:to_s)
+    end
+
+    # turn json hash (can be ruby has or serialized string) back into Paragraph
+    def self.from_json(json)
+      data = json.is_a?(String) ? JSON.parse(json) : json
+
+      init_hash, other_hash = data.slice(*init_kw_params), data.except(*init_kw_params)
+
+      obj = self.new(**init_hash.symbolize_keys)
+      other_hash.each do |key, value|
+        obj.send("#{key}=".to_sym, value)
+      end
+
+      return obj
+    end
+
+    # Can take json array of hashes, either as a ruby Array or serialized string.
+    # Each hash will be sent to from_json.
+    def self.from_json_array(json)
+      data = json.is_a?(String) ? JSON.parse(json, symbolize_names: true) : json
+      data.collect { |hash| self.from_json(hash) }
+    end
   end
 end

--- a/spec/models/oral_history_content/paragraph_spec.rb
+++ b/spec/models/oral_history_content/paragraph_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe OralHistoryContent::Paragraph do
+  describe "JSON serialization" do
+    let(:paragraph) do
+      described_class.new(
+        text: "foo",
+        paragraph_index:12,
+        included_timestamps:[1020],
+        pdf_logical_page_number: 2
+      ).tap do |p|
+        p.assumed_speaker_name = "ROCHKIND"
+        p.previous_timestamp = 900
+      end
+    end
+
+    it "round trips to json" do
+      json = paragraph.as_json
+      expect(json).to be_kind_of(Hash)
+      expect(json).to be_present
+
+      newp = described_class.from_json(json)
+
+      expect(newp.as_json).to eq json
+    end
+
+    it "to_json is string" do
+      expect(paragraph.as_json.to_json).to eq paragraph.to_json
+    end
+
+    it "has instance vars equiv after round-tripping" do
+      newp = described_class.from_json(paragraph.as_json)
+
+      paragraph.instance_variables.each do |ivar_name|
+        expect(paragraph.instance_variable_get(ivar_name)).to eq (
+          newp.instance_variable_get(ivar_name)
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Preparing to calculate and cache paragraphs extracted from PDFs, in order to provide HtML view based on them.

Felt like there shoudl have been a less hacky but still concise way to just like "make it serializable", but this is all I got!  ActiveRecord::Serializable was just a pain. 
