### PR TITLE
Tweaks to buggy code alerting user of QA autocomplete errors

### DIFF
--- a/app/frontend/javascript/admin/qa_autocomplete.js
+++ b/app/frontend/javascript/admin/qa_autocomplete.js
@@ -83,15 +83,15 @@ function addAutocomplete(element) {
       showNoSuggestionNotice: true,
       serviceUrl: qa_search_url,
 
-
-
       onSearchError: function (query, jqXHR, textStatus, errorThrown) {
         var errorText = "Error fetching results from " + $(this).data("scihist-qa-autocomplete") + ":<br/>" + textStatus + ": " + errorThrown;
         var container = $($(this).autocomplete().suggestionsContainer);
 
         console.error(errorText);
-
         $(errorContainer).html("<i class='fa fa-exclamation-triangle' aria-hidden='true'></i> " + errorText)
+
+        // Pretty hacky way to show error message in dropdown, reaching into
+        // autocomplete internals. Based on how autocomplete shows no-results message.
         container.empty();
         container.append(errorContainer);
         container.css("top",   $(this).position()['top'] + 50);

--- a/app/frontend/javascript/admin/qa_autocomplete.js
+++ b/app/frontend/javascript/admin/qa_autocomplete.js
@@ -83,15 +83,12 @@ function addAutocomplete(element) {
       showNoSuggestionNotice: true,
       serviceUrl: qa_search_url,
 
-      onSearchError: function (query, jqXHR, textStatus, errorThrown) {
-        console.log("autocomplete error fetching results: " + textStatus + ": " + errorThrown);
 
-        // Pretty hacky way to show error message in dropdown, reaching into
-        // autocomplete internals. Based on how autocomplete shows no-results message.
-        var container = $($(this).autocomplete().suggestionsContainer)
-        container.empty();
-        container.append(errorContainer);
-        container.show();
+      // The hacky error reporting code we used was not working;
+      // in this case it seems fine to just use a JS alert to tell staff immediately
+      // about problems with QA.
+      onSearchError: function (query, jqXHR, textStatus, errorThrown) {
+        alert("Problem fetching results from " + qa_search_url + ":\n" + textStatus + ": " + errorThrown);
       },
 
       transformResult: function(response) {

--- a/app/frontend/javascript/admin/qa_autocomplete.js
+++ b/app/frontend/javascript/admin/qa_autocomplete.js
@@ -84,11 +84,19 @@ function addAutocomplete(element) {
       serviceUrl: qa_search_url,
 
 
-      // The hacky error reporting code we used was not working;
-      // in this case it seems fine to just use a JS alert to tell staff immediately
-      // about problems with QA.
+
       onSearchError: function (query, jqXHR, textStatus, errorThrown) {
-        alert("Problem fetching results from " + qa_search_url + ":\n" + textStatus + ": " + errorThrown);
+        var errorText = "Error fetching results from " + $(this).data("scihist-qa-autocomplete") + ":<br/>" + textStatus + ": " + errorThrown;
+        var container = $($(this).autocomplete().suggestionsContainer);
+
+        console.error(errorText);
+
+        $(errorContainer).html("<i class='fa fa-exclamation-triangle' aria-hidden='true'></i> " + errorText)
+        container.empty();
+        container.append(errorContainer);
+        container.css("top",   $(this).position()['top'] + 50);
+        container.css("left",  $(this).position()['left']);
+        container.show();
       },
 
       transformResult: function(response) {


### PR DESCRIPTION
Ref #2674 
The QA autocomplete JS was actually calling an error handling method. The code was working OK but the error message was being displayed at the bottom of the page. I adjusted it so it shows up in the right place (see screenshot below). Tested in dev and it now works fine.