### PR TITLE
Don't cite paragraph numbers in OH AI source links.

### DIFF
--- a/app/components/oral_history/ai_conversation_citation_component.html.erb
+++ b/app/components/oral_history/ai_conversation_citation_component.html.erb
@@ -4,8 +4,7 @@
     <%= link_to(link_to_source,
                 target: "_blank",
                 class: "default-link-style text-decoration-underline") do -%>
-      <%= citation_item.short_citation_title -%> —
-      ¶<%= citation_item.short_citation_paragraphs -%>
+      <%= citation_item.short_citation_title -%>
       <%- if citation_item.nearest_timecode_formatted.present? %> near <%= citation_item.nearest_timecode_formatted %><%- end -%>
     <%- end -%>
 

--- a/app/components/oral_history/ai_conversation_display_component.rb
+++ b/app/components/oral_history/ai_conversation_display_component.rb
@@ -157,6 +157,7 @@ module OralHistory
         end
       end
 
+      # unused
       def short_citation_paragraphs
         [paragraph_start, paragraph_end].uniq.join("-")
       end


### PR DESCRIPTION
They are artificial, can change, and there's no way for users to actually use them as a reference at present. Users in testing found them confusing. We're going to try to add page numbers for many instead, although not quite there yet.
