### PR TITLE
Avoid unnecessary testing with real browser in system specs

### DIFF
--- a/spec/system/admin/asset_list_spec.rb
+++ b/spec/system/admin/asset_list_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-RSpec.describe "Oral History Access Interviewee bio", :logged_in_user, type: :system, queue_adapter: :test  do
+RSpec.describe "Oral History Access Interviewee bio", :logged_in_user, type: :system, js: false, queue_adapter: :test  do
   let!(:normal_asset) { create(:asset, title: "normal asset", parent: create(:work, title: "Parent work")) }
   let!(:orphaned_asset) { create(:asset, title: "orphaned asset", parent: nil) }
 

--- a/spec/system/admin/oral_history_request_spec.rb
+++ b/spec/system/admin/oral_history_request_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Oral History Access Request Administration", :logged_in_user, type: :system, queue_adapter: :test  do
+RSpec.describe "Oral History Access Request Administration", :logged_in_user, type: :system, js: false, queue_adapter: :test  do
   let!(:work) do
     create(:oral_history_work, :available_by_request, availability_mode: :reviewed_request, published: true)
   end

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-RSpec.describe "Logins", type: :system do
+RSpec.describe "Logins", type: :system, js: false do
   
   # NOTE:
   # System tests are slow and tend to be flaky, so please try

--- a/spec/system/oral_history_collection_show_spec.rb
+++ b/spec/system/oral_history_collection_show_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe "Collection show page", solr: true, indexable_callbacks: true do
+describe "Collection show page", solr: true, indexable_callbacks: true, js: false do
   describe "smoke test" do
     let(:collection) do
       create(:collection,

--- a/spec/system/work/oral_history_work_spec.rb
+++ b/spec/system/work/oral_history_work_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe "Oral history work", logged_in_user: :editor, queue_adapter: :test do
+describe "Oral history work", logged_in_user: :editor, js: false, queue_adapter: :test do
   let(:work) { FactoryBot.create(:oral_history_work) }
 
   describe "combined audio derivatives" do


### PR DESCRIPTION
Ref #214. Speeds up spec by ~15 seconds on MacBook. 

By default our `system` specs test with a headless Chrome. This is quite slow. 

by putting `js: false` in metadata for example group or example, they will not use a real browser to test, but use `rack-test`, basically just ruby code.  

This makes them basically as fast as `request` spec might be, but without having to refactor to use that API, still with convenient user-agent-centric API.  Also if you're trying to debug why one is failing, you can always `js: true` again, and look at it in a real browser!

Some of our system specs were using real. browser, but will pass just fine with no changes with `js: false` without real browser.  We just change these to just js:false for some real low-hanging fruit spec speed up. 

We do still need real browser sometimes -- it's currently the only way we have to test JS, and sometimes we really do want to test in a real browser environment to be sure everything is copacetic. But we don't need it every time. 

**Q**: Do we want to maek `js: false` *default* in our system specs, so you have to opt-in to real browser as a special case?  This PR does not yet do that, `js: true` (real browser) is still default. But that might keep tests faster as a default, only opting in when you really want a real browser and JS execution. 