### PR TITLE
use latest verison of Github Actions astral-sh/setup-uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             # have a checked in Gemfile.lock
 
         - name: Install uv for python dependencies
-          uses: astral-sh/setup-uv@v3
+          uses: astral-sh/setup-uv@v8.1.0
           with:
             enable-cache: true
 


### PR DESCRIPTION
For python uv dependency manager. GH Actions was complaining about our old version of setup-uv.
