### PR TITLE
Admin tool to generate QR code for collection url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,6 +110,11 @@ gem "attr_json", "~> 2.3"
 
 gem 'kithe', "~> 2.19"
 
+# QR code generation (see QrCodeCreator service). chunky_png is already
+# a dependency of rqrcode, but we also use it directly ourselves.
+gem "rqrcode", "~> 3.0"
+gem "chunky_png"
+
 gem "traject", ">= 3.5" # to include support for HTTP basic auth in Solr url
 
 gem 'simple_form', "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,7 @@ GEM
       launchy
     childprocess (5.1.0)
       logger (~> 1.5)
+    chunky_png (1.4.0)
     citeproc (1.1.0)
       date
       forwardable
@@ -681,6 +682,10 @@ GEM
     rinku (2.0.6)
     roda (3.102.0)
       rack
+    rqrcode (3.2.0)
+      chunky_png (~> 1.0)
+      rqrcode_core (~> 2.0)
+    rqrcode_core (2.1.0)
     rsolr (2.6.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
@@ -875,6 +880,7 @@ DEPENDENCIES
   browser (~> 6.0)
   capybara (>= 2.15)
   capybara-screenshot
+  chunky_png
   citeproc-ruby (~> 2.0)
   content_disposition (~> 1.0)
   csv (~> 3.3.0)
@@ -926,6 +932,7 @@ DEPENDENCIES
   resque-heroku-signals
   resque-pool
   rinku (~> 2.0)
+  rqrcode (~> 3.0)
   rsolr (~> 2.4)
   rspec-rails (~> 8.0)
   ruby-openai (~> 8.0)

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -54,11 +54,10 @@ class Admin::CollectionsController < AdminController
 
   # GET /admin/collections/:id/generate_qr_code(?box=B&folder=F)
   #
-  # Generate a QR code (with the SHI logo composited in the center) pointing at
-  # the *public* collection page, optionally scoped to a box and folder. Returns
-  # the PNG inline (disposition "inline") so it opens in a new browser tab.
+  # Generate a QR code pointing at the *public* collection page, optionally
+  # scoped to a box and folder. Returns the PNG inline with a nice filename.
   def generate_qr_code
-    authorize! :update, @collection
+    authorize! :read, @collection
 
     box    = params[:box].presence
     folder = params[:folder].presence

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -1,5 +1,6 @@
 class Admin::CollectionsController < AdminController
-  before_action :set_collection, only: [:show, :edit, :update, :destroy]
+  before_action :set_collection, only: [:show, :edit, :update, :destroy, :generate_qr_code]
+
   before_action :sort_link_maker, only: [:index]
 
   # GET /collections
@@ -49,6 +50,28 @@ class Admin::CollectionsController < AdminController
   # GET /collections/1.json
   def show
     authorize! :update, @collection
+  end
+
+  # GET /admin/collections/:id/generate_qr_code(?box=B&folder=F)
+  #
+  # Generate a QR code (with the SHI logo composited in the center) pointing at
+  # the *public* collection page, optionally scoped to a box and folder. Returns
+  # the PNG inline (disposition "inline") so it opens in a new browser tab.
+  def generate_qr_code
+    authorize! :update, @collection
+
+    box    = params[:box].presence
+    folder = params[:folder].presence
+
+    # nil query params are omitted by the url helper.
+    public_url = collection_url(@collection, box_id: box, folder_id: folder)
+
+    # For now no superimposed icon, we need spec
+    png = QrCodeCreator.new(public_url).call
+
+    send_data png.to_blob,
+      type: "image/png",
+      disposition: ContentDisposition.format(disposition: "inline", filename: qr_code_filename(box, folder))
   end
 
   # GET /collections/new
@@ -128,6 +151,16 @@ class Admin::CollectionsController < AdminController
     # Use callbacks to share common setup or constraints between actions.
     def set_collection
       @collection = Collection.find_by_friendlier_id!(params[:id])
+    end
+
+    # eg "qr_col_abc123.png", or "qr_col_abc123_b5f2.png" when scoped to box 5, folder 2.
+    def qr_code_filename(box, folder, extension: "png")
+      suffix = ""
+      suffix << "b#{box}" if box
+      suffix << "f#{folder}" if folder
+      name = "qr_col_#{@collection.friendlier_id}"
+      name << "_#{suffix}" if suffix.present?
+      "#{name}.#{extension}"
     end
 
     # Params method just for #index.

--- a/app/services/qr_code_creator.rb
+++ b/app/services/qr_code_creator.rb
@@ -1,0 +1,99 @@
+require 'rqrcode'
+require 'chunky_png'
+
+# Generate a QR code PNG for a URL (or any string), optionally with a custom
+# icon composited into the center.
+#
+# The typical way to embed a custom icon in a QR code is weirdly to just add
+# a lot of error tolerance and stick it in the middle -- that's what we're doing.
+# When an icon is given the QR is encoded at error-correction level :h
+# (~30% recovery), which is what keeps it scannable with the center covered.
+#
+# Keep icon_ratio at or below ~0.22 (22% of width) to stay within that budget.
+# Without an icon we use rqrcode's default error-correction level.
+#
+# We use rqqrcode to encode and render the
+# QR matrix, and ChunkyPNG (already a dependency of rqrcode) to scale and
+# composite the icon -- which must be a PNG too.
+#
+# Usage:
+#
+#     image = QrCodeCreator.new(
+#       "https://digital.sciencehistory.org/works/abc123",
+#       icon_path: Rails.root.join("app/assets/images/logo.png").to_s
+#     ).call
+#
+#     image.save("out.png")   # => write to disk
+#     image.to_blob           # => PNG bytes, eg for send_data
+#
+class QrCodeCreator
+  attr_reader :data, :icon_path, :module_px, :quiet_zone, :icon_ratio, :icon_pad
+
+  # @param data [String] the URL (or other string) to encode
+  # @param icon_path [String, nil] path to a PNG icon to composite into the
+  #   center. When given, the QR is encoded at error-correction level :h so it
+  #   stays scannable with the center covered. When nil (the default), a plain
+  #   QR is produced at rqrcode's default error-correction level.
+  # @param module_px [Integer] pixel size of each QR "module" (square)
+  # @param quiet_zone [Integer] width of the white border, in modules
+  # @param icon_ratio [Float] icon width as a fraction of the QR width; keep
+  #   <= ~0.22 so the code stays scannable
+  # @param icon_pad [Integer] white padding, in pixels, added around the icon
+  #   so it reads cleanly against the QR modules
+  def initialize(data, icon_path: nil, module_px: 12, quiet_zone: 4, icon_ratio: 0.22, icon_pad: 6)
+    @data = data
+    @icon_path = icon_path
+    @module_px = module_px
+    @quiet_zone = quiet_zone
+    @icon_ratio = icon_ratio
+    @icon_pad = icon_pad
+  end
+
+  # @return [ChunkyPNG::Image] the QR code, with the icon composited in the
+  #   center if one was given. Call #to_blob for PNG bytes, or #save(path).
+  def call
+    canvas = generate_qr
+
+    compose_icon!(canvas) if icon_path
+
+    canvas
+  end
+
+  private
+
+  # Encode + render the QR matrix to a ChunkyPNG::Image via rqrcode. With an
+  # icon we bump to error-correction level :h (~30% recovery) so the center icon
+  # doesn't render the code unscannable; without one we use rqrcode's default.
+  def generate_qr
+    qr = icon_path ? RQRCode::QRCode.new(data, level: :h) : RQRCode::QRCode.new(data)
+    qr.as_png(
+      module_px_size: module_px,
+      border_modules: quiet_zone,
+      color: "black",
+      fill: "white"
+    )
+  end
+
+  # Scale the icon to icon_ratio of the QR width (preserving aspect ratio), set
+  # it on a solid white pad so it reads cleanly against the QR modules, and
+  # composite the result centered onto the QR.
+  def compose_icon!(canvas)
+    icon = scaled_icon(canvas.width)
+
+    padded = ChunkyPNG::Image.new(icon.width + icon_pad * 2, icon.height + icon_pad * 2, ChunkyPNG::Color::WHITE)
+    padded.compose!(icon, icon_pad, icon_pad)
+
+    x = (canvas.width - padded.width) / 2
+    y = (canvas.height - padded.height) / 2
+    canvas.compose!(padded, x, y)
+  end
+
+  # Load the PNG icon and bilinear-resample it to icon_ratio of the QR width,
+  # keeping its aspect ratio.
+  def scaled_icon(qr_width)
+    icon = ChunkyPNG::Image.from_file(icon_path)
+    target_w = (qr_width * icon_ratio).round
+    target_h = (icon.height * (target_w.to_f / icon.width)).round
+    icon.resample_bilinear(target_w, target_h)
+  end
+end

--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -22,3 +22,22 @@
     <dd><%= number_with_delimiter(@collection.contained_asset_count(only_published: true)) %></dd>
   </div>
 </dl>
+
+<hr>
+
+<h2>QR Code link to Collection</h2>
+
+<%= form_tag generate_qr_code_admin_collection_path(@collection), method: :get, target: "_blank", class: "row gx-2 gy-2 align-items-end" do %>
+  <div class="col-auto">
+    <%= label_tag :box, "Box (optional)", class: "form-label mb-0" %>
+    <%= text_field_tag :box, nil, class: "form-control" %>
+  </div>
+  <div class="col-auto">
+    <%= label_tag :folder, "Folder (optional)", class: "form-label mb-0" %>
+    <%= text_field_tag :folder, nil, class: "form-control" %>
+  </div>
+  <div class="col-auto">
+    <%= button_tag "Generate", type: "submit", class: "btn btn-primary" %>
+  </div>
+<% end %>
+

--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -28,14 +28,16 @@
 <h2>QR Code link to Collection</h2>
 
 <%= form_tag generate_qr_code_admin_collection_path(@collection), method: :get, target: "_blank", class: "row gx-2 gy-2 align-items-end" do %>
-  <div class="col-auto">
-    <%= label_tag :box, "Box (optional)", class: "form-label mb-0" %>
-    <%= text_field_tag :box, nil, class: "form-control" %>
-  </div>
-  <div class="col-auto">
-    <%= label_tag :folder, "Folder (optional)", class: "form-label mb-0" %>
-    <%= text_field_tag :folder, nil, class: "form-control" %>
-  </div>
+  <% if @collection.department == 'Archives' %>
+    <div class="col-auto">
+      <%= label_tag :box, "Box (optional)", class: "form-label mb-0" %>
+      <%= text_field_tag :box, nil, class: "form-control" %>
+    </div>
+    <div class="col-auto">
+      <%= label_tag :folder, "Folder (optional)", class: "form-label mb-0" %>
+      <%= text_field_tag :folder, nil, class: "form-control" %>
+    </div>
+  <% end %>
   <div class="col-auto">
     <%= button_tag "Generate", type: "submit", class: "btn btn-primary" %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -336,7 +336,11 @@ Rails.application.routes.draw do
 
     put "/asset_files/:id/submit_hocr_and_textonly_pdf",            to: "assets#submit_hocr_and_textonly_pdf"
 
-    resources :collections
+    resources :collections do
+      member do
+        get :generate_qr_code
+      end
+    end
 
     # Note "assets" is Rails reserved word for routing, oops. So we use
     # asset_files.

--- a/spec/controllers/admin/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin/admin_collections_controller_spec.rb
@@ -9,6 +9,36 @@ RSpec.describe Admin::CollectionsController, :logged_in_user, type: :controller 
       expect(newly_created.published?).to be true
     end
 
+    describe "#generate_qr_code" do
+      let(:collection) { create(:collection) }
+
+      it "returns an inline PNG named after the collection" do
+        get :generate_qr_code, params: { id: collection.friendlier_id }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq "image/png"
+        expect(response.headers["Content-Disposition"]).to include("inline")
+        expect(response.headers["Content-Disposition"]).to include("qr_col_#{collection.friendlier_id}.png")
+        # a valid PNG signature
+        expect(response.body[0, 8].bytes).to eq [137, 80, 78, 71, 13, 10, 26, 10]
+      end
+
+      it "includes box and folder in the url and filename when given" do
+        received_url = nil
+        allow(QrCodeCreator).to receive(:new) do |url, **_opts|
+          received_url = url
+          instance_double(QrCodeCreator, call: ChunkyPNG::Image.new(1, 1))
+        end
+
+        get :generate_qr_code, params: { id: collection.friendlier_id, box: "5", folder: "2" }
+
+        expect(received_url).to include("/collections/#{collection.friendlier_id}")
+        expect(received_url).to include("box_id=5")
+        expect(received_url).to include("folder_id=2")
+        expect(response.headers["Content-Disposition"]).to include("qr_col_#{collection.friendlier_id}_b5f2.png")
+      end
+    end
+
     context "filter collections" do
       render_views
       let!(:collection) {

--- a/spec/services/qr_code_creator_spec.rb
+++ b/spec/services/qr_code_creator_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+require 'chunky_png'
+
+# Uses real rqrcode encoding and real ChunkyPNG compositing (no mocking) so
+# we're testing actual output.
+describe QrCodeCreator do
+  let(:url) { "https://digital.sciencehistory.org/works/abc123" }
+  let(:icon_path) { Rails.root.join("spec/test_support/images/30x30.png").to_s }
+
+  describe "without an icon" do
+    it "produces a valid, square, black-and-white PNG QR code" do
+      img = described_class.new(url).call
+
+      expect(img).to be_a(ChunkyPNG::Image)
+      expect(img.width).to be > 0
+      expect(img.height).to eq(img.width) # QR codes are square
+
+      # A plain QR is strictly black and white -- no icon compositing happened.
+      expect(img.pixels.uniq).to contain_exactly(ChunkyPNG::Color::BLACK, ChunkyPNG::Color::WHITE)
+
+      # And it round-trips to a valid PNG blob.
+      expect(ChunkyPNG::Image.from_blob(img.to_blob).dimension).to eq(img.dimension)
+    end
+  end
+
+  describe "with an icon" do
+    it "composites the (colored) icon into the center of a valid, square PNG" do
+      img = described_class.new(url, icon_path: icon_path).call
+
+      expect(img).to be_a(ChunkyPNG::Image)
+      expect(img.width).to be > 0
+      expect(img.height).to eq(img.width)
+
+      # The composited icon introduces colors beyond the plain QR's black/white,
+      # proving the icon actually made it onto the code.
+      colors = img.pixels.uniq
+      expect(colors.length).to be > 2
+      expect(colors).not_to contain_exactly(ChunkyPNG::Color::BLACK, ChunkyPNG::Color::WHITE)
+
+      # And it lands in the middle: the central region contains icon colors,
+      # rather than being only plain black/white QR modules.
+      bw = [ChunkyPNG::Color::BLACK, ChunkyPNG::Color::WHITE]
+      qx, qy = img.width / 4, img.height / 4
+      center_colors = (qx...(qx * 3)).flat_map { |x| (qy...(qy * 3)).map { |y| img[x, y] } }.uniq
+      expect(center_colors - bw).not_to be_empty
+    end
+  end
+end


### PR DESCRIPTION
Closes #3527 potentially

Does not include custom branding yet, I haven't been able to find an example or style guide.  But still includes logic to add in the icon, which does significantly increase complexity, as it requires image compositing! 

* Note that the common way to put a logo in a QR Code seems to be just to turn up error tolerance very high then just smack it on top of the QR code occluding some data. Weird, but there seems to be no good way to do otherwise in ruby or python, and this seems to be what peopel do, as far as I can tell. https://stackoverflow.com/questions/45481990/how-to-insert-logo-in-the-center-of-qrcode-in-python

This code was pretty much all Claude Code generated, including tests! Particularly useful for figuring out ChunkyPNG api for compositing -- that would have taken me forever otherwise. 

I did review code and sometimes tweak it manually (or in furtehr instructions to Claude). 

 

- **add QrCodeCreator service object, can superimpose an icon in middle**
- **admin/collections_controller#generate_qr_code**
- **admin ui for generating collection url qr code**
- **only show box and folder for QR code gen when archives**
