### PR TITLE
AI feedback rating defaluts to 3

### DIFF
--- a/app/frontend/stylesheets/local/range_input_as_star_rating.scss
+++ b/app/frontend/stylesheets/local/range_input_as_star_rating.scss
@@ -12,7 +12,6 @@ input[type=range].star-rating {
   --stars: 5;
   --starsize: 3rem;
   --symbol: var(--star);
-  --value: 1;
   --w: calc(var(--stars) * var(--starsize));
   --x: calc(100% * (var(--value) / var(--stars)));
   block-size: var(--starsize);

--- a/app/views/oral_history_conversation_feedback/new.html.erb
+++ b/app/views/oral_history_conversation_feedback/new.html.erb
@@ -18,15 +18,15 @@
 
       <%= f.input "rating", as: :range, required: false,
           label: "How useful was the answer to you?",
-          default: 1,
+          default: 3,
           input_html: {
             class: 'star-rating',
             min: 1,
             max: 5,
+            value: 3,
             step: 1,
-            style: "--value:0",
-            value: 0,
-            oninput:"this.style.setProperty('--value', `${this.valueAsNumber}`)" } %>
+            style: "--value:3",
+            oninput:"if (this.value == 0) this.value = 1; this.style.setProperty('--value', `${this.valueAsNumber}`)" } %>
 
       <%= f.input "comment", as: :text,
           label: "Any other comments or feedback?",


### PR DESCRIPTION
We were trying to make it start out with no stars selected, but that wasn't working. We're using weird CSS to make an HTML range input look like stars. A range input can't actually have no value selected, it has to have in this case between 1 and 5, our attempt to have it unselected left it in a weird inconsistent state wehre you couldn't select only 1 star to begin with, I was unable to figure out a better solution.

So for now just start out with 3/5 selected.
