### PR TITLE
ExtractedPdfTextParagraphSplitter can allow_failure_to_sync and just skip extracting timestamps

### DIFF
--- a/app/jobs/oral_history_store_extracted_paragraphs_job.rb
+++ b/app/jobs/oral_history_store_extracted_paragraphs_job.rb
@@ -1,7 +1,7 @@
 class OralHistoryStoreExtractedParagraphsJob < ApplicationJob
 
   # TODO extract this to a method in OralHistoryContent, yeah.
-  def perform(oral_history_content)
-    OralHistoryContent::ParagraphContainer.create(oral_history_content: oral_history_content)
+  def perform(oral_history_content, allow_failure_to_sync: false)
+    OralHistoryContent::ParagraphContainer.create(oral_history_content: oral_history_content, allow_failure_to_sync: allow_failure_to_sync)
   end
 end

--- a/app/models/oral_history_content/paragraph_container.rb
+++ b/app/models/oral_history_content/paragraph_container.rb
@@ -12,6 +12,8 @@ class OralHistoryContent
 
     attr_json :paragraphs, OralHistoryContent::Paragraph.to_type, array: true
 
+    attr_json :warnings, :string, array: true
+
     attr_json :created_at, :datetime, default: -> { Time.current.utc }
 
     # start times that go with fingerprint to calculate offsets from transcript
@@ -32,7 +34,7 @@ class OralHistoryContent
     #
     # Will do computational work of calculating paragraphs from stored extracted_pdf_text_json
     # derivative.
-    def self.create(oral_history_content:)
+    def self.create(oral_history_content:, allow_failure_to_sync: false)
       work = oral_history_content.work
       pdf_asset = oral_history_content.work.members.find { |a| a.respond_to?(:role) && a.role == "transcript" }
 
@@ -55,10 +57,14 @@ class OralHistoryContent
       combined_audio_fingerprint = combined_audio.fingerprint
       file_start_times = combined_audio.calculate_start_times
 
-      paragraphs = OralHistory::ExtractedPdfTextParagraphSplitter.new(
+      splitter = OralHistory::ExtractedPdfTextParagraphSplitter.new(
         extracted_pdf_text: extracted_pdf_text,
-        file_start_times: file_start_times.to_h
-      ).paragraphs
+        file_start_times: file_start_times.to_h,
+        allow_failure_to_sync: allow_failure_to_sync
+      )
+
+      paragraphs = splitter.paragraphs
+      warnings = splitter.warnings
 
       container = OralHistoryContent::ParagraphContainer.new(
         paragraphs: paragraphs,
@@ -67,10 +73,13 @@ class OralHistoryContent
         file_start_times: file_start_times,
         combined_audio_fingerprint: combined_audio_fingerprint
       )
+      container.warnings = warnings if warnings
 
       # And save it in the model passed in
       oral_history_content.extracted_pdf_paragraphs = container
       oral_history_content.save!
+
+      return container
     end
 
     # Will fetch the work#members if not already fetched. Fingerprinting includes

--- a/app/services/oral_history/extracted_pdf_text_paragraph_splitter.rb
+++ b/app/services/oral_history/extracted_pdf_text_paragraph_splitter.rb
@@ -47,13 +47,18 @@ module OralHistory
     # we make it legal html5 custom tag cause seems better. With placeholder for % interpolation.
     PAGE_BREAK_MARKER = "<PAGE-BREAK next='%s'></PAGE-BREAK>"
 
-    attr_reader :extracted_pdf_text, :file_start_times
+    attr_reader :extracted_pdf_text, :file_start_times, :allow_failure_to_sync
 
 
     # @param extracted_pdf_text [Hash] jsonable Hash of text and structural metadata from PDF
     #        as returned by OralHistory::ExtractPdftext
     #
     # @param validate [Boolean] default true, will validate extracted_pdf_text to a JSON schema.
+    #
+    # @param allow_failure_to_sync [Boolean] default falst. When default, if we have timestamps that
+    # need to be sync'd with audio segment start times, but we don't have file_start_times to
+    # support, we'll raise. If this is true, we'll just ignore timestamp info in this case,
+    # and include a message in #warnings.
     #
     # @param file_start_times [Hash] as if might come from metadata 'start_times' in an
     #   oral_history_content&.combined_audio_component_metadata. Eg
@@ -68,7 +73,7 @@ module OralHistory
     #    actual order of files. While optional, if it is needed for accurate timestamps,
     #    it's required and you'll get an error.
     #
-    def initialize(extracted_pdf_text:, validate: false, file_start_times: nil)
+    def initialize(extracted_pdf_text:, validate: false, file_start_times: nil, allow_failure_to_sync: false)
       unless extracted_pdf_text.kind_of?(Hash) && extracted_pdf_text["pages"].kind_of?(Array)
         raise ArgumentError.new("extracted_pdf_text: needs to be a hash matching ExtractPdfText::JSON_SCHEMER")
       end
@@ -80,10 +85,24 @@ module OralHistory
 
       @extracted_pdf_text = extracted_pdf_text
       @file_start_times = file_start_times
+      @allow_failure_to_sync = allow_failure_to_sync
+      @has_failure_to_sync = false
+      @max_timestamp_file_offset_index = nil # basically for warnings
     end
 
     def paragraphs
       @paragraphs ||= create_paragraphs
+    end
+
+    # Anything that was odd or missed in paragraph construction
+    def warnings
+      warnings = []
+
+      if @has_failure_to_sync
+        warnings << "Failed to sync some timestamps, with #{@max_timestamp_file_offset_index + 1} audio segments, but file_start_times #{file_start_times.inspect}"
+      end
+
+      warnings
     end
 
     # @return [OralHistory::Paragraph]
@@ -168,6 +187,8 @@ module OralHistory
           p2.assumed_speaker_name = p1.speaker_name || p1.assumed_speaker_name
         end
       end
+
+      @max_timestamp_file_offset_index = timestamp_file_offset_index
 
       return all_paragraphs
     end
@@ -296,11 +317,17 @@ module OralHistory
         # we need to add on the start time of current non-0 segment
         offset = file_start_times&.values&.dig(current_index)
 
-        unless offset.present?
-          raise Error.new("Could not find file start time offset for index #{current_index.inspect} in offsets #{file_start_times.inspect}")
-        end
+        if offset.present?
+          timestamp += offset
+        else
+          unless allow_failure_to_sync
+            raise Error.new("Could not find file start time offset for index #{current_index.inspect} in offsets #{file_start_times.inspect}")
+          end
 
-        timestamp += offset
+          # can't do it without offset
+          timestamp = nil
+          @has_failure_to_sync = true
+        end
       end
 
       # Do we have a speaker name? Remove it from text but record it as speaker name.

--- a/lib/tasks/store_extracted_pdf_paragraphs.rake
+++ b/lib/tasks/store_extracted_pdf_paragraphs.rake
@@ -14,10 +14,10 @@ namespace :scihist do
       scope.find_each(batch_size: 10) do |oc|
         # TODO make it lazy optionally? or better based on freshness!
         if ENV['BG_JOB'] == "true"
-          OralHistoryStoreExtractedParagraphsJob.set(queue: "special_jobs").perform_later(oc)
+          OralHistoryStoreExtractedParagraphsJob.set(queue: "special_jobs").perform_later(oc, allow_failure_to_sync: true)
         else
           begin
-            OralHistoryContent::ParagraphContainer.create(oral_history_content: oc)
+            OralHistoryContent::ParagraphContainer.create(oral_history_content: oc, allow_failure_to_sync: true)
           rescue StandardError => e
             errors += 1
             puts "store_extracted_pdf_paragraphs: error on oral_history_content #{oc.id}, work #{oc&.work&.friendlier_id}, #{e}\n\n"

--- a/spec/models/oral_history_content/paragraph_container_spec.rb
+++ b/spec/models/oral_history_content/paragraph_container_spec.rb
@@ -96,5 +96,25 @@ describe OralHistoryContent::ParagraphContainer do
 
       expect(oral_history_content.extracted_pdf_paragraphs.fresh?(oral_history_content: oral_history_content)).to be false
     end
+
+    describe "with warnings" do
+      # missing mp3 assets, so there will be a sync warning
+      let(:work) do
+        create(:oral_history_work, members: [
+          pdf_asset,
+          mp3_asset,
+        ])
+      end
+
+      it "stores warnings" do
+        container = OralHistoryContent::ParagraphContainer.create(
+          oral_history_content: oral_history_content,
+          allow_failure_to_sync: true
+        )
+
+        expect(container.warnings).to be_present
+        expect(container.warnings).to include(/Failed to sync some timestamps/)
+      end
+    end
   end
 end

--- a/spec/services/oral_history/extracted_pdf_text_paragraph_splitter_spec.rb
+++ b/spec/services/oral_history/extracted_pdf_text_paragraph_splitter_spec.rb
@@ -201,6 +201,19 @@ describe OralHistory::ExtractedPdfTextParagraphSplitter do
           expect(with_timestamps.collect(&:included_timestamps).collect(&:first)).to eq [150 * 60, 5*60 + 152*60, 10*60 +  152*60]
         end
       end
+
+      describe "with insufficient file_start_times and allow_failure_to_sync" do
+        let(:splitter) { described_class.new(extracted_pdf_text: extracted_pdf_text, allow_failure_to_sync: true) }
+
+        it "syncs what it can, with warning" do
+          paragraphs = splitter.paragraphs
+
+          marker_index = paragraphs.index { |p| p.text =~ described_class::END_OF_AUDIO_FILE_RE }
+          expect(paragraphs.slice(marker_index..-1)).to all(satisfy { |p| p.included_timestamps.blank? })
+
+          expect(splitter.warnings).to include "Failed to sync some timestamps, with 2 audio segments, but file_start_times nil"
+        end
+      end
     end
   end
 


### PR DESCRIPTION
When turning PDF text into paragraphs, to extract timestamps sometimes requires arithamtic to turn internal start-over-at-new-audio-file timestamps into the whole-interview timestamps we want.  We need audio file duration info to do this. 

Prior ot this PR, if we lacked sufficient audio file duration info to do this, we just raised. Now, we can optionally just take it in stride, ignore timeestamps that we can't properly place, and generate a warning about it that we store with the storeed paragraphs in OralHistoryContent. 

This allows us to move forward with the generated paragraphs that can still provide value as an HTML transcript with pagination info, and as chunks for AI with pagination info. 

- ExtractedPdfTextParagraphSplitter can allow_failure_to_sync and just skip extracting timestamps
- ParagraphContainer#create can store warnings
- store pdf paragrpah job takes allow_failure_to_sync param
- store pdf paragraphs rake sends allow_failure_to_sync: true
