### PR TITLE
Avoid unnecessary inline asset promotion in specs

### DIFF
--- a/spec/controllers/admin/assets_controller_spec.rb
+++ b/spec/controllers/admin/assets_controller_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Admin::AssetsController, :logged_in_user, type: :controller do
   # almost more of an integration test, we're going to do real stuff, it will be slow
   context "#setup_work_from_pdf_source", queue_adapter: :inline do
     let(:asset) do
-      create(:asset, :inline_promoted_file,
+      create(:asset_with_inline_promoted_file,
               file: File.open(Rails.root + "spec/test_support/pdf/sample-text-and-image-small.pdf"),
               parent: create(:work))
     end

--- a/spec/controllers/admin/works_controller_batch_publish_spec.rb
+++ b/spec/controllers/admin/works_controller_batch_publish_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
 
     context "work with corrupt file" do
       let(:corrupt_tiff_path) { Rails.root + "spec/test_support/images/corrupt_bad.tiff" }
-      let(:bad_asset) {create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))}
+      let(:bad_asset) {create(:asset_with_inline_promoted_file, file: File.open(corrupt_tiff_path))}
       let(:good_asset) {create(:asset_with_faked_file) }
       let(:work_with_bad_asset) { create(:work, :with_complete_metadata, published: false, members: [bad_asset, good_asset]) }
       before do
@@ -556,7 +556,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
 
         context "work has assets with invalid files" do
           let(:corrupt_tiff_path) { Rails.root + "spec/test_support/images/corrupt_bad.tiff" }
-          let(:bad_asset) {create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))}
+          let(:bad_asset) {create(:asset_with_inline_promoted_file, file: File.open(corrupt_tiff_path))}
           let(:good_asset) {create(:asset_with_faked_file) }
           let(:parent_work) { create(:work, :with_complete_metadata, published: false, members: [bad_asset, good_asset]) }
           before do

--- a/spec/controllers/admin/works_controller_batch_publish_spec.rb
+++ b/spec/controllers/admin/works_controller_batch_publish_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
     context "work with corrupt file" do
       let(:corrupt_tiff_path) { Rails.root + "spec/test_support/images/corrupt_bad.tiff" }
       let(:bad_asset) {create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))}
-      let(:good_asset) {create(:asset, :inline_promoted_file) }
+      let(:good_asset) {create(:asset_with_faked_file) }
       let(:work_with_bad_asset) { create(:work, :with_complete_metadata, published: false, members: [bad_asset, good_asset]) }
       before do
         controller.current_user.works_in_cart << unpublishable_work
@@ -155,7 +155,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
     end
 
     context "work with a png instead of a tiff" do
-      let(:png) { create(:asset, :inline_promoted_file) }
+      let(:png) { create(:asset_with_faked_file, :png) }
       let(:work_with_png) { create(:work, :with_complete_metadata, published: false, members: [png]) }
 
       before do
@@ -187,7 +187,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
     end
 
     context "work with a legitimate portrait png" do
-      let(:portrait_png) { create(:asset, :inline_promoted_file, role: "portrait") }
+      let(:portrait_png) { create(:asset_with_faked_file, :png, role: "portrait") }
       let(:work) { create(:work, :with_complete_metadata, published: false, members: [portrait_png]) }
       before do
         controller.current_user.works_in_cart << work
@@ -341,16 +341,14 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
 
     context "create audio derivatives",  logged_in_user: :admin do
 
-      let!(:audio_asset_1)  { create(:asset, :inline_promoted_file,
+      let!(:audio_asset_1)  { create(:asset_with_faked_file, :mp3,
           position: 1,
-          title: "Audio asset 1",
-          file: File.open((Rails.root + "spec/test_support/audio/5-seconds-of-silence.mp3"))
+          title: "Audio asset 1"
         )
       }
-      let!(:audio_asset_2)  { create(:asset, :inline_promoted_file,
+      let!(:audio_asset_2)  { create(:asset_with_faked_file, :mp3,
           position: 2,
-          title: "Audio asset 2",
-          file: File.open((Rails.root + "spec/test_support/audio/10-seconds-of-silence.mp3"))
+          title: "Audio asset 2"
         )
       }
       let!(:oral_history) { FactoryBot.create(
@@ -559,7 +557,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
         context "work has assets with invalid files" do
           let(:corrupt_tiff_path) { Rails.root + "spec/test_support/images/corrupt_bad.tiff" }
           let(:bad_asset) {create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))}
-          let(:good_asset) {create(:asset, :inline_promoted_file) }
+          let(:good_asset) {create(:asset_with_faked_file) }
           let(:parent_work) { create(:work, :with_complete_metadata, published: false, members: [bad_asset, good_asset]) }
           before do
             allow(Rails.logger).to receive(:warn)

--- a/spec/controllers/admin/works_controller_oral_histories_spec.rb
+++ b/spec/controllers/admin/works_controller_oral_histories_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
     context "work with corrupt file" do
       let(:corrupt_tiff_path) { Rails.root + "spec/test_support/images/corrupt_bad.tiff" }
       let(:bad_asset) {create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))}
-      let(:good_asset) {create(:asset, :inline_promoted_file) }
+      let(:good_asset) {create(:asset_with_faked_file) }
       let(:work_with_bad_asset) { create(:work, :with_complete_metadata, published: false, members: [bad_asset, good_asset]) }
       before do
         controller.current_user.works_in_cart << unpublishable_work
@@ -155,7 +155,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
     end
 
     context "work with a png instead of a tiff" do
-      let(:png) { create(:asset, :inline_promoted_file) }
+      let(:png) { create(:asset_with_faked_file, :png) }
       let(:work_with_png) { create(:work, :with_complete_metadata, published: false, members: [png]) }
 
       before do
@@ -187,7 +187,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
     end
 
     context "work with a legitimate portrait png" do
-      let(:portrait_png) { create(:asset, :inline_promoted_file, role: "portrait") }
+      let(:portrait_png) { create(:asset_with_faked_file, :png, role: "portrait") }
       let(:work) { create(:work, :with_complete_metadata, published: false, members: [portrait_png]) }
       before do
         controller.current_user.works_in_cart << work
@@ -320,16 +320,14 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
 
     context "create audio derivatives",  logged_in_user: :admin do
 
-      let!(:audio_asset_1)  { create(:asset, :inline_promoted_file,
+      let!(:audio_asset_1)  { create(:asset_with_faked_file, :mp3,
           position: 1,
-          title: "Audio asset 1",
-          file: File.open((Rails.root + "spec/test_support/audio/5-seconds-of-silence.mp3"))
+          title: "Audio asset 1"
         )
       }
-      let!(:audio_asset_2)  { create(:asset, :inline_promoted_file,
+      let!(:audio_asset_2)  { create(:asset_with_faked_file, :mp3,
           position: 2,
-          title: "Audio asset 2",
-          file: File.open((Rails.root + "spec/test_support/audio/10-seconds-of-silence.mp3"))
+          title: "Audio asset 2"
         )
       }
       let!(:oral_history) { FactoryBot.create(
@@ -538,7 +536,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
         context "work has assets with invalid files" do
           let(:corrupt_tiff_path) { Rails.root + "spec/test_support/images/corrupt_bad.tiff" }
           let(:bad_asset) {create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))}
-          let(:good_asset) {create(:asset, :inline_promoted_file) }
+          let(:good_asset) {create(:asset_with_faked_file) }
           let(:parent_work) { create(:work, :with_complete_metadata, published: false, members: [bad_asset, good_asset]) }
           before do
             allow(Rails.logger).to receive(:warn)

--- a/spec/controllers/admin/works_controller_oral_histories_spec.rb
+++ b/spec/controllers/admin/works_controller_oral_histories_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
 
     context "work with corrupt file" do
       let(:corrupt_tiff_path) { Rails.root + "spec/test_support/images/corrupt_bad.tiff" }
-      let(:bad_asset) {create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))}
+      let(:bad_asset) {create(:asset_with_inline_promoted_file, file: File.open(corrupt_tiff_path))}
       let(:good_asset) {create(:asset_with_faked_file) }
       let(:work_with_bad_asset) { create(:work, :with_complete_metadata, published: false, members: [bad_asset, good_asset]) }
       before do
@@ -535,7 +535,7 @@ RSpec.describe Admin::WorksController, :logged_in_user, type: :controller, queue
 
         context "work has assets with invalid files" do
           let(:corrupt_tiff_path) { Rails.root + "spec/test_support/images/corrupt_bad.tiff" }
-          let(:bad_asset) {create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))}
+          let(:bad_asset) {create(:asset_with_inline_promoted_file, file: File.open(corrupt_tiff_path))}
           let(:good_asset) {create(:asset_with_faked_file) }
           let(:parent_work) { create(:work, :with_complete_metadata, published: false, members: [bad_asset, good_asset]) }
           before do

--- a/spec/controllers/admin/works_controller_spec.rb
+++ b/spec/controllers/admin/works_controller_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe Admin::WorksController, type: :controller, queue_adapter: :test d
 
         context "work has assets with invalid files" do
           let(:corrupt_tiff_path) { Rails.root + "spec/test_support/images/corrupt_bad.tiff" }
-          let(:bad_asset) {create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))}
+          let(:bad_asset) {create(:asset_with_inline_promoted_file, file: File.open(corrupt_tiff_path))}
           let(:good_asset) {create(:asset_with_faked_file) }
           let(:parent_work) { create(:work, :with_complete_metadata, published: false, members: [bad_asset, good_asset]) }
           before do

--- a/spec/controllers/admin/works_controller_spec.rb
+++ b/spec/controllers/admin/works_controller_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe Admin::WorksController, type: :controller, queue_adapter: :test d
         context "work has assets with invalid files" do
           let(:corrupt_tiff_path) { Rails.root + "spec/test_support/images/corrupt_bad.tiff" }
           let(:bad_asset) {create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))}
-          let(:good_asset) {create(:asset, :inline_promoted_file) }
+          let(:good_asset) {create(:asset_with_faked_file) }
           let(:parent_work) { create(:work, :with_complete_metadata, published: false, members: [bad_asset, good_asset]) }
           before do
             allow(Rails.logger).to receive(:warn)

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -73,7 +73,7 @@ describe DownloadsController do
     end
 
     describe "non-promoted file" do
-      let(:asset) { create(:asset, :inline_promoted_file, :non_promoted_file) }
+      let(:asset) { create(:asset_with_inline_promoted_file, :non_promoted_file) }
 
       it "does not give access" do
         expect {

--- a/spec/factories/asset_factory.rb
+++ b/spec/factories/asset_factory.rb
@@ -141,6 +141,13 @@ FactoryBot.define do
         }
       end
 
+      trait :png do
+        faked_file { File.open((Rails.root + "spec/test_support/images/30x30.png")) }
+        faked_content_type { "image/png" }
+        faked_height { 30 }
+        faked_width { 30 }
+      end
+
       trait :pdf do
         faked_file { File.open((Rails.root + "spec/test_support/pdf/sample.pdf")) }
         faked_content_type { "application/pdf" }

--- a/spec/factories/asset_factory.rb
+++ b/spec/factories/asset_factory.rb
@@ -7,6 +7,9 @@ FactoryBot.define do
     title { 'Test title' }
     published { true }
 
+
+    # ** DO NOT USE THIS UNLESS YOU REALLY NEED IT, IT IS SLOW! **
+    #
     # This will take a real file and send it through the real logic
     # for extracting metadata and creating derivatives -- but make sure to do it
     # inline instead of in bg ActiveJobs.
@@ -18,7 +21,7 @@ FactoryBot.define do
     #
     # Will use a default small png, but you can pass `file:` with whatever file you want,
     # of any media type.
-    trait :inline_promoted_file do
+    factory :asset_with_inline_promoted_file do
       file { File.open((Rails.root + "spec/test_support/images/30x30.png")) }
       after(:build) do |asset|
         asset.file_attacher.set_promotion_directives(promote: :inline, create_derivatives: :inline)

--- a/spec/factories/asset_factory.rb
+++ b/spec/factories/asset_factory.rb
@@ -21,10 +21,18 @@ FactoryBot.define do
     #
     # Will use a default small png, but you can pass `file:` with whatever file you want,
     # of any media type.
+    #
+    # Skips derivatives by default, but add :with_derivatives if desired.
     factory :asset_with_inline_promoted_file do
       file { File.open((Rails.root + "spec/test_support/images/30x30.png")) }
       after(:build) do |asset|
-        asset.file_attacher.set_promotion_directives(promote: :inline, create_derivatives: :inline)
+        asset.file_attacher.set_promotion_directives(promote: :inline, create_derivatives: :false)
+      end
+
+      trait :with_derivatives do
+        after(:build) do |asset|
+          asset.file_attacher.set_promotion_directives(create_derivatives: :inline)
+        end
       end
     end
 

--- a/spec/factories/collection_factory.rb
+++ b/spec/factories/collection_factory.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     published { true }
 
     trait :with_representative do
-      representative { build(:asset, :inline_promoted_file, published: true) }
+      representative { build(:asset_with_faked_file, published: true) }
     end
   end
 end

--- a/spec/models/asset/asset_ingest_validation_spec.rb
+++ b/spec/models/asset/asset_ingest_validation_spec.rb
@@ -10,7 +10,7 @@ describe "Asset ingest validation" do
 
     describe "inline promotion" do
       it "does not ingest" do
-        asset = create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))
+        asset = create(:asset_with_inline_promoted_file, file: File.open(corrupt_tiff_path))
 
         expect(asset.promotion_failed?).to be true
 
@@ -61,7 +61,7 @@ describe "Asset ingest validation" do
   describe ".promotion_failed scope" do
     let(:corrupt_tiff_path) { Rails.root + "spec/test_support/images/corrupt_bad.tiff" }
     let!(:good_asset) { create(:asset_with_faked_file)}
-    let!(:bad_asset) { create(:asset, :inline_promoted_file, file: File.open(corrupt_tiff_path))}
+    let!(:bad_asset) { create(:asset_with_inline_promoted_file, file: File.open(corrupt_tiff_path))}
 
     it "includes only failed assets" do
       failed = Asset.promotion_failed.to_a
@@ -74,7 +74,7 @@ describe "Asset ingest validation" do
 
   describe "Unknown file type" do
     it "does not ingest" do
-      asset = create(:asset, :inline_promoted_file, file: StringIO.new("not a recognized file type with binary data \xF0\xA4\xAD"))
+      asset = create(:asset_with_inline_promoted_file, file: StringIO.new("not a recognized file type with binary data \xF0\xA4\xAD"))
 
       expect(asset.promotion_failed?).to be true
       expect(asset.file_attacher.cached?).to be true

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -13,7 +13,7 @@ describe Asset do
   end
 
   describe "initial checksum creation", queue_adapter: :inline do
-    let!(:asset) { create(:asset_with_inline_promoted_file, :no_derivatives_creation) }
+    let!(:asset) { create(:asset_with_inline_promoted_file) }
     it "checks the asset after storing it" do
       expect(asset.fixity_checks.count).to eq 1
     end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -13,7 +13,7 @@ describe Asset do
   end
 
   describe "initial checksum creation", queue_adapter: :inline do
-    let!(:asset) { create(:asset, :inline_promoted_file) }
+    let!(:asset) { create(:asset_with_inline_promoted_file) }
     it "checks the asset after storing it" do
       expect(asset.fixity_checks.count).to eq 1
     end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -13,7 +13,7 @@ describe Asset do
   end
 
   describe "initial checksum creation", queue_adapter: :inline do
-    let!(:asset) { create(:asset_with_inline_promoted_file) }
+    let!(:asset) { create(:asset_with_inline_promoted_file, :no_derivatives_creation) }
     it "checks the asset after storing it" do
       expect(asset.fixity_checks.count).to eq 1
     end

--- a/spec/models/dzi_package_spec.rb
+++ b/spec/models/dzi_package_spec.rb
@@ -35,14 +35,14 @@ describe DziPackage do
 
   describe "Asset life-cycle automatic actions", queue_adapter: :test do
     describe "asset creation" do
-      let(:asset) { create(:asset, :inline_promoted_file, :bg_derivatives)}
+      let(:asset) { create(:asset_with_inline_promoted_file, :bg_derivatives)}
 
       it "queues dzi creation" do
         asset
         expect(CreateDziJob).to have_been_enqueued.with(asset)
       end
       describe "with derivatives off" do
-        let(:asset) { create(:asset, :inline_promoted_file, :no_derivatives_creation)}
+        let(:asset) { create(:asset_with_inline_promoted_file, :no_derivatives_creation)}
         it "does not create dzi" do
           asset
           expect(CreateDziJob).not_to have_been_enqueued.with(asset)

--- a/spec/models/dzi_package_spec.rb
+++ b/spec/models/dzi_package_spec.rb
@@ -42,7 +42,7 @@ describe DziPackage do
         expect(CreateDziJob).to have_been_enqueued.with(asset)
       end
       describe "with derivatives off" do
-        let(:asset) { create(:asset_with_inline_promoted_file, :no_derivatives_creation)}
+        let(:asset) { create(:asset_with_inline_promoted_file)}
         it "does not create dzi" do
           asset
           expect(CreateDziJob).not_to have_been_enqueued.with(asset)

--- a/spec/serializers/viewer_member_info_serializer_spec.rb
+++ b/spec/serializers/viewer_member_info_serializer_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 describe ViewerMemberInfoSerializer, type: :model, queue_adapter: :inline do
   include Rails.application.routes.url_helpers
 
-  let(:grandchild) { create(:asset, :inline_promoted_file).tap { |g| g.reload } }
+  let(:grandchild) { create(:asset_with_faked_file, :fake_dzi).tap { |g| g.reload } }
   let(:child) { create(:public_work, members: [grandchild], representative: grandchild, position: 2)}
-  let(:asset) { create(:asset, :inline_promoted_file, position: 1).tap { |g| g.reload } }
-  let(:non_published_asset) { create(:asset, :inline_promoted_file, published: false) }
+  let(:asset) { create(:asset_with_faked_file, :fake_dzi, position: 1).tap { |g| g.reload } }
+  let(:non_published_asset) { create(:asset_with_faked_file, published: false) }
   let(:work)  { create(:public_work, members: [child, asset, non_published_asset]) }
 
   let(:serializer) { ViewerMemberInfoSerializer.new(work) }

--- a/spec/serializers/work_oai_dc_serialization_spec.rb
+++ b/spec/serializers/work_oai_dc_serialization_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe WorkOaiDcSerialization do
-  let(:member_asset1) { create(:asset, :inline_promoted_file)}
-  let(:member_asset2) { create(:asset, :inline_promoted_file)}
+  let(:member_asset1) { create(:asset_with_faked_file)}
+  let(:member_asset2) { create(:asset_with_faked_file)}
   let(:collection) { create(:collection, title: "My Local Collection") }
   let(:work) { create(:work, :with_complete_metadata,
     description: "This starts out with <b>tags</b>\n\nAnother paragraph",

--- a/spec/services/asset_graphic_only_pdf_creator_spec.rb
+++ b/spec/services/asset_graphic_only_pdf_creator_spec.rb
@@ -28,7 +28,7 @@ describe AssetGraphicOnlyPdfCreator, type: :model do
     }
   }
 
-  let(:asset) { create(:asset, :inline_promoted_file, file: File.open(tiff_path)) }
+  let(:asset) { create(:asset_with_inline_promoted_file, file: File.open(tiff_path)) }
 
   it "creates a PDF" do
     pdf_file = creator.create

--- a/spec/services/orphan_s3_originals_spec.rb
+++ b/spec/services/orphan_s3_originals_spec.rb
@@ -32,13 +32,13 @@ describe OrphanS3Originals do
   describe "two legit assets, one video and one image, plus two orphans" do
     # Two legitimate, non-orphan assets:
     let(:asset_n)  {
-      create(:asset, :inline_promoted_file,
+      create(:asset_with_inline_promoted_file,
         file: File.open((Rails.root + "spec/test_support/images/20x20.png"))
       )
     }
     let(:asset_v)  {
       # Video derivatives creation has problems in test due to HLS....
-      create(:asset, :inline_promoted_file, :no_derivatives_creation,
+      create(:asset_with_inline_promoted_file, :no_derivatives_creation,
         file: File.open((Rails.root + "spec/test_support/video/sample_video.mp4"))
       )
     }

--- a/spec/services/orphan_s3_originals_spec.rb
+++ b/spec/services/orphan_s3_originals_spec.rb
@@ -38,7 +38,7 @@ describe OrphanS3Originals do
     }
     let(:asset_v)  {
       # Video derivatives creation has problems in test due to HLS....
-      create(:asset_with_inline_promoted_file, :no_derivatives_creation,
+      create(:asset_with_inline_promoted_file,
         file: File.open((Rails.root + "spec/test_support/video/sample_video.mp4"))
       )
     }

--- a/spec/services/pdf_to_page_images_spec.rb
+++ b/spec/services/pdf_to_page_images_spec.rb
@@ -109,7 +109,7 @@ describe PdfToPageImages do
     end
 
     describe "on_existing_dup" do
-      let!(:duplicate) { create(:asset, :fake_dzi, :inline_promoted_file, file: File.open(pdf_path), parent: work, extracted_pdf_source_info: { page_index: 1 }) }
+      let!(:duplicate) { create(:asset_with_faked_file, :pdf, :fake_dzi, parent: work, extracted_pdf_source_info: { page_index: 1 }) }
       let!(:original_file_id) { duplicate.file.id }
       let!(:original_dzi_id) { duplicate.dzi_manifest_file.id }
       let!(:original_derivatives_json) { duplicate.file_derivatives.as_json }

--- a/spec/services/s3_path_iterator_spec.rb
+++ b/spec/services/s3_path_iterator_spec.rb
@@ -36,16 +36,8 @@ describe S3PathIterator do
   end
 
   describe "Using actual files" do
-    let!(:asset_1)  { create(:asset, :inline_promoted_file,
-        position: 1,
-        file: File.open((Rails.root + "spec/test_support/images/20x20.png"))
-      )
-    }
-    let!(:asset_2)  { create(:asset, :inline_promoted_file,
-        position: 2,
-        file: File.open((Rails.root + "spec/test_support/images/20x20.png"))
-      )
-    }
+    let!(:asset_1)  { create(:asset_with_faked_file, position: 1) }
+    let!(:asset_2)  { create(:asset_with_faked_file, position: 2) }
     let!(:work) { FactoryBot.create( :public_work, members: [asset_1, asset_2]) }
     let(:file_paths_1) { [work.members.first.file_data["id"], work.members.second.file_data["id"]] }
     let(:file_paths_2) { [] }

--- a/spec/services/work_combined_audio_creator_spec.rb
+++ b/spec/services/work_combined_audio_creator_spec.rb
@@ -5,7 +5,7 @@ describe "Combined Audio" do
   let(:cmd) { cmd = TTY::Command.new(printer: :null)}
 
   context "one viable mp3, characterized during the test" do
-    let!(:mp3)  { create(:asset, :inline_promoted_file,
+    let!(:mp3)  { create(:asset_with_inline_promoted_file,
         position: 1,
         parent_id: work.id,
         file: File.open((Rails.root + "spec/test_support/audio/5-seconds-of-silence.mp3"))
@@ -38,13 +38,13 @@ describe "Combined Audio" do
   end
 
   context "two viable originals - an mp3 and a flac" do
-    let!(:mp3_1)  { create(:asset, :inline_promoted_file,
+    let!(:mp3_1)  { create(:asset_with_inline_promoted_file,
         position: 1,
         parent_id: work.id,
         file: File.open((Rails.root + "spec/test_support/audio/5-seconds-of-silence.mp3"))
       )
     }
-    let!(:flac_2)  { create(:asset, :inline_promoted_file,
+    let!(:flac_2)  { create(:asset_with_inline_promoted_file,
         position: 2,
         parent_id: work.id,
         file: File.open((Rails.root + "spec/test_support/audio/5-seconds-of-silence.flac"))

--- a/spec/system/catalog_search_spec.rb
+++ b/spec/system/catalog_search_spec.rb
@@ -13,7 +13,7 @@ describe CatalogController, solr: true, indexable_callbacks: true do
         description: 'priceless work',
         date_of_work: { start: "2019" },
         subject: ["one", "two", "three", "four", "five", "six"],
-        representative: create(:asset, :inline_promoted_file, published: true),
+        representative: create(:asset_with_faked_file, published: true),
         members: [
           create(:public_work, date_of_work: { start: "2020" }),
           create(:public_work, date_of_work: { start: "2021" })
@@ -23,7 +23,7 @@ describe CatalogController, solr: true, indexable_callbacks: true do
     let!(:collection) do
       create(:collection,
         description: 'priceless collection',
-        representative: create(:asset, :inline_promoted_file, published: true),
+        representative: create(:asset_with_faked_file, published: true),
         contains: [work1] )
     end
 

--- a/spec/system/collection/edit_collection_spec.rb
+++ b/spec/system/collection/edit_collection_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe "Edit Collection form", logged_in_user: :editor, type: :system, q
   let(:collection) {
     FactoryBot.create(
         :collection,
-        representative: FactoryBot.create(:asset,
-                                          :inline_promoted_file,
-                                          file: File.open((Rails.root + "spec/test_support/images/30x30.png"))) )
+        representative: FactoryBot.create(:asset_with_faked_file))
   }
 
   scenario "edits collection and changes thumbnail" do


### PR DESCRIPTION
Ref #214. Speeds up specs by ~20 seconds on MacBook. 

The factory trait `with_inline_promoted_file` created factory models that went through full actual promotion process, with all real derivatives created the real way. This is quite slow!  It was being done in specs that this was simply not necessary, and specs could still easily pass without it. 

Switched these specs to the `asset_with_faked_file` factory instead.  Switched `with_inline_promoted_file` to a sub-factory instead of a trait -- it should be used only in specific places where necessary, it shoudln't be conveniently mixed and matched with other setup. This will hopefully make it harder to use accidentally unawares. 

Specs that needed real derivative creation to pass were left using `asset_with_inline_promoted_file` sub-factory -- they could potentially be refactored to work differently and save time, but first focusing on low-hanging fruit. Initial review said, yeah, i see the value of testing real deriv creation there, even if there might be other ways to approach with some thought. 

This PR was prepared with help of Claude Code, identifying which specs were using inline promotion and good candidates for switching, and then doing the code writing to switch. 

- **switch some factory use from inline_promoted to asset_with_faked_file for performance**
- **switch to asset_with_faked_file for performance**
- **swap with_inline_promoted_file from trait to factory**
- **make instance of inline_promoted_file somewhat faster without derivatives**
- **even if you need inline_promoted_file, if you don't need derivatives we can save time**
