### PR TITLE
'Washington DC' changed to 'Washington, D.C.' in OH biography controlled list

### DIFF
--- a/app/models/work/place_lists.rb
+++ b/app/models/work/place_lists.rb
@@ -13,7 +13,7 @@ class Work
       ["California", "CA"],
       ["Colorado", "CO"],
       ["Connecticut", "CT"],
-      ["Washington DC", "DC"],
+      ["Washington, D.C.", "DC"],
       ["Delaware", "DE"],
       ["Florida", "FL"],
       ["Georgia", "GA"],


### PR DESCRIPTION
Closes #3352
