### PR TITLE
Set up test-prof for spec profiling and tools for spec perf improvement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -213,6 +213,7 @@ group :test do
   gem "db-query-matchers", "< 2.0"
   gem 'rails-controller-testing'
   gem 'axe-core-rspec', "~> 4.3" # accessibilty testing
+  gem "test-prof", "~> 1.0" # profiling tests but ALSO some tools we use to improve test performance
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -772,6 +772,7 @@ GEM
       ruby-progressbar
     statsd-ruby (1.5.0)
     stringio (3.2.0)
+    test-prof (1.6.1)
     thor (1.5.0)
     thread_safe (0.3.6)
     tilt (2.7.0)
@@ -940,6 +941,7 @@ DEPENDENCIES
   sinatra (>= 4.0)
   sitemap_generator (~> 6.0)
   solr_wrapper (~> 4.0)
+  test-prof (~> 1.0)
   traject (>= 3.5)
   uppy-s3_multipart
   view_component (~> 4.9)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -265,6 +265,17 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
+  # set default type from WHATEVER sub-directory spec is in, even non-standard
+  # ones, if not already set. useful for test-prof profiling that summaries by type
+  config.define_derived_metadata do |metadata|
+    next if metadata[:type]
+
+    relative = metadata[:file_path].sub(%r{^.*/spec/}, "")
+    first_dir = relative.split("/").first
+
+    metadata[:type] = first_dir.to_sym if first_dir.present?
+  end
+
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:


### PR DESCRIPTION
Ref #214

- set default spec 'type' by directory for ALL dirs, useful for categorizing test profiling
- add test-prof to Gemfile
