### PR TITLE
group RedisCacheStore errors for single honeybadger error, and with custom HB message telling you it's from redis-cache-store

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,6 +98,30 @@ Rails.application.configure do
       connect_timeout: ScihistDigicoll::Env.lookup(:ephemeral_redis_connect_timeout),
       read_timeout:    ScihistDigicoll::Env.lookup(:ephemeral_redis_read_timeout   ),
       write_timeout:   ScihistDigicoll::Env.lookup(:ephemeral_redis_write_timeout  ),
+
+      # Customize Rails' RedisCacheStore::DEFAULT_ERROR_HANDLER.
+      #
+      # We add a honeybadger_fingerrpint to context, so our honeybadger config
+      # customization can group all with the same Exception class as ONE error,
+      # instead of splitting them based on stack trace variations as before.
+      # So brief Redis outage should not spam us with multiple HB errors.
+      #
+      # Customized from DEFAULT_ERROR_HANDLER in activesupport 8.1.2.1
+      # https://github.com/rails/rails/blob/v8.1.2.1/activesupport/lib/active_support/cache/redis_cache_store.rb#L44-L53
+      error_handler: -> (method:, returning:, exception:) do
+        Rails.logger.error("RedisCacheStore: #{method} failed, returned #{returning.inspect}: #{exception.class}: #{exception.message}")
+
+        ActiveSupport.error_reporter&.report(
+          exception,
+          severity: :warning,
+          source: "redis_cache_store.active_support",
+          context: {
+            cache_store_method: method,
+            honeybadger_fingerprint: "redis_cache_store_error-#{exception.class.name}",
+            honeybadger_error_message: "(redis_cache_store) #{exception.detailed_message(highlight: false)}"
+          }
+        )
+      end,
     }
   end
 

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -23,12 +23,26 @@ Honeybadger.configure do |config|
   }.delete_if { |_k, v| v.blank? }
 
   config.before_notify do |notice|
-    secrets.each do |secret_name, secret_value|
-      notice.error_message.gsub!(secret_value, "[:#{secret_name}]") unless secret_value.blank?
+    # SHI customization, let honey badger fingerprint be supplied in context, so
+    # we can force grouping of errors that would not otherwise be grouped from
+    # an eg
+    #
+    #    ActiveSupport.error_reporter&.report(..., context: { honeybadger_fingerprint: f } _
+    if notice.context && notice.context[:honeybadger_fingerprint]
+      notice.fingerprint = notice.context[:honeybadger_fingerprint]
+      notice.context.delete(:honeybadger_fingerprint)
     end
 
-    # Make sure all get combined into ONE error group from HB, slight differences in how
-    # they were reported made them many errors, too noisy.
+    # And similarly, let us pass through custom HB error message
+    if notice.context && notice.context[:honeybadger_error_message]
+      notice.error_message = notice.context[:honeybadger_error_message]
+      notice.context.delete(:honeybadger_error_message)
+    end
 
+    # Filter secrets from error messages, AFTER any customization we've done of them.
+    secrets.each do |secret_name, secret_value|
+      next if secret_value.blank?
+      notice.error_message = notice.error_message.gsub(secret_value, "[:#{secret_name}]")
+    end
   end
 end


### PR DESCRIPTION
Closes #3531

Done in consultation with Claude Code -- I would not have figured out these technqiues without Claude, although Claude intiially suggested doing it ins omewhat more complex ways, and wasy that *over* grouped exceptions, and I argued with it to get to this way that i am happy with. Ended up writing most of the lines of code myself, but couldn't have gotten there without Claude.  
