### PR TITLE
Default feature_ai_for_basic_internal to true

### DIFF
--- a/lib/scihist_digicoll/env.rb
+++ b/lib/scihist_digicoll/env.rb
@@ -778,6 +778,6 @@ module ScihistDigicoll
 
     define_key "disable_downloads", default: false, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM
 
-    define_key "feature_ai_for_basic_internal", default: false, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM
+    define_key "feature_ai_for_basic_internal", default: true, system_env_transform: Kithe::ConfigBase::BOOLEAN_TRANSFORM
   end
 end


### PR DESCRIPTION
Not needed before launch, just making things more tidy. 

We'll leave the flag there for now, in initial period after launch, to let us still disable this if we need to for some reason.
