### PR TITLE
Use Kithe::BatchIndexableAroundAction from Kithe 2.19

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,7 +108,7 @@ gem "device_detector", "~> 1.0" # user-agent parsing we use for logging
 
 gem "attr_json", "~> 2.3"
 
-gem 'kithe', "~> 2.17"
+gem 'kithe', "~> 2.19"
 
 gem "traject", ">= 3.5" # to include support for HTTP basic auth in Solr url
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -390,7 +390,7 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    kithe (2.18.0)
+    kithe (2.19.0)
       attr_json (~> 2.0)
       fastimage (~> 2.0)
       fx (>= 0.6.0, < 1)
@@ -895,7 +895,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   json_schemer (~> 2.5.0)
   kaminari (~> 1.2)
-  kithe (~> 2.17)
+  kithe (~> 2.19)
   listen (~> 3.3)
   lockbox
   lograge (< 2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,13 +23,9 @@ class ApplicationController < ActionController::Base
     redirect_to root_path, alert: "You don't have permission to access that page."
   end
 
-  around_action :batch_kithe_indexable
-
-  def batch_kithe_indexable
-    Kithe::Indexable.index_with(batching: true) do
-      yield
-    end
-  end
+  # Batch multiple kithe solr index updates taking place in a Rails action
+  # into fewer http requests to solr
+  include Kithe::BatchIndexableAroundAction
 
   before_action do
     timecode = Time.now.gmtime.to_i


### PR DESCRIPTION
Using the around_action filter from gem source instead of local app will hopefully keep the generic kithe indexing wrapper line out of 'application' stack traces used by Rails and Honeybadger.  Closes #3122

See https://github.com/sciencehistory/kithe/pull/196