### PR TITLE
rename ExtractedPdfTextParagraphSplitter => PdfParagraphSplitter and other related classes more consistently

### DIFF
--- a/app/jobs/store_oral_history_pdf_paragraphs_job.rb
+++ b/app/jobs/store_oral_history_pdf_paragraphs_job.rb
@@ -1,4 +1,4 @@
-class OralHistoryStoreExtractedParagraphsJob < ApplicationJob
+class StoreOralHistoryPdfParagraphsJob < ApplicationJob
 
   # TODO extract this to a method in OralHistoryContent, yeah.
   def perform(oral_history_content, allow_failure_to_sync: false)

--- a/app/models/oral_history_content/paragraph_container.rb
+++ b/app/models/oral_history_content/paragraph_container.rb
@@ -57,7 +57,7 @@ class OralHistoryContent
       combined_audio_fingerprint = combined_audio.fingerprint
       file_start_times = combined_audio.calculate_start_times
 
-      splitter = OralHistory::ExtractedPdfTextParagraphSplitter.new(
+      splitter = OralHistory::PdfParagraphSplitter.new(
         extracted_pdf_text: extracted_pdf_text,
         file_start_times: file_start_times.to_h,
         allow_failure_to_sync: allow_failure_to_sync

--- a/app/services/oral_history/pdf_paragraph_splitter.rb
+++ b/app/services/oral_history/pdf_paragraph_splitter.rb
@@ -18,7 +18,7 @@ module OralHistory
   # * handles timestamps taht reset after `[END OF AUDIO` markers, re-seqencing
   #  full-transcript timestamps.
   #
-  class ExtractedPdfTextParagraphSplitter
+  class PdfParagraphSplitter
     class Error < StandardError; end
 
     # any page beginning with one of these is deemed post-transcript material. Normalized

--- a/lib/tasks/store_pdf_paragraphs.rake
+++ b/lib/tasks/store_pdf_paragraphs.rake
@@ -1,6 +1,6 @@
 namespace :scihist do
   namespace :oral_history do
-    task :store_extracted_pdf_paragraphs => [:environment] do
+    task :store_pdf_paragraphs => [:environment] do
       # no ohms
       scope = OralHistoryContent.where(ohms_xml_text: [nil, ""])
 

--- a/lib/tasks/store_pdf_paragraphs.rake
+++ b/lib/tasks/store_pdf_paragraphs.rake
@@ -14,7 +14,7 @@ namespace :scihist do
       scope.find_each(batch_size: 10) do |oc|
         # TODO make it lazy optionally? or better based on freshness!
         if ENV['BG_JOB'] == "true"
-          OralHistoryStoreExtractedParagraphsJob.set(queue: "special_jobs").perform_later(oc, allow_failure_to_sync: true)
+          StoreOralHistoryPdfParagraphsJob.set(queue: "special_jobs").perform_later(oc, allow_failure_to_sync: true)
         else
           begin
             OralHistoryContent::ParagraphContainer.create(oral_history_content: oc, allow_failure_to_sync: true)

--- a/spec/components/oral_history/paragraph_transcript_component_spec.rb
+++ b/spec/components/oral_history/paragraph_transcript_component_spec.rb
@@ -7,7 +7,7 @@ describe OralHistory::ParagraphTranscriptComponent, type: :component do
     # We could make tests go faster by loading pre-formed Paragraph json instead of
     # transforming it live? Is that still safe enough?
     let(:extracted_pdf_text) { OralHistory::ExtractPdfText.new(pdf_file_path: oh_pdf_path).extract_pdf_text }
-    let(:splitter) { OralHistory::ExtractedPdfTextParagraphSplitter.new(extracted_pdf_text: extracted_pdf_text, file_start_times: file_start_times) }
+    let(:splitter) { OralHistory::PdfParagraphSplitter.new(extracted_pdf_text: extracted_pdf_text, file_start_times: file_start_times) }
 
     # A good one that has <T:> timestamps and lets us test a number of things.
     let(:oh_pdf_path) { Rails.root + "spec/test_support/pdf/oh/macfarlane_1982_sequence_timestamps_example.pdf" }

--- a/spec/components/previews/oral_history/paragraph_transcript_component_preview.rb
+++ b/spec/components/previews/oral_history/paragraph_transcript_component_preview.rb
@@ -22,7 +22,7 @@ module OralHistory
     def compute_paragraphs_from_pdf(pdf_file_path:, file_start_times:)
       extracted_pdf_text = OralHistory::ExtractPdfText.new(pdf_file_path: pdf_file_path).extract_pdf_text
 
-      splitter = OralHistory::ExtractedPdfTextParagraphSplitter.new(extracted_pdf_text: extracted_pdf_text, file_start_times: file_start_times)
+      splitter = OralHistory::PdfParagraphSplitter.new(extracted_pdf_text: extracted_pdf_text, file_start_times: file_start_times)
 
       splitter.paragraphs
     end

--- a/spec/services/oral_history/pdf_paragraph_splitter_spec.rb
+++ b/spec/services/oral_history/pdf_paragraph_splitter_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe OralHistory::ExtractedPdfTextParagraphSplitter do
+describe OralHistory::PdfParagraphSplitter do
   let(:extracted_pdf_text) { OralHistory::ExtractPdfText.new(pdf_file_path: oh_pdf_path).extract_pdf_text }
 
   let(:splitter) { described_class.new(extracted_pdf_text: extracted_pdf_text) }
@@ -180,7 +180,7 @@ describe OralHistory::ExtractedPdfTextParagraphSplitter do
       it "raises if it does not have file_start_times sequencing info" do
         expect {
           splitter.paragraphs
-        }.to raise_error( OralHistory::ExtractedPdfTextParagraphSplitter::Error, "Could not find file start time offset for index 1 in offsets nil")
+        }.to raise_error( OralHistory::PdfParagraphSplitter::Error, "Could not find file start time offset for index 1 in offsets nil")
       end
 
       describe "with file_start_times offsets" do
@@ -274,7 +274,7 @@ describe OralHistory::ExtractedPdfTextParagraphSplitter do
       it "raises if it does not have file_start_times sequencing info" do
         expect {
           splitter.paragraphs
-        }.to raise_error( OralHistory::ExtractedPdfTextParagraphSplitter::Error, "Could not find file start time offset for index 1 in offsets nil")
+        }.to raise_error( OralHistory::PdfParagraphSplitter::Error, "Could not find file start time offset for index 1 in offsets nil")
       end
 
       describe "with file_start_times offsets" do


### PR DESCRIPTION
- rename ExtractedPdfTextParagraphSplitter => PdfParagraphSplitter
- rename rake store_extracted_pdf_paragraphs => store_pdf_paragraphs
- rename OralHistoryStoreExtractedParagraphsJob => StoreOralHistoryPdfParagraphsJob
