### PR TITLE
Rights-holder is required for published works with rights statements implying copyright

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -51,6 +51,18 @@ class Work < Kithe::Work
     work.validates_presence_of :rights
   end
 
+  # to publish, we need rights_holder if rights statement is in list
+  validates_presence_of :rights_holder,
+    message: "can't be blank if rights statement is a copyright status",
+    if: -> {
+      published? && rights && rights.in?(%w{
+        http://rightsstatements.org/vocab/InC/1.0/
+        http://rightsstatements.org/vocab/InC-EDU/1.0/
+        https://creativecommons.org/licenses/by-nc-nd/4.0/
+        https://creativecommons.org/licenses/by/4.0/
+    })
+  }
+
   attr_json :review_requested, :boolean
   attr_json :review_requested_at, :datetime
   attr_json :review_requested_by, :string

--- a/spec/controllers/admin/google_arts_and_culture_downloads_controller_spec.rb
+++ b/spec/controllers/admin/google_arts_and_culture_downloads_controller_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Admin::GoogleArtsAndCultureDownloadsController, :logged_in_user, 
       department: "Museum",
       format: ['physical_object'],
       rights: 'https://creativecommons.org/licenses/by/4.0/',
+      rights_holder: 'Science History Institute',
       created_at: Time.parse("2020-01-01"),
       updated_at: Time.parse("2021-01-01"),
       members: default_members
@@ -144,7 +145,8 @@ RSpec.describe Admin::GoogleArtsAndCultureDownloadsController, :logged_in_user, 
       let(:candidate_attrs) do
         library_work_attrs.merge(
           title: "Wrong library rights",
-          rights: 'https://creativecommons.org/licenses/by/4.0/'
+          rights: 'https://creativecommons.org/licenses/by/4.0/',
+          rights_holder: "I don't know"
         )
       end
 
@@ -263,6 +265,7 @@ RSpec.describe Admin::GoogleArtsAndCultureDownloadsController, :logged_in_user, 
           library_work_attrs.merge(
             title: "In range wrong library rights",
             rights: 'https://creativecommons.org/licenses/by/4.0/',
+            rights_holder: "I don't know",
             created_at: Time.parse("2022-06-01"),
             updated_at: Time.parse("2023-06-01")
           )

--- a/spec/factories/work_factory.rb
+++ b/spec/factories/work_factory.rb
@@ -220,6 +220,7 @@ FactoryBot.define do
       }
       date_of_work { [ Work::DateOfWork.new(start: "1986-06-03") ] }
       rights { "https://creativecommons.org/licenses/by-nc-nd/4.0/" }
+      rights_holder { "Science History Institute"}
       place  { [{category: "place_of_interview", value:"University of Maryland, College Park"}] }
       format { ['text'] }
       genre { ["Oral histories"] }
@@ -369,6 +370,7 @@ FactoryBot.define do
       created_at { DateTime.now }
       date_of_work { [ Work::DateOfWork.new(start: "1986-06-03") ] }
       rights { "https://creativecommons.org/licenses/by-nc-nd/4.0/" }
+      rights_holder { "Some Lab, Inc."}
       department { "Archives" }
       members { [ build(:asset_with_faked_file, :video, published: true) ] }
 

--- a/spec/system/catalog_search_spec.rb
+++ b/spec/system/catalog_search_spec.rb
@@ -155,7 +155,7 @@ describe CatalogController, solr: true, indexable_callbacks: true do
     let!(:published_and_public_domain_but_too_recent) { create(:public_work, title: title_for_search, rights: cc_public_domain, date_of_work: too_recent) }
 
     let!(:unpublished_but_public_domain)  { create(:public_work, title: title_for_search, rights: cc_public_domain) }
-    let!(:published_but_copyrighted)  { create(:public_work, title: title_for_search, date_of_work: matching_date, rights: in_copyright) }
+    let!(:published_but_copyrighted)  { create(:public_work, title: title_for_search, date_of_work: matching_date, rights: in_copyright, rights_holder: "Science History Institute") }
 
     it "can use limits to find works we consider copyright free" do
       visit search_catalog_path


### PR DESCRIPTION
Closes #3500

Some test data violated this new requirement and had to be fixed as well.

**Turns out there are 760 works that fail this requirement. We'll leave in draft until we decide what to do with those and/or change nature of requirements.** Tracking that discussion on original ticket #3500. 

We wouldn't want to put this requirement into production with 760 records that fail, as we then wouldn't be able to edit those records at all (while published anyway) without fixing them to meet requirement!

That's a result of doing this as an ActiveRecord validation, which is pretty much invariant. I'm not sure if we really are best using AR validations for this sort of thing... but it's what we used for the existing rules for "in order to publish", so staying consistent without choosing a refactor at present! 