### PR TITLE
Use test-prof's `let_it_be`  to create test data persistent between examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,12 @@ set up, and you can run against dev_s3 mode:
 
 In dev_s3, all files are put in our shared dev bucket. The above command manually sets an S3_DEV_PREFIX, so it won't mess with or accidentally delete your ordinary dev files.
 
+#### We use recipes from test-prof for our specs
+
+Particularly [let_it_be](https://github.com/test-prof/test-prof/blob/master/docs/recipes/let_it_be.md) and [before_all](https://github.com/test-prof/test-prof/blob/master/docs/recipes/before_all.md) from [test-prof](https://github.com/test-prof/test-prof) can be used to re-use data between examples in a file without re-creating it. This gives us significant test suite speed-ups, consider it.
+
+We don't yet use [AnyFixture](https://github.com/test-prof/test-prof/blob/master/docs/recipes/any_fixture.md), but have considered it.
+
 ## Production deployment
 
 We deploy to AWS, the deployment is done _mostly_ automatically by some ansible playbooks:

--- a/app/services/oral_history/pdf_paragraph_splitter.rb
+++ b/app/services/oral_history/pdf_paragraph_splitter.rb
@@ -132,9 +132,10 @@ module OralHistory
       (first_index..(extracted_pdf_text_pages.count - 1)).each do |page_index|
         page_json = extracted_pdf_text_pages[page_index]
 
-        # dup em so we can modify the list to remove page numbers paragraphs. We don't
-        # care about blocks for processing at the moment.
-        page_paragraphs_json = page_json["blocks"].collect {|h| h["paragraphs"]}.flatten
+        # dup the list so we can modify the list to remove page numbers paragraphs. We don't
+        # care about blocks for processing at the moment. Dup the elements so we can mutate
+        # them in procesing too.
+        page_paragraphs_json = page_json["blocks"].collect {|h| h["paragraphs"].deep_dup}.flatten
 
         # usually on bottom, sometimes on top
         logical_page_number = extract_and_remove_logical_page_number(page_paragraphs_json)
@@ -281,8 +282,8 @@ module OralHistory
       #     ____________________________________ *Footnote
       if paragraphs_json.present? && (note_index = (paragraphs_json.last['text'] =~ /_{15,} ?\*/))
 
-        # we need to cut that last paragraph to stop there
-        paragraphs_json.last['text'].slice!(note_index..-1)
+        # we need to cut that last paragraph to stop there; replace element with new hash
+        paragraphs_json.last['text'] = paragraphs_json.last['text'][0...note_index]
       end
     end
 

--- a/spec/controllers/collection_show_controller_spec.rb
+++ b/spec/controllers/collection_show_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 # (that is a rails 'functional' test)?
 RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :controller do
   describe "unpublished collection" do
-    let(:collection) { create(:collection, published: false) }
+    let_it_be(:collection) { create(:collection, published: false) }
 
     describe "non-logged-in user", logged_in_user: false do
       it "has permission denied" do
@@ -38,7 +38,7 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
   end
 
   describe "Bad params" do
-    let(:collection) { create(:collection, friendlier_id: "faked") }
+    let_it_be(:collection) { create(:collection, friendlier_id: "faked") }
     it "doesn't throw an error when facet.page is a hash" do
       get :facet, params: {
         id:              "subject_facet",
@@ -253,7 +253,7 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
 
   describe "display box and folder", indexable_callbacks: true do
     render_views
-    let!(:collection) { create(:collection, title: "The Collection") }
+    let_it_be(:collection) { create(:collection, title: "The Collection") }
     let(:parsed){ parsed = Nokogiri::HTML(response.body) }
     let(:containers_as_displayed) { parsed.css('.scihist-results-list-item-box-and-folder').map {|x| x.text} }
     let(:titles_as_displayed) { parsed.css('.scihist-results-list-item-head a').map {|x| x.text} }
@@ -329,24 +329,18 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
   describe "search form with box and folder", indexable_callbacks: true do
     render_views
     describe "smoke test" do
-      let(:b1f1) {
-        Work::PhysicalContainer.new({ box:1, folder:1 })
-      }
-      let(:b1f2) {
-        Work::PhysicalContainer.new({ box:1, folder:2 })
-      }
-      let(:b12f1) {
-        Work::PhysicalContainer.new({ box:12, folder:1 })
-      }
-      let!(:works) {
-        [
-          create(:work, :published, physical_container: b1f1, title: "b1_f1_1", contained_by:   [collection]),
-          create(:work, :published, physical_container: b1f1, title: "b1_f1_2", contained_by:   [collection]),
-          create(:work, :published, physical_container: b1f2, title: "b1_f1_3", contained_by:   [collection]),
-          create(:work, :published, physical_container: b1f2, title: "b12_f1",  contained_by:   [collection]),
+      before_all do
+        @collection = create(:collection, friendlier_id: "faked", department: "Archives")
+        @works = [
+          create(:work, :published, physical_container: Work::PhysicalContainer.new({ box:1, folder:1 }), title: "b1_f1_1", contained_by: [@collection]),
+          create(:work, :published, physical_container: Work::PhysicalContainer.new({ box:1, folder:1 }), title: "b1_f1_2", contained_by: [@collection]),
+          create(:work, :published, physical_container: Work::PhysicalContainer.new({ box:1, folder:2 }), title: "b1_f1_3", contained_by: [@collection]),
+          create(:work, :published, physical_container: Work::PhysicalContainer.new({ box:12, folder:1 }), title: "b12_f1",  contained_by: [@collection]),
         ]
-      }
-      let!(:collection) { create(:collection, friendlier_id: "faked", department: "Archives") }
+      end
+      before(:each) { @works.each(&:update_index) }
+      let(:collection) { @collection }
+      let(:works) { @works }
       let(:box_and_folder_params) do
         {"q"=>"", "box_id"=>"1", "folder_id"=>"1", "sort"=>"", "collection_id"=> collection.friendlier_id }
       end
@@ -367,17 +361,22 @@ RSpec.describe CollectionShowController, :logged_in_user, solr: true, type: :con
       end
     end
    describe "edge cases" do
+      before_all do
+        @collection = create(:collection, friendlier_id: "faked", department: "Archives")
+        @work = create(:work, :published,
+          title: "archival_work",
+          physical_container: Work::PhysicalContainer.new({
+            "box"=>"apples, pears and mangos 1234",
+            "folder"=> "lions and tigers and bears oh my 5678"
+          }),
+          contained_by: [@collection]
+        )
+      end
+      before(:each) { @work.update_index }
+      let(:collection) { @collection }
+      let(:work) { @work }
       let(:parsed){ parsed = Nokogiri::HTML(response.body) }
       let(:titles_as_displayed) { parsed.css('.scihist-results-list-item-head a').map {|x| x.text} }
-      let!(:work) { create(:work, :published,
-        title: "archival_work",
-        physical_container: Work::PhysicalContainer.new({
-          "box"=>"apples, pears and mangos 1234",
-          "folder"=> "lions and tigers and bears oh my 5678"
-        }),
-        contained_by:   [collection])
-      }
-      let!(:collection) { create(:collection, friendlier_id: "faked", department: "Archives") }
       it "does not return works that don't match" do
         get :index, params: {
           "q"=>"",

--- a/spec/models/asset/derivatives_spec.rb
+++ b/spec/models/asset/derivatives_spec.rb
@@ -4,11 +4,11 @@ describe "derivative creation" do
 
   let(:flac_file_path) { Rails.root.join("spec/test_support/audio/5-seconds-of-silence.flac")}
   let(:flac_file_sha512) { Digest::SHA512.hexdigest(File.read(flac_file_path)) }
-  let!(:flac_asset) { FactoryBot.create(:asset, file: File.open(flac_file_path)) }
+  let(:flac_asset) { FactoryBot.create(:asset, file: File.open(flac_file_path)) }
 
   let(:mp3_file_path) { Rails.root.join("spec/test_support/audio/5-seconds-of-silence.mp3")}
   let(:mp3_file_sha512) { Digest::SHA512.hexdigest(File.read(mp3_file_path)) }
-  let!(:mp3_asset) { FactoryBot.create(:asset, file: File.open(mp3_file_path)) }
+  let(:mp3_asset) { FactoryBot.create(:asset, file: File.open(mp3_file_path)) }
 
 
   describe 'pdf asset' do

--- a/spec/models/oral_history_content_spec.rb
+++ b/spec/models/oral_history_content_spec.rb
@@ -136,9 +136,9 @@ describe OralHistoryContent do
   end
 
   describe "scopes" do
-    let!(:ohms_oh) { create(:oral_history_work, :ohms_xml, :public_files, title: "OHMS OH") }
-    let!(:immediate_oh) { create(:oral_history_work, :public_files, title: "Public OH") }
-    let!(:embargoed_oh) { create(:oral_history_work, :available_by_request, title: "Embargoed OH", availability_mode: "embargoed") }
+    let_it_be(:ohms_oh) { create(:oral_history_work, :ohms_xml, :public_files, title: "OHMS OH") }
+    let_it_be(:immediate_oh) { create(:oral_history_work, :public_files, title: "Public OH") }
+    let_it_be(:embargoed_oh) { create(:oral_history_work, :available_by_request, title: "Embargoed OH", availability_mode: "embargoed") }
 
     it "fetches ohms" do
       results = OralHistoryContent.with_ohms.to_a

--- a/spec/policies/access_policy_spec.rb
+++ b/spec/policies/access_policy_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 describe "access policies:" do
-  let!(:published_asset) { create(:asset_with_faked_file) }
-  let!(:unpublished_asset) { create(:asset_with_faked_file, published: false) }
+  let_it_be(:published_asset) { create(:asset_with_faked_file) }
+  let_it_be(:unpublished_asset) { create(:asset_with_faked_file, published: false) }
 
-  let!(:collection) { create(:collection) }
+  let_it_be(:collection) { create(:collection) }
 
   let(:comment_you_can_delete) { Admin::QueueItemComment.new(user: user)}
   let(:coment_you_can_t_delete) { Admin::QueueItemComment.new(user: nil)}

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,8 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'test_prof/recipes/rspec/before_all'
+require 'test_prof/recipes/rspec/let_it_be'
 
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/serializers/google_arts_and_culture/work_serializer_spec.rb
+++ b/spec/serializers/google_arts_and_culture/work_serializer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe GoogleArtsAndCulture::WorkSerializer do
-  let!(:work) do
+  let_it_be(:work) do
     create(
       :public_work,
       members: [
@@ -50,7 +50,7 @@ RSpec.describe GoogleArtsAndCulture::WorkSerializer do
       allow(serializer).to receive(:test_mode).and_return(true)
     end
 
-    let!(:work) do
+    let_it_be(:work) do
       create(:work, :with_complete_metadata,
         creator_attributes: {
           "0"=>{"category"=> "author",     "value"=>"author_1" },
@@ -97,7 +97,7 @@ RSpec.describe GoogleArtsAndCulture::WorkSerializer do
     end
 
     context "creator; contributor; publisher" do
-      let!(:work) do
+      let_it_be(:work) do
         create(:work, :extra_creator_metadata)
       end
 

--- a/spec/services/google_arts_and_culture/exporter_spec.rb
+++ b/spec/services/google_arts_and_culture/exporter_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'zip'
 
 RSpec.describe GoogleArtsAndCulture::Exporter do
-  let!(:work_1) do
+  let_it_be(:work_1) do
     create(
       :public_work,
       members: [
@@ -11,7 +11,7 @@ RSpec.describe GoogleArtsAndCulture::Exporter do
     )
   end
 
-  let!(:work_2) do
+  let_it_be(:work_2) do
     create(
       :public_work,
       members: [
@@ -20,7 +20,7 @@ RSpec.describe GoogleArtsAndCulture::Exporter do
     )
   end
 
-  let!(:work_3) do
+  let_it_be(:work_3) do
     create(
       :private_work,
       members: [

--- a/spec/services/oral_history/chunk_fetcher_spec.rb
+++ b/spec/services/oral_history/chunk_fetcher_spec.rb
@@ -115,11 +115,11 @@ describe OralHistory::ChunkFetcher do
   # Duplicates what's in OralHistoryCotent scope checks and is slow, but important
   # enough to ensure coverage here too sorry.
   describe "access limits" do
-    let!(:ohms_oh) { create(:oral_history_work, :ohms_xml, :public_files, title: "OHMS OH", published: true) }
-    let!(:immediate_oh) { create(:oral_history_work, :public_files, title: "Public OH", published: true) }
-    let!(:needs_approval_oh) { create(:oral_history_work, :available_by_request, title: "Needs approval OH", availability_mode: "reviewed_request", published: true)}
-    let!(:upon_request_oh) { create(:oral_history_work, :available_by_request, title: "Automatic Approval OH", availability_mode: "automatic_request", published: true) }
-    let!(:private_oh) {
+    let_it_be(:ohms_oh) { create(:oral_history_work, :ohms_xml, :public_files, title: "OHMS OH", published: true) }
+    let_it_be(:immediate_oh) { create(:oral_history_work, :public_files, title: "Public OH", published: true) }
+    let_it_be(:needs_approval_oh) { create(:oral_history_work, :available_by_request, title: "Needs approval OH", availability_mode: "reviewed_request", published: true)}
+    let_it_be(:upon_request_oh) { create(:oral_history_work, :available_by_request, title: "Automatic Approval OH", availability_mode: "automatic_request", published: true) }
+    let_it_be(:private_oh) {
       create(:oral_history_work,
         title: "NOT available OH",
         members: [
@@ -129,11 +129,11 @@ describe OralHistory::ChunkFetcher do
       )
     }
 
-    let!(:chunk_ohms_oh) { create(:oral_history_chunk, oral_history_content: ohms_oh.oral_history_content) }
-    let!(:chunk_immediate_oh) { create(:oral_history_chunk, oral_history_content: immediate_oh.oral_history_content) }
-    let!(:chunk_needs_approval_oh) { create(:oral_history_chunk, oral_history_content: needs_approval_oh.oral_history_content) }
-    let!(:chunk_upon_request_oh) { create(:oral_history_chunk, oral_history_content: upon_request_oh.oral_history_content) }
-    let!(:chunk_private_oh) { create(:oral_history_chunk, oral_history_content: private_oh.oral_history_content) }
+    let_it_be(:chunk_ohms_oh) { create(:oral_history_chunk, oral_history_content: ohms_oh.oral_history_content) }
+    let_it_be(:chunk_immediate_oh) { create(:oral_history_chunk, oral_history_content: immediate_oh.oral_history_content) }
+    let_it_be(:chunk_needs_approval_oh) { create(:oral_history_chunk, oral_history_content: needs_approval_oh.oral_history_content) }
+    let_it_be(:chunk_upon_request_oh) { create(:oral_history_chunk, oral_history_content: upon_request_oh.oral_history_content) }
+    let_it_be(:chunk_private_oh) { create(:oral_history_chunk, oral_history_content: private_oh.oral_history_content) }
 
     it "enforces ohms_only" do
       results = OralHistory::ChunkFetcher.new(top_k: 10, question_embedding: fake_vector, access_limit: :immediate_ohms_only).fetch_chunks

--- a/spec/services/oral_history/chunk_fetcher_spec.rb
+++ b/spec/services/oral_history/chunk_fetcher_spec.rb
@@ -20,29 +20,26 @@ describe OralHistory::ChunkFetcher do
   let(:fake_question_embedding) { fake_vector(0.03263719,-0.021255592,-0.018256947,0.012259656,0.008308401)}
 
 
-  let(:work1) { create(:oral_history_work, :public_files, published: true) }
+  let_it_be(:work1) { create(:oral_history_work, :public_files, published: true) }
 
-
-  let!(:chunk1) { create(:oral_history_chunk,
+  let_it_be(:chunk1) { create(:oral_history_chunk,
                   oral_history_content: work1.oral_history_content,
                   embedding: fake_vector(0.01759516,-0.0453438, -0.029577527, -0.032289326, 0.012045433),
                   speakers: ["SMITH"])}
 
-  let!(:chunk2) { create(:oral_history_chunk,
+  let_it_be(:chunk2) { create(:oral_history_chunk,
                         oral_history_content: work1.oral_history_content,
                         embedding: fake_vector(0.059072047,-0.021131188,-0.013840758,-0.0077753244,-0.02725617),
                         speakers: ["SMITH", "JONES"], text: "Chunk 2")}
 
+  let_it_be(:work2) { create(:oral_history_work, :public_files, published: true) }
 
-  let(:work2) { create(:oral_history_work, :public_files, published: true) }
-
-
-  let!(:chunk3) { create(:oral_history_chunk,
+  let_it_be(:chunk3) { create(:oral_history_chunk,
                         oral_history_content: work2.oral_history_content,
                         embedding: fake_vector(0.015151533,-0.01646033,-0.021422518,-0.024602171,0.009659404),
                         speakers: ["SMITH", "JONES"], text: "Chunk 3")}
 
-  let!(:chunk4) { create(:oral_history_chunk,
+  let_it_be(:chunk4) { create(:oral_history_chunk,
                         oral_history_content: work2.oral_history_content,
                         embedding: fake_vector(0.013049184,-0.019433592,-0.024848722,-0.010990473,0.024592385),
                         speakers: ["SMITH", "JONES"], text: "Chunk 3")}

--- a/spec/services/oral_history/pdf_paragraph_splitter_spec.rb
+++ b/spec/services/oral_history/pdf_paragraph_splitter_spec.rb
@@ -1,12 +1,11 @@
 require 'rails_helper'
 
 describe OralHistory::PdfParagraphSplitter do
-  let(:extracted_pdf_text) { OralHistory::ExtractPdfText.new(pdf_file_path: oh_pdf_path).extract_pdf_text }
-
   let(:splitter) { described_class.new(extracted_pdf_text: extracted_pdf_text) }
 
   describe "very old transcript" do
-    let(:oh_pdf_path) { Rails.root + "spec/test_support/pdf/oh/rice_1984_sample_pages_fhb2l9q.pdf"}
+    let_it_be(:oh_pdf_path) { Rails.root + "spec/test_support/pdf/oh/rice_1984_sample_pages_fhb2l9q.pdf"}
+    let_it_be(:extracted_pdf_text) { OralHistory::ExtractPdfText.new(pdf_file_path: oh_pdf_path).extract_pdf_text }
 
     it "extracts good paragraphs" do
       paragraphs = splitter.paragraphs
@@ -50,7 +49,8 @@ describe OralHistory::PdfParagraphSplitter do
   end
 
   describe "old transcript with upper page numbers, and asterisk footnotes" do
-    let(:oh_pdf_path) { Rails.root + "spec/test_support/pdf/oh/prelog_1984_sample_pages_2514nm37q.pdf"}
+    let_it_be(:oh_pdf_path) { Rails.root + "spec/test_support/pdf/oh/prelog_1984_sample_pages_2514nm37q.pdf"}
+    let_it_be(:extracted_pdf_text) { OralHistory::ExtractPdfText.new(pdf_file_path: oh_pdf_path).extract_pdf_text }
 
     it "can still get page numbers" do
       paragraphs = splitter.paragraphs
@@ -90,7 +90,8 @@ describe OralHistory::PdfParagraphSplitter do
   end
 
   describe "with page with figure and no assigned page number" do
-    let(:oh_pdf_path) { Rails.root + "spec/test_support/pdf/oh/boyer-skipped-page-example.pdf" }
+    let_it_be(:oh_pdf_path) { Rails.root + "spec/test_support/pdf/oh/boyer-skipped-page-example.pdf" }
+    let_it_be(:extracted_pdf_text) { OralHistory::ExtractPdfText.new(pdf_file_path: oh_pdf_path).extract_pdf_text }
 
     it "can process and properly number pages" do
       paragraphs = splitter.paragraphs
@@ -107,7 +108,8 @@ describe OralHistory::PdfParagraphSplitter do
   end
 
   describe "with two interviews in one pdf" do
-    let(:oh_pdf_path) { Rails.root + "spec/test_support/pdf/oh/glusker_2022_sequence_timestamps_example.pdf" }
+    let_it_be(:oh_pdf_path) { Rails.root + "spec/test_support/pdf/oh/glusker_2022_sequence_timestamps_example.pdf" }
+    let_it_be(:extracted_pdf_text) { OralHistory::ExtractPdfText.new(pdf_file_path: oh_pdf_path).extract_pdf_text }
     let(:file_start_times) { { "random1" => 60*60*2, "random2" => 60*60*4, "random3" => 60*60*6 } }
     let(:splitter) { described_class.new(extracted_pdf_text: extracted_pdf_text, file_start_times: file_start_times) }
 
@@ -122,7 +124,8 @@ describe OralHistory::PdfParagraphSplitter do
   end
 
   describe "mid-era transcript, with minute timestamp style" do
-    let(:oh_pdf_path) { Rails.root + "spec/test_support/pdf/oh/Macfarlane_1982_sample_pages_subbr8.pdf"}
+    let_it_be(:oh_pdf_path) { Rails.root + "spec/test_support/pdf/oh/Macfarlane_1982_sample_pages_subbr8.pdf"}
+    let_it_be(:extracted_pdf_text) { OralHistory::ExtractPdfText.new(pdf_file_path: oh_pdf_path).extract_pdf_text }
 
     it "extracts timestamps" do
       paragraphs = splitter.paragraphs
@@ -181,7 +184,9 @@ describe OralHistory::PdfParagraphSplitter do
     end
 
     describe "that need re-sequencing for starting over at new audio files" do
-      let(:oh_pdf_path) { Rails.root + "spec/test_support/pdf/oh/macfarlane_1982_sequence_timestamps_example.pdf"}
+      let_it_be(:oh_pdf_path) { Rails.root + "spec/test_support/pdf/oh/macfarlane_1982_sequence_timestamps_example.pdf"}
+      let_it_be(:extracted_pdf_text) { OralHistory::ExtractPdfText.new(pdf_file_path: oh_pdf_path).extract_pdf_text }
+
 
       it "raises if it does not have file_start_times sequencing info" do
         expect {
@@ -225,7 +230,8 @@ describe OralHistory::PdfParagraphSplitter do
 
 
   describe "newer transcript, with new style per-paragraph timestamps" do
-    let(:oh_pdf_path) { Rails.root + "spec/test_support/pdf/oh/glusker_2022_sample_pages_ebnw2l9.pdf"}
+    let_it_be(:oh_pdf_path) { Rails.root + "spec/test_support/pdf/oh/glusker_2022_sample_pages_ebnw2l9.pdf"}
+    let_it_be(:extracted_pdf_text) { OralHistory::ExtractPdfText.new(pdf_file_path: oh_pdf_path).extract_pdf_text }
 
     it "extracts timestamps" do
       paragraphs = splitter.paragraphs
@@ -275,7 +281,9 @@ describe OralHistory::PdfParagraphSplitter do
 
 
     describe "that need re-sequencing for starting over at new audio files" do
-      let(:oh_pdf_path) { Rails.root + "spec/test_support/pdf/oh/glusker_2022_sequence_timestamps_example.pdf"}
+      let_it_be(:oh_pdf_path) { Rails.root + "spec/test_support/pdf/oh/glusker_2022_sequence_timestamps_example.pdf"}
+      let_it_be(:extracted_pdf_text) { OralHistory::ExtractPdfText.new(pdf_file_path: oh_pdf_path).extract_pdf_text }
+
 
       it "raises if it does not have file_start_times sequencing info" do
         expect {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,5 @@
 require 'webmock/rspec'
 require 'axe-rspec'
-require 'test_prof/recipes/rspec/before_all'
-require 'test_prof/recipes/rspec/let_it_be'
 
 
 SCIHIST_WEBMOCK_USED = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'webmock/rspec'
 require 'axe-rspec'
 require 'test_prof/recipes/rspec/before_all'
+require 'test_prof/recipes/rspec/let_it_be'
 
 
 SCIHIST_WEBMOCK_USED = true

--- a/spec/system/oral_history_with_audio_spec.rb
+++ b/spec/system/oral_history_with_audio_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 # Testing the view that has an audio player, sometimes with OHMS.
 describe "Oral history with audio display", type: :system, js: true do
-  let(:portrait) { create(:asset_with_faked_file, role: "portrait")}
+  let_it_be(:portrait) { create(:asset_with_faked_file, role: "portrait")}
 
-  let!(:parent_work) do
+  let_it_be(:parent_work, reload: true) do
     create(:oral_history_work, :published, :ohms_xml, members: [portrait])
   end
 
@@ -16,7 +16,7 @@ describe "Oral history with audio display", type: :system, js: true do
     Rails.root.join("spec/test_support/audio/5-seconds-of-silence.mp3")
   }
 
-  let!(:audio_assets) {
+  let_it_be(:audio_assets) {
     (1..4).to_a.map do |i|
       create(:asset_with_faked_file, :mp3,
         title: "Track #{i}",
@@ -30,11 +30,11 @@ describe "Oral history with audio display", type: :system, js: true do
     end
   }
 
-  let!(:published_audio_assets) {
+  let_it_be(:published_audio_assets) {
     audio_assets.select {|a| a.published }
   }
 
-  let!(:image_assets) {
+  let_it_be(:image_assets) {
     (5..8).to_a.map do |i|
       create(:asset_with_faked_file,
         title: "Regular file #{i}",
@@ -303,44 +303,6 @@ describe "Oral history with audio display", type: :system, js: true do
 
   describe "when you are logged-in staff", :logged_in_user, type: :system, js: true do
 
-    let!(:parent_work) do
-      build(:oral_history_work, rights: "http://creativecommons.org/publicdomain/mark/1.0/")
-    end
-    let(:audio_file_path) { Rails.root.join("spec/test_support/audio/5-seconds-of-silence.mp3")}
-    let(:audio_file_sha512) { Digest::SHA512.hexdigest(File.read(audio_file_path)) }
-
-    let!(:audio_assets) {
-      (1..4).to_a.map do |i|
-        create(:asset_with_faked_file, :mp3,
-          title: "Track #{i}",
-          position: i - 1,
-          parent: parent_work,
-
-          # All of these are published except for the second one.
-          published: i != 2
-        )
-      end
-    }
-
-    let!(:published_audio_assets) {
-      audio_assets.select {|a| a.published }
-    }
-
-    let!(:image_assets) {
-      (5..8).to_a.map do |i|
-        create(:asset_with_faked_file,
-          title: "Regular file #{i}",
-          faked_derivatives: {},
-          position: i - 1,
-
-          #5, #7 and #8 are published, but not #6:
-          published: i != 6,
-
-          parent: parent_work
-        )
-      end
-    }
-
     before do
       parent_work.representative = image_assets[0]
       parent_work.save!
@@ -394,11 +356,9 @@ describe "Oral history with audio display", type: :system, js: true do
     let(:ohms_xml_path) { Rails.root + "spec/test_support/ohms_xml/legacy/duarte_OH0344.xml" }
     let(:interviewer_profile) { InterviewerProfile.create(name: "Smith, John", profile: "This has some <i>html</i>")}
 
-    let(:parent_work) {
-      create(:oral_history_work, :published, rights: "http://creativecommons.org/publicdomain/mark/1.0/").tap do |work|
-        work.oral_history_content!.update(ohms_xml_text: File.read(ohms_xml_path), interviewer_profiles: [interviewer_profile])
-      end
-    }
+    before do
+      parent_work.oral_history_content!.update(ohms_xml_text: File.read(ohms_xml_path), interviewer_profiles: [interviewer_profile])
+    end
 
     it "can display, and search, without errors" do
       visit work_path(audio_assets.first.parent.friendlier_id)


### PR DESCRIPTION
Records created with `let` are torn down and re-created with every example. 

Our ActiveRecord stuff is quite expensive to create though, especially Assets with files that need to be stored in shrine. 

test-prof gives you [let_it_be](https://github.com/test-prof/test-prof/blob/master/docs/recipes/let_it_be.md) which magically keeps the records created around for the entire block, instead of re-creating them for each example.  This can save us lots of time in files that re-use the same read-only fixed data in many examples -- create it once, instead of once per example. 

Even if you are mutating the record, you can use `let_it_be(:reload)` to reload it from disk in every example, and still save lots of time compared to re-creating it fully. 

These files were identified as top time saving candidates by Claude Code, who also wrote most of the refactoring. This PR saves about 4.5 seconds on my MacBook, not huge, but not nothing -- it also loads the `let_it_be` method into our app and demo's it though, we can use it going forward!

In making this change, we discovered that `PdfParagraphSplitter` had what could be considered a bug where it mutated one of it's arguments -- which made it not re-usable like we wanted to, but also it shouldn't have been doing that. We fixed that. 

- **Make sure PdfParagraphSplitter does not mutate extracted_pdf_text jsonable input**
- **enable let_it_be from test-prof**
- **refactor specs to use let_it_be for re-used expensive data, for performance. from claude code.**
- **move test-prof requires to rails-helper, some of them need rails loaded first to load full func**
- **use let_it_be for persistent test data, with reload to allow mutations**
