### PR TITLE
rake scihist:data_fixes:migrate_oh_paragraph_data

### DIFF
--- a/lib/tasks/data_fixes/migrate_oh_paragraph_data.rake
+++ b/lib/tasks/data_fixes/migrate_oh_paragraph_data.rake
@@ -1,0 +1,24 @@
+namespace :scihist do
+  namespace :data_fixes do
+
+    desc """
+      Migrate already stored PDF paragraph text from OralHistoryContent#extracted_pdf_paragraphs to
+      #extracted_paragraph_container. Pursuant to https://github.com/sciencehistory/scihist_digicoll/pull/3471
+
+    """
+    task :migrate_oh_paragraph_data => :environment do
+      progress_bar = ProgressBar.create(total: OralHistoryContent.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+
+      OralHistoryContent.find_each(batch_size: 10) do |oc|
+        if oc.extracted_paragraph_container.nil? && oc.json_attributes["extracted_pdf_paragraphs"]
+          oc.extracted_paragraph_container = oc.json_attributes["extracted_pdf_paragraphs"]
+          oc.json_attributes.delete("extracted_pdf_paragraphs")
+        oc.save!
+        end
+        GC.start
+
+        progress_bar.increment
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix data accidentally orphaned in https://github.com/sciencehistory/scihist_digicoll/pull/3471

Verified on staging -- ChunkValidator validates all OH works after this, no more chunk validation failed!

And our extracted paragraphs are back (could have been fairly easily recreated, this is pure derivative data, but wouldn't want to leave the old copy taking up massive space in DB). 

- [x] `heroku run -r production rake scihist:data_fixes:migrate_oh_paragraph_data`
