### PR TITLE
stub actual PDF extraction when not necessary in specs

### DIFF
--- a/spec/services/pdf_to_page_images_spec.rb
+++ b/spec/services/pdf_to_page_images_spec.rb
@@ -189,21 +189,27 @@ describe PdfToPageImages do
     end
   end
 
-  describe "#create_assets_for_pages" do
+  # This one is super slow if we don't mock create_asset_for_page individually, test that
+  # itself please.
+  describe "#create_assets_for_pages, mocked" do
     let(:pdf_path) { Rails.root + "spec/test_support/pdf/3-page-text-and-image.pdf"}
     let(:work) { create(:work) }
 
-    it "creates all assets" do
-      stub_extract_jpeg_for_page(service)
-      stub_extract_hocr_for_page(service)
+    it "creates asset for each page" do
+      allow(service).to receive(:create_asset_for_page)
+
       service.create_assets_for_pages(work: work, source_pdf_sha512: nil, source_pdf_asset_pk: nil)
 
-      extracted_assets = work.members.where(role: PdfToPageImages::EXTRACTED_PAGE_ROLE).order(:position).to_a
-
-      expect(extracted_assets.count).to eq 3
-      expect(extracted_assets.collect(&:position)).to eq [1,2,3]
-      expect(extracted_assets.all? { |a| a.hocr.present? }).to be true
-      expect(extracted_assets.all? { |a| a.file.present? }).to be true
+      (1..service.num_pdf_pages).each do |page_num|
+        expect(service).to have_received(:create_asset_for_page).ordered.
+          with(
+            page_num,
+            work: work,
+            on_existing_dup: :insert_dup,
+            source_pdf_sha512: nil,
+            source_pdf_asset_pk: nil
+          )
+      end
     end
   end
 end

--- a/spec/services/pdf_to_page_images_spec.rb
+++ b/spec/services/pdf_to_page_images_spec.rb
@@ -5,6 +5,26 @@ describe PdfToPageImages do
   let(:pdf_path) { Rails.root + "spec/test_support/pdf/sample-text-and-image-small.pdf"}
   let(:service) { PdfToPageImages.new(pdf_path) }
 
+  let(:stub_jpeg_path) { Rails.root + "spec/test_support/images/30x30.jpg" }
+  let(:sample_hocr) { File.read(Rails.root + "spec/test_support/hocr_xml/extract_from_pdf_sample.300.hocr") }
+
+  # Each call gets a fresh Tempfile copy so the service's ensure-block cleanup
+  # doesn't break things across multiple calls.
+  def stub_extract_jpeg_for_page(service)
+    jpeg_path = stub_jpeg_path
+    allow(service).to receive(:extract_jpeg_for_page) do
+      t = Tempfile.new(["page_", ".jpg"])
+      t.binmode
+      t.write(File.binread(jpeg_path.to_s))
+      t.rewind
+      t
+    end
+  end
+
+  def stub_extract_hocr_for_page(service)
+    allow(service).to receive(:extract_hocr_for_page).and_return(sample_hocr)
+  end
+
   describe "#extract_jpeg_for_page" do
     it "extracts a good image" do
       image_file = service.extract_jpeg_for_page(1)
@@ -125,6 +145,8 @@ describe PdfToPageImages do
       end
 
       it ":overwrite uses existing with update", queue_adapter: :test do
+        stub_extract_jpeg_for_page(service)
+        stub_extract_hocr_for_page(service)
         asset = service.create_asset_for_page(1, work: work, on_existing_dup: :overwrite, source_pdf_sha512: "newsha512", source_pdf_asset_pk: "newid")
 
         expect(asset.id).to eq duplicate.id
@@ -153,6 +175,8 @@ describe PdfToPageImages do
       end
 
       it ":insert_dup just inserts anyway" do
+        stub_extract_jpeg_for_page(service)
+        stub_extract_hocr_for_page(service)
         asset = service.create_asset_for_page(1, work: work, on_existing_dup: :insert_dup, source_pdf_sha512: nil, source_pdf_asset_pk: nil)
 
         expect(asset.id).not_to eq duplicate.id
@@ -170,6 +194,8 @@ describe PdfToPageImages do
     let(:work) { create(:work) }
 
     it "creates all assets" do
+      stub_extract_jpeg_for_page(service)
+      stub_extract_hocr_for_page(service)
       service.create_assets_for_pages(work: work, source_pdf_sha512: nil, source_pdf_asset_pk: nil)
 
       extracted_assets = work.members.where(role: PdfToPageImages::EXTRACTED_PAGE_ROLE).order(:position).to_a


### PR DESCRIPTION
Ref #214

Testing PdfToPageImages, actual shell out to `vips` and `pdftotext` for actual pdf extraction is very slow. We want to test the actual shell out at least a little bit to prove it owrks, but in many tests we can mock it instead. 

Saves ~6 seconds in this test file! 

We had Claude help us do this, starting with prompt:

> So these are slow becaues they are shelling out to CLI process for actual PDF extraction. 
>
> I do want to do that for the example on :70. 
>
> But for the others, maybe we coudl use rspec expectations to mock the CLI call.  but still have a test that gives us confidence the right thing is happening?  Can you suggest how we'd do that?  If you need to change the unit under test to allow dependency injeciton so we can mock, that could be one approach.

(It mocked internal methods instead of changing to allow dependency injection of the CLI call-out, which is fine). 

Saves around 6 seconds!
