### PR TITLE
Add provenance to Cart export

### DIFF
--- a/app/serializers/work_cart_serializer.rb
+++ b/app/serializers/work_cart_serializer.rb
@@ -68,6 +68,7 @@ class WorkCartSerializer
       format:                   'Format',
       genre:                    'Genre',
       description:              'Description',
+      provenance:               'Provenance',
       subject:                  'Subject/s',
       series_arrangement:       'Series Arrangement',
       physical_container:       'Physical Container',
@@ -93,7 +94,7 @@ class WorkCartSerializer
   # { :title => method(work), :additional_title => method(work), ... }
   def column_methods
     @column_methods ||= @column_keys.map do |column_label|
-    
+
       # create the proc
       new_proc = if self.respond_to? column_label
         # If k is defined in this class, use that (e.g. :created)
@@ -104,7 +105,7 @@ class WorkCartSerializer
       else
         raise "Unknown column: #{column_label}"
       end
-    
+
       [column_label, new_proc]
     end.to_h
   end

--- a/spec/serializers/work_cart_serializer_spec.rb
+++ b/spec/serializers/work_cart_serializer_spec.rb
@@ -12,7 +12,7 @@ describe WorkCartSerializer do
         "Title", "Additional title",
         "URL", "External ID", "Department", "Creator",
         "Date", "Medium", "Extent", "Place", "Format", "Genre",
-        "Description", "Subject/s", "Series Arrangement",
+        "Description", "Provenance", "Subject/s", "Series Arrangement",
         "Physical Container", "Collection", "Rights",
         "Rights Holder", "Additional Credit",
         "Digitization Funder", "Admin Note",
@@ -42,17 +42,18 @@ describe WorkCartSerializer do
       expect(report[1][10]).to eq 'image|mixed_material' # format
       expect(report[1][11]).to eq 'Lithographs'         # genre
       expect(report[1][12]).to eq 'Description 1'       # description
-      expect(report[1][13]).to eq 's1|s2|s3'            # subject
-      expect(report[1][14]).to eq 'Series arrangement 1|Series arrangement 2'
-      expect(report[1][15]).to eq 'Box: Box|Page: Page|Part: Part|Reel: Reel|Folder: Folder|Volume: Volume|Shelfmark: Shelfmark'
-      expect(report[1][16]).to eq 'Test title' # collection
-      expect(report[1][17]).to eq "http://rightsstatements.org/vocab/NoC-US/1.0/"
-      expect(report[1][18]).to eq "Rights Holder"
-      expect(report[1][19]).to eq "photographed_by:Douglas Lockard|photographed_by:Mark Backrath"
-      expect(report[1][20]).to eq "Daniel Sanford"
-      expect(report[1][21]).to eq "Admin Note"
-      expect(Date.parse(report[1][22])).to be_a Date
+      expect(report[1][13]).to start_with "This is a provenance" # provenance
+      expect(report[1][14]).to eq 's1|s2|s3'            # subject
+      expect(report[1][15]).to eq 'Series arrangement 1|Series arrangement 2'
+      expect(report[1][16]).to eq 'Box: Box|Page: Page|Part: Part|Reel: Reel|Folder: Folder|Volume: Volume|Shelfmark: Shelfmark'
+      expect(report[1][17]).to eq 'Test title' # collection
+      expect(report[1][18]).to eq "http://rightsstatements.org/vocab/NoC-US/1.0/"
+      expect(report[1][19]).to eq "Rights Holder"
+      expect(report[1][20]).to eq "photographed_by:Douglas Lockard|photographed_by:Mark Backrath"
+      expect(report[1][21]).to eq "Daniel Sanford"
+      expect(report[1][22]).to eq "Admin Note"
       expect(Date.parse(report[1][23])).to be_a Date
+      expect(Date.parse(report[1][24])).to be_a Date
     end
   end
 


### PR DESCRIPTION
Added after 'description' because that's where it is in the metadata form, seemed as good as any. So later columns are all bumped.

Closes #3501
