### PR TITLE
store source_fingerprint for OH chunks, and facilities for making sure those in db match current source data correctly

### DIFF
--- a/app/models/oral_history_content/ohms_xml/legacy_transcript.rb
+++ b/app/models/oral_history_content/ohms_xml/legacy_transcript.rb
@@ -94,6 +94,13 @@ class OralHistoryContent
         @transcript_paragraphs
       end
 
+      # fingerprint our source data, so we can say if a fingerprint isn't fresh cause source data has changed
+      def source_fingerprint
+        @source_fingerprint ||= {
+          "xml_md5" => Digest::MD5.hexdigest(@nokogiri_xml.to_xml)
+        }
+      end
+
       private
 
       # @return [Array<Integer>] array timecodes included in line number ranges, as numbers of seconds

--- a/app/models/oral_history_content/ohms_xml/vtt_transcript.rb
+++ b/app/models/oral_history_content/ohms_xml/vtt_transcript.rb
@@ -104,6 +104,12 @@ class OralHistoryContent
         @transcript_text ||= paragraphs.collect(&:text_with_forced_speaker_label).join("\n\n")
       end
 
+      def source_fingerprint
+        @source_fingerprint ||= {
+          "webvtt_md5" => Digest::MD5.hexdigest(raw_webvtt_text)
+        }
+      end
+
       # our cue wraps webvtt cue with further parsed escaped content
       #
       # Each queue has an array of 0 or more 'paragraphs', each paragraph

--- a/app/models/oral_history_content/paragraph_container.rb
+++ b/app/models/oral_history_content/paragraph_container.rb
@@ -86,6 +86,15 @@ class OralHistoryContent
       return container
     end
 
+    # our sources are the PDF itself and the audio file start times, so
+    # use those as fingerprint.
+    def source_fingerprint
+      @source_fingerprint ||= {
+        "pdf_md5" => self.pdf_md5,
+        "combined_audio_fingerprint" => self.combined_audio_fingerprint
+      }
+    end
+
     # Will fetch the work#members if not already fetched. Fingerprinting includes
     # audio files as well as PDF becuase the audio file lengths are used to calculate
     # offsets for some internal timestamps.
@@ -93,8 +102,10 @@ class OralHistoryContent
       combined_audio = CombinedAudioDerivativeCreator.new(oral_history_content.work)
       pdf_asset = oral_history_content.work.members.find { |a| a.respond_to?(:role) && a.role == "transcript" }
 
-      (self.pdf_md5 == pdf_asset.file_metadata&.dig("md5")) &&
-        (combined_audio.fingerprint == self.combined_audio_fingerprint)
+      self.source_fingerprint == {
+        "pdf_md5" => pdf_asset.file_metadata&.dig("md5"),
+        "combined_audio_fingerprint" => combined_audio.fingerprint
+      }
     end
   end
 end

--- a/app/services/oral_history/chunk_validator.rb
+++ b/app/services/oral_history/chunk_validator.rb
@@ -8,14 +8,42 @@ module OralHistory
       end
     end
 
-    attr_reader :oral_history_content, :chunks, :friendlier_id
+    attr_reader :oral_history_content, :chunks, :friendlier_id, :check_source_fingerprints
+
+    # Does some weird SQL tricks to efficiently get the list of UNIQUE source_fingerprints from related chunks
+    # to an OralHistoryContent.
+    #
+    # They will be json strings in attribute `uniq_source_fingerprints` on each OralHistoryContent,
+    # load from json and we can check for freshness of all extant chunks
+    #
+    # @example
+    #
+    #     scope = OralHistoryContent.where(something)
+    #     scope = OralHistoryChunkValidator.with_uniq_source_fingerprints(scope)
+    #     oc = scope.first
+    #     source_fingerprints = oc.uniq_source_fingerprints.collect { |s| JSON.parse(s) }
+    #
+    def self.with_uniq_source_fingerprints(scope)
+      unless scope.model_name.name == "OralHistoryContent"
+        raise ArgumentError.new("can only work with an OralHistoryContent not a #{scope&.model_name&.name || scope.class.name}")
+      end
+
+      scope.joins(:oral_history_chunks).
+        select("oral_history_content.*", "array_agg(DISTINCT oral_history_chunks.other_metadata ->> 'source_fingerprint') AS uniq_source_fingerprints").
+        group("oral_history_content.id")
+    end
 
     # @param oral_history_content [OralHistoryContent] should have many associations pre-loaded,
     #   with strict_loading enabled, to avoid n+1, if you are doing many of these!
-    def initialize(oral_history_content)
+    def initialize(oral_history_content, check_source_fingerprints: true)
       @oral_history_content = oral_history_content
       @chunks = oral_history_content.oral_history_chunks
       @friendlier_id = oral_history_content.work.friendlier_id
+      @check_source_fingerprints = !! check_source_fingerprints
+
+      unless oral_history_content
+        raise ArgumentError.new("oral_history_content must not be nil")
+      end
     end
 
     # Returns true, or raises a OralHistory::ChunkValidator::Failure
@@ -43,6 +71,28 @@ module OralHistory
         end
 
         validate_chunk_sequence
+      end
+
+      if check_source_fingerprints
+        unless oral_history_content.respond_to?(:uniq_source_fingerprints)
+          raise ArgumentError.new("Cannot check_source_fingerprints without `uniq_source_fingerprints` attribute, either set check_source_fingerprints: false or use .with_uniq_source_fingerprints to prepare scope for fetch")
+        end
+
+        fresh_fingerprint = OralHistory::TranscriptChunker.new(oral_history_content: oral_history_content).computed_source_fingerprint
+
+        passed, failed = oral_history_content.uniq_source_fingerprints.partition do |source_fingerprint_json|
+          source_fingerprint = source_fingerprint_json && JSON.parse(source_fingerprint_json)
+
+          # is it fresh with one we compute now?
+          fresh_fingerprint == source_fingerprint
+        end
+
+        unless passed.present?
+          raise_error("Chunks do not have fresh source_fingerprint. Expected: #{fresh_fingerprint.inspect} ; Actual: #{failed.inspect}")
+        end
+        if failed.present?
+          raise_error("Some chunks do not have fresh source_fingerprint. Expected: #{fresh_fingerprint.inspect} ; Actual: #{source_fingerprint_json.inspect}")
+        end
       end
 
       return true

--- a/app/services/oral_history/chunk_validator.rb
+++ b/app/services/oral_history/chunk_validator.rb
@@ -74,15 +74,22 @@ module OralHistory
       end
 
       if check_source_fingerprints
-        unless oral_history_content.respond_to?(:uniq_source_fingerprints)
-          raise ArgumentError.new("Cannot check_source_fingerprints without `uniq_source_fingerprints` attribute, either set check_source_fingerprints: false or use .with_uniq_source_fingerprints to prepare scope for fetch")
+        uniq_source_fingerprints = if oral_history_content.oral_history_chunks.loaded?
+          oral_history_content.oral_history_chunks.collect { |c| c.other_metadata["source_fingerprint"] }.uniq
+        elsif oral_history_content.respond_to?(:uniq_source_fingerprints)
+          oral_history_content.uniq_source_fingerprints
+        else
+          raise ArgumentError.new(<<~EOS)
+            Cannot check_source_fingerprints. Need one of:
+            * `uniq_source_fingerprints` attribute, see .with_uniq_source_fingerprints to prepare scope for fetch
+            * pre-fetch/load oral_history_chunks
+            * set check_source_fingerprints: false to skip
+          EOS
         end
 
         fresh_fingerprint = OralHistory::TranscriptChunker.new(oral_history_content: oral_history_content).computed_source_fingerprint
 
-        passed, failed = oral_history_content.uniq_source_fingerprints.partition do |source_fingerprint_json|
-          source_fingerprint = source_fingerprint_json && JSON.parse(source_fingerprint_json)
-
+        passed, failed = uniq_source_fingerprints.partition do |source_fingerprint|
           # is it fresh with one we compute now?
           fresh_fingerprint == source_fingerprint
         end
@@ -91,7 +98,7 @@ module OralHistory
           raise_error("Chunks do not have fresh source_fingerprint. Expected: #{fresh_fingerprint.inspect} ; Actual: #{failed.inspect}")
         end
         if failed.present?
-          raise_error("Some chunks do not have fresh source_fingerprint. Expected: #{fresh_fingerprint.inspect} ; Actual: #{source_fingerprint_json.inspect}")
+          raise_error("Some chunks do not have fresh source_fingerprint. Expected: #{fresh_fingerprint.inspect} ; Actual: #{failed.inspect}")
         end
       end
 

--- a/app/services/oral_history/chunk_validator.rb
+++ b/app/services/oral_history/chunk_validator.rb
@@ -71,34 +71,9 @@ module OralHistory
         end
 
         validate_chunk_sequence
-      end
 
-      if check_source_fingerprints
-        uniq_source_fingerprints = if oral_history_content.oral_history_chunks.loaded?
-          oral_history_content.oral_history_chunks.collect { |c| c.other_metadata["source_fingerprint"] }.uniq
-        elsif oral_history_content.respond_to?(:uniq_source_fingerprints)
-          oral_history_content.uniq_source_fingerprints
-        else
-          raise ArgumentError.new(<<~EOS)
-            Cannot check_source_fingerprints. Need one of:
-            * `uniq_source_fingerprints` attribute, see .with_uniq_source_fingerprints to prepare scope for fetch
-            * pre-fetch/load oral_history_chunks
-            * set check_source_fingerprints: false to skip
-          EOS
-        end
-
-        fresh_fingerprint = OralHistory::TranscriptChunker.new(oral_history_content: oral_history_content).computed_source_fingerprint
-
-        passed, failed = uniq_source_fingerprints.partition do |source_fingerprint|
-          # is it fresh with one we compute now?
-          fresh_fingerprint == source_fingerprint
-        end
-
-        unless passed.present?
-          raise_error("Chunks do not have fresh source_fingerprint. Expected: #{fresh_fingerprint.inspect} ; Actual: #{failed.inspect}")
-        end
-        if failed.present?
-          raise_error("Some chunks do not have fresh source_fingerprint. Expected: #{fresh_fingerprint.inspect} ; Actual: #{failed.inspect}")
+        if check_source_fingerprints
+          validate_source_fingerprints
         end
       end
 
@@ -130,6 +105,37 @@ module OralHistory
         unless firstc.text.present?
           raise_error("chunk #{chunk.id} has no text")
         end
+      end
+    end
+
+    def validate_source_fingerprints
+      # get uniq list of existing fingerprints from either loaded into memory chunks,
+      # or efficient SQL fetched attribute.
+      uniq_source_fingerprints = if oral_history_content.oral_history_chunks.loaded?
+        oral_history_content.oral_history_chunks.collect { |c| c.other_metadata["source_fingerprint"] }.uniq
+      elsif oral_history_content.respond_to?(:uniq_source_fingerprints)
+        oral_history_content.uniq_source_fingerprints
+      else
+        raise ArgumentError.new(<<~EOS)
+          Cannot check_source_fingerprints. Need one of:
+          * `uniq_source_fingerprints` attribute, see .with_uniq_source_fingerprints to prepare scope for fetch
+          * pre-fetch/load oral_history_chunks
+          * set check_source_fingerprints: false to skip
+        EOS
+      end
+
+      fresh_fingerprint = OralHistory::TranscriptChunker.new(oral_history_content: oral_history_content).computed_source_fingerprint
+
+      passed, failed = uniq_source_fingerprints.partition do |source_fingerprint|
+        # is it fresh with one we compute now?
+        fresh_fingerprint == source_fingerprint
+      end
+
+      unless passed.present?
+        raise_error("Chunks do not have fresh source_fingerprint. Expected: #{fresh_fingerprint.inspect} ; Actual: #{failed.inspect}")
+      end
+      if failed.present?
+        raise_error("Some chunks do not have fresh source_fingerprint. Expected: #{fresh_fingerprint.inspect} ; Actual: #{failed.inspect}")
       end
     end
 

--- a/app/services/oral_history/plain_text_paragraph_splitter.rb
+++ b/app/services/oral_history/plain_text_paragraph_splitter.rb
@@ -22,6 +22,12 @@ module OralHistory
       @paragraphs ||= split_paragraphs
     end
 
+    def source_fingerprint
+      @source_fingerprint ||= {
+        "text_md5" => Digest::MD5.hexdigest(plain_text)
+      }
+    end
+
     private
 
     def split_paragraphs

--- a/app/services/oral_history/transcript_chunker.rb
+++ b/app/services/oral_history/transcript_chunker.rb
@@ -56,11 +56,9 @@ module OralHistory
     # * #paragraphs method that returns array of OralHistoryContent::Paragraph,
     #
     # * #source_fingerprint that returns a jsonable hash of info that can be used
-    # to determine freshness of source material.
+    # to determine that chunks are still fresh, were created based on still-fresh
+    # sources, by comparing hash equality to one created later.
     #
-    # * #fresh_source_fingerprint?(source_fingerprint) that returns Boolean, if
-    #   jsonable-hash source fingerprint passed in is fresh with current
-    #   oral_history_content or not.
     #
     # @return [#paragraphs, #source_fingerprint]
     def paragraph_source
@@ -272,7 +270,8 @@ module OralHistory
         speakers: speakers,
         other_metadata: {
           "timestamps" => paragraph_timestamps,
-          "page_numbers" => paragraph_page_numbers
+          "page_numbers" => paragraph_page_numbers,
+          "source_fingerprint" => paragraph_source.source_fingerprint.merge("paragraph_source_class" => paragraph_source.class.name)
         }.compact
       )
     end

--- a/app/services/oral_history/transcript_chunker.rb
+++ b/app/services/oral_history/transcript_chunker.rb
@@ -271,9 +271,14 @@ module OralHistory
         other_metadata: {
           "timestamps" => paragraph_timestamps,
           "page_numbers" => paragraph_page_numbers,
-          "source_fingerprint" => paragraph_source.source_fingerprint.merge("paragraph_source_class" => paragraph_source.class.name)
+          "source_fingerprint" => computed_source_fingerprint
         }.compact
       )
+    end
+
+    # add a paragraph_source_class name to the paragraph source's own source_fingerprint please.
+    def computed_source_fingerprint
+      paragraph_source.source_fingerprint.merge("paragraph_source_class" => paragraph_source.class.name)
     end
 
     private

--- a/app/services/oral_history/transcript_chunker.rb
+++ b/app/services/oral_history/transcript_chunker.rb
@@ -39,24 +39,7 @@ module OralHistory
 
       @oral_history_content = oral_history_content
 
-      # different ways of extracting paragraphs, they all should return array of OralHistoryContent::Paragraph
-      @paragraphs = if oral_history_content.ohms_xml&.legacy_transcript.present?
-        oral_history_content.ohms_xml.legacy_transcript.paragraphs
-
-      elsif oral_history_content.ohms_xml&.vtt_transcript.present?
-        oral_history_content.ohms_xml.vtt_transcript.paragraphs
-
-      elsif oral_history_content.extracted_pdf_paragraphs.present?
-        oral_history_content.extracted_pdf_paragraphs.paragraphs
-
-      elsif oral_history_content.searchable_transcript_source.present?
-        OralHistory::PlainTextParagraphSplitter.new(
-          plain_text: oral_history_content.searchable_transcript_source
-        ).paragraphs
-
-      else
-        raise ArgumentError.new("#{self.class.name} can't find paragraph source content for: #{oral_history_content.inspect}")
-      end
+      @paragraphs = self.paragraph_source.paragraphs
 
       # For matching to speaker names, assume it's "lastname, first dates" type heading,
       # take last name and upcase
@@ -65,6 +48,40 @@ module OralHistory
         collect { |c| c.value.split(",").first.upcase }
 
       @allow_embedding_wait_seconds = allow_embedding_wait_seconds
+    end
+
+    # different ways of extracting paragraphs for different types of source content,
+    # all the objects we return should have:
+    #
+    # * #paragraphs method that returns array of OralHistoryContent::Paragraph,
+    #
+    # * #source_fingerprint that returns a jsonable hash of info that can be used
+    # to determine freshness of source material.
+    #
+    # * #fresh_source_fingerprint?(source_fingerprint) that returns Boolean, if
+    #   jsonable-hash source fingerprint passed in is fresh with current
+    #   oral_history_content or not.
+    #
+    # @return [#paragraphs, #source_fingerprint]
+    def paragraph_source
+      @paragraph_source ||= begin
+        if oral_history_content.ohms_xml&.legacy_transcript.present?
+          oral_history_content.ohms_xml.legacy_transcript
+
+        elsif oral_history_content.ohms_xml&.vtt_transcript.present?
+          oral_history_content.ohms_xml.vtt_transcript
+
+        elsif oral_history_content.extracted_pdf_paragraphs.present?
+          oral_history_content.extracted_pdf_paragraphs
+
+        elsif oral_history_content.searchable_transcript_source.present?
+          OralHistory::PlainTextParagraphSplitter.new(
+            plain_text: oral_history_content.searchable_transcript_source
+          )
+        else
+          raise ArgumentError.new("#{self.class.name} can't find paragraph source content for: #{oral_history_content.inspect}")
+        end
+      end
     end
 
     def num_paragraphs

--- a/lib/tasks/create_oral_history_chunks.rake
+++ b/lib/tasks/create_oral_history_chunks.rake
@@ -16,6 +16,9 @@ namespace :scihist do
 
     `ONLY_AVAILABLE_IMMEDATE=true` limit to only those available immediate ('really free access')
 
+    `ONLY_INVALID=true` validate including source_fingerprint and only create for ones that are
+        invalid/stale , implies OVERWRITE_CHUNKS.
+
   """
   task :create_oral_history_chunks => [:environment] do
     scope = OralHistoryContent.includes(:work => :members).joins(:work).where(work: { published: true})
@@ -30,6 +33,12 @@ namespace :scihist do
 
     total_count = scope.count
 
+    # have to do after we take 'count' cause it will mess up the count
+    only_invalid = (ENV['ONLY_INVALID'] == "true")
+    if only_invalid
+      scope = OralHistory::ChunkValidator.with_uniq_source_fingerprints(scope)
+    end
+
     progress_bar = ProgressBar.create(total: total_count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
 
     skipped_count = 0
@@ -39,7 +48,7 @@ namespace :scihist do
     scope.find_each(batch_size: 50) do |oh_content|
       progress_bar.increment
 
-      overwrite_chunks = ENV['OVERWRITE_CHUNKS'] == "true"
+      overwrite_chunks = (ENV['OVERWRITE_CHUNKS'] == "true") || only_invalid
       use_dummy_embedding = ENV['USE_DUMMY_EMBEDDING'] == "true"
 
       # Make sure we skip truly embargoed/non-public stuff, which is
@@ -50,6 +59,17 @@ namespace :scihist do
         unless oh_content.work.members.to_a.find {|asset| asset.role == "transcript" && asset.published?}
           skipped_count += 1
           next
+        end
+      end
+
+      if only_invalid
+        begin
+          OralHistory::ChunkValidator.new(oh_content, check_source_fingerprints: true).validate!
+          # if we didn't raise, it's valid, so
+          skipped_count +=1
+          next
+        rescue OralHistory::ChunkValidator::Failure => e
+          # invalid, we're just proceeding!
         end
       end
 

--- a/lib/tasks/create_oral_history_chunks.rake
+++ b/lib/tasks/create_oral_history_chunks.rake
@@ -33,6 +33,7 @@ namespace :scihist do
 
     total_count = scope.count
 
+    # include fingerprints with performant SELECT,
     # have to do after we take 'count' cause it will mess up the count
     only_invalid = (ENV['ONLY_INVALID'] == "true")
     if only_invalid

--- a/spec/services/oral_history/chunk_validator_spec.rb
+++ b/spec/services/oral_history/chunk_validator_spec.rb
@@ -29,7 +29,7 @@ describe OralHistory::ChunkValidator do
 
   let(:oral_history_content) { work.oral_history_content }
 
-  let(:validator) { described_class.new(oral_history_content)}
+  let(:validator) { described_class.new(oral_history_content, check_source_fingerprints: false)}
 
 
   describe "good chunks" do
@@ -132,6 +132,60 @@ describe OralHistory::ChunkValidator do
       expect {
         validator.validate!
       }.to raise_error(OralHistory::ChunkValidator::Failure, /Embargoed OH has 3 chunks/)
+    end
+  end
+
+  describe "with check_source_fingerprints" do
+    let(:validator) do
+      oral_history_content.save!
+      oc_with_fingerprints = OralHistory::ChunkValidator.with_uniq_source_fingerprints(
+        OralHistoryContent.where(id: oral_history_content.id)
+      ).first
+
+      described_class.new(oc_with_fingerprints, check_source_fingerprints: true)
+    end
+
+    let(:chunks) do
+      [
+        build(:oral_history_chunk, start_paragraph_number: 1, end_paragraph_number: 4),
+        build(:oral_history_chunk, start_paragraph_number: 4, end_paragraph_number: 6),
+        build(:oral_history_chunk, start_paragraph_number: 5, end_paragraph_number: 6)
+      ]
+    end
+
+    it "fails without good source fingerprints" do
+      expect {
+        validator.validate!
+      }.to raise_error(OralHistory::ChunkValidator::Failure, /Chunks do not have fresh source_fingerprint/)
+    end
+
+    describe "with good source fingerprint and good chunks" do
+      let(:good_source_fingerprint) do
+        OralHistory::TranscriptChunker.new(oral_history_content: oral_history_content).computed_source_fingerprint
+      end
+
+      let(:good_chunks) do
+        [
+          build(:oral_history_chunk, start_paragraph_number: 1, end_paragraph_number: 4, other_metadata: { "source_fingerprint": good_source_fingerprint}),
+          build(:oral_history_chunk, start_paragraph_number: 4, end_paragraph_number: 6, other_metadata: { "source_fingerprint": good_source_fingerprint}),
+          build(:oral_history_chunk, start_paragraph_number: 5, end_paragraph_number: 6,other_metadata: { "source_fingerprint": good_source_fingerprint})
+        ]
+      end
+
+      let(:validator) do
+        oral_history_content.oral_history_chunks = good_chunks
+        oral_history_content.save!
+
+        oc_with_fingerprints = OralHistory::ChunkValidator.with_uniq_source_fingerprints(
+          OralHistoryContent.where(id: oral_history_content.id)
+        ).first
+
+        described_class.new(oc_with_fingerprints, check_source_fingerprints: true)
+      end
+
+      it "passes" do
+        expect(validator.validate!).to eq true
+      end
     end
   end
 end

--- a/spec/services/oral_history/transcript_chunker_spec.rb
+++ b/spec/services/oral_history/transcript_chunker_spec.rb
@@ -95,6 +95,9 @@ describe OralHistory::TranscriptChunker do
 
         expect(record.speakers).to eq ["HANFORD", "BOHNING"]
 
+        # includes source_fingerprint
+        expect(record.other_metadata["source_fingerprint"]).to be_present
+
         # json standard says hash keys must be string, pg will insist
         list_of_paragraphs.each do |paragraph|
           timestamp_data = record.other_metadata["timestamps"][paragraph.paragraph_index.to_s]
@@ -139,6 +142,8 @@ describe OralHistory::TranscriptChunker do
           expect(chunks).to be_present
           expect(chunks.first.start_paragraph_number).to eq 1
           expect(chunks.last.end_paragraph_number).to eq legacy_transcript.paragraphs.count
+
+          expect(chunks).to all(satisfy { |c| c.other_metadata["source_fingerprint"].present? })
         end
       end
     end
@@ -184,6 +189,22 @@ describe OralHistory::TranscriptChunker do
 
           expect(second_chunk.first(1)).to eq (first_chunk.last(1))
         end
+      end
+    end
+
+    describe "create_db_records" do
+      before do
+        allow(OralHistoryChunk).to receive(:get_openai_embeddings) { |*args| [OralHistoryChunk::FAKE_EMBEDDING] * args.count }
+      end
+
+      it "saves source_fingerprint" do
+        chunker.create_db_records
+
+        chunks =  oral_history_content.reload.oral_history_chunks
+
+        expect(chunks).to be_present
+
+        expect(chunks).to all(satisfy { |c| c.other_metadata["source_fingerprint"].present? })
       end
     end
   end
@@ -254,6 +275,9 @@ describe OralHistory::TranscriptChunker do
               expect(chunk.other_metadata["page_numbers"][paragraph_number.to_s]).to be_present
             end
           end
+
+          # source metadata
+          expect(chunks).to all(satisfy { |c| c.other_metadata["source_fingerprint"].present? })
         end
       end
     end
@@ -319,6 +343,8 @@ describe OralHistory::TranscriptChunker do
           expect(chunks).to be_present
           expect(chunks.first.start_paragraph_number).to eq 1
           expect(chunks.last.end_paragraph_number).to eq splitter.paragraphs.count
+
+          expect(chunks).to all(satisfy { |c| c.other_metadata["source_fingerprint"].present? })
         end
       end
     end


### PR DESCRIPTION
- factor out 'paragraph_source' that we can use duck-typed to source and freshness info
- Each paragraph source can create a source_fingerprint hash which is saved with each chunk
- ChunkValidator can check source_fingerprints for freshness, using fancy performant SQL provided in scope
- ChunkValidator can use already fetched into memory chunks to validate source_fingerprints too
- ChunkValidator only validate source fingerprints for items expected to have chunks at all
- WIP rake create_oral_history_chunks can create only for invalid; our SQL select scope isn't currently working as desired though

## After merge and deploy

- [ ] Re-create all chunks on production, with latest logic, and fingerprint info!  This will cost us maybe $40. 
  - `heroku run -r production ONLY_INVALID=true OVERWRITE_CHUNKS=true ./bin/rake scihist:create_oral_history_chunks`
  - Spin special_workers up to 1 or 2 workers, until all re-created. 
  - Spin special workers down
  - Sync prod to staging, so staging has up to date chunks


Afterwords, running the rake again should queue ZERO jobs, cause `ONLY_INVALID` and they should all be valid! 