### PR TITLE
When AI answer links to PDF, specify specific page destination in anchor

### DIFF
--- a/app/components/oral_history/ai_conversation_citation_component.rb
+++ b/app/components/oral_history/ai_conversation_citation_component.rb
@@ -12,19 +12,23 @@ module OralHistory
         # If OHMS, we link directly to work page with anchor to take to specific paragraph
         if citation_item.can_link_to_html_transcript?
           work_path(citation_item.work.friendlier_id, anchor: "p=#{citation_item.paragraph_start}")
-        elsif citation_item.work.oral_history_content.available_by_request_manual_review?
+        elsif citation_item.oral_history_content.available_by_request_manual_review?
           # they will need to request, just go to Work page, and trigger open request form
           work_path(citation_item.work.friendlier_id, anchor: "modal-auto-open=oh-request-trigger")
         else
-          # otherwise, for now wit only staff viewers,  if it's not approval required, we
+          # otherwise, for now with only staff viewers,  if it's not approval required, we
           # we let them see it, and go right , to PDF. May need to rethink if ever for other audience.
           #
           # If we have a page number, we can try linking to page, which some
           # browsers can handle. (mobile usually cannot)
-          #  oops, this doens't work yet, we need to take account offset to do this, although
-          #  we do have offset now and could do that...
-          #anchor = "page=#{citation_item.page_number}" if citation_item.page_number
-          view_transcript_pdf_path(citation_item.work)
+          if citation_item.page_number
+            anchor_page_number = citation_item.page_number.to_i
+            offset = citation_item.oral_history_content&.extracted_pdf_paragraphs&.logical_page_number_offset
+
+            anchor_page_number += offset.to_i if offset
+          end
+
+          view_transcript_pdf_path(citation_item.work, anchor_page: anchor_page_number)
         end
       end
     end

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -108,9 +108,12 @@ class DownloadsController < ApplicationController
       raise ActionController::RoutingError.new("No PDF transcript found")
     end
 
-    redirect_to download_path("pdf", asset, disposition: :inline)
-  end
+    if params[:anchor_page]
+      anchor = "page=#{params[:anchor_page]}"
+    end
 
+    redirect_to download_path("pdf", asset, disposition: :inline, anchor: anchor)
+  end
 
   private
 

--- a/app/models/oral_history_content/paragraph_container.rb
+++ b/app/models/oral_history_content/paragraph_container.rb
@@ -16,6 +16,9 @@ class OralHistoryContent
 
     attr_json :created_at, :datetime, default: -> { Time.current.utc }
 
+    # Add this offset to logical page number to get physical page number
+    attr_json :logical_page_number_offset, :integer
+
     # start times that go with fingerprint to calculate offsets from transcript
     # Array of arrays.
     attr_json :file_start_times, ActiveModel::Type::Value.new
@@ -68,6 +71,7 @@ class OralHistoryContent
 
       container = OralHistoryContent::ParagraphContainer.new(
         paragraphs: paragraphs,
+        logical_page_number_offset: splitter.logical_page_number_offset,
         source_version: ENV['SOURCE_VERSION'],
         pdf_md5: pdf_md5,
         file_start_times: file_start_times,

--- a/app/services/oral_history/pdf_paragraph_splitter.rb
+++ b/app/services/oral_history/pdf_paragraph_splitter.rb
@@ -49,6 +49,8 @@ module OralHistory
 
     attr_reader :extracted_pdf_text, :file_start_times, :allow_failure_to_sync
 
+    attr_reader :logical_page_number_offset
+
 
     # @param extracted_pdf_text [Hash] jsonable Hash of text and structural metadata from PDF
     #        as returned by OralHistory::ExtractPdftext
@@ -107,6 +109,9 @@ module OralHistory
 
     # @return [OralHistory::Paragraph]
     def create_paragraphs
+      # will be set on first page
+      @logical_page_number_offset = nil
+
       extracted_pdf_text_pages = extracted_pdf_text["pages"]
 
       all_paragraphs = []
@@ -133,6 +138,12 @@ module OralHistory
 
         # usually on bottom, sometimes on top
         logical_page_number = extract_and_remove_logical_page_number(page_paragraphs_json)
+
+        # set offset if not set yet and available. The first numbered page
+        # we find may not be 1, so we have to do some math.
+        if @logical_page_number_offset.nil? && logical_page_number
+          @logical_page_number_offset = first_index + (1 - logical_page_number) # could go negative
+        end
 
         last_paragraph = all_paragraphs.last
 

--- a/lib/tasks/data_fixes/backfill_pdf_page_offset.rake
+++ b/lib/tasks/data_fixes/backfill_pdf_page_offset.rake
@@ -1,0 +1,51 @@
+namespace :scihist do
+  namespace :data_fixes do
+
+    desc """
+      Calculate and add logical_page_number_offset to OralHistoryContent where required
+    """
+    task :backfill_pdf_page_offset => :environment do
+      scope = OralHistoryContent.includes(:work => :members).
+        where("json_attributes -> 'extracted_pdf_paragraphs' is not null").
+        where("json_attributes -> 'extracted_pdf_paragraphs' -> 'logical_page_number_offset' is null")
+
+      progress_bar = ProgressBar.create(total: scope.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+
+      scope.find_each(batch_size: 10) do |oral_history_content|
+        pdf_asset = oral_history_content.work.members.find { |a| a.respond_to?(:role) && a.role == "transcript" }
+
+        unless pdf_asset
+          progress_bar.log "Could not create for #{oral_history_content.work.friendlier_id}, missing pdf_asset"
+          next
+        end
+
+        extracted_pdf_text_json = pdf_asset.file_derivatives[:extracted_pdf_text_json]
+
+        unless extracted_pdf_text_json
+          progress_bar.log "Could not create for #{oral_history_content.work.friendlier_id}, missing extracted_pdf_text_json"
+          next
+        end
+
+        extracted_pdf_text = JSON.parse(extracted_pdf_text_json.read)
+
+        splitter = OralHistory::PdfParagraphSplitter.new(
+          extracted_pdf_text: extracted_pdf_text,
+          allow_failure_to_sync: true
+        )
+        splitter.paragraphs # trigger calculation
+
+        offset = splitter.logical_page_number_offset
+
+        unless offset
+          progress_bar.log "Could not create for #{oral_history_content.work.friendlier_id}, could not find offset"
+          next
+        end
+
+        oral_history_content.extracted_pdf_paragraphs.logical_page_number_offset = splitter.logical_page_number_offset
+        oral_history_content.save!
+
+        progress_bar.increment
+      end
+    end
+  end
+end

--- a/spec/components/oral_history/ai_conversation_citation_component_spec.rb
+++ b/spec/components/oral_history/ai_conversation_citation_component_spec.rb
@@ -50,4 +50,25 @@ describe OralHistory::AiConversationCitationComponent, type: :component do
   it "renders link to paragraph" do
     expect(component.link_to_source).to eq work_path(citation_item.work.friendlier_id, anchor: "p=#{citation_item.paragraph_start}")
   end
+
+  describe "automatic requestable" do
+    let(:work) do
+      build(:oral_history_work,
+        friendlier_id: "12ab12ab12",
+        date_of_work: { start: "2012" },
+        creator: [{ category: "interviewee", value: "Hanford, William E., 1908-1996"},
+                  { category: "interviewer", value: "Bohning, James J."}]
+      ).tap do |work|
+        work.oral_history_content.extracted_pdf_paragraphs = OralHistoryContent::ParagraphContainer.new(
+          paragraphs: JSON.parse(File.read(paragraphs_json_path)),
+          logical_page_number_offset: 5
+        )
+        work.oral_history_content.available_by_request_mode = "automatic"
+      end
+    end
+
+    it "generates link to PDF with page number" do
+      expect(component.link_to_source).to eq view_transcript_pdf_path(work, anchor_page: "9")
+    end
+  end
 end

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -227,6 +227,13 @@ describe DownloadsController do
         }.to raise_error(ActionController::RoutingError)
       end
     end
+
+    describe "with anchor_page param" do
+      it "redirects to url with page anchor" do
+        get :transcript_pdf, params: { work_id: work.friendlier_id, anchor_page: "9" }
+        expect(response).to redirect_to %r{#page=9\Z}
+      end
+    end
   end
 
   describe "#transcript_html" do

--- a/spec/models/oral_history_content/paragraph_container_spec.rb
+++ b/spec/models/oral_history_content/paragraph_container_spec.rb
@@ -69,6 +69,8 @@ describe OralHistoryContent::ParagraphContainer do
       expect(oral_history_content.extracted_pdf_paragraphs.paragraphs).to all(be_kind_of(OralHistoryContent::Paragraph))
       expect(oral_history_content.extracted_pdf_paragraphs.fresh?(oral_history_content: oral_history_content)).to be true
 
+      expect(oral_history_content.extracted_pdf_paragraphs.logical_page_number_offset).to eq 0
+
       # changing pdf md5 makes not fresh anymore. LOTS of saves to DB and reloads here, very
       # bad performance, but good semantics for now.
       old_pdf_md5 = pdf_asset.file_metadata["md5"]

--- a/spec/services/oral_history/pdf_paragraph_splitter_spec.rb
+++ b/spec/services/oral_history/pdf_paragraph_splitter_spec.rb
@@ -35,6 +35,12 @@ describe OralHistory::PdfParagraphSplitter do
       expect(paragraphs.last.text).to eq "I think I'll close the taping for now. Thank you for the interview, Dr. Rice."
     end
 
+    it "calculates logical_page_number_offset" do
+      splitter.paragraphs
+
+      expect(splitter.logical_page_number_offset).to eq 6
+    end
+
     it "joins paragraphs split across pages, with marker" do
       paragraphs = splitter.paragraphs
 


### PR DESCRIPTION
Closes #3443 

Most browsers when displaying a PDF can go to page with `#page=NN` on the end. 

But that's physical PDF page, we need the offset from logical page-number-on-page in citation to translate to link. 

We were already calculating that as a necessary part of splitting the PDF into transcript paragraphs (ignoring front matter and labelling with logical marked page number). But we need to expose it from the PdfParagraphSplitter, and save it in the DB as metadata with the paragraphs (in ParagraphContainer). 

Then we just need to make the AiConversationCitationComponent use that when linking directly to a PDF from a ctiation with a page number. 

Except the link is actually to a redirect from DownloadsController and `#fragments` don't make it through redirects (they aren't sent to back-end with HTTP request at all!), so we supply it to DownloadsController as a query param, and the controller then redirects to it as a fragment. 

## After merge and deploy

We need to run a rake task in production to back-fill the offset metadata

- [ ] `heroku run rake scihist:data_fixes:backfill_pdf_page_offset -r production` should take under 5 minutes to run. 
