### PR TITLE
Autoseek on Play for iOS browsers

### DIFF
--- a/app/frontend/javascript/audio/timecode_in_anchor.js
+++ b/app/frontend/javascript/audio/timecode_in_anchor.js
@@ -28,11 +28,9 @@ domready(function() {
     }
 
     var playerDomEl = document.querySelector("*[data-role=now-playing-container] audio, .video-player video");
-    const videoJsPlayer = videojs(playerDomEl);
 
-    if (playerDomEl) {
-
-
+    // Another file should actually be creating the videoJSPlayer obj we need, wait for it if needed.
+    onVideoJSSetupFor(playerDomEl, function(videoJsPlayer) {
       // Try to seek and then auto-play. player might not be in state where it can
       // seek yet, if it is not then try to wait and seek when we can.
       if (playerDomEl.readyState >=  playerDomEl.HAVE_METADATA) {
@@ -76,7 +74,7 @@ domready(function() {
           });
         }
       }
-    }
+    });
   } else if (paragraphNumber && hasOhTabs()) {
       // OH transcript paragraph number, need to make sure we've switched to transcript tab,
       // then scroll to element leaving room for navbar
@@ -129,6 +127,31 @@ function seekAndAutoPlay(player, timeCodeSeconds) {
   if (playPromise !== undefined) {
     playPromise.catch(error => {
       console.log(`could not autoplay: ${error}`);
+    });
+  }
+}
+
+ // Another file is creating the videoJS object, asyncrornous to this file.
+ //
+ // It may or may not have already been created; we want to execute the callback
+ // only when it has, and not execute the callback if it never does!
+function onVideoJSSetupFor(htmlMediaElement, callback) {
+  if (! htmlMediaElement) {
+    // wasn't even on page, we need do nothing.
+    return;
+  }
+
+  const existingPlayer = videojs.getPlayer(htmlMediaElement);
+
+  if (existingPlayer) {
+    // already exists
+    callback(existingPlayer);
+  } else {
+    videojs.hook('setup', function(createdPlayer) {
+      // if multiple on a page, make sure it's the one we want
+      if (createdPlayer.el().contains(htmlMediaElement)) {
+        callback(createdPlayer);
+      }
     });
   }
 }

--- a/app/frontend/javascript/audio/timecode_in_anchor.js
+++ b/app/frontend/javascript/audio/timecode_in_anchor.js
@@ -31,13 +31,14 @@ domready(function() {
 
     // Another file should actually be creating the videoJSPlayer obj we need, wait for it if needed.
     onVideoJSSetupFor(playerDomEl, function(videoJsPlayer) {
+
       // Try to seek and then auto-play. player might not be in state where it can
       // seek yet, if it is not then try to wait and seek when we can.
       if (playerDomEl.readyState >=  playerDomEl.HAVE_METADATA) {
-        seekAndAutoPlay(playerDomEl, timeCodeSeconds);
+        seekAndAutoPlay(videoJsPlayer, timeCodeSeconds);
       } else {
         playerDomEl.addEventListener("loadedmetadata", function(event) {
-          seekAndAutoPlay(playerDomEl, timeCodeSeconds);
+          seekAndAutoPlay(videoJsPlayer, timeCodeSeconds);
         });
       }
 
@@ -119,10 +120,10 @@ function hasOhTabs() {
 //
 // Must be called when player is in a readyState where we can seek,
 // at least HAVE_METADATA. https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState
-function seekAndAutoPlay(player, timeCodeSeconds) {
-  player.currentTime = timeCodeSeconds;
+function seekAndAutoPlay(videoJsPlayer, timeCodeSeconds) {
+  videoJsPlayer.currentTime(timeCodeSeconds);
 
-  var playPromise  = player.play();
+  var playPromise  = videoJsPlayer.play();
 
   if (playPromise !== undefined) {
     playPromise.catch(error => {

--- a/app/frontend/javascript/audio/timecode_in_anchor.js
+++ b/app/frontend/javascript/audio/timecode_in_anchor.js
@@ -36,10 +36,10 @@ domready(function() {
       // Try to seek and then auto-play. player might not be in state where it can
       // seek yet, if it is not then try to wait and seek when we can.
       if (playerDomEl.readyState >=  playerDomEl.HAVE_METADATA) {
-        setupTimeSeek(playerDomEl, timeCodeSeconds);
+        seekAndAutoPlay(playerDomEl, timeCodeSeconds);
       } else {
         playerDomEl.addEventListener("loadedmetadata", function(event) {
-          setupTimeSeek(playerDomEl, timeCodeSeconds);
+          seekAndAutoPlay(playerDomEl, timeCodeSeconds);
         });
       }
 
@@ -116,9 +116,12 @@ function hasOhTabs() {
   return !!document.querySelector("#ohmsScrollable .tab-pane.active")
 }
 
+// Seek to selected time, and TRY to auto-play the audio. Either or both might
+// not work in some browsers trying to prevent spammy playing.
+//
 // Must be called when player is in a readyState where we can seek,
 // at least HAVE_METADATA. https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState
-function setupTimeSeek(player, timeCodeSeconds) {
+function seekAndAutoPlay(player, timeCodeSeconds) {
   player.currentTime = timeCodeSeconds;
 
   var playPromise  = player.play();

--- a/app/frontend/javascript/audio/timecode_in_anchor.js
+++ b/app/frontend/javascript/audio/timecode_in_anchor.js
@@ -27,19 +27,19 @@ domready(function() {
       history.scrollRestoration = 'manual';
     }
 
-    var player = document.querySelector("*[data-role=now-playing-container] audio, .video-player video");
-    const videoJsPlayer = videojs(player);
+    var playerDomEl = document.querySelector("*[data-role=now-playing-container] audio, .video-player video");
+    const videoJsPlayer = videojs(playerDomEl);
 
-    if (player) {
+    if (playerDomEl) {
 
 
       // Try to seek and then auto-play. player might not be in state where it can
       // seek yet, if it is not then try to wait and seek when we can.
-      if (player.readyState >=  player.HAVE_METADATA) {
-        setupTimeSeek(player, timeCodeSeconds);
+      if (playerDomEl.readyState >=  playerDomEl.HAVE_METADATA) {
+        setupTimeSeek(playerDomEl, timeCodeSeconds);
       } else {
-        player.addEventListener("loadedmetadata", function(event) {
-          setupTimeSeek(player, timeCodeSeconds);
+        playerDomEl.addEventListener("loadedmetadata", function(event) {
+          setupTimeSeek(playerDomEl, timeCodeSeconds);
         });
       }
 
@@ -49,9 +49,9 @@ domready(function() {
       //
       // If it runs when not needed cause earlier seek DID work -- it should just be
       // seeking to where we already are anyway!
-      videoJsPlayer.one('play', function() {
+      videoJsPlayer.one('play', function() { // 'one' will only hook once then de-register
         videoJsPlayer.currentTime(timeCodeSeconds);
-        // it's already playing, it will not help to play again!
+        // it's already playing, it will not help to play again, no need we're good.
       });
 
       // For OH

--- a/app/frontend/javascript/audio/timecode_in_anchor.js
+++ b/app/frontend/javascript/audio/timecode_in_anchor.js
@@ -14,11 +14,13 @@
 import domready from 'domready';
 import {gotoTocSegmentAtTimecode, gotoTranscriptTimecode, scrollToElement} from './helpers/ohms_player_helpers.js';
 import * as bootstrap from 'bootstrap';
+import videojs from 'video.js';
 
 domready(function() {
   var hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ''));
   var timeCodeSeconds = window.location.hash.includes("=") && hashParams.get("t");
   var paragraphNumber = window.location.hash.includes("=") && hashParams.get("p");
+
 
   if (timeCodeSeconds) {
     if (history.scrollRestoration) {
@@ -26,10 +28,13 @@ domready(function() {
     }
 
     var player = document.querySelector("*[data-role=now-playing-container] audio, .video-player video");
+    const videoJsPlayer = videojs(player);
+
     if (player) {
 
-      // player might not be in state where it can seek yet, if not then wait
-      // and seek when we can.
+
+      // Try to seek and then auto-play. player might not be in state where it can
+      // seek yet, if it is not then try to wait and seek when we can.
       if (player.readyState >=  player.HAVE_METADATA) {
         setupTimeSeek(player, timeCodeSeconds);
       } else {
@@ -37,6 +42,17 @@ domready(function() {
           setupTimeSeek(player, timeCodeSeconds);
         });
       }
+
+      // If all else fails, on some very persnickety user-agents (iOS), there's no
+      // way to seek UNTIL user presses play. Using video.js event and seek API is also important,
+      // as it seems to work around some iOS issues with doing both those operations too!
+      //
+      // If it runs when not needed cause earlier seek DID work -- it should just be
+      // seeking to where we already are anyway!
+      videoJsPlayer.one('play', function() {
+        videoJsPlayer.currentTime(timeCodeSeconds);
+        // it's already playing, it will not help to play again!
+      });
 
       // For OH
       //


### PR DESCRIPTION
Closes #3290 , alternative to #3451 

1. Basic realization (thanks @eddierubeiz and LLM's) is that seeking after a `loadedmetadata` event won't work on iOS
    * because iOS may not load metadata until user presses 'play', and/or because iOS won't let you seek after that non-user-initiated event!
    * But we can wait for a 'play' event and then seek there, which will effectively make the audio start playing where we wanted to seek to when user presses play 
  
2. But we needed to switch from trying to use API directly on html5 media element to using API on our video-js player to make this work. (thanks Claude and ChatGPT)
    * We had been trying to use just html5 direct API to keep this code "decoupled" from our use of video-js, but that didn't work here and was possibly always a bad idea
    * The video-js "play" button isn't the real browser html5 "play" button, which added complications or outright impossibilties to both hooking into the 'play' event and being allowed to seek after it! But video-js has it's own API for events and playing and seeking etc, which worked more reliably -- which makes sense in retrospect. 
    * Also switch to video-js API for _seeking_ was necessary, didn't totally understand why, but it works and makes sense ot be consistent -- we use videoJS api now!

3. To use videoJS api, we needed a reference to videoJS player, which was created in a different JS file async to this. 
    * Figuring out how to get that reference without accidentally creating two videoJS objects was another trick
    * There would have been other solutions available, including ES6 import/export, but this seems good to me. 

In process, changed some names of variables/methods and added comments to reduce confusion in some things I found confusing. 

@eddierubeiz Please test and confirm!  

## current "solved" situation

On desktop browsers, it can SEEK on load, but still can’t PLAY on load on chrome, firefox, or safari desktop. It used to play on load but maybe doesn't anywhere anymore? Oh well, it degrades nicely to seeking on load still.

On mobile iOS  it can’t even seek on load, but I have it working to do so on/before play, while still seeking on load on desktop!

## commits

- basic proof of concept
- change js var name from player to playerDomEl to be clear
- change name of JS function setupTimeSeek to seekAndAutoPlay for clarity
- don't double-create videoJS object, wait for other file to create it
- use videoJS API for all seeking, not HTML5 player directly, more reliable when we are using VideoJS
