### PR TITLE
Add Claude Code configuration files

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,23 @@
+# Claude Code Instructions
+
+## Running rspec
+
+Use `./bin/chruby-exec-rspec` instead of bare `rspec` or the `chruby-exec` pattern. Never run multiple rspec processes in parallel — there is shared state that will conflict.
+
+**IMPORTANT: Never put env vars before the command.** Pass them as the first arguments to the script instead — it handles setting them:
+
+```
+# correct
+./bin/chruby-exec-rspec TEST_STACK_PROF=1 TEST_STACK_PROF_FORMAT=json spec/foo_spec.rb
+
+# WRONG — interferes with our allow-listing of ./bin/chruby-exec-rspec command in permissions
+TEST_STACK_PROF=1 TEST_STACK_PROF_FORMAT=json ./bin/chruby-exec-rspec spec/foo_spec.rb
+```
+
+## Running other Ruby commands
+
+Prefix Ruby shell commands (`ruby`, `bundle`, `rake`, etc.) with `chruby-exec $(cat .ruby-version) --`:
+
+```
+chruby-exec $(cat .ruby-version) -- bundle exec rake
+```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "sandbox": {
+    "enabled": true,
+    "excludedCommands": [
+      "./bin/chruby-exec-rspec *"
+    ],
+    "autoAllowBashIfSandboxed": true,
+    "allowUnsandboxedCommands": false,
+    "network": {
+      "allowUnixSockets": ["/tmp/.s.PGSQL.5432", "/private/tmp/.s.PGSQL.5432"],
+      "allowLocalBinding": true
+    },
+    "filesystem": {
+      "allowWrite": ["/tmp", "/Users/jrochkind/.gem"]
+    }
+  },
+  "permissions": {
+    "allow": [
+      "Bash(./bin/chruby-exec-rspec *)"
+    ]
+  },
+  "env": {
+    "SE_AVOID_STATS": "true"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -64,5 +64,6 @@ node_modules
 # Brew bundle creates this pretty useless file, it's not a useful lock file like you think
 Brewfile.lock.json
 
+.claude/settings.local.json
 
 


### PR DESCRIPTION
Getting Claude Code set up to be able to run `rspec` effectively was a bit challenging for me. It is important it can run rspec to a) check on it's work and make sure tests pass, and b) I was actually working on optimizing specs themselves, and wanted it to be able to run test-prof profiling tools and such too. 

We needed it to be able to run `rspec` and other tools with `chruby` (@eddierubeiz you do use chruby too right?) , which it was having trouble doing.  It appears to run not in a normal shell, so adding chruby `source`ing to bash or zsh config files did not seem to work reliably.  

After [some investigation and community help](https://github.com/postmodern/chruby/discussions/506), it seemed telling it to prefix ever command with `chruby-exec` was the way to go, and telling it to do so in CLAUDE.md. 

Running capybara with chromedriver was however being defeated by the sandbox (Claude's, MacOS's, not sure). Tried switching to cuprite instead of chromedriver for our capybara browser tests -- no difference. Excluding from sandbox seems to be what people actually do -- to be careful we weren't exempting anything extra accidentally, i wanted to be sure to allow-list only commands starting with `rspec` -- but our chruby-exec prefix messed with that!

Wound up with a 'wrapper' script at `./bin/chruby-exec-rspec' which wraps the chruby, and ALSO wraps supplying inline ENV (like FPROF=1 for test-prof) supplied in a non-initial location, so we can allow-list strictly `./bin/chruby-exec-rspec`. 

Even when exempted from the sandbox, we were still getting prompts "Do you want to let Claude execute this" for every possible different `rspec` command arguments, of which there are constnat new ones. So in addition to exempting from sandbox, we exempt all executions prefixed `./bin/chruby-exec-rspec` from that prompt too, with `permissions`/`allow` key. 

Claude is now succesfully executing whatever rspec it wants to it's heart's content, which was helpful for the rspec optmiization work for #214 