### PR TITLE
raise solr timeout from 2 to 3

### DIFF
--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -7,4 +7,4 @@ test: &test
 production:
   adapter: solr
   url: <%= ScihistDigicoll::Env.lookup!(:solr_url) %>
-  timeout: 2
+  timeout: 3


### PR DESCRIPTION
It used to be 4 back in the day. (see https://github.com/sciencehistory/scihist_digicoll/pull/2961) At this point, our puma situation is such that we have headroom to have workers waiting longer, and better to have a slow response than error screen. See if this helps?
