### PR TITLE
Highlight beginning of quote on OH transcript from AI answer link

### DIFF
--- a/app/components/oral_history/ai_conversation_citation_component.rb
+++ b/app/components/oral_history/ai_conversation_citation_component.rb
@@ -51,7 +51,9 @@ module OralHistory
       # we can't do it for now.
       return nil unless words.count > 4
 
-      # now get first six words
+      # now get first six words -- because highlighting more than that can be
+      # distracting AND cause more words, more chance we'll run into something
+      # that is un-highlightable such as split between legacy OHMS lines.
       words.first(6).join(" ")
     end
   end

--- a/app/components/oral_history/ai_conversation_citation_component.rb
+++ b/app/components/oral_history/ai_conversation_citation_component.rb
@@ -11,7 +11,10 @@ module OralHistory
       @link_to_source ||= begin
         # If OHMS, we link directly to work page with anchor to take to specific paragraph
         if citation_item.can_link_to_html_transcript?
-          work_path(citation_item.work.friendlier_id, anchor: "p=#{citation_item.paragraph_start}")
+          # and also try to trigger some search term highlighting on the page.
+          # Get first six words. Warning, highlighting is imperfect it might miss it.
+          highlight_query = citation_item.quote.split.first(6).join(" ")
+          work_path(citation_item.work.friendlier_id, anchor: "p=#{citation_item.paragraph_start}&tqh=#{highlight_query}")
         elsif citation_item.work.oral_history_content.available_by_request_manual_review?
           # they will need to request, just go to Work page, and trigger open request form
           work_path(citation_item.work.friendlier_id, anchor: "modal-auto-open=oh-request-trigger")

--- a/app/components/oral_history/ai_conversation_citation_component.rb
+++ b/app/components/oral_history/ai_conversation_citation_component.rb
@@ -14,7 +14,7 @@ module OralHistory
           # and also try to trigger some search term highlighting on the page.
           # Get first six words. Warning, highlighting is imperfect it might miss it.
           highlight_query = citation_item.quote.split.first(6).join(" ")
-          work_path(citation_item.work.friendlier_id, anchor: "p=#{citation_item.paragraph_start}&tqh=#{highlight_query}")
+          work_path(citation_item.work.friendlier_id, anchor: "p=#{citation_item.paragraph_start}&th=#{highlight_query}")
         elsif citation_item.work.oral_history_content.available_by_request_manual_review?
           # they will need to request, just go to Work page, and trigger open request form
           work_path(citation_item.work.friendlier_id, anchor: "modal-auto-open=oh-request-trigger")

--- a/app/components/oral_history/ai_conversation_citation_component.rb
+++ b/app/components/oral_history/ai_conversation_citation_component.rb
@@ -9,12 +9,10 @@ module OralHistory
 
     def link_to_source
       @link_to_source ||= begin
-        # If OHMS, we link directly to work page with anchor to take to specific paragraph
+        # If OHMS, we link directly to work page with anchor to take to specific paragraph,
+        # with some search-term highlighting triggered.
         if citation_item.can_link_to_html_transcript?
-          # and also try to trigger some search term highlighting on the page.
-          # Get first six words. Warning, highlighting is imperfect it might miss it.
-          highlight_query = citation_item.quote.split.first(6).join(" ")
-          work_path(citation_item.work.friendlier_id, anchor: "p=#{citation_item.paragraph_start}&th=#{highlight_query}")
+          work_path(citation_item.work.friendlier_id, anchor: "p=#{citation_item.paragraph_start}&th=#{transcript_highlight_value}")
         elsif citation_item.work.oral_history_content.available_by_request_manual_review?
           # they will need to request, just go to Work page, and trigger open request form
           work_path(citation_item.work.friendlier_id, anchor: "modal-auto-open=oh-request-trigger")
@@ -30,6 +28,31 @@ module OralHistory
           view_transcript_pdf_path(citation_item.work)
         end
       end
+    end
+
+    # request transcript highlight from OH page, it's imperfect and might
+    # miss it but worth a try.  We try to catch some, one we can't
+    # catch is if quote goes across multiple legacy OHMS transcript lines.
+    def transcript_highlight_value
+      #byebug if citation_item.quote =~ /Tuesday/
+      quote = citation_item.quote
+
+      # highlight can't do speaker labels, remove that if we have it.
+      quote = quote.sub(OralHistory::PdfParagraphSplitter::SPEAKER_NAME_RE, '')
+
+      # if there is '...' in there, it COULD be claude's own omission elipses
+      # joining text that isn't next to each other, so stop there in the quote
+      # Claude may use ... or unicode …
+      quote = quote.split(/\.\.\.|…/).first
+
+      words = quote.split(' ')
+
+      # if that trimming hasn't left us with at least 4, nevermind,
+      # we can't do it for now.
+      return nil unless words.count > 4
+
+      # now get first six words
+      words.first(6).join(" ")
     end
   end
 end

--- a/app/frontend/javascript/audio/ohms_search.js
+++ b/app/frontend/javascript/audio/ohms_search.js
@@ -124,6 +124,8 @@ Search.regexpStrForSearch = function(query) {
 // that works for our DOM. Should we add a data- hook?
 //
 // Highlights every hit, results a list of result objects.
+//
+// WARNING: Can not search phrases that go across 'line' markup, will miss them!
 Search.searchTranscript = function(query) {
   var _self = this;
 
@@ -454,6 +456,21 @@ $(document).on("shown.bs.tab", ".work-show-audio", function(event) {
     Search.resultsModeVal = "transcript";
     if (Search.currentResults()) {
       Search.currentResults().draw();
+    }
+  }
+});
+
+// Anchor in query #tqh=escaped&2Fsearch => results in highlighting that in transcript tab,
+// does not scroll to query at present, but we could add another param to control that?
+// At present used for links from AI that already scroll to paragraph.
+$(document).ready(function() {
+  // Only if we have a #ohTranscript, otherwise we can't highlight in it!
+  if ($("#ohTranscript").length) {
+    const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+
+    const transcriptSearchQ = hashParams.get("tqh"); // transcript query for highlight
+    if (transcriptSearchQ) {
+      Search.searchTranscript(transcriptSearchQ);
     }
   }
 });

--- a/app/frontend/javascript/audio/ohms_search.js
+++ b/app/frontend/javascript/audio/ohms_search.js
@@ -139,7 +139,7 @@ Search.searchTranscript = function(query) {
   // 1: before match
   // 2: match
   // 3: after match
-  var find_re = new RegExp("((?:\\S*\\s+\\S*){0,1})(" + query + ")((?:\\s*\\S+\\s*){0,4})", "gi")
+  var find_re = new RegExp("((?:\\S*\\s+\\S*){0,1})(" + Search.escapeRegExp(query) + ")((?:\\s*\\S+\\s*){0,4})", "gi")
 
   return $("*[data-searchable-transcript-line]").map(function() {
     var line = $(this);
@@ -148,6 +148,7 @@ Search.searchTranscript = function(query) {
     var match = line.text().match(find_re);
 
     if (match) {
+
       var highlightedMatch = match[1] + _self.wrapInHighlight(match[2]) + match[3];
 
       // Actually highlight in source HTML, using HTML-safe regexp.

--- a/app/frontend/javascript/audio/ohms_search.js
+++ b/app/frontend/javascript/audio/ohms_search.js
@@ -460,7 +460,7 @@ $(document).on("shown.bs.tab", ".work-show-audio", function(event) {
   }
 });
 
-// Anchor in query #tqh=escaped&2Fsearch => results in highlighting that in transcript tab,
+// Anchor in query #th=escaped&2Fsearch => results in highlighting that in transcript tab,
 // does not scroll to query at present, but we could add another param to control that?
 // At present used for links from AI that already scroll to paragraph.
 $(document).ready(function() {
@@ -468,9 +468,9 @@ $(document).ready(function() {
   if ($("#ohTranscript").length) {
     const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ''));
 
-    const transcriptSearchQ = hashParams.get("tqh"); // transcript query for highlight
-    if (transcriptSearchQ) {
-      Search.searchTranscript(transcriptSearchQ);
+    const transcriptHighlightQ = hashParams.get("th"); // (t)ranscript (h)ighlighting
+    if (transcriptHighlightQ) {
+      Search.searchTranscript(transcriptHighlightQ);
     }
   }
 });

--- a/spec/components/oral_history/ai_conversation_citation_component_spec.rb
+++ b/spec/components/oral_history/ai_conversation_citation_component_spec.rb
@@ -48,6 +48,6 @@ describe OralHistory::AiConversationCitationComponent, type: :component do
   end
 
   it "renders link to paragraph" do
-    expect(component.link_to_source).to eq work_path(citation_item.work.friendlier_id, anchor: "p=#{citation_item.paragraph_start}&tqh=This is a long enough quote")
+    expect(component.link_to_source).to eq work_path(citation_item.work.friendlier_id, anchor: "p=#{citation_item.paragraph_start}&th=This is a long enough quote")
   end
 end

--- a/spec/components/oral_history/ai_conversation_citation_component_spec.rb
+++ b/spec/components/oral_history/ai_conversation_citation_component_spec.rb
@@ -48,6 +48,6 @@ describe OralHistory::AiConversationCitationComponent, type: :component do
   end
 
   it "renders link to paragraph" do
-    expect(component.link_to_source).to eq work_path(citation_item.work.friendlier_id, anchor: "p=#{citation_item.paragraph_start}")
+    expect(component.link_to_source).to eq work_path(citation_item.work.friendlier_id, anchor: "p=#{citation_item.paragraph_start}&tqh=This is a long enough quote")
   end
 end

--- a/spec/system/oral_history_with_audio_spec.rb
+++ b/spec/system/oral_history_with_audio_spec.rb
@@ -293,6 +293,12 @@ describe "Oral history with audio display", type: :system, js: true do
       expect(page).to have_text("00:04:16") # nearest ToC section
       expect(page).to have_text("Many family members are scientists.") # open synopsis for 04:16
     end
+
+    it "can highlight chosen text on page from url anchor" do
+      visit work_path(parent_work.friendlier_id, anchor: "tab=ohTranscript&th=his interests lay along")
+
+      expect(page).to have_selector("span.ohms-highlight", text: "his interests lay along")
+    end
   end
 
   describe "when you are logged-in staff", :logged_in_user, type: :system, js: true do


### PR DESCRIPTION
We had existing client-side JS code to highlight search results on OH pages. 

We use that to implement listening on page load, if `#th=QUERY` is on end of URL, trigger search with highlight.  th stands for "transcript highlight". 

This code was already pretty futzy... we try to work around some known work-around-able issues in the code that generates the link (in AI citation component), but there are still some known cases it could fail (and just not highlight). 

* In Legacy OHMS transcripts, each "line" is in it's own <span>, and we can't find/highlight a phrase that's split across spans
* Curly apostrophes in original are turned to straight in claude answer, which leads to us searching for not exactly the same string and not finding it. 

There are prob more we don't know about too. We can try to figure out how to make this better at some point if we need to. 

We also found an existing bug where the search query was not being regex-esscpaed in the JS -- unlikely to be triggered before, cause of what people are likely to enter in search box (that I think few if any use anyway!). 

Ref #3444 solves it for HTML, not yet for PDF. 