### PR TITLE
automatically create chunks when OH works are published

### DIFF
--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -362,6 +362,10 @@ class Admin::WorksController < AdminController
 
     @work.class.transaction do
       @work.update!(published: true)
+
+      # TODO, should we have a "on publish" service class to batch more of these? If we add another.
+      OhTranscriptChunkerJob.on_publish_perform_later_if_needed(@work)
+
       if params[:cascade] == 'true'
         @work.all_descendent_members.find_each do |member|
           member.update!(published: true)
@@ -563,6 +567,12 @@ class Admin::WorksController < AdminController
     Work.transaction do
       current_user.works_in_cart.find_each do |work|
         work.update!(published: publish_value)
+
+        # TODO, should we have a "on publish" service class to batch more of these? If we add another.
+        if publish_value
+          OhTranscriptChunkerJob.on_publish_perform_later_if_needed(work)
+        end
+
         if params[:cascade] == 'true'
           work.all_descendent_members.find_each do |member|
             member.update!(published: true)

--- a/app/jobs/oh_transcript_chunker_job.rb
+++ b/app/jobs/oh_transcript_chunker_job.rb
@@ -7,7 +7,40 @@ class OhTranscriptChunkerJob < ApplicationJob
   # In a local constnat only so we can stub to something different in tests
   CHUNKER_CLASS = OralHistory::TranscriptChunker
 
-  def perform(oral_history_content, delete_existing: false, use_dummy_embedding: false, only_if_invalid: false)
+  # @param delete_existing [Boolean] default false. if true, existing chunks will be deleted before creating new ones. If false,
+  #     will raise and refuse to create new if existing!
+  #
+  # @param use_dummy_embedding [Boolean] default false, if treu will not calculate real embedding vector
+  #    ($ expensive, slow), but will use a fake dummy 0 vector. Mostly used for testing, makes
+  #    chunks pretty useless.
+  #
+  # @param only_if_invalid [Boolean] default false. If true, we will do nothing if valid chunks already exist.
+  #
+  # @param refresh_extracted_pdf_paragraphs [Boolean]. default false. If true, will first
+  #    create fresh extracted_pdf_paragraphs if it is possible and paragraphs are missing
+  #    or not fresh.
+  def perform(oral_history_content, delete_existing: false, use_dummy_embedding: false, only_if_invalid: false, refresh_extracted_pdf_paragraphs: false)
+
+    if refresh_extracted_pdf_paragraphs
+      members = oral_history_content.work.members
+      transcript_asset = members.loaded? ? members.find {|a| a.role == "transcript" } : members.where(role: "transcript").first
+
+      # if we have extracted_pdf_text_json and don't have fresh paragraphs stored, we must refresh
+      if transcript_asset && transcript_asset.file_derivatives[:extracted_pdf_text_json].present? && (
+            oral_history_content.extracted_pdf_paragraphs.nil? || !oral_history_content.extracted_pdf_paragraphs.fresh?(oral_history_content: oral_history_content)
+         )
+        Rails.logger.info("#{self.class.name}: refresh_extracted_pdf_paragraphs:true and needs paragraphs, so creating.")
+
+        begin
+          OralHistoryContent::ParagraphContainer.create(
+            oral_history_content: oral_history_content,
+            allow_failure_to_sync: true
+          )
+        rescue PdfParagraphSplitter::Error => e
+          Rails.logger.error("#{self.class.name}: Could not create extracted_pdf_paragraphs: #{e}")
+        end
+      end
+    end
 
     if only_if_invalid
       if OralHistory::ChunkValidator.new(oral_history_content, check_source_fingerprints: true).validate

--- a/app/jobs/oh_transcript_chunker_job.rb
+++ b/app/jobs/oh_transcript_chunker_job.rb
@@ -14,7 +14,7 @@ class OhTranscriptChunkerJob < ApplicationJob
     # in production -- even if someone has left API keys set!
     use_dummy_embedding = ScihistDigicoll::Env.lookup(:use_dummy_embedding_on_oh_publish)
 
-    self.perform_later(oral_history_content,
+    self.perform_later(oral_history_content: oral_history_content,
       only_if_invalid: true,
       refresh_extracted_pdf_paragraphs: false,
       delete_existing: true,
@@ -22,6 +22,14 @@ class OhTranscriptChunkerJob < ApplicationJob
     )
   end
 
+  # @param oral_history_content [OralHistoryContent] model to perform chunk creation on. optional
+  #   this param or work, from which we'll look it up.
+  #
+  # @param work [Work] optional provide this instead of oral_history_content, we'll look it up
+  #   in the job. Can be a convenience if you're doing for a lot of works and you don't want
+  #   to look up all their oral histories, although you should check work.association(:oral_history_content).scope.exist?
+  #   first to avoid unnecessary jobs and an exception here.
+  #
   # @param delete_existing [Boolean] default false. if true, existing chunks will be deleted before creating new ones. If false,
   #     will raise and refuse to create new if existing!
   #
@@ -34,7 +42,12 @@ class OhTranscriptChunkerJob < ApplicationJob
   # @param refresh_extracted_pdf_paragraphs [Boolean]. default false. If true, will first
   #    create fresh extracted_pdf_paragraphs if it is possible and paragraphs are missing
   #    or not fresh.
-  def perform(oral_history_content, delete_existing: false, use_dummy_embedding: false, only_if_invalid: false, refresh_extracted_pdf_paragraphs: false)
+  def perform(oral_history_content:nil, work:nil, delete_existing: false, use_dummy_embedding: false, only_if_invalid: false, refresh_extracted_pdf_paragraphs: false)
+    unless work ^ oral_history_content
+      raise ArgumentError.new("Exactly one of work:#{work} and oral_history_content#{oral_history_content} must be provided")
+    end
+    # look it up from work if needed
+    (oral_history_content ||= work.oral_history_content) or raise ArgumentError.new("work #{work.friendlier_id} has no oral_history_content")
 
     if refresh_extracted_pdf_paragraphs
       members = oral_history_content.work.members

--- a/app/jobs/oh_transcript_chunker_job.rb
+++ b/app/jobs/oh_transcript_chunker_job.rb
@@ -7,6 +7,21 @@ class OhTranscriptChunkerJob < ApplicationJob
   # In a local constnat only so we can stub to something different in tests
   CHUNKER_CLASS = OralHistory::TranscriptChunker
 
+
+  # Just some default params, including by default not doing $$ API calls on staging.
+  def self.perform_later_on_publish(oral_history_content)
+    # because it's so expensive, we don't normally do real embedding API calls if not
+    # in production -- even if someone has left API keys set!
+    use_dummy_embedding = ScihistDigicoll::Env.lookup(:use_dummy_embedding_on_oh_publish)
+
+    self.perform_later(oral_history_content,
+      only_if_invalid: true,
+      refresh_extracted_pdf_paragraphs: false,
+      delete_existing: true,
+      use_dummy_embedding: use_dummy_embedding
+    )
+  end
+
   # @param delete_existing [Boolean] default false. if true, existing chunks will be deleted before creating new ones. If false,
   #     will raise and refuse to create new if existing!
   #

--- a/app/jobs/oh_transcript_chunker_job.rb
+++ b/app/jobs/oh_transcript_chunker_job.rb
@@ -4,7 +4,18 @@
 #
 # Refuses to run if there are already chunks, cause that would create a real mess!
 class OhTranscriptChunkerJob < ApplicationJob
-  def perform(oral_history_content, delete_existing: false, use_dummy_embedding: false)
+  # In a local constnat only so we can stub to something different in tests
+  CHUNKER_CLASS = OralHistory::TranscriptChunker
+
+  def perform(oral_history_content, delete_existing: false, use_dummy_embedding: false, only_if_invalid: false)
+
+    if only_if_invalid
+      if OralHistory::ChunkValidator.new(oral_history_content, check_source_fingerprints: true).validate
+        Rails.logger.info("#{self.class.name}: called with only_if_invalid, and oral history #{oral_history_content.id} is valid, so not creating chunks.")
+        return
+      end
+    end
+
     if oral_history_content.oral_history_chunks.exists?
       if delete_existing
         oral_history_content.oral_history_chunks.delete_all
@@ -14,7 +25,7 @@ class OhTranscriptChunkerJob < ApplicationJob
       end
     end
 
-    OralHistory::TranscriptChunker.new(oral_history_content: oral_history_content, allow_embedding_wait_seconds: 10).create_db_records(use_dummy_embedding: use_dummy_embedding)
+    CHUNKER_CLASS.new(oral_history_content: oral_history_content, allow_embedding_wait_seconds: 10).create_db_records(use_dummy_embedding: use_dummy_embedding)
   end
 
 end

--- a/app/jobs/oh_transcript_chunker_job.rb
+++ b/app/jobs/oh_transcript_chunker_job.rb
@@ -8,15 +8,22 @@ class OhTranscriptChunkerJob < ApplicationJob
   CHUNKER_CLASS = OralHistory::TranscriptChunker
 
 
-  # Just some default params, including by default not doing $$ API calls on staging.
-  def self.perform_later_on_publish(oral_history_content)
+  # For using after a work is published, will no op if the work does not have an
+  # oral_history_content
+  def self.on_publish_perform_later_if_needed(work)
+    # unless it's already in-memory or a quick exist db check shows it exists,
+    # then this is not needed.
+    unless work.association(:oral_history_content).loaded? || work.association(:oral_history_content).scope.exists?
+      return
+    end
+
     # because it's so expensive, we don't normally do real embedding API calls if not
     # in production -- even if someone has left API keys set!
     use_dummy_embedding = ScihistDigicoll::Env.lookup(:use_dummy_embedding_on_oh_publish)
 
-    self.perform_later(oral_history_content: oral_history_content,
+    self.perform_later(work: work,
       only_if_invalid: true,
-      refresh_extracted_pdf_paragraphs: false,
+      refresh_extracted_pdf_paragraphs: true,
       delete_existing: true,
       use_dummy_embedding: use_dummy_embedding
     )

--- a/app/services/oral_history/chunk_validator.rb
+++ b/app/services/oral_history/chunk_validator.rb
@@ -46,6 +46,17 @@ module OralHistory
       end
     end
 
+    # @returns [Boolean] for if valid. Won't raise. Doesn't provide access to message on why not,
+    #   use validate! with error raised for that.
+    def validate
+      # kind of cheesey implementaion relying on internally catching exception which is sometimes
+      # bad performance, but no big deal it works.
+      validate!
+      return true
+    rescue Failure
+      return false
+    end
+
     # Returns true, or raises a OralHistory::ChunkValidator::Failure
     def validate!
       if embargoed?

--- a/app/services/oral_history/transcript_chunker.rb
+++ b/app/services/oral_history/transcript_chunker.rb
@@ -88,6 +88,12 @@ module OralHistory
 
 
     def create_db_records(use_dummy_embedding: false)
+      # If we want to override this for some reason we can add a param, but
+      # I don't think we ever want to do this, and we were accidentally, causing problems.
+      if oral_history_content.oral_history_chunks.exists?
+        raise ArgumentError.new("Can't create_db_records when oral_history_chunks already exist, will lead to inconsistent confusion.")
+      end
+
       # array of arrays of paragraphs
       chunk_arrays = split_chunks
 

--- a/app/services/oral_history/transcript_chunker.rb
+++ b/app/services/oral_history/transcript_chunker.rb
@@ -32,6 +32,7 @@ module OralHistory
     # @param allow_embedding_wait_seconds [Integer] if we exceed open ai rate limit for getting
     #    embedding, can we wait and try again? With maximum wait being this many seconds.
     #    Default 0, so, no.
+    #
     def initialize(oral_history_content:, allow_embedding_wait_seconds: 0)
       unless oral_history_content.kind_of?(OralHistoryContent)
         raise ArgumentError.new("argument must be OralHistoryContent, but was #{oral_history_content.class.name}")

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -706,6 +706,13 @@ module ScihistDigicoll
 
     define_key :openai_api_key
 
+    # We have a hook to auto create embeddings on OH publish. Because so $expensive,
+    # we guard to not do by default in non-production, even if API keys are set (which they
+    # often won't be), to avoid accidental $$.
+    define_key :use_dummy_embedding_on_oh_publish, default: -> {
+      ! self.production?
+    }
+
     # nil means use default, but we can define if we want to put all OCR work on, say, `special_jobs`.
     define_key :active_job_ocr_queue
 

--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -710,7 +710,7 @@ module ScihistDigicoll
     # we guard to not do by default in non-production, even if API keys are set (which they
     # often won't be), to avoid accidental $$.
     define_key :use_dummy_embedding_on_oh_publish, default: -> {
-      ! self.production?
+      ! ScihistDigicoll::Env.production?
     }
 
     # nil means use default, but we can define if we want to put all OCR work on, say, `special_jobs`.

--- a/lib/tasks/create_oral_history_chunks.rake
+++ b/lib/tasks/create_oral_history_chunks.rake
@@ -78,7 +78,7 @@ namespace :scihist do
       end
 
       # enqueue to special_jobs so we can control concurrency to avoid rate limit
-      OhTranscriptChunkerJob.set(queue: "special_jobs").perform_later(oh_content, delete_existing: overwrite_chunks, use_dummy_embedding: use_dummy_embedding)
+      OhTranscriptChunkerJob.set(queue: "special_jobs").perform_later(oral_history_content: oh_content, delete_existing: overwrite_chunks, use_dummy_embedding: use_dummy_embedding)
 
       enqueued_count += 1
 

--- a/lib/tasks/create_oral_history_chunks.rake
+++ b/lib/tasks/create_oral_history_chunks.rake
@@ -66,13 +66,9 @@ namespace :scihist do
       end
 
       if only_invalid
-        begin
-          OralHistory::ChunkValidator.new(oh_content, check_source_fingerprints: true).validate!
-          # if we didn't raise, it's valid, so
+        unless OralHistory::ChunkValidator.new(oh_content, check_source_fingerprints: true).validate
           skipped_count +=1
           next
-        rescue OralHistory::ChunkValidator::Failure => e
-          # invalid, we're just proceeding!
         end
       end
 
@@ -81,10 +77,10 @@ namespace :scihist do
         next
       end
 
-      enqueued_count += 1
-
       # enqueue to special_jobs so we can control concurrency to avoid rate limit
       OhTranscriptChunkerJob.set(queue: "special_jobs").perform_later(oh_content, delete_existing: overwrite_chunks, use_dummy_embedding: use_dummy_embedding)
+
+      enqueued_count += 1
 
       # try to keep from blowing up our memory with so much pre-fetching
       GC.start

--- a/spec/controllers/admin/works_controller_batch_publish_spec.rb
+++ b/spec/controllers/admin/works_controller_batch_publish_spec.rb
@@ -221,6 +221,27 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
 
         expect(publishable_work.reload).to be_published
         expect(publishable_work.published_at).to eq Time.now
+
+        expect(OhTranscriptChunkerJob).not_to have_been_enqueued
+      end
+
+      describe "oral history work" do
+        let(:oh_work) { create(:oral_history_work, :published, published: false) }
+        before do
+          controller.current_user.works_in_cart << oh_work
+        end
+
+        it "enqueues chunk creating job" do
+          put :batch_publish_toggle, params: { publish: "on" }
+
+          expect(OhTranscriptChunkerJob).to have_been_enqueued.with(
+            work: oh_work,
+            only_if_invalid: true,
+            refresh_extracted_pdf_paragraphs: true,
+            delete_existing: true,
+            use_dummy_embedding: true # cause testing env
+          )
+        end
       end
     end
   end

--- a/spec/controllers/admin/works_controller_spec.rb
+++ b/spec/controllers/admin/works_controller_spec.rb
@@ -285,6 +285,9 @@ RSpec.describe Admin::WorksController, type: :controller, queue_adapter: :test d
           expect(work.members.first.content_type).to eq "image/tiff"
           put :publish, params: { id: work.friendlier_id, cascade: 'true' }
           expect(response.status).to redirect_to(admin_work_path(work))
+
+          expect(OhTranscriptChunkerJob).not_to have_been_enqueued
+
           work.reload
           expect(work.published?).to be true
           expect(work.published_at).to eq Time.now
@@ -297,6 +300,24 @@ RSpec.describe Admin::WorksController, type: :controller, queue_adapter: :test d
           work.reload
           expect(work.published?).to be true
           expect(work.members.all? {|m| m.published?}).to be false
+        end
+
+        describe "oral history work" do
+          let(:work) do
+            create(:oral_history_work, :published, published: false)
+          end
+
+          it "enqueues chunk creating job" do
+            put :publish, params: { id: work.friendlier_id }
+
+            expect(OhTranscriptChunkerJob).to have_been_enqueued.with(
+              work: work,
+              only_if_invalid: true,
+              refresh_extracted_pdf_paragraphs: true,
+              delete_existing: true,
+              use_dummy_embedding: true # cause testing env
+            )
+          end
         end
       end
 

--- a/spec/factories/asset_factory.rb
+++ b/spec/factories/asset_factory.rb
@@ -99,7 +99,7 @@ FactoryBot.define do
         # other arbitrary metadata
         faked_metadata { {} }
 
-        # An array of Kithe::Derivative objects that we will add to the faked Asset.
+        # A Hash of derivative names/Shrine::UploadedFile objects that we will add to the faked Asset.
         # By default, we take every derivative defined in Kithe::Asset, if they
         # apply to this Asset, and just fake the original asset as the derivative.
         #
@@ -108,7 +108,7 @@ FactoryBot.define do
         #
         #   { one: create(:stored_uploaded_file, content_type: "image/jpeg") }
         #
-        # Nil means we'll create some by default in after(:build)
+        # nil means we'll create some by default in after(:build)
         faked_derivatives { nil }
       end
 

--- a/spec/jobs/oh_transcript_chunker_job_spec.rb
+++ b/spec/jobs/oh_transcript_chunker_job_spec.rb
@@ -27,7 +27,7 @@ describe OhTranscriptChunkerJob, type: :job do
     expect(mock_chunker_class).to receive(:new).and_return(mock_chunker)
     expect(mock_chunker).to receive(:create_db_records)
 
-    described_class.perform_now(oral_history_content)
+    described_class.perform_now(oral_history_content: oral_history_content)
   end
 
   describe "only_if_invalid" do
@@ -36,7 +36,7 @@ describe OhTranscriptChunkerJob, type: :job do
         expect(mock_chunker_class).to receive(:new).and_return(mock_chunker)
         expect(mock_chunker).to receive(:create_db_records)
 
-        described_class.perform_now(oral_history_content, only_if_invalid: true)
+        described_class.perform_now(oral_history_content: oral_history_content, only_if_invalid: true)
       end
     end
 
@@ -49,7 +49,7 @@ describe OhTranscriptChunkerJob, type: :job do
         expect(mock_chunker_class).to receive(:new).and_return(mock_chunker)
         expect(mock_chunker).to receive(:create_db_records)
 
-        described_class.perform_now(oral_history_content, only_if_invalid: true)
+        described_class.perform_now(oral_history_content: oral_history_content, only_if_invalid: true)
       end
     end
 
@@ -74,7 +74,7 @@ describe OhTranscriptChunkerJob, type: :job do
 
         expect(Rails.logger).to receive(:info).with(/is valid, so not creating chunks/)
 
-        described_class.perform_now(oral_history_content, only_if_invalid: true)
+        described_class.perform_now(oral_history_content: oral_history_content, only_if_invalid: true)
       end
     end
   end
@@ -103,7 +103,7 @@ describe OhTranscriptChunkerJob, type: :job do
 
         expect(Rails.logger).to receive(:info).with(/needs paragraphs, so creating/)
 
-        described_class.perform_now(oral_history_content, refresh_extracted_pdf_paragraphs: true)
+        described_class.perform_now(oral_history_content: oral_history_content, refresh_extracted_pdf_paragraphs: true)
       end
     end
 
@@ -123,7 +123,7 @@ describe OhTranscriptChunkerJob, type: :job do
 
         expect(Rails.logger).not_to receive(:info).with(/needs paragraphs, so creating/)
 
-        described_class.perform_now(oral_history_content, refresh_extracted_pdf_paragraphs: true)
+        described_class.perform_now(oral_history_content: oral_history_content, refresh_extracted_pdf_paragraphs: true)
       end
     end
 
@@ -143,7 +143,7 @@ describe OhTranscriptChunkerJob, type: :job do
 
         expect(Rails.logger).to receive(:info).with(/needs paragraphs, so creating/)
 
-        described_class.perform_now(oral_history_content, refresh_extracted_pdf_paragraphs: true)
+        described_class.perform_now(oral_history_content: oral_history_content, refresh_extracted_pdf_paragraphs: true)
       end
     end
   end

--- a/spec/jobs/oh_transcript_chunker_job_spec.rb
+++ b/spec/jobs/oh_transcript_chunker_job_spec.rb
@@ -78,4 +78,73 @@ describe OhTranscriptChunkerJob, type: :job do
       end
     end
   end
+
+  describe "refresh_extracted_pdf_paragraphs" do
+    # give it proper PDF set up that we can create paragraphs from
+
+    let(:transcript_asset) do
+      build(:asset_with_faked_file, :pdf,
+        published: true, role: "transcript",
+        faked_file: File.open(Rails.root + "spec/test_support/pdf/oh/Macfarlane_1982_sample_pages_subbr8.pdf"),
+        faked_derivatives: {
+          "extracted_pdf_text_json" => build(:stored_uploaded_file, file: Rails.root + "spec/test_support/pdf/oh/Macfarlane_1982_extracted_paragraphs.json")
+        }
+      )
+    end
+
+    let(:work) { build(:oral_history_work, :published, members: [transcript_asset] ) }
+
+    describe "missing extracted_pdf_paragraphs" do
+      it "will create extracted_pdf_paragraphs" do
+        expect(OralHistoryContent::ParagraphContainer).to receive(:create).with(
+          oral_history_content: oral_history_content,
+          allow_failure_to_sync: true
+        )
+
+        expect(Rails.logger).to receive(:info).with(/needs paragraphs, so creating/)
+
+        described_class.perform_now(oral_history_content, refresh_extracted_pdf_paragraphs: true)
+      end
+    end
+
+    describe "fresh and valid extracted_pdf_paragraphs" do
+      before do
+        oral_history_content.extracted_pdf_paragraphs = OralHistoryContent::ParagraphContainer.new(
+          pdf_md5: transcript_asset.file_metadata["md5"],
+          combined_audio_fingerprint: CombinedAudioDerivativeCreator.new(work).fingerprint
+        )
+      end
+
+      it "does not replace extracted_pdf_paragraphs" do
+        expect(OralHistoryContent::ParagraphContainer).not_to receive(:create).with(
+          oral_history_content: oral_history_content,
+          allow_failure_to_sync: true
+        )
+
+        expect(Rails.logger).not_to receive(:info).with(/needs paragraphs, so creating/)
+
+        described_class.perform_now(oral_history_content, refresh_extracted_pdf_paragraphs: true)
+      end
+    end
+
+    describe "existing not-fresh extracted_pdf_paragraphs" do
+      before do
+        oral_history_content.extracted_pdf_paragraphs = OralHistoryContent::ParagraphContainer.new(
+          pdf_md5: "bad md5",
+          combined_audio_fingerprint: "bad fingerprint",
+        )
+      end
+
+      it "will create new extracted_pdf_paragraphs" do
+        expect(OralHistoryContent::ParagraphContainer).to receive(:create).with(
+          oral_history_content: oral_history_content,
+          allow_failure_to_sync: true
+        )
+
+        expect(Rails.logger).to receive(:info).with(/needs paragraphs, so creating/)
+
+        described_class.perform_now(oral_history_content, refresh_extracted_pdf_paragraphs: true)
+      end
+    end
+  end
 end

--- a/spec/jobs/oh_transcript_chunker_job_spec.rb
+++ b/spec/jobs/oh_transcript_chunker_job_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+describe OhTranscriptChunkerJob, type: :job do
+  # Don't actually run the chunker
+  let(:mock_chunker) do
+    instance_double(OralHistory::TranscriptChunker).tap do |double|
+      allow(double).to receive(:create_db_records)
+    end
+  end
+
+  let (:mock_chunker_class) do
+    chunker = instance_double(OralHistory::TranscriptChunker)
+
+    class_double(OralHistory::TranscriptChunker).tap do |klass|
+      allow(klass).to receive(:new).and_return(mock_chunker)
+    end
+  end
+
+  before do
+    stub_const("OhTranscriptChunkerJob::CHUNKER_CLASS", mock_chunker_class)
+  end
+
+  let(:work) { build(:oral_history_work, :published) }
+  let(:oral_history_content) { work.oral_history_content }
+
+  it "calls chunker to create chunks" do
+    expect(mock_chunker_class).to receive(:new).and_return(mock_chunker)
+    expect(mock_chunker).to receive(:create_db_records)
+
+    described_class.perform_now(oral_history_content)
+  end
+
+  describe "only_if_invalid" do
+    describe "with no chunks" do
+      it "calls chunker" do
+        expect(mock_chunker_class).to receive(:new).and_return(mock_chunker)
+        expect(mock_chunker).to receive(:create_db_records)
+
+        described_class.perform_now(oral_history_content, only_if_invalid: true)
+      end
+    end
+
+    describe "with invalid chunks" do
+      before do
+        oral_history_content.oral_history_chunks << build(:oral_history_chunk)
+      end
+
+      it "calls chunker" do
+        expect(mock_chunker_class).to receive(:new).and_return(mock_chunker)
+        expect(mock_chunker).to receive(:create_db_records)
+
+        described_class.perform_now(oral_history_content, only_if_invalid: true)
+      end
+    end
+
+    describe "with valid chunks" do
+      before do
+        # give it a paragraph source
+        oral_history_content.searchable_transcript_source = "Paragraph 1\n\nParagraph 2"
+
+        chunk = build(:oral_history_chunk, start_paragraph_number: 1, end_paragraph_number: 2)
+        computed_fingerprint = OralHistory::TranscriptChunker.new(oral_history_content: oral_history_content).computed_source_fingerprint
+        chunk.other_metadata['source_fingerprint'] = computed_fingerprint
+
+        oral_history_content.oral_history_chunks << chunk
+
+        # Make sure it's valid
+        OralHistory::ChunkValidator.new(oral_history_content, check_source_fingerprints: true).validate!
+      end
+
+      it "does not call chunker" do
+        expect(mock_chunker_class).not_to receive(:new)
+        expect(mock_chunker).not_to receive(:create_db_records)
+
+        expect(Rails.logger).to receive(:info).with(/is valid, so not creating chunks/)
+
+        described_class.perform_now(oral_history_content, only_if_invalid: true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
There are some OH/AI related data that we can't create on PDF ingest, because it depends on other metadata and data being filled out.  We *do* have the derivative 'extracted_pdf_text_json` on the PDF, created on ingest. But then:

* For PDF text extraction, the OralHistoryContent#extracted_pdf_paragraphs is extracted from the 'extracted_pdf_text_json`, with additional interpretation added, and really needs the audio file time lenghts to sync all timecodes. 

* The "chunks", whether using `extracted_pdf_paragraphs`, `searchable_fulltext`, or OHMS, needs those things to exist -- and is expensive, we don't want to keep doing it. And isn't used utnil a work is published. 

So we want both those things to be created when a work is published. How do we trigger that?

We COULD do it as an ActiveRecord after_commit callback to _always_ do it, but those have begun to be a pain -- and this is a potentially very expensive operation (chunk embedding calcuation) to end up doing accidentally. 

So we're going to trigger it in the admin works controller, only when someone uses admin function to publish. Won't be triggered by publishing from other code. (If chunks are not up to date, we have a nightly job that should warn us, after all). 

And what we trigger is a bg job, to create both of these things -- if necessary, it won't create them if we ALREADY have ones that are good/up to date, which we can tell becuase we stored source material fingerprints!  

`OhTranscriptChunkerJob` has been enhanced with lots of params to do this "only if necessary" full creation of derivative data, so can be used in other contexts too. A convenience method has been created to create it iwth the right params for this use case. An option to pass a `Work` instead of `OralHistoryContent` has been added, so the "lookup" of `work.oral_history_content` can be delayed into the bg job, instead of causing a slowdown doing it for lots of works in a batch edit. 

Phew, this has ended up being a LOT, for what seemed straightforward! To keep this PR from getting even bigger, we push some other tasks off to other PRs (which I plan to work on this week still). 

## Future PR's

- We also want to refactor to put some of this complicated object setup in FactoryBot fixtures for different kinds of OH works. This has gotten confusing, better to put the confusing stuff in a re-usable factory. 

- Change the `OralHistoryContent#extracted_pdf_paragraphs` name to be maybe `extracted_pdf_paragraph_container` or something like that to be less confusing? Not sure. But it's been confusing me. 