### PR TITLE
Only log bad legacy OH url if referer presenet, and only at debug level

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -15,7 +15,7 @@ class StaticController < ApplicationController
   end
 
   def oh_legacy_url_not_found
-    Rails.logger.warn("Unknown legacy oral histories url: #{request.url}; referer: #{request.referer} ")
+    Rails.logger.debug("Unknown legacy oral histories url: #{request.url}; referer: #{request.referer} ") if request.referer
 
     @original_url = request.url
     @original_referer = request.referer


### PR DESCRIPTION
Debug level won't show up at all in production. We were getting so many of these from bots, that it was filling up our logs. The point of logging them was on original implementation to find anyone wrongly pointing at old unsupported urls, and use referer to see who (whether internal or external) and get it fixed. But we definitely didn't look at these anymore, and the bot ones don't have referer so aren't very actionable anyway.

Hopefully keep from filling up our papertrial log limit in cases where bots are flooding us iwth these old bad ones.
