### PR TITLE
reduce batch size of validate_oral_history_chunks to tiny 2

### DIFF
--- a/lib/tasks/validate_oral_history_chunks.rake
+++ b/lib/tasks/validate_oral_history_chunks.rake
@@ -20,7 +20,7 @@ namespace :scihist do
 
     errors = []
 
-    OralHistoryContent.includes(:oral_history_chunks, :work).strict_loading.find_each(batch_size: 10) do |oral_history_content|
+    OralHistoryContent.includes(:oral_history_chunks, :work).strict_loading.find_each(batch_size: 2) do |oral_history_content|
       begin
         OralHistory::ChunkValidator.new(oral_history_content).validate!
       rescue OralHistory::ChunkValidator::Failure => e


### PR DESCRIPTION
to try to stay within heroku standard-1x memory limits. #3521 didn't do it. Let's try a tiny size
