### PR TITLE
Get LLM to use page numbers from PDF paragraphs in citations, and link directly to new HTML transcripts

### DIFF
--- a/app/components/oral_history/ai_conversation_citation_component.html.erb
+++ b/app/components/oral_history/ai_conversation_citation_component.html.erb
@@ -11,7 +11,7 @@
 
 
     <span data-shi-slot="footnote-badges">
-      <% unless citation_item.oral_history_content.has_ohms_transcript? %>
+      <% unless citation_item.can_link_to_html_transcript? %>
         <span class="badge text-body bg-warning border border-warning-subtle ms-2">PDF-only</span>
       <% end %>
 

--- a/app/components/oral_history/ai_conversation_citation_component.html.erb
+++ b/app/components/oral_history/ai_conversation_citation_component.html.erb
@@ -4,9 +4,9 @@
     <%= link_to(link_to_source,
                 target: "_blank",
                 class: "default-link-style text-decoration-underline") do -%>
-      <%= citation_item.short_citation_title -%>
-      <%- if citation_item.page_number.present? -%> p. <%= citation_item.page_number %><%- end -%>
-      <%- if citation_item.nearest_timecode_formatted.present? %> near <%= citation_item.nearest_timecode_formatted %><%- end -%>
+<%= citation_item.short_citation_title -%>
+<%- if citation_item.page_number.present? -%>, p. <%= citation_item.page_number %><%- end -%>
+<%- if citation_item.nearest_timecode_formatted.present? %> near <%= citation_item.nearest_timecode_formatted %><%- end -%>
     <%- end -%>
 
 

--- a/app/components/oral_history/ai_conversation_citation_component.html.erb
+++ b/app/components/oral_history/ai_conversation_citation_component.html.erb
@@ -5,6 +5,7 @@
                 target: "_blank",
                 class: "default-link-style text-decoration-underline") do -%>
       <%= citation_item.short_citation_title -%>
+      <%- if citation_item.page_number.present? -%> p. <%= citation_item.page_number %><%- end -%>
       <%- if citation_item.nearest_timecode_formatted.present? %> near <%= citation_item.nearest_timecode_formatted %><%- end -%>
     <%- end -%>
 

--- a/app/components/oral_history/ai_conversation_citation_component.rb
+++ b/app/components/oral_history/ai_conversation_citation_component.rb
@@ -17,7 +17,11 @@ module OralHistory
       else
         # otherwise, for now wit only staff viewers,  if it's not approval required, we
         # we let them see it, and go right , to PDF. May need to rethink if ever for other audience.
-        view_transcript_pdf_path(citation_item.work)
+        #
+        # If we have a page number, we can try linking to page, which some
+        # browsers can handle. (mobile usually cannot)
+        anchor = "page=#{citation_item.page_number}" if citation_item.page_number
+        view_transcript_pdf_path(citation_item.work, anchor: anchor)
       end
     end
 

--- a/app/components/oral_history/ai_conversation_citation_component.rb
+++ b/app/components/oral_history/ai_conversation_citation_component.rb
@@ -9,7 +9,7 @@ module OralHistory
 
     def link_to_source
       # If OHMS, we link directly to work page with anchor to take to specific paragraph
-      if citation_item.work.oral_history_content.has_ohms_transcript?
+      if citation_item.can_link_to_html_transcript?
         work_path(citation_item.work.friendlier_id, anchor: "p=#{citation_item.paragraph_start}")
       elsif citation_item.work.oral_history_content.available_by_request_manual_review?
         # they will need to request, just go to Work page, and trigger open request form

--- a/app/components/oral_history/ai_conversation_citation_component.rb
+++ b/app/components/oral_history/ai_conversation_citation_component.rb
@@ -20,8 +20,10 @@ module OralHistory
         #
         # If we have a page number, we can try linking to page, which some
         # browsers can handle. (mobile usually cannot)
-        anchor = "page=#{citation_item.page_number}" if citation_item.page_number
-        view_transcript_pdf_path(citation_item.work, anchor: anchor)
+        #  oops, this doens't work yet, we need to take account offset to do this, although
+        #  we do have offset now and could do that...
+        #anchor = "page=#{citation_item.page_number}" if citation_item.page_number
+        view_transcript_pdf_path(citation_item.work)
       end
     end
 

--- a/app/components/oral_history/ai_conversation_citation_component.rb
+++ b/app/components/oral_history/ai_conversation_citation_component.rb
@@ -2,30 +2,31 @@ module OralHistory
   class AiConversationCitationComponent < ApplicationComponent
     attr_reader :citation_item
 
-    # @param citation_item [OralHistory::AiConversation::CitationItem]
+    # @param citation_item [OralHistory::AiConversationDisplayComponent::CitationItem]
     def initialize(citation_item)
       @citation_item = citation_item
     end
 
     def link_to_source
-      # If OHMS, we link directly to work page with anchor to take to specific paragraph
-      if citation_item.can_link_to_html_transcript?
-        work_path(citation_item.work.friendlier_id, anchor: "p=#{citation_item.paragraph_start}")
-      elsif citation_item.work.oral_history_content.available_by_request_manual_review?
-        # they will need to request, just go to Work page, and trigger open request form
-        work_path(citation_item.work.friendlier_id, anchor: "modal-auto-open=oh-request-trigger")
-      else
-        # otherwise, for now wit only staff viewers,  if it's not approval required, we
-        # we let them see it, and go right , to PDF. May need to rethink if ever for other audience.
-        #
-        # If we have a page number, we can try linking to page, which some
-        # browsers can handle. (mobile usually cannot)
-        #  oops, this doens't work yet, we need to take account offset to do this, although
-        #  we do have offset now and could do that...
-        #anchor = "page=#{citation_item.page_number}" if citation_item.page_number
-        view_transcript_pdf_path(citation_item.work)
+      @link_to_source ||= begin
+        # If OHMS, we link directly to work page with anchor to take to specific paragraph
+        if citation_item.can_link_to_html_transcript?
+          work_path(citation_item.work.friendlier_id, anchor: "p=#{citation_item.paragraph_start}")
+        elsif citation_item.work.oral_history_content.available_by_request_manual_review?
+          # they will need to request, just go to Work page, and trigger open request form
+          work_path(citation_item.work.friendlier_id, anchor: "modal-auto-open=oh-request-trigger")
+        else
+          # otherwise, for now wit only staff viewers,  if it's not approval required, we
+          # we let them see it, and go right , to PDF. May need to rethink if ever for other audience.
+          #
+          # If we have a page number, we can try linking to page, which some
+          # browsers can handle. (mobile usually cannot)
+          #  oops, this doens't work yet, we need to take account offset to do this, although
+          #  we do have offset now and could do that...
+          #anchor = "page=#{citation_item.page_number}" if citation_item.page_number
+          view_transcript_pdf_path(citation_item.work)
+        end
       end
     end
-
   end
 end

--- a/app/components/oral_history/ai_conversation_citation_component.rb
+++ b/app/components/oral_history/ai_conversation_citation_component.rb
@@ -2,6 +2,7 @@ module OralHistory
   class AiConversationCitationComponent < ApplicationComponent
     attr_reader :citation_item
 
+    # @param citation_item [OralHistory::AiConversation::CitationItem]
     def initialize(citation_item)
       @citation_item = citation_item
     end

--- a/app/components/oral_history/ai_conversation_display_component.rb
+++ b/app/components/oral_history/ai_conversation_display_component.rb
@@ -139,6 +139,10 @@ module OralHistory
         response_hash["paragraph_end"]
       end
 
+      def page_number
+        response_hash["page_number"]
+      end
+
       def anchor
         "footnote-#{number}"
       end

--- a/app/components/oral_history/ai_conversation_display_component.rb
+++ b/app/components/oral_history/ai_conversation_display_component.rb
@@ -151,6 +151,14 @@ module OralHistory
         "ref-#{anchor}"
       end
 
+      def can_link_to_html_transcript?
+        # has OHMS, or has PDF Text AND is really free access.
+        oral_history_content.has_ohms_transcript? || (
+          oral_history_content.available_by_request_off? &&
+          oral_history_content.extracted_pdf_paragraphs.present?
+        )
+      end
+
       def nearest_timecode_formatted
         # we could have more complicated algorithm to find best timestamp, but good enough
         # for now.

--- a/app/models/oral_history_chunk.rb
+++ b/app/models/oral_history_chunk.rb
@@ -44,6 +44,24 @@ class OralHistoryChunk < ApplicationRecord
   )
 
 
+  def paragraphs_formatted_for_provision
+    self.text.split("\n\n").collect.with_index do |paragraph_text, index|
+      str = "[OH#{ self.oral_history_content.work.oral_history_number }"
+
+      # do we have a page number?
+      paragraph_index = self.start_paragraph_number + index
+      page_number = self.other_metadata&.dig("page_numbers", paragraph_index.to_s)
+
+      if page_number.present?
+        str += "|pg#{page_number}"
+      end
+
+      str += "|¶#{ self.start_paragraph_number + index }]"
+
+      str += " #{paragraph_text}"
+    end
+  end
+
   # One or more texts, do one request to OpenAI to get one or more embedding
   # vectors back. Can include multiple texts to do a bulk request for all of them.
   def self.get_openai_embeddings(*texts)

--- a/app/views/claude_interactor/initial_user_prompt.text.erb
+++ b/app/views/claude_interactor/initial_user_prompt.text.erb
@@ -32,8 +32,8 @@ CHUNK ID: <%= chunk.id %>
 SPEAKERS: <%= chunk.speakers.join(", ") %>
 PARAGRAPH NUMBERS: <%= chunk.start_paragraph_number.upto(chunk.end_paragraph_number).to_a.join(", ") %>
 TEXT:
-<% chunk.text.chomp.split("\n\n").each_with_index do |paragraph, index| %>
-[OH<%= chunk.oral_history_content.work.oral_history_number %>|P<%= chunk.start_paragraph_number + index %>] <%= paragraph %>
+<%- chunk.paragraphs_formatted_for_provision.each do |text| -%>
+<%= text %>
 
 <% end %>
 <%- end -%>

--- a/app/views/claude_interactor/system_instructions.text.erb
+++ b/app/views/claude_interactor/system_instructions.text.erb
@@ -13,6 +13,7 @@ Output a single valid JSON object with this structure (no code fences, preambles
         {
           "chunk_id": <chunk_id>,
           "oral_history_title": "<oral_history_title>",
+          "page_number": <string>,
           "paragraph_start": <number>,
           "paragraph_end": <number>,
           "quote": "<direct quote excerpt>"

--- a/app/views/claude_interactor/system_instructions.text.erb
+++ b/app/views/claude_interactor/system_instructions.text.erb
@@ -13,7 +13,7 @@ Output a single valid JSON object with this structure (no code fences, preambles
         {
           "chunk_id": <chunk_id>,
           "oral_history_title": "<oral_history_title>",
-          "page_number": <string>,
+          "page_number": <string|null>,
           "paragraph_start": <number>,
           "paragraph_end": <number>,
           "quote": "<direct quote excerpt>"

--- a/app/views/claude_interactor/system_instructions.text.erb
+++ b/app/views/claude_interactor/system_instructions.text.erb
@@ -63,6 +63,9 @@ Output a single valid JSON object with this structure (no code fences, preambles
 - When synthesizing information from multiple oral histories, cite each one. A claim can have multiple citations.
 - Chunks may contain multiple paragraphs; always cite the specific supporting paragraph numbers, not the whole chunk unless necessary.
 - Never make claims without citations
+- Include 'page_number' field when the paragraphs used for the quote have page numbers given.
+  - It can be a range like "10-11" if the paragraphs used for the quote cover more than one page.
+  - It can be omitted only if the paragraphs used for the quote do not include page number info.
 
 
 

--- a/lib/tasks/create_oral_history_chunks.rake
+++ b/lib/tasks/create_oral_history_chunks.rake
@@ -36,7 +36,7 @@ namespace :scihist do
     enqueued_count = 0
 
 
-    scope.find_each(batch_size: 200) do |oh_content|
+    scope.find_each(batch_size: 50) do |oh_content|
       progress_bar.increment
 
       overwrite_chunks = ENV['OVERWRITE_CHUNKS'] == "true"

--- a/lib/tasks/store_pdf_paragraphs.rake
+++ b/lib/tasks/store_pdf_paragraphs.rake
@@ -7,7 +7,7 @@ namespace :scihist do
       # for now, only publicially accessible ones without request, we aren't
       # totally able to calculate offsets for non-public ones. This scope is currently
       # not great performance.
-      scope = scope.available_immediate
+      #scope = scope.available_immediate
 
       progress_bar = ProgressBar.create(total: scope.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
       errors = 0

--- a/spec/components/oral_history/ai_conversation_citation_component_spec.rb
+++ b/spec/components/oral_history/ai_conversation_citation_component_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+describe OralHistory::AiConversationCitationComponent, type: :component do
+  let(:paragraphs_json_path) { Rails.root + "spec/test_support/pdf/oh/Macfarlane_1982_extracted_paragraphs.json"}
+
+  let(:work) {
+    build(:oral_history_work,
+      friendlier_id: "12ab12ab12",
+      date_of_work: { start: "2012" },
+      creator: [{ category: "interviewee", value: "Hanford, William E., 1908-1996"},
+                { category: "interviewer", value: "Bohning, James J."}]
+    ).tap do |work|
+      work.oral_history_content.extracted_pdf_paragraphs = OralHistoryContent::ParagraphContainer.new(
+        paragraphs: JSON.parse(File.read(paragraphs_json_path))
+      )
+    end
+  }
+
+  let(:oral_history_content) { work.oral_history_content }
+
+  let(:oral_history_chunk) { build(:oral_history_chunk, oral_history_content: oral_history_content) }
+
+  let(:citation_item) do
+    OralHistory::AiConversationDisplayComponent::CitationItem.new(
+      chunk: oral_history_chunk,
+      response_hash: {
+        "page_number" => "4",
+        "paragraph_start" => oral_history_chunk.start_paragraph_number,
+        "paragraph_end" => oral_history_chunk.start_paragraph_number,
+        "quote" => "This is a long enough quote that it will trigger only showing first 55 chars then rest behind javascript disclosure link"
+      }
+    )
+  end
+
+  let(:component) { described_class.new(citation_item) }
+
+  let!(:rendered) { render_inline component }
+
+  it "renders citation with page number and timecode if present" do
+    expect(page). to have_text %r{Hanford, 2012,\s+p\. 4\s+near \d\d:\d\d:\d\d}
+  end
+
+  it "renders first part of quote" do
+    within(".citation-quote-truncated") do
+      expect(page).to have_text /This is a long enough.*…/
+      expect(page).to have_selector("*[data-scihist-citation-quote-show=true]", text: "Read more")
+    end
+  end
+
+  it "renders link to paragraph" do
+    expect(component.link_to_source).to eq work_path(citation_item.work.friendlier_id, anchor: "p=#{citation_item.paragraph_start}")
+  end
+end

--- a/spec/services/oral_history/claude_interactor_spec.rb
+++ b/spec/services/oral_history/claude_interactor_spec.rb
@@ -32,7 +32,7 @@ describe OralHistory::ClaudeInteractor do
        SPEAKERS: SMITH
        PARAGRAPH NUMBERS: 12
        TEXT:
-       [OH0012|P12] SMITH: If you think back to your time together at school, what kind of a student was Gordon?
+       [OH0012|¶12] SMITH: If you think back to your time together at school, what kind of a student was Gordon?
 
        ------------------------------
        ORAL HISTORY TITLE: Oral history interview with William John Bailey
@@ -41,12 +41,45 @@ describe OralHistory::ClaudeInteractor do
        SPEAKERS: SMITH, JONES
        PARAGRAPH NUMBERS: 12, 13
        TEXT:
-       [OH0012|P12] SMITH: If you think back to your time together at school, what kind of a student was Gordon?
+       [OH0012|¶12] SMITH: If you think back to your time together at school, what kind of a student was Gordon?
 
-       [OH0012|P13] JONES: He was a good student. He has always been a tremendous student. Even in grammar school. But, he was a year ahead of me. I wasn't in his class.
+       [OH0012|¶13] JONES: He was a good student. He has always been a tremendous student. Even in grammar school. But, he was a year ahead of me. I wasn't in his class.
 
        ------------------------------
       EOS
+    end
+
+    describe "with page numbers" do
+      let(:chunk1) {
+        create(:oral_history_chunk,
+          oral_history_content: work.oral_history_content,
+          speakers: ["SMITH"],
+          start_paragraph_number: 12,
+          end_paragraph_number: 12,
+          text: "SMITH: If you think back to your time together at school, what kind of a student was Gordon?",
+          other_metadata: {
+            "page_numbers" => {
+              "12" => 9
+            }
+          }
+        )
+      }
+
+      it "includes page numbers in output" do
+        expect(interaction.render_user_prompt([chunk1])).to include <<~EOS.strip
+         ## RETRIEVED CONTEXT CHUNKS
+         ------------------------------
+         ORAL HISTORY TITLE: Oral history interview with William John Bailey
+         ORAL HISTORY ID: OH#{chunk1.oral_history_content.work.oral_history_number}
+         CHUNK ID: #{chunk1.id}
+         SPEAKERS: SMITH
+         PARAGRAPH NUMBERS: 12
+         TEXT:
+         [OH0012|pg9|¶12] SMITH: If you think back to your time together at school, what kind of a student was Gordon?
+
+         ------------------------------
+        EOS
+      end
     end
   end
 


### PR DESCRIPTION
This includes:

* including page numbers when giving paragrapsh to claude to summaraize
* Instructing claude to use those page numbers in the citations it returns to us
* Using those page numbers in the on-screen citations
* Knowing that we can link directly to the new derived-from-PDF HTML transcripts, for "really freely available" transcripts. 
