### PR TITLE
rename OralHistoryContent#extracted_pdf_paragraphs to #extracted_paragraph_container

### DIFF
--- a/app/components/oral_history/ai_conversation_citation_component.rb
+++ b/app/components/oral_history/ai_conversation_citation_component.rb
@@ -24,7 +24,7 @@ module OralHistory
           # browsers can handle. (mobile usually cannot)
           if citation_item.page_number
             anchor_page_number = citation_item.page_number.to_i
-            offset = citation_item.oral_history_content&.extracted_pdf_paragraphs&.logical_page_number_offset
+            offset = citation_item.oral_history_content&.extracted_paragraph_container&.logical_page_number_offset
 
             anchor_page_number += offset.to_i if offset
           end

--- a/app/components/oral_history/ai_conversation_display_component.rb
+++ b/app/components/oral_history/ai_conversation_display_component.rb
@@ -155,7 +155,7 @@ module OralHistory
         # has OHMS, or has PDF Text AND is really free access.
         oral_history_content.has_ohms_transcript? || (
           oral_history_content.available_by_request_off? &&
-          oral_history_content.extracted_pdf_paragraphs.present?
+          oral_history_content.extracted_paragraph_container.present?
         )
       end
 

--- a/app/components/work_oh_audio_show_component.html.erb
+++ b/app/components/work_oh_audio_show_component.html.erb
@@ -163,8 +163,8 @@
               <%= render OralHistory::LegacyTranscriptComponent.new(work.oral_history_content.ohms_xml.legacy_transcript,
                                                                     transcript_log_id: work.oral_history_content.ohms_xml.accession) %>
 
-            <% elsif work.oral_history_content&.extracted_pdf_paragraphs.present? %>
-              <%= render OralHistory::ParagraphTranscriptComponent.new(work.oral_history_content.extracted_pdf_paragraphs.paragraphs) %>
+            <% elsif work.oral_history_content&.extracted_paragraph_container.present? %>
+              <%= render OralHistory::ParagraphTranscriptComponent.new(work.oral_history_content.extracted_paragraph_container.paragraphs) %>
             <% end %>
           </div>
         <% end %>

--- a/app/components/work_oh_audio_show_component.rb
+++ b/app/components/work_oh_audio_show_component.rb
@@ -43,7 +43,7 @@ class WorkOhAudioShowComponent < ApplicationComponent
   def has_transcript?
     has_ohms_transcript? || (
       ScihistDigicoll::Env.lookup(:feature_display_pdf_paragraph_transcripts) &&
-      work&.oral_history_content&.extracted_pdf_paragraphs.present?
+      work&.oral_history_content&.extracted_paragraph_container.present?
     )
   end
 

--- a/app/jobs/oh_transcript_chunker_job.rb
+++ b/app/jobs/oh_transcript_chunker_job.rb
@@ -47,7 +47,7 @@ class OhTranscriptChunkerJob < ApplicationJob
   # @param only_if_invalid [Boolean] default false. If true, we will do nothing if valid chunks already exist.
   #
   # @param refresh_extracted_pdf_paragraphs [Boolean]. default false. If true, will first
-  #    create fresh extracted_pdf_paragraphs if it is possible and paragraphs are missing
+  #    create fresh extracted_paragraph_container if it is possible and paragraphs are missing
   #    or not fresh.
   def perform(oral_history_content:nil, work:nil, delete_existing: false, use_dummy_embedding: false, only_if_invalid: false, refresh_extracted_pdf_paragraphs: false)
     unless work ^ oral_history_content
@@ -62,7 +62,7 @@ class OhTranscriptChunkerJob < ApplicationJob
 
       # if we have extracted_pdf_text_json and don't have fresh paragraphs stored, we must refresh
       if transcript_asset && transcript_asset.file_derivatives[:extracted_pdf_text_json].present? && (
-            oral_history_content.extracted_pdf_paragraphs.nil? || !oral_history_content.extracted_pdf_paragraphs.fresh?(oral_history_content: oral_history_content)
+            oral_history_content.extracted_paragraph_container.nil? || !oral_history_content.extracted_paragraph_container.fresh?(oral_history_content: oral_history_content)
          )
         Rails.logger.info("#{self.class.name}: refresh_extracted_pdf_paragraphs:true and needs paragraphs, so creating.")
 
@@ -72,7 +72,7 @@ class OhTranscriptChunkerJob < ApplicationJob
             allow_failure_to_sync: true
           )
         rescue PdfParagraphSplitter::Error => e
-          Rails.logger.error("#{self.class.name}: Could not create extracted_pdf_paragraphs: #{e}")
+          Rails.logger.error("#{self.class.name}: Could not create extracted_paragraph_container: #{e}")
         end
       end
     end

--- a/app/models/oral_history_content.rb
+++ b/app/models/oral_history_content.rb
@@ -59,7 +59,7 @@ class OralHistoryContent < ApplicationRecord
 
   # an array of OralHistoryCotent::Paragraphs extracted from PDF, with source.provenance
   # metadata to tell freshness.
-  attr_json :extracted_pdf_paragraphs, OralHistoryContent::ParagraphContainer.to_type
+  attr_json :extracted_paragraph_container, OralHistoryContent::ParagraphContainer.to_type
 
   enum :combined_audio_derivatives_job_status,  {
     queued:    'queued',
@@ -69,7 +69,7 @@ class OralHistoryContent < ApplicationRecord
   }
 
   # omit really long ones from inspect
-  self.filter_attributes = [:json_attributes, :extracted_pdf_paragraphs]
+  self.filter_attributes = [:json_attributes, :extracted_paragraph_container]
 
 
   # Some assets marked non-published in this work are still available by request. That feature needs to be turned

--- a/app/models/oral_history_content/paragraph_container.rb
+++ b/app/models/oral_history_content/paragraph_container.rb
@@ -80,7 +80,7 @@ class OralHistoryContent
       container.warnings = warnings if warnings
 
       # And save it in the model passed in
-      oral_history_content.extracted_pdf_paragraphs = container
+      oral_history_content.extracted_paragraph_container = container
       oral_history_content.save!
 
       return container

--- a/app/services/oral_history/transcript_chunker.rb
+++ b/app/services/oral_history/transcript_chunker.rb
@@ -70,8 +70,8 @@ module OralHistory
         elsif oral_history_content.ohms_xml&.vtt_transcript.present?
           oral_history_content.ohms_xml.vtt_transcript
 
-        elsif oral_history_content.extracted_pdf_paragraphs.present?
-          oral_history_content.extracted_pdf_paragraphs
+        elsif oral_history_content.extracted_paragraph_container.present?
+          oral_history_content.extracted_paragraph_container
 
         elsif oral_history_content.searchable_transcript_source.present?
           OralHistory::PlainTextParagraphSplitter.new(

--- a/lib/tasks/create_oral_history_chunks.rake
+++ b/lib/tasks/create_oral_history_chunks.rake
@@ -12,7 +12,7 @@ namespace :scihist do
     `USE_DUMMY_EMBEDDING=true` for a test run where you want to create chunk records
     (usually in staging) without actually getting an embedding vector from remote API.
 
-    `ONLY_EXTRACTED_PDF_PARAGRAPHS=true` limit to only those with extracted_pdf_paragraphs present
+    `ONLY_EXTRACTED_PDF_PARAGRAPHS=true` limit to only those with extracted_paragraph_container present
 
     `ONLY_AVAILABLE_IMMEDATE=true` limit to only those available immediate ('really free access')
 
@@ -24,7 +24,7 @@ namespace :scihist do
     scope = OralHistoryContent.preload(:work => :members).joins(:work).where(work: { published: true}).strict_loading
 
     if ENV['ONLY_EXTRACTED_PDF_PARAGRAPHS'] == "true"
-      scope = scope.where("oral_history_content.json_attributes -> 'extracted_pdf_paragraphs' is not NULL")
+      scope = scope.where("oral_history_content.json_attributes -> 'extracted_paragraph_container' is not NULL")
     end
 
     if ENV['ONLY_AVAILABLE_IMMEDATE'] == "true"

--- a/lib/tasks/data_fixes/backfill_pdf_page_offset.rake
+++ b/lib/tasks/data_fixes/backfill_pdf_page_offset.rake
@@ -6,8 +6,8 @@ namespace :scihist do
     """
     task :backfill_pdf_page_offset => :environment do
       scope = OralHistoryContent.includes(:work => :members).
-        where("json_attributes -> 'extracted_pdf_paragraphs' is not null").
-        where("json_attributes -> 'extracted_pdf_paragraphs' -> 'logical_page_number_offset' is null")
+        where("json_attributes -> 'extracted_paragraph_container' is not null").
+        where("json_attributes -> 'extracted_paragraph_container' -> 'logical_page_number_offset' is null")
 
       progress_bar = ProgressBar.create(total: scope.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
 
@@ -41,7 +41,7 @@ namespace :scihist do
           next
         end
 
-        oral_history_content.extracted_pdf_paragraphs.logical_page_number_offset = splitter.logical_page_number_offset
+        oral_history_content.extracted_paragraph_container.logical_page_number_offset = splitter.logical_page_number_offset
         oral_history_content.save!
 
         progress_bar.increment

--- a/spec/components/oral_history/ai_conversation_citation_component_spec.rb
+++ b/spec/components/oral_history/ai_conversation_citation_component_spec.rb
@@ -55,7 +55,7 @@ describe OralHistory::AiConversationCitationComponent, type: :component do
     let(:available_by_request_mode) { "automatic" }
 
     it "generates link to PDF with page number" do
-      expect(component.link_to_source).to eq view_transcript_pdf_path(work, anchor_page: (work.oral_history_content.extracted_pdf_paragraphs.logical_page_number_offset + 4).to_s)
+      expect(component.link_to_source).to eq view_transcript_pdf_path(work, anchor_page: (work.oral_history_content.extracted_paragraph_container.logical_page_number_offset + 4).to_s)
     end
   end
 end

--- a/spec/factories/work_factory.rb
+++ b/spec/factories/work_factory.rb
@@ -273,7 +273,7 @@ FactoryBot.define do
           OralHistoryContent.new(
             interviewee_biographies: [build(:interviewee_biography)],
             interviewer_profiles:    [build(:interviewer_profile)],
-            extracted_pdf_paragraphs: JSON.parse(File.read(Rails.root + "spec/test_support/pdf/oh/Macfarlane_1982_sample_pages_paragraph_container.json"))
+            extracted_paragraph_container: JSON.parse(File.read(Rails.root + "spec/test_support/pdf/oh/Macfarlane_1982_sample_pages_paragraph_container.json"))
           )
         }
       end

--- a/spec/factory_specs/work_factory_spec.rb
+++ b/spec/factory_specs/work_factory_spec.rb
@@ -57,8 +57,8 @@ describe "work factory" do
       let(:work) { build(:oral_history_work, :with_extracted_paragraph_container)}
 
       it "has fresh paragraph data" do
-        expect(work.oral_history_content.extracted_pdf_paragraphs).to be_present
-        expect(work.oral_history_content.extracted_pdf_paragraphs.fresh?(
+        expect(work.oral_history_content.extracted_paragraph_container).to be_present
+        expect(work.oral_history_content.extracted_paragraph_container.fresh?(
           oral_history_content: work.oral_history_content)
         ).to eq true
       end

--- a/spec/jobs/oh_transcript_chunker_job_spec.rb
+++ b/spec/jobs/oh_transcript_chunker_job_spec.rb
@@ -88,8 +88,8 @@ describe OhTranscriptChunkerJob, type: :job do
 
     let(:work) { build(:oral_history_work, :published, :public_files ) }
 
-    describe "missing extracted_pdf_paragraphs" do
-      it "will create extracted_pdf_paragraphs" do
+    describe "missing extracted_paragraph_container" do
+      it "will create extracted_paragraph_container" do
         expect(OralHistoryContent::ParagraphContainer).to receive(:create).with(
           oral_history_content: oral_history_content,
           allow_failure_to_sync: true
@@ -101,15 +101,15 @@ describe OhTranscriptChunkerJob, type: :job do
       end
     end
 
-    describe "fresh and valid extracted_pdf_paragraphs" do
+    describe "fresh and valid extracted_paragraph_container" do
       before do
-        oral_history_content.extracted_pdf_paragraphs = OralHistoryContent::ParagraphContainer.new(
+        oral_history_content.extracted_paragraph_container = OralHistoryContent::ParagraphContainer.new(
           pdf_md5: transcript_asset.file_metadata["md5"],
           combined_audio_fingerprint: CombinedAudioDerivativeCreator.new(work).fingerprint
         )
       end
 
-      it "does not replace extracted_pdf_paragraphs" do
+      it "does not replace extracted_paragraph_container" do
         expect(OralHistoryContent::ParagraphContainer).not_to receive(:create).with(
           oral_history_content: oral_history_content,
           allow_failure_to_sync: true
@@ -121,15 +121,15 @@ describe OhTranscriptChunkerJob, type: :job do
       end
     end
 
-    describe "existing not-fresh extracted_pdf_paragraphs" do
+    describe "existing not-fresh extracted_paragraph_container" do
       before do
-        oral_history_content.extracted_pdf_paragraphs = OralHistoryContent::ParagraphContainer.new(
+        oral_history_content.extracted_paragraph_container = OralHistoryContent::ParagraphContainer.new(
           pdf_md5: "bad md5",
           combined_audio_fingerprint: "bad fingerprint",
         )
       end
 
-      it "will create new extracted_pdf_paragraphs" do
+      it "will create new extracted_paragraph_container" do
         expect(OralHistoryContent::ParagraphContainer).to receive(:create).with(
           oral_history_content: oral_history_content,
           allow_failure_to_sync: true

--- a/spec/models/oral_history_content/paragraph_container_spec.rb
+++ b/spec/models/oral_history_content/paragraph_container_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe OralHistoryContent::ParagraphContainer do
-  describe "#extracted_pdf_paragraphs" do
+  describe "#extracted_paragraph_container" do
     # has two embedded inteviews, three audio files total, requires timestamp arithmatic
     let(:pdf_file_path) { Rails.root + "spec/test_support/pdf/oh/glusker_2022_sequence_timestamps_example.pdf" }
 
@@ -62,14 +62,14 @@ describe OralHistoryContent::ParagraphContainer do
       container = OralHistoryContent::ParagraphContainer.create(
         oral_history_content: oral_history_content,
       )
-      expect(oral_history_content.extracted_pdf_paragraphs).to be_present
+      expect(oral_history_content.extracted_paragraph_container).to be_present
 
       oral_history_content.reload
 
-      expect(oral_history_content.extracted_pdf_paragraphs.paragraphs).to all(be_kind_of(OralHistoryContent::Paragraph))
-      expect(oral_history_content.extracted_pdf_paragraphs.fresh?(oral_history_content: oral_history_content)).to be true
+      expect(oral_history_content.extracted_paragraph_container.paragraphs).to all(be_kind_of(OralHistoryContent::Paragraph))
+      expect(oral_history_content.extracted_paragraph_container.fresh?(oral_history_content: oral_history_content)).to be true
 
-      expect(oral_history_content.extracted_pdf_paragraphs.logical_page_number_offset).to eq 0
+      expect(oral_history_content.extracted_paragraph_container.logical_page_number_offset).to eq 0
 
       # changing pdf md5 makes not fresh anymore. LOTS of saves to DB and reloads here, very
       # bad performance, but good semantics for now.
@@ -78,7 +78,7 @@ describe OralHistoryContent::ParagraphContainer do
       pdf_asset.file_attacher.write
       pdf_asset.save!
       oral_history_content.reload
-      expect(oral_history_content.extracted_pdf_paragraphs.fresh?(
+      expect(oral_history_content.extracted_paragraph_container.fresh?(
         oral_history_content: oral_history_content
       )).to be false
 
@@ -87,7 +87,7 @@ describe OralHistoryContent::ParagraphContainer do
       pdf_asset.save!
       oral_history_content.reload
 
-      expect(oral_history_content.extracted_pdf_paragraphs.fresh?(oral_history_content: oral_history_content)).to be true
+      expect(oral_history_content.extracted_paragraph_container.fresh?(oral_history_content: oral_history_content)).to be true
 
       # changing an audio file fingerprint makes it not fresh anymore, as
       # start time offsets might be different.
@@ -96,7 +96,7 @@ describe OralHistoryContent::ParagraphContainer do
       mp3_asset.save!
       oral_history_content.reload
 
-      expect(oral_history_content.extracted_pdf_paragraphs.fresh?(oral_history_content: oral_history_content)).to be false
+      expect(oral_history_content.extracted_paragraph_container.fresh?(oral_history_content: oral_history_content)).to be false
     end
 
     describe "with warnings" do

--- a/spec/services/oral_history/transcript_chunker_spec.rb
+++ b/spec/services/oral_history/transcript_chunker_spec.rb
@@ -209,7 +209,7 @@ describe OralHistory::TranscriptChunker do
     end
   end
 
-  describe "extracted_pdf_paragraphs" do
+  describe "extracted_paragraph_container" do
     let(:work) {
       build(:oral_history_work, :with_extracted_paragraph_container,
         creator: [{ category: "interviewee", value: "Hanford, William E., 1908-1996"},
@@ -230,11 +230,11 @@ describe OralHistory::TranscriptChunker do
       end
 
       it "begins with first paragraph" do
-        expect(chunks.first.first.text).to eq oral_history_content.extracted_pdf_paragraphs.paragraphs.first.text
+        expect(chunks.first.first.text).to eq oral_history_content.extracted_paragraph_container.paragraphs.first.text
       end
 
       it "ends with last paragraph" do
-        expect(chunks.last.last.text).to eq oral_history_content.extracted_pdf_paragraphs.paragraphs.last.text
+        expect(chunks.last.last.text).to eq oral_history_content.extracted_paragraph_container.paragraphs.last.text
       end
 
       it "has two paragraphs of overlap in each chunk" do
@@ -260,7 +260,7 @@ describe OralHistory::TranscriptChunker do
 
           expect(chunks).to be_present
           expect(chunks.first.start_paragraph_number).to eq 1
-          expect(chunks.last.end_paragraph_number).to eq oral_history_content.extracted_pdf_paragraphs.paragraphs.count
+          expect(chunks.last.end_paragraph_number).to eq oral_history_content.extracted_paragraph_container.paragraphs.count
 
           # and they should all have page numbers too, becuase for PDF ones we've got em!
           expect(chunks).to all(satisfy { |c| c.other_metadata["page_numbers"].present? })


### PR DESCRIPTION
Maybe somewhat less confusing if longer? Returns an OralHistoryContent::ParagraphContainer object which itself has a #paragraphs accessor, so was confusing me. You know what they say about the hard things in CS.
