### PR TITLE
Move the Google Arts and Culture link in the admin menu to be in the "reporting" section.

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -85,13 +85,13 @@
               <li><%= link_to "Interviewer Profiles", admin_interviewer_profiles_path %></li>
               <li><%= link_to "Interviewee Biographies", admin_interviewee_biographies_path %></li>
               <li><%= link_to "OH AI Q&A Log", admin_oh_ai_conversations_path %></li>
-              <li><%= link_to "GAC downloads", admin_google_arts_and_culture_downloads_path %></li>
 
               <li><hr></li>
               <li><%= link_to "Job Queues", admin_resque_server_path %></li>
               <li><%= link_to "Fixity Report", admin_fixity_report_path %></li>
               <li><%= link_to "Storage Report", admin_storage_report_path %></li>
               <li><%= link_to "Orphan Report", admin_orphan_report_path %></li>
+              <li><%= link_to "GAC downloads", admin_google_arts_and_culture_downloads_path %></li>
               <li><hr></li>
               <% if current_user %>
                 <li><%= link_to "Logout", logout_path %></li>


### PR DESCRIPTION
No issue reference here; trivial.