### PR TITLE
Admin dashboard Asset count for a Collection

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -44,10 +44,11 @@ class Admin::CollectionsController < AdminController
   end
   helper_method :sort_link_maker
 
+  # ADMIN dashboard show
   # GET /collections/1
   # GET /collections/1.json
   def show
-    authorize! :read, @collection
+    authorize! :update, @collection
   end
 
   # GET /collections/new

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -70,6 +70,43 @@ class Collection < Kithe::Collection
     self.representative = CollectionThumbAsset.new(title: "collection-thumbnail-placeholder", parent: self)
   end
 
+
+  # Finds count of assets contained in works that are in collection. Will also
+  # include ONE level of child works.
+  #
+  # @param only_published [Boolean] default false, if true count is only of assets
+  #     which are published and in published Works. If you want both numbers, you do
+  #     have to call this twice, two queries -- the one query combined version
+  #     was complicated enough SQL that it did not seem worth it to try to do all in one.
+  #
+  def contained_asset_count(only_published: false)
+    # this is just a relation, will not result in a query yet
+    direct_ids = self.contains.select(:id)
+
+    # This too is just a relation, not resuling in a query yet
+    # Assets in Works that are members collection
+    qualifying = Work.where(id: direct_ids)
+
+    if only_published
+      qualifying = qualifying.where(published: true)
+    end
+
+    # OR in works whose
+    # parents are members of collection -- only ONE level of child work
+    # included, which should be fine. Ideally we'd need none, see https://github.com/sciencehistory/scihist_digicoll/issues/3511
+    qualifying = qualifying
+                   .or(Work.where(parent_id: direct_ids))
+                   .select(:id)
+
+    final_query = Asset.where(parent_id: qualifying)
+
+    if only_published
+      final_query = final_query.where(published: true)
+    end
+
+    final_query.count
+  end
+
   # Some collections define an arbitrary default sort field.
   # We use this for the inital presentation when you first visit the collection page,
   # before the user searches inside the collection or alter the sort order.

--- a/app/views/admin/collections/index.html.erb
+++ b/app/views/admin/collections/index.html.erb
@@ -52,7 +52,7 @@
       <tr>
         <td><%= thumb_image_tag(collection.leaf_representative, size: :mini, image_missing_text: true) %>
         <td><%= collection.friendlier_id %>
-        <td><%= link_to(collection.title, collection_path(collection)) %><%= publication_badge(collection) %></td>
+        <td><%= link_to(collection.title, admin_collection_path(collection)) %><%= publication_badge(collection) %></td>
         <td><%= collection.department %></td>
         <td class="datestamp"><%=  l collection.created_at.to_date, format: :admin %> </td>
         <td class="datestamp"><%=  l collection.updated_at.to_date, format: :admin %> </td>

--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -1,0 +1,24 @@
+<div>
+  <div>Managing a collection</div>
+  <h1><%= @collection.title %> <%= publication_badge(@collection) %>   <%= link_to "Public view", collection_path(@collection), class: "btn btn-sm btn-outline-secondary" %></h1>
+</div>
+
+<hr>
+
+<h2>Asset Count</h2>
+<ul class="text-muted small">
+<li>An <code>Asset</code> in the Digital Collections is an ingested file -- image, audio, or video.</li>
+<li>Note: A Work can be in more than one collection, so it's attached assets can be multiply counted in simultaneous collections</li>
+</ul>
+
+<dl class="d-flex flex-wrap gap-4">
+  <div class="bg-light border px-3 pt-1">
+    <dt>All assets</dt>
+    <dd><%= number_with_delimiter(@collection.contained_asset_count) %></dd>
+  </div>
+
+  <div class="bg-light border px-3 pt-1">
+    <dt>Published assets</dt>
+    <dd><%= number_with_delimiter(@collection.contained_asset_count(only_published: true)) %></dd>
+  </div>
+</dl>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -336,7 +336,7 @@ Rails.application.routes.draw do
 
     put "/asset_files/:id/submit_hocr_and_textonly_pdf",            to: "assets#submit_hocr_and_textonly_pdf"
 
-    resources :collections, except: [:show]
+    resources :collections
 
     # Note "assets" is Rails reserved word for routing, oops. So we use
     # asset_files.


### PR DESCRIPTION
Closes #3165

Adds method Collection#contained_asset_count, that will do a count. Can do it as all, or as just published. 

* Note it does count ONE level of child work. That's enough for now, I don't think we have anything more than that, keeps the SQL under control. See also #3511 

* If you want both all and published, as we do, that's two invocations of the method, two separate SQL queries. Seems okay performance wise, one query for both would be better, but would be much squirrelier SQL, this is fine. Also if we wanted to fetch for a whole list of Collections at once without an inefficient query per collection, would need fancier SQL. This is fine!

Add a previously absent Collection dashboard admin 'show' page, that only has these statistics on it at present.  
