### PR TITLE
Re-model how OH access/request settings are modelled in DB

### DIFF
--- a/app/components/oral_history/admin/available_by_request_component.html.erb
+++ b/app/components/oral_history/admin/available_by_request_component.html.erb
@@ -1,51 +1,54 @@
-form-select<div class="card bg-light mb-3">
-  <h2 class="card-header h3">Un-Published Assets Available By Request</h2>
+<div class="card bg-light mb-3">
+  <h2 class="card-header h3">Availability/Request Mode</h2>
   <div class="card-body">
     <div class="text-muted text-small mb-2">
-      <p>Make <b>marked non-published</b> assets be available anyway by request, after the patron fills out a form?</p>
+      <p>Set <b>marked non-published</b> assets to be available anyway by request, <b>or</b> mark this oral history as embargoed.</p>
     </div>
 
-    <% if allow_change_by_request? %>
-      <%= form_with(model: work.oral_history_content!, url: update_oh_available_by_request_admin_work_path(work), method: :put, local: true) do |f|  %>
+    <%= form_with(model: work.oral_history_content!, url: update_oh_available_by_request_admin_work_path(work), method: :put, local: true) do |f|  %>
 
-        <table class="table table-sm">
-          <tr>
-            <td style="width: 2rem">
-              <%= f.radio_button :available_by_request_mode, "off" %>
-            </td>
-            <td>
-              <label for="oral_history_content_available_by_request_mode_off">No</label>
-              <div class="text-muted">Disabled / Off</div>
-              <div class="text-muted">NOT using 'Available by Request' feature</div>
+      <table class="table table-sm">
+        <tr>
+          <td style="width: 2rem">
+            <%= f.radio_button :availability_mode, "direct" %>
+          </td>
+          <td>
+            <label for="oral_history_content_availability_direct">Direct</label>
+            <div class="text-muted">NOT using 'Available by Request' feature</div>
+            <div class="text-muted">Published items are available to public, non-published items are not.</div>
+          </td>
+        </tr>
+        <tr>
+          <td><%= f.radio_button :availability_mode, "automatic_request" %></td>
+          <td>
+            <label for="oral_history_content_availability_automatic_request">Automatic Request</label>
+            <div class="text-muted">Automatic delivery of selected assets after filling out a form</div>
+            <div class="text-muted">Used with <code>free access, without internet release</code></div>
+          </td>
+        </tr>
+        <tr>
+          <td><%= f.radio_button :availability_mode, "reviewed_request" %></td>
+          <td>
+            <label for="oral_history_content_available_by_request_mode_manual_review">Reviewed Request</label>
+            <div class="text-muted">Delivery of selected assets after filling out a form and an administrator approves</div>
+            <div class="text-muted">Used with <code>restricted</code>, <code>permissions required</code>, and others</div>
+          </td>
+        </tr>
+        <tr>
+          <td><%= f.radio_button :availability_mode, "embargoed" %></td>
+          <td>
+            <label for="oral_history_content_available_by_request_mode_manual_review">Embargoed</label>
+            <div class="text-muted">Not available to any users, not using 'Available by Request' feature.</div>
+            <div class="text-muted">Assets should still be set to non-published for full safety</div>
+            <div class="text-muted">Used with <code>restricted</code>, <code>embargoed</code></div>
+          </td>
+        </tr>
+      </table>
 
-            </td>
-          </tr>
-          <tr>
-            <td><%= f.radio_button :available_by_request_mode, "automatic" %></td>
-            <td>
-              <label for="oral_history_content_available_by_request_mode_automatic">Automatic</label>
-              <div class="text-muted">Yes, after filling out a form</div>
-              <div class="text-muted">Used with <code>free access, without internet release</code></div>
-            </td>
-          </tr>
-          <tr>
-            <td><%= f.radio_button :available_by_request_mode, "manual_review" %></td>
-            <td>
-              <label for="oral_history_content_available_by_request_mode_manual_review">Manual Review</label>
-              <div class="text-muted">Yes, after filling out a form and an administrator approves</div>
-              <div class="text-muted">Used with <code>restricted</code>, <code>permissions required</code>, and others</div>
-            </td>
-          </tr>
-        </table>
+      <%= submit_tag "Save Changes", class: "btn btn-primary mb-3" %>
 
-            <%# f.select :available_by_request_mode,
-                    OralHistoryContent::AVAILABLE_BY_REQUEST_INPUT_PROMPT,
-                    {},
-                    class: "form-select" %>
-
-        <%= submit_tag "Save Changes", class: "btn btn-primary mb-3" %>
-
-
+      <% if private_asset_members.present? %>
+        <h3 class="h4">Selected assets can be available by request</h3>
         <table class="table table-sm">
           <% private_asset_members.each do |asset| %>
             <tr>
@@ -65,10 +68,10 @@ form-select<div class="card bg-light mb-3">
             </tr>
           <% end %>
         </table>
+      <% else %>
+        <hr>
+        <p>There are no unpublished assets.</p>
       <% end %>
-    <% else %>
-      <hr>
-      <p>There are no unpublished assets.</p>
     <% end %>
   </div>
 </div>

--- a/app/components/oral_history/admin/available_by_request_component.rb
+++ b/app/components/oral_history/admin/available_by_request_component.rb
@@ -12,13 +12,6 @@ module OralHistory
       def private_asset_members
         @private_asset_members ||= work.members.find_all { |m| m.kind_of?(Asset) && !m.published? }
       end
-
-      # only show the panel to change by-request status if we have
-      # non-published items, OR if it's already set to something other than
-      # 'off'
-      def allow_change_by_request?
-        private_asset_members.present? || (work.oral_history_content && !work.oral_history_content.available_by_request_off?)
-      end
     end
   end
 end

--- a/app/components/oral_history/ai_conversation_citation_component.html.erb
+++ b/app/components/oral_history/ai_conversation_citation_component.html.erb
@@ -15,7 +15,7 @@
         <span class="badge text-body bg-warning border border-warning-subtle ms-2">PDF-only</span>
       <% end %>
 
-      <% if citation_item.oral_history_content.available_by_request_manual_review? %>
+      <% if citation_item.oral_history_content.availability_reviewed_request? %>
           <span class="badge bg-danger-subtle border border-danger-subtle text-body ms-2">Restricted</span>
       <% end %>
     </span>

--- a/app/components/oral_history/ai_conversation_citation_component.rb
+++ b/app/components/oral_history/ai_conversation_citation_component.rb
@@ -13,7 +13,7 @@ module OralHistory
         # with some search-term highlighting triggered.
         if citation_item.can_link_to_html_transcript?
           work_path(citation_item.work.friendlier_id, anchor: "p=#{citation_item.paragraph_start}&th=#{transcript_highlight_value}")
-        elsif citation_item.oral_history_content.available_by_request_manual_review?
+        elsif citation_item.oral_history_content.availability_reviewed_request?
           # they will need to request, just go to Work page, and trigger open request form
           work_path(citation_item.work.friendlier_id, anchor: "modal-auto-open=oh-request-trigger")
         else

--- a/app/components/oral_history/ai_conversation_display_component.rb
+++ b/app/components/oral_history/ai_conversation_display_component.rb
@@ -154,7 +154,7 @@ module OralHistory
       def can_link_to_html_transcript?
         # has OHMS, or has PDF Text AND is really free access.
         oral_history_content.has_ohms_transcript? || (
-          oral_history_content.available_by_request_off? &&
+          oral_history_content.availability_direct? &&
           oral_history_content.extracted_paragraph_container.present?
         )
       end

--- a/app/components/work_file_list_show_component.html.erb
+++ b/app/components/work_file_list_show_component.html.erb
@@ -32,7 +32,7 @@
 
           <p><span class="by-request-items-label">By request</span> <%= available_by_request_sentence %></p>
 
-          <% if @work.oral_history_content.availability_automatic_request? %>
+          <% if @work.oral_history_content&.availability_automatic_request? %>
             <p>
               Fill out a brief form to <span class="text-danger">receive immediate access</span> to these files.
             </p>
@@ -42,7 +42,7 @@
             </p>
           <% end %>
 
-          <% unless @work.oral_history_content.availability_automatic_request? %>
+          <% unless @work.oral_history_content&.availability_automatic_request? %>
             <p>Usage is subject to restrictions set by the interviewee.</p>
           <% end %>
 
@@ -70,7 +70,7 @@
     <div class="mb-4 pe-3">
       <% if available_by_request_assets.present? || member_list_for_display.present? %>
         <%= render "rights_and_social", work: @work %>
-      <% else %>
+      <% elsif @work.oral_history_content&.availability_embargoed? %>
         <div class="alert alert-info" role="alert">
           <i class="fa fa-info-circle" aria-hidden="true"></i>
           This oral history is currently unavailable. Please see the description of this interview to learn more about its future availability.

--- a/app/components/work_file_list_show_component.html.erb
+++ b/app/components/work_file_list_show_component.html.erb
@@ -20,7 +20,6 @@
         </figure>
       <% end %>
 
-
       <%= DescriptionDisplayFormatter.new(@work.description).format  %>
     </div>
   </div>
@@ -33,7 +32,7 @@
 
           <p><span class="by-request-items-label">By request</span> <%= available_by_request_sentence %></p>
 
-          <% if @work.oral_history_content.available_by_request_automatic? %>
+          <% if @work.oral_history_content.availability_automatic_request? %>
             <p>
               Fill out a brief form to <span class="text-danger">receive immediate access</span> to these files.
             </p>
@@ -43,7 +42,7 @@
             </p>
           <% end %>
 
-          <% unless @work.oral_history_content.available_by_request_automatic? %>
+          <% unless @work.oral_history_content.availability_automatic_request? %>
             <p>Usage is subject to restrictions set by the interviewee.</p>
           <% end %>
 

--- a/app/components/work_file_list_show_component.rb
+++ b/app/components/work_file_list_show_component.rb
@@ -80,7 +80,7 @@ class WorkFileListShowComponent < ApplicationComponent
   end
 
   def request_button_name
-    if @work.oral_history_content.available_by_request_automatic?
+    if @work.oral_history_content.availability_automatic_request?
       "Get Access"
     else
       "Request Access"
@@ -91,7 +91,7 @@ class WorkFileListShowComponent < ApplicationComponent
     @available_by_request_assets ||= begin
       unless work.is_oral_history? &&
             work.oral_history_content &&
-            (! work.oral_history_content.available_by_request_off?)
+            work.oral_history_content.available_by_request?
         []
       else
         all_members.find_all { |member| member.kind_of?(Asset) && !member.published? && member.oh_available_by_request? }

--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -314,7 +314,7 @@ class Admin::WorksController < AdminController
   def update_oh_available_by_request
     authorize! :update, @work
     @work.transaction do
-      @work.oral_history_content!.update( params.require(:oral_history_content).permit(:available_by_request_mode))
+      @work.oral_history_content!.update( params.require(:oral_history_content).permit(:availability_mode))
 
       params[:available_by_request]&.each_pair do |asset_pk, value|
         @work.members.find{ |m| m.id == asset_pk}&.update(oh_available_by_request: value)

--- a/app/controllers/oral_history_requests_controller.rb
+++ b/app/controllers/oral_history_requests_controller.rb
@@ -116,7 +116,7 @@ class OralHistoryRequestsController < ApplicationController
       return
     end
 
-    if @work.oral_history_content.available_by_request_automatic?
+    if @work.oral_history_content.availability_automatic_request?
       @oral_history_request.update!(delivery_status: "automatic")
 
       # If they are already logged in, they can just be directed to see this

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -100,7 +100,7 @@ class WorksController < ApplicationController
 
   # We use a different ViewComponent depending on work characteristics, polymorophically kind of.
   def view_component
-    @view_component ||= if @work.is_oral_history? && @work.oral_history_content&.available_by_request_off? && has_oh_audio_member?
+    @view_component ||= if @work.is_oral_history? && !@work.oral_history_content&.available_by_request? && has_oh_audio_member?
       # special OH audio player template
       WorkOhAudioShowComponent.new(@work)
     elsif @work.is_oral_history?

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -149,14 +149,16 @@ class WorkIndexer < Kithe::Indexer
 
     to_field "oh_availability_facet" do |rec, acc|
       if rec.is_oral_history? && rec.oral_history_content
-        request_mode = rec.oral_history_content.available_by_request_mode
+        availability_mode = rec.oral_history_content.availability_mode
 
-        value = if request_mode == "automatic"
+        value = if availability_mode == "automatic_request"
           "Upon request"
-        elsif request_mode == "manual_review"
+        elsif availability_mode == "reviewed_request"
           "Permission required"
-        elsif request_mode == "off" && rec.members.any? { |m| m.published? && !m.role_portrait? }
+        elsif availability_mode == "direct"
           "Immediate"
+        elsif availability_mode == "embargoed"
+          "Embargoed"
         end
 
         acc << value if value

--- a/app/models/oral_history_content.rb
+++ b/app/models/oral_history_content.rb
@@ -115,53 +115,23 @@ class OralHistoryContent < ApplicationRecord
     {direct: 'direct', automatic_request: 'automatic_request', reviewed_request: 'reviewed_request', embargoed: 'embargoed'},
     prefix: "availability"
 
+  def available_by_request?
+    availability_automatic_request? || availability_reviewed_request?
+  end
+
   # scopes for finding certain kinds of OH's. We add ".distinct" to them all to make them all composable,
   # even though really only needed for available_immediate, does not hurt.
 
   # has ohms, non-empty ohms text. Could be legacy or new
   scope :with_ohms, -> { where.not(ohms_xml_text: [nil, ""]).distinct }
 
-  # Immediate availability, fully public. Has no request mode turned on -- currently
-  # this is a mess TECHNICAL DEBT we need to amke sure it ALSO has at least one
-  # non-portrait member that is public, to distinguish from totally secret non-published
-  # non-requestable OH.
-  #
-  # WARNING:  THESE MAY NOT WORK WITHOUT PERFORMANCE ISSUES, SEE
-  # https://github.com/sciencehistory/scihist_digicoll/issues/3253
+  # note that rails enum for `availability_mode` above gives us scopes for
+  # availability_direct availability_automatic_request, availability_reviewed_request
+  # availability_embargoed
 
-  scope :available_immediate, -> {
-    # empty available_by_request_mode is assumed off
-    where(available_by_request_mode: ["off", nil]).
-    joins(work: :members).
-    where(members: { published: true})
-    .where.not(members: { role: 'portrait' } ).
-    distinct # needed cause of the join to avoid dups
-  }
-
-  # IMMEDIATE after request, no approval needed, unlike needs_approval.
-  scope :upon_request, -> { where(available_by_request_mode: "automatic").distinct  }
-
-  scope :needs_approval, -> { where(available_by_request_mode: "manual_review").distinct  }
-
-  # available_by_request_mode off and no public PDFs is totally embargoed private
-  scope :fully_embargoed,  -> {
-    where(available_by_request_mode: ["off", nil]).
-    joins(work: :members).
-    where.not(members: { published: true}).
-    distinct
-  }
-
-  # Have to write the confusing opposite of above
-  # Everything that either doesn't have request mode OFF, OR has a published non-portrait
-  # member. GAH.
+  # We'll provide this for convenience?
   scope :all_except_fully_embargoed, -> {
-    where.not(available_by_request_mode: ["off", nil]).
-      joins(work: :members).
-      or(
-        OralHistoryContent.joins(work: :members).
-        where(members: {  published: true } ).
-        where.not(members: { role: "portrait" })
-      ).distinct
+    where(availability_mode: ["direct", "automatic_request", "reviewed_request"])
   }
 
   after_commit :after_commit_update_work_index_if_needed

--- a/app/models/oral_history_content.rb
+++ b/app/models/oral_history_content.rb
@@ -134,6 +134,10 @@ class OralHistoryContent < ApplicationRecord
     where(availability_mode: ["direct", "automatic_request", "reviewed_request"])
   }
 
+  scope :direct_or_automatic, -> {
+    where(availability_mode: ["direct", "automatic_request"])
+  }
+
   after_commit :after_commit_update_work_index_if_needed
 
   # Sets IO to be combined_audio_m4a, writing directly to "store" storage,

--- a/app/models/oral_history_content.rb
+++ b/app/models/oral_history_content.rb
@@ -72,21 +72,8 @@ class OralHistoryContent < ApplicationRecord
   self.filter_attributes = [:json_attributes, :extracted_paragraph_container]
 
 
-  # DEPRECATED, working to replace with availability_mode
-  #
-  # Some assets marked non-published in this work are still available by request. That feature needs to be turned
-  # on here at the work level, in one of two modes:
-  #
-  #   * automatic: after filling out request form, user gets access without human intervention
-  #   * manual_review: after filling out request form, request needs to be approved by human
-  #   * off: by request form feature not enabled
-  #
-  # Once enabled at the work level, individual assets also need their oh_available_by_request flag
-  # set, for extra sure this non-published asset is meant to be available by request.
-  #
-  # backed by a pg enum. methods such as `available_by_request_off?` are available,
-  # along with scopes like `OralHistoryContent.available_by_request_automatic`
-  #enum :available_by_request_mode, {off: 'off', automatic: 'automatic', manual_review: 'manual_review'}, prefix: :available_by_request
+  # These can be removed after we migrate to remove the old available_by_request_mode column
+  self.ignored_columns += [:available_by_request_mode]
   def available_by_request_mode
     raise TypeError.new("No longer supported, use #availability_mode")
   end

--- a/app/models/oral_history_content.rb
+++ b/app/models/oral_history_content.rb
@@ -86,7 +86,10 @@ class OralHistoryContent < ApplicationRecord
   #
   # backed by a pg enum. methods such as `available_by_request_off?` are available,
   # along with scopes like `OralHistoryContent.available_by_request_automatic`
-  enum :available_by_request_mode, {off: 'off', automatic: 'automatic', manual_review: 'manual_review'}, prefix: :available_by_request
+  #enum :available_by_request_mode, {off: 'off', automatic: 'automatic', manual_review: 'manual_review'}, prefix: :available_by_request
+  def available_by_request_mode
+    raise TypeError.new("No longer supported, use #availability_mode")
+  end
 
 
   # Different availability modes for OH, including some where non-published assets are

--- a/app/models/oral_history_content.rb
+++ b/app/models/oral_history_content.rb
@@ -72,6 +72,8 @@ class OralHistoryContent < ApplicationRecord
   self.filter_attributes = [:json_attributes, :extracted_paragraph_container]
 
 
+  # DEPRECATED, working to replace with availability_mode
+  #
   # Some assets marked non-published in this work are still available by request. That feature needs to be turned
   # on here at the work level, in one of two modes:
   #
@@ -86,6 +88,32 @@ class OralHistoryContent < ApplicationRecord
   # along with scopes like `OralHistoryContent.available_by_request_automatic`
   enum :available_by_request_mode, {off: 'off', automatic: 'automatic', manual_review: 'manual_review'}, prefix: :available_by_request
 
+
+  # Different availability modes for OH, including some where non-published assets are
+  # still requestable.
+  #
+  #   * direct: "Normal" mode, published assets are directly available to the public with
+  #     a click, non-published assets are simply not.
+  #
+  #   * automatic_request: after filling out request form, user gets access to designated non-public
+  #     assets without human intervention
+  #
+  #   * reviewed_request: after filling out request form, request needs to be approved by human
+  #
+  #   * embargoed: Signal that non-published assets should be strictly controlled and not available
+  #     for AI features etc. We need this at Work level for performance and clarity reasons,
+  #     not to have to examine individual assets and guess intent.
+  #     Assets should still be non-published for safety.
+  #
+  # For request modes enabled at the work level, individual assets also need their oh_available_by_request flag
+  # set, to be extra sure this non-published asset is meant to be available by request.
+  #
+  # backed by a pg enum. methods such as `availability_direct?` or `availabiltiy_reviewed_request?`
+  # are available, along with scopes like `OralHistoryContent.availability_embargoed`
+  #
+  enum :availability_mode,
+    {direct: 'direct', automatic_request: 'automatic_request', reviewed_request: 'reviewed_request', embargoed: 'embargoed'},
+    prefix: "availability"
 
   # scopes for finding certain kinds of OH's. We add ".distinct" to them all to make them all composable,
   # even though really only needed for available_immediate, does not hurt.

--- a/app/models/oral_history_request.rb
+++ b/app/models/oral_history_request.rb
@@ -13,7 +13,7 @@ class OralHistoryRequest < ApplicationRecord
   validates :oral_history_requester, presence: true
 
   validates :intended_use, presence: true, if: -> {
-    work&.oral_history_content&.available_by_request_manual_review?
+    work&.oral_history_content&.availability_reviewed_request?
   }
 
   enum :delivery_status, %w{pending automatic approved rejected dismissed}.map {|v| [v, v]}.to_h, prefix: :delivery_status

--- a/app/policies/access_policy.rb
+++ b/app/policies/access_policy.rb
@@ -50,7 +50,7 @@ class AccessPolicy
         asset.published? ||
           (
             asset.oh_available_by_request? &&
-            asset.parent.oral_history_content.available_by_request_automatic?
+            asset.parent.oral_history_content.availability_automatic_request?
           )
       end
     end

--- a/app/services/oral_history/category_with_chunks_count.rb
+++ b/app/services/oral_history/category_with_chunks_count.rb
@@ -46,22 +46,16 @@ module OralHistory
         OralHistoryContent.joins(:work).where(work: { published: true }).where.associated(:oral_history_chunks).distinct
     end
 
-    # DANGER: Note we are counting on having no "embargoed" OH's in valid_chunks_scope --
-    #         they should not have chunks created. See #3253
-    #
-    #         That danger pplies to all chunks but ohms, as if they have chunks embargoed
-    #         OHs would be included in available_by_request_mode off
-    #
     def scope_for_category
       case category
       when :immediate_ohms_only
-        valid_chunks_scope.where.not( ohms_xml_text: [nil, ""])
+        valid_chunks_scope.with_ohms
       when :immediate_only
-        valid_chunks_scope.where(available_by_request_mode: ["off", nil])
+        valid_chunks_scope.availability_direct
       when :immediate_or_automatic
-        valid_chunks_scope.where(available_by_request_mode: ["off", nil, "automatic"])
+        valid_chunks_scope.direct_or_automatic
       when :all
-        valid_chunks_scope
+        valid_chunks_scope.all_except_fully_embargoed
       else
         raise TypeError, "how did we get here, unrecognized category #{category}"
       end

--- a/app/services/oral_history/chunk_fetcher.rb
+++ b/app/services/oral_history/chunk_fetcher.rb
@@ -88,21 +88,16 @@ module OralHistory
 
       # Apply any limits to certain OH's
       #
-      # NOTE:  We can't use full logic for elminating "fully embargoed" that we implemented in scopes,
-      #        crashes postgres. See https://github.com/sciencehistory/scihist_digicoll/issues/3253
-      #
-      #        For now we RELY upon fully embargoed OH's not being chunked.
-      #
       case access_limit
       when :immediate_ohms_only
         # right now all OHMS are immediate, so.
-        relation = relation.joins(:oral_history_content).where.not(oral_history_content: { ohms_xml_text: [nil, ""]})
+        relation = relation.joins(:oral_history_content).merge(OralHistoryContent.with_ohms).merge(OralHistoryContent.availability_direct)
       when :immediate_only
-        relation = relation.joins(:oral_history_content).where(oral_history_content: { available_by_request_mode: ["off", nil] })
+        relation = relation.joins(:oral_history_content).merge(OralHistoryContent.availability_direct)
       when :immediate_or_automatic
-        relation = relation.joins(:oral_history_content).where(oral_history_content: { available_by_request_mode: ["off", "automatic"] })
+        relation = relation.joins(:oral_history_content).where(oral_history_content: { availability_mode: ["direct", "automatic_request"] })
       else
-        # TODO not excluding totally embargoed, see https://github.com/sciencehistory/scihist_digicoll/issues/3253
+        relation = relation.joins(:oral_history_content).merge(OralHistoryContent.all_except_fully_embargoed)
       end
 
       # Add our nearnest neighbor embedding query!

--- a/app/services/oral_history/chunk_validator.rb
+++ b/app/services/oral_history/chunk_validator.rb
@@ -91,15 +91,8 @@ module OralHistory
       return true
     end
 
-    # Have to check for presence of unpublished transcript , bad data model, see
-    # https://github.com/sciencehistory/scihist_digicoll/issues/3253
     def embargoed?
-      unless defined?(@embargoed)
-        @embargoed = oral_history_content.available_by_request_off? &&
-          (transcript = oral_history_content.work.members.find {|a| a.role == "transcript"}) &&
-          (transcript.nil? || !transcript.published?)
-      end
-      @embargoed
+      oral_history_content.availability_embargoed?
     end
 
     def validate_chunk_sequence

--- a/app/services/oral_history/transcript_chunker.rb
+++ b/app/services/oral_history/transcript_chunker.rb
@@ -38,6 +38,11 @@ module OralHistory
         raise ArgumentError.new("argument must be OralHistoryContent, but was #{oral_history_content.class.name}")
       end
 
+      # for now refuse to do this for safety
+      if oral_history_content.availability_embargoed?
+        raise ArgumentError.new("Will not chunk an embargoed OralHistoryContent, work friendlier_id: #{oral_history_content.work.friendlier_id}")
+      end
+
       @oral_history_content = oral_history_content
 
       @paragraphs = self.paragraph_source.paragraphs

--- a/app/views/oral_history_requests/_alert.html.erb
+++ b/app/views/oral_history_requests/_alert.html.erb
@@ -4,7 +4,7 @@
 
 <%= render Blacklight::System::ModalComponent.new do |component| %>
   <% component.with_title do %>
-    <% if @work.oral_history_content.available_by_request_manual_review? %>
+    <% if @work.oral_history_content.availability_reviewed_request? %>
         Request Oral History Access
       <% else %>
         Get Oral History Access

--- a/app/views/oral_history_requests/_form.html.erb
+++ b/app/views/oral_history_requests/_form.html.erb
@@ -6,7 +6,7 @@
     <p>
       To receive files for "<%= @work.title %>" by email, please fill out the form below.
 
-      <% if @work.oral_history_content.available_by_request_automatic? %>
+      <% if @work.oral_history_content.availability_automatic_request? %>
         <span class="text-danger">You will receive these files immediately after submitting this form.</span>
       <% else %>
         <span class="text-danger">After your request is received, you will receive an email response, usually within
@@ -68,9 +68,9 @@
         <%= f.input :intended_use,
           as: :text,
           label: "Intended use",
-          hint: (@work.oral_history_content.available_by_request_automatic? ? "So that we can better understand our audience, please tell us how you plan to use the oral history you have requested." : "Please tell us how you intend to use this oral history interview to help us inform you about any relevant interviewee restrictions."),
+          hint: (@work.oral_history_content.availability_automatic_request? ? "So that we can better understand our audience, please tell us how you plan to use the oral history you have requested." : "Please tell us how you intend to use this oral history interview to help us inform you about any relevant interviewee restrictions."),
           input_html: { value: remembered_form_values["intended_use"] },
-          required: @oral_history_request.work&.oral_history_content&.available_by_request_manual_review?
+          required: @oral_history_request.work&.oral_history_content&.availability_reviewed_request?
         %>
       </div>
     </div>

--- a/app/views/oral_history_requests/new.html.erb
+++ b/app/views/oral_history_requests/new.html.erb
@@ -1,6 +1,6 @@
 <%= render Blacklight::System::ModalComponent.new do |component| %>
   <% component.with_title do %>
-    <% if @work.oral_history_content.available_by_request_manual_review? %>
+    <% if @work.oral_history_content.availability_reviewed_request? %>
       Request Oral History Access
     <% else %>
       Get Oral History Access

--- a/db/migrate/20260609143410_add_availability_mode.rb
+++ b/db/migrate/20260609143410_add_availability_mode.rb
@@ -1,0 +1,7 @@
+class AddAvailabilityMode < ActiveRecord::Migration[8.1]
+  def change
+    create_enum :oh_availability_mode_type, %w[direct automatic_request reviewed_request embargoed]
+
+    add_column :oral_history_content, :availability_mode, :enum, enum_type: :oh_availability_mode_type, null: false, default: "direct"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_16_175054) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_09_143410) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "oh_availability_mode_type", ["direct", "automatic_request", "reviewed_request", "embargoed"]
   create_enum "available_by_request_mode_type", ["off", "automatic", "manual_review"]
 
   create_function :kithe_models_friendlier_id_gen, sql_definition: <<-'SQL'
@@ -288,6 +289,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_175054) do
   end
 
   create_table "oral_history_content", force: :cascade do |t|
+    t.enum "availability_mode", default: "direct", null: false, enum_type: "oh_availability_mode_type"
     t.uuid "work_id", null: false
     t.string "combined_audio_fingerprint"
     t.jsonb "combined_audio_component_metadata"

--- a/lib/tasks/create_oral_history_chunks.rake
+++ b/lib/tasks/create_oral_history_chunks.rake
@@ -54,15 +54,10 @@ namespace :scihist do
       overwrite_chunks = (ENV['OVERWRITE_CHUNKS'] == "true") || only_invalid
       use_dummy_embedding = ENV['USE_DUMMY_EMBEDDING'] == "true"
 
-      # Make sure we skip truly embargoed/non-public stuff, which is
-      # currently a bit tricky in the metadata.
-      # See https://github.com/sciencehistory/scihist_digicoll/issues/3253
-      if oh_content.available_by_request_off?
-        # Not requestable, but does it have a published transcript? If not, no go
-        unless oh_content.work.members.to_a.find {|asset| asset.role == "transcript" && asset.published?}
-          skipped_count += 1
-          next
-        end
+      # Not creating chunks for embargoed items, safest to make sure they are not used.
+      if oh_content.availability_embargoed?
+        skipped_count += 1
+        next
       end
 
       if only_invalid

--- a/lib/tasks/data_fixes/migrate_oh_availability_mode.rake
+++ b/lib/tasks/data_fixes/migrate_oh_availability_mode.rake
@@ -18,15 +18,15 @@ namespace :scihist do
 
 
       OralHistoryContent.includes(:work => :members).select("oral_history_content.*").find_each(batch_size: 10) do |oc|
-        if oc.available_by_request_mode == 'automatic'
+        if oc.attributes["available_by_request_mode"] == 'automatic'
           oc.availability_mode = "automatic_request"
           counts["automatic_request"] += 1
 
-        elsif oc.available_by_request_mode == "manual_review"
+        elsif oc.attributes["available_by_request_mode"] == "manual_review"
           oc.availability_mode = "reviewed_request"
           counts["reviewed_request"] += 1
 
-        elsif oc.available_by_request_mode == "off" && oc.work.published? && !oc.work.members.find { |a| a.published? }
+        elsif oc.attributes["available_by_request_mode"] == "off" && oc.work.published? && !oc.work.members.find { |a| a.published? }
           oc.availability_mode = "embargoed"
           counts["embargoed"] += 1
 

--- a/lib/tasks/data_fixes/migrate_oh_availability_mode.rake
+++ b/lib/tasks/data_fixes/migrate_oh_availability_mode.rake
@@ -1,0 +1,47 @@
+namespace :scihist do
+  namespace :data_fixes do
+    desc """
+    Copy data from old OralHistoryContent#available_by_request_mode to new #availability_mode
+    """
+    task :migrate_oh_availability_mode => :environment do
+      progress_bar = ProgressBar.create(total: OralHistoryContent.count, format: Kithe::STANDARD_PROGRESS_BAR_FORMAT)
+
+      counts = Hash.new { 0 }
+
+      # The trick is that old "off" could mean new "direct" or "embargoed" -- this confusion
+      # is in fact why we are migrating to new metadata model here.
+      #
+      # if work is published, available_by_request_mode is off AND there are NO published
+      # assets, we consider "embargoed". Otherwise "direct"
+      #
+      # Select * to get around that we may be ActiveRecord ignoring the old field by default.
+
+
+      OralHistoryContent.includes(:work => :members).select("oral_history_content.*").find_each(batch_size: 10) do |oc|
+        if oc.available_by_request_mode == 'automatic'
+          oc.availability_mode = "automatic_request"
+          counts["automatic_request"] += 1
+
+        elsif oc.available_by_request_mode == "manual_review"
+          oc.availability_mode = "reviewed_request"
+          counts["reviewed_request"] += 1
+
+        elsif oc.available_by_request_mode == "off" && oc.work.published? && !oc.work.members.find { |a| a.published? }
+          oc.availability_mode = "embargoed"
+          counts["embargoed"] += 1
+
+        else
+          oc.availability_mode = "direct"
+          counts["direct"] += 1
+        end
+
+        oc.save!
+
+        GC.start
+        progress_bar.increment
+      end
+
+      puts "\nSync'd availability_mode: #{counts}"
+    end
+  end
+end

--- a/spec/components/oral_history/ai_conversation_citation_component_spec.rb
+++ b/spec/components/oral_history/ai_conversation_citation_component_spec.rb
@@ -13,9 +13,9 @@ describe OralHistory::AiConversationCitationComponent, type: :component do
 
   let(:oral_history_content) { work.oral_history_content }
 
-  let(:available_by_request_mode) { nil }
+  let(:availability_mode) { nil }
   before do
-    oral_history_content.available_by_request_mode = available_by_request_mode if available_by_request_mode
+    oral_history_content.availability_mode = availability_mode if availability_mode
   end
 
   let(:oral_history_chunk) { build(:oral_history_chunk, oral_history_content: oral_history_content) }
@@ -52,7 +52,7 @@ describe OralHistory::AiConversationCitationComponent, type: :component do
   end
 
   describe "automatic requestable" do
-    let(:available_by_request_mode) { "automatic" }
+    let(:availability_mode) { "automatic_request" }
 
     it "generates link to PDF with page number" do
       expect(component.link_to_source).to eq view_transcript_pdf_path(work, anchor_page: (work.oral_history_content.extracted_paragraph_container.logical_page_number_offset + 4).to_s)

--- a/spec/controllers/admin/works_controller_batch_publish_spec.rb
+++ b/spec/controllers/admin/works_controller_batch_publish_spec.rb
@@ -377,7 +377,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
         put :update_oh_available_by_request, params: {
           id: work.friendlier_id,
           oral_history_content: {
-            available_by_request_mode: "automatic"
+            availability_mode: "automatic_request"
           },
           available_by_request: {
             was_true_asset.id => "false",
@@ -387,7 +387,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
         }
         expect(response).to redirect_to(admin_work_path(work, anchor: "tab=nav-oral-histories"))
 
-        expect(work.reload.oral_history_content.available_by_request_mode).to eq("automatic")
+        expect(work.reload.oral_history_content.availability_mode).to eq("automatic_request")
         expect(was_false_asset.reload.oh_available_by_request).to be true
         expect(was_true_asset.reload.oh_available_by_request).to be false
       end

--- a/spec/controllers/admin/works_controller_oral_histories_spec.rb
+++ b/spec/controllers/admin/works_controller_oral_histories_spec.rb
@@ -356,7 +356,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
         put :update_oh_available_by_request, params: {
           id: work.friendlier_id,
           oral_history_content: {
-            available_by_request_mode: "automatic"
+            availability_mode: "automatic_request"
           },
           available_by_request: {
             was_true_asset.id => "false",
@@ -366,7 +366,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
         }
         expect(response).to redirect_to(admin_work_path(work, anchor: "tab=nav-oral-histories"))
 
-        expect(work.reload.oral_history_content.available_by_request_mode).to eq("automatic")
+        expect(work.reload.oral_history_content.availability_mode).to eq("automatic_request")
         expect(was_false_asset.reload.oh_available_by_request).to be true
         expect(was_true_asset.reload.oh_available_by_request).to be false
       end

--- a/spec/controllers/oral_history_requests_controller_spec.rb
+++ b/spec/controllers/oral_history_requests_controller_spec.rb
@@ -145,7 +145,7 @@ describe OralHistoryRequestsController, type: :controller do
     describe "email functionality" do
       let(:work) { create(:oral_history_work, :available_by_request)}
       describe "automatic delivery" do
-        let(:work) { create(:oral_history_work, :available_by_request, available_by_request_mode: :automatic)}
+        let(:work) { create(:oral_history_work, :available_by_request, availability_mode: :automatic_request)}
 
         describe "already logged in" do
           let(:requester_email) { OralHistoryRequester.new(email: full_create_params[:patron_email]) }
@@ -187,7 +187,7 @@ describe OralHistoryRequestsController, type: :controller do
 
       describe "manual review" do
         # same as old style, we just let them know that they'll get an email.
-        let(:work) { create(:oral_history_work, :available_by_request, available_by_request_mode: :manual_review)}
+        let(:work) { create(:oral_history_work, :available_by_request, availability_mode: :reviewed_request)}
 
         it "emails admin, and lets user know" do
           expect {

--- a/spec/factories/work_factory.rb
+++ b/spec/factories/work_factory.rb
@@ -311,7 +311,7 @@ FactoryBot.define do
 
       trait :available_by_request do
         transient do
-          available_by_request_mode { :manual_review }
+          availability_mode { :reviewed_request }
         end
 
         members {[
@@ -327,7 +327,7 @@ FactoryBot.define do
         ]}
         after(:build) do |work, evaluator|
           work.representative = work.members.to_a.find {|w| w.published? } if work.representative.nil?
-          work.oral_history_content!.available_by_request_mode = evaluator.available_by_request_mode
+          work.oral_history_content!.availability_mode = evaluator.availability_mode
         end
       end
 

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -116,20 +116,20 @@ describe WorkIndexer do
       expect(output_hash["oh_availability_facet"]).to eq ["Immediate"]
     end
 
-    describe "with no published or requestable files" do
+    describe "with embargoed files" do
       let(:work) do
         work = build(:oral_history_work, :published, format: ['text'])
         work.members.each { |m| m.published = false }
         work.members.concat build(:asset_with_faked_file, published: true, role: "portrait")
-        work.oral_history_content!.available_by_request_mode = "off"
+        work.oral_history_content!.availability_mode = "embargoed"
 
         work
       end
 
-      it "does not have an availability value at all" do
+      it "indexes as embargoed" do
         output_hash = WorkIndexer.new.map_record(work)
 
-        expect(output_hash["oh_availability_facet"]).to be_blank
+        expect(output_hash["oh_availability_facet"]).to eq ["Embargoed"]
       end
     end
 

--- a/spec/mailers/oral_history_delivery_spec.rb
+++ b/spec/mailers/oral_history_delivery_spec.rb
@@ -19,11 +19,10 @@ RSpec.describe OralHistoryDeliveryMailer, :type => :mailer do
     end
 
     let!(:work) do
-      create(:oral_history_work, :published).tap do |work|
+      build(:oral_history_work, :published, :available_by_request).tap do |work|
         work.members = members
         work.representative =  representative
         work.save!
-        work.oral_history_content!.update(available_by_request_mode: :automatic)
       end
     end
 

--- a/spec/models/oral_history_content_spec.rb
+++ b/spec/models/oral_history_content_spec.rb
@@ -136,19 +136,9 @@ describe OralHistoryContent do
   end
 
   describe "scopes" do
-    let!(:ohms_oh) { create(:oral_history_work, :ohms_xml, :public_files, title: "OHMS OH")}
+    let!(:ohms_oh) { create(:oral_history_work, :ohms_xml, :public_files, title: "OHMS OH") }
     let!(:immediate_oh) { create(:oral_history_work, :public_files, title: "Public OH") }
-    let!(:needs_approval_oh) { create(:oral_history_work, :available_by_request, title: "Needs approval OH", available_by_request_mode: "manual_review")}
-    let!(:upon_request_oh) { create(:oral_history_work, :available_by_request, title: "Automatic Approval OH", available_by_request_mode: "automatic") }
-    let!(:private_oh) {
-      create(:oral_history_work,
-        title: "NOT available OH",
-        members: [
-          create(:asset, role: :portrait, published: true),
-          create(:asset_with_faked_file, :pdf, role: :transcript, published: false)
-        ]
-      )
-    }
+    let!(:embargoed_oh) { create(:oral_history_work, :available_by_request, title: "Embargoed OH", availability_mode: "embargoed") }
 
     it "fetches ohms" do
       results = OralHistoryContent.with_ohms.to_a
@@ -156,79 +146,15 @@ describe OralHistoryContent do
       expect(results).to include(ohms_oh.oral_history_content)
 
       expect(results).not_to include(immediate_oh.oral_history_content)
-      expect(results).not_to include(needs_approval_oh.oral_history_content)
-      expect(results).not_to include(upon_request_oh.oral_history_content)
-      expect(results).not_to include(private_oh.oral_history_content)
-    end
-
-    it "fetches immediate" do
-      results = OralHistoryContent.available_immediate.to_a
-
-      expect(results).to include(immediate_oh.oral_history_content)
-      expect(results).to include(ohms_oh.oral_history_content)
-      expect(results.count).to eq 2
-
-      expect(results).not_to include(needs_approval_oh.oral_history_content)
-      expect(results).not_to include(upon_request_oh.oral_history_content)
-      expect(results).not_to include(private_oh.oral_history_content)
-    end
-
-    it "fetches upon_request" do
-      results = OralHistoryContent.upon_request.to_a
-
-      expect(results).to include(upon_request_oh.oral_history_content)
-
-      expect(results).not_to include(ohms_oh.oral_history_content)
-      expect(results).not_to include(immediate_oh.oral_history_content)
-
-      expect(results).not_to include(needs_approval_oh.oral_history_content)
-      expect(results).not_to include(private_oh.oral_history_content)
-    end
-
-    it "fetches (upon_request OR immediate)" do
-      # have to do crazy thing with removing then adding DISTICNT to get it to work
-      results = OralHistoryContent.available_immediate.or( OralHistoryContent.upon_request ).to_a
-
-      expect(results).to include(upon_request_oh.oral_history_content)
-      expect(results).to include(ohms_oh.oral_history_content)
-      expect(results).to include(immediate_oh.oral_history_content)
-
-      expect(results).not_to include(needs_approval_oh.oral_history_content)
-      expect(results).not_to include(private_oh.oral_history_content)
-    end
-
-    it "fetches needs_approval" do
-      results = OralHistoryContent.needs_approval.to_a
-
-      expect(results).to include(needs_approval_oh.oral_history_content)
-
-
-      expect(results).not_to include(upon_request_oh.oral_history_content)
-      expect(results).not_to include(ohms_oh.oral_history_content)
-      expect(results).not_to include(immediate_oh.oral_history_content)
-      expect(results).not_to include(private_oh.oral_history_content)
-    end
-
-    it "fetches fully_embarboed" do
-      results = OralHistoryContent.fully_embargoed.to_a
-
-      expect(results).to include(private_oh.oral_history_content)
-
-      expect(results).not_to include(needs_approval_oh.oral_history_content)
-      expect(results).not_to include(upon_request_oh.oral_history_content)
-      expect(results).not_to include(ohms_oh.oral_history_content)
-      expect(results).not_to include(immediate_oh.oral_history_content)
     end
 
     it "fetches all except fully embargoed" do
       results = OralHistoryContent.all_except_fully_embargoed.to_a
 
-      expect(results).to include(needs_approval_oh.oral_history_content)
-      expect(results).to include(upon_request_oh.oral_history_content)
       expect(results).to include(ohms_oh.oral_history_content)
       expect(results).to include(immediate_oh.oral_history_content)
 
-      expect(results).not_to include(private_oh.oral_history_content)
+      expect(results).not_to include(embargoed_oh.oral_history_content)
     end
   end
 end

--- a/spec/policies/access_policy_spec.rb
+++ b/spec/policies/access_policy_spec.rb
@@ -155,7 +155,7 @@ describe "access policies:" do
       describe "automatically requestable" do
         let(:asset) {
           build(:asset, published: false, oh_available_by_request: true,
-            parent: build(:oral_history_work,  :available_by_request, available_by_request_mode: :automatic)
+            parent: build(:oral_history_work,  :available_by_request, availability_mode: :automatic_request)
           )
         }
 
@@ -167,7 +167,7 @@ describe "access policies:" do
       describe "manually requestable" do
         let(:asset) {
           build(:asset, published: false, oh_available_by_request: true,
-            parent: build(:oral_history_work,  :available_by_request, available_by_request_mode: :manual_review)
+            parent: build(:oral_history_work,  :available_by_request, availability_mode: :reviewed_request)
           )
         }
 

--- a/spec/services/oral_history/chunk_fetcher_spec.rb
+++ b/spec/services/oral_history/chunk_fetcher_spec.rb
@@ -117,8 +117,8 @@ describe OralHistory::ChunkFetcher do
   describe "access limits" do
     let!(:ohms_oh) { create(:oral_history_work, :ohms_xml, :public_files, title: "OHMS OH", published: true) }
     let!(:immediate_oh) { create(:oral_history_work, :public_files, title: "Public OH", published: true) }
-    let!(:needs_approval_oh) { create(:oral_history_work, :available_by_request, title: "Needs approval OH", available_by_request_mode: "manual_review", published: true)}
-    let!(:upon_request_oh) { create(:oral_history_work, :available_by_request, title: "Automatic Approval OH", available_by_request_mode: "automatic", published: true) }
+    let!(:needs_approval_oh) { create(:oral_history_work, :available_by_request, title: "Needs approval OH", availability_mode: "reviewed_request", published: true)}
+    let!(:upon_request_oh) { create(:oral_history_work, :available_by_request, title: "Automatic Approval OH", availability_mode: "automatic_request", published: true) }
     let!(:private_oh) {
       create(:oral_history_work,
         title: "NOT available OH",

--- a/spec/services/oral_history/chunk_validator_spec.rb
+++ b/spec/services/oral_history/chunk_validator_spec.rb
@@ -114,6 +114,7 @@ describe OralHistory::ChunkValidator do
         ],
         published: true,
         oral_history_content: OralHistoryContent.new(
+          availability_mode: "embargoed",
           searchable_transcript_source: transcript_txt,
           oral_history_chunks: chunks
         )

--- a/spec/system/admin/oral_history_request_spec.rb
+++ b/spec/system/admin/oral_history_request_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "Oral History Access Request Administration", :logged_in_user, type: :system, queue_adapter: :test  do
   let!(:work) do
-    create(:oral_history_work, :available_by_request, available_by_request_mode: :manual_review, published: true)
+    create(:oral_history_work, :available_by_request, availability_mode: :reviewed_request, published: true)
   end
 
   context "A request exists for a manual_review work" do

--- a/spec/system/oral_history_by_request_spec.rb
+++ b/spec/system/oral_history_by_request_spec.rb
@@ -145,10 +145,10 @@ describe "Oral History with by-request delivery", type: :system, js: true, queue
     end
   end
 
-  describe "when you visit an OH with nothing available at all period", js: false do
+  describe "when you visit an OH that is embargoed", js: false do
     let!(:work) do
       build(:oral_history_work, :published, members: [build(:asset_with_faked_file, :pdf, role: :transcript, published: false)]).tap do |work|
-        work.oral_history_content!.update(availability_mode: :direct)
+        work.oral_history_content!.update(availability_mode: :embargoed)
       end
     end
 

--- a/spec/system/oral_history_by_request_spec.rb
+++ b/spec/system/oral_history_by_request_spec.rb
@@ -148,7 +148,7 @@ describe "Oral History with by-request delivery", type: :system, js: true, queue
   describe "when you visit an OH with nothing available at all period", js: false do
     let!(:work) do
       build(:oral_history_work, :published, members: [build(:asset_with_faked_file, :pdf, role: :transcript, published: false)]).tap do |work|
-        work.oral_history_content!.update(available_by_request_mode: :off)
+        work.oral_history_content!.update(availability_mode: :direct)
       end
     end
 

--- a/spec/system/oral_history_by_request_spec.rb
+++ b/spec/system/oral_history_by_request_spec.rb
@@ -13,7 +13,7 @@ describe "Oral History with by-request delivery", type: :system, js: true, queue
   context "When you visit an OH with protected by request, automatic delivery assets" do
     let!(:work) do
       build(:oral_history_work, :published, members: [preview_pdf, protected_pdf, protected_mp3, portrait], representative: preview_pdf).tap do |work|
-        work.oral_history_content!.update(available_by_request_mode: :automatic)
+        work.oral_history_content!.update(availability_mode: :automatic_request)
       end
     end
 
@@ -95,9 +95,7 @@ describe "Oral History with by-request delivery", type: :system, js: true, queue
 
   context "When you visit an OH with protected by request, approved delivery assets" do
     let!(:work) do
-      build(:oral_history_work, :published, members: [preview_pdf, protected_pdf, protected_mp3], representative: preview_pdf).tap do |work|
-        work.oral_history_content!.update(available_by_request_mode: :manual_review)
-      end
+      create(:oral_history_work, :published, :available_by_request, members: [preview_pdf, protected_pdf, protected_mp3])
     end
 
     it "shows the page without error" do


### PR DESCRIPTION
Closes #3253 

**Before**: We had `available_by_request_mode` with values `off`, `automatic`, and `manual_review`. 

If request mode was `off` an OH might be "ordinary" public files, OR might be fully embarboed with _no_ public files. The only way to tell the difference was the `published` status of the work and assets, no way to tell _intent_ other than that.  

This was confusing, possibly error--prone in an area (embargo) it's important to get right, _and_ often a performance challenge (had to fetch assets to figure out what was going on with work). 

**Now**, replaced by `availability_mode` with explicit values `direct`, `automatic_request`, `reviewed_request`, and `embargoed`. 

There is a rake task to translate from old model to new. 

As before, we use rails `enum` feature which among other things automatically provides query methods (like`availability_direct?`) and activerecord fetch scopes (like `OralHistoryContent.availability_reviewed_request.count`). 

There was a LOT of code that had to be changed. Will do some QA in staging too, don't totally trust just the tests. 

## Data migration

This PR leaves the old column in DB there but "hides" it from the app. This is necessary because heroku deploy model means there can be some time when old code (which needs old data) and new code is running simultaneous, overlap. 

### On deploy

- [x] run `heroku rake scihist:data_fixes:migrate_oh_availability_mode -r production`

### After deploy

- [ ] Do another PR to actually fully remove the database column, and the code to "hide" it which is no longer necessary. 

## Commits

- add OralHistoryContent#availability_mode to replace #available_by_request_mode
- rake scihist:data_fixes:migrate_oh_availability_mode
- Switch admin OH dashboard from attribute available_by_request_mode to availability_mode
- Move much use of OralHistoryContent#available_by_request_mode to #availability_mode
- another round of moving OralHistoryContent#available_by_request_mode => availability_mode
- Cover attribute available_by_request_mode to raise, then fix what breaks in tests
- add available_by_request_mode to ActiveRecord ignored_columns, which finds some more breakagest of ix
- refuse to chunk embargoed OH, for safety
- Don't show embargoed message unless oral history is actually tagged embargoed



