### PR TITLE
WorkVideoShowComponent can support work with multiple video files

### DIFF
--- a/app/components/oral_history/paragraph_transcript_component.rb
+++ b/app/components/oral_history/paragraph_transcript_component.rb
@@ -60,12 +60,19 @@ module OralHistory
     def render_timestamp_marker(start_seconds)
       content_tag("a",
                   format_ohms_timestamp(start_seconds),
-                  href: "#{base_link}#t=#{start_seconds}",
+                  href: "#{base_link}##{timestamp_anchor(start_seconds)}",
                   class: "ohms-transcript-timestamp default-link-style",
                     # must be formatted exactly the same in JS transcript highlighter
                     # code that searches for it.
                   data: { "ohms_timestamp_s" => "%.3f" % start_seconds.round(3)}
       )
+    end
+
+    # Fragment identifier for a timestamp link. VttTranscriptComponent extends this
+    # to also name the asset (`&a=<id>`), for switching segments of a multi-segment
+    # video work; plain audio oral histories (single combined derivative) don't.
+    def timestamp_anchor(start_seconds)
+      "t=#{start_seconds}"
     end
 
     # usually a new page or timestamp are just indicated by change in metadata between

--- a/app/components/oral_history/vtt_transcript_component.rb
+++ b/app/components/oral_history/vtt_transcript_component.rb
@@ -4,20 +4,32 @@ module OralHistory
       scrubber.tags = ['i', 'b', 'u', 'a']
     end
 
-    attr_reader :vtt_transcript, :base_link
+    attr_reader :vtt_transcript, :base_link, :asset_friendlier_id
 
     # @param vtt_transcript [OralHistoryContent::OhmsXml::VttTranscript]
     #
     # @param base_link [String] if you want timestamps to link to a separate page, with
     #   anchor on end. If blank, will just have href to same page with anchor, to be
     #   picked up by JS.
-    def initialize(vtt_transcript, base_link: nil)
+    # @param asset_friendlier_id [String] when set, timestamp links include `&a=<id>` in the
+    #   anchor, so JS can switch to the right asset on a multi-segment work before seeking.
+    def initialize(vtt_transcript, base_link: nil, asset_friendlier_id: nil)
       @vtt_transcript = vtt_transcript
       @base_link = base_link
+      @asset_friendlier_id = asset_friendlier_id
     end
 
     def sanitized_footnotes
       @sanitized_footnotes ||= vtt_transcript.footnotes.collect { |ref, text| [ref, scrub_footnote_text(text)] }.to_h
+    end
+
+    # Extends the base `t=<seconds>` anchor with `&a=<friendlier_id>` when we know
+    # the asset, so JS can switch to the right segment of a multi-segment video work
+    # before seeking. Kept short deliberately.
+    def timestamp_anchor(start_seconds)
+      anchor = super
+      anchor += "&a=#{asset_friendlier_id}" if asset_friendlier_id.present?
+      anchor
     end
 
 

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -148,13 +148,13 @@
         <% video_assets.each do |asset| %>
           <div class="d-flex border-top border-1 av-transcript-line <%= "av-now-playing" if asset == initial_video_asset %>">
             <div class="p-2 ps-0 mt-1">
-              <%= link_to "#", data: { av_media: av_media_for(asset) } do %>
+              <%= link_to "#", data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id } do %>
                 <%= render ThumbComponent.new(asset, thumb_size: :mini) %>
               <% end %>
             </div>
             <div class="text-break p-2">
               <div>
-                <%= link_to "#", data: { av_media: av_media_for(asset) } do %>
+                <%= link_to "#", data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id } do %>
                   <%= asset.title %>
                 <% end %>
               </div>
@@ -180,7 +180,7 @@
 
 
         <div class="show-video-transcript-content" data-transcript-content-target itemprop="transcript">
-          <%= render OralHistory::VttTranscriptComponent.new(OralHistoryContent::OhmsXml::VttTranscript.new(initial_vtt_transcript_str)) %>
+          <%= render OralHistory::VttTranscriptComponent.new(OralHistoryContent::OhmsXml::VttTranscript.new(initial_vtt_transcript_str), asset_friendlier_id: initial_video_asset.friendlier_id) %>
         </div>
       </div>
     </div>

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -116,6 +116,32 @@
       <% else %> <%# no video file available %>
         <%= tag "img", src: asset_path("placeholderbox.svg", alt: "") %>
       <% end %>
+
+      <% if video_assets.length > 1 %>
+        <div class="av-transcript-list mt-2 border border-dark">
+          <h2 class="bg-dark text-light fs-5 py-1 px-2 m-0">Multiple Segments</h2>
+          <% video_assets.each do |asset| %>
+            <div class="d-flex px-2 av-transcript-line <%= "av-now-playing" if asset == initial_video_asset %>">
+              <div class="p-2 ps-0 mt-1">
+                <%= link_to asset_transcript_path(asset), data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id }, class: "av-thumb-wrap" do %>
+                  <%= render ThumbComponent.new(asset, thumb_size: :mini) %>
+                  <span class="av-thumb-play-icon" aria-hidden="true"></span>
+                <% end %>
+              </div>
+              <div class="text-break p-2">
+                <div>
+                  <%= link_to asset_transcript_path(asset), data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id } do %>
+                    <%= asset.title %>
+                  <% end %>
+                </div>
+                <div class="small text-muted">
+                  <%= format_ohms_timestamp(asset.file_metadata["duration_seconds"]) %>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
     </div>
 
     <%= render "works/rights_and_social", work: work %>
@@ -134,32 +160,6 @@
         </p>
       </div>
     <% end %>
-
-    <% if video_assets.length > 1 %>
-      <h2 class="attribute-sub-head">Includes Multiple Segments</h2>
-      <div class="av-transcript-list">
-        <% video_assets.each do |asset| %>
-          <div class="d-flex border-top border-1 av-transcript-line <%= "av-now-playing" if asset == initial_video_asset %>">
-            <div class="p-2 ps-0 mt-1">
-              <%= link_to asset_transcript_path(asset), data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id } do %>
-                <%= render ThumbComponent.new(asset, thumb_size: :mini) %>
-              <% end %>
-            </div>
-            <div class="text-break p-2">
-              <div>
-                <%= link_to asset_transcript_path(asset), data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id } do %>
-                  <%= asset.title %>
-                <% end %>
-              </div>
-              <div class="small text-muted">
-                <%= format_ohms_timestamp(asset.file_metadata["duration_seconds"]) %>
-              </div>
-            </div>
-          </div>
-        <% end %>
-      </div>
-    <% end %>
-
   </div>
 
   <% if has_vtt_transcript? %>

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -141,13 +141,13 @@
         <% video_assets.each do |asset| %>
           <div class="d-flex border-top border-1 av-transcript-line">
             <div class="p-2 ps-0 mt-1">
-              <%= link_to "#", data: { } do %>
+              <%= link_to "#", data: { av_media: av_media_for(asset) } do %>
                 <%= render ThumbComponent.new(asset, thumb_size: :mini) %>
               <% end %>
             </div>
             <div class="text-break p-2">
               <div>
-                <%= link_to "#", data: { } do %>
+                <%= link_to "#", data: { av_media: av_media_for(asset) } do %>
                   <%= asset.title %>
                 <% end %>
               </div>

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -116,13 +116,6 @@
       <% else %> <%# no video file available %>
         <%= tag "img", src: asset_path("placeholderbox.svg", alt: "") %>
       <% end %>
-
-      <% if video_assets.length > 1 %>
-        <div class="av-now-playing-label bg-dark text-light d-flex justify-content-between px-2 py-1">
-          <span class="av-now-playing-title"><%= initial_video_asset.title %></span>
-          <span class="av-now-playing-position"><%= video_assets.index(initial_video_asset) + 1 %> / <%= video_assets.length %></span>
-        </div>
-      <% end %>
     </div>
 
     <%= render "works/rights_and_social", work: work %>

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -127,6 +127,10 @@
                   <%= link_to asset_transcript_path(asset), data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id }, class: "av-thumb-wrap" do %>
                     <%= render ThumbComponent.new(asset, thumb_size: :mini) %>
                     <span class="av-thumb-play-icon" aria-hidden="true"></span>
+                    <span class="av-thumb-now-playing-icon">
+                      <i class="fa fa-television" aria-hidden="true"></i>
+                      <span class="visually-hidden">Currently loaded</span>
+                    </span>
                   <% end %>
                 </div>
                 <div class="text-break p-2">

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -134,6 +134,32 @@
         </p>
       </div>
     <% end %>
+
+    <% if video_assets.length > 1 %>
+      <h2 class="attribute-sub-head">Includes Multiple Segments</h2>
+      <div class="av-transcript-list">
+        <% video_assets.each do |asset| %>
+          <div class="d-flex border-top border-1 av-transcript-line">
+            <div class="p-2 ps-0 mt-1">
+              <%= link_to "#", data: { } do %>
+                <%= render ThumbComponent.new(asset, thumb_size: :mini) %>
+              <% end %>
+            </div>
+            <div class="text-break p-2">
+              <div>
+                <%= link_to "#", data: { } do %>
+                  <%= asset.title %>
+                <% end %>
+              </div>
+              <div class="small text-muted">
+                <%= format_ohms_timestamp(asset.file_metadata["duration_seconds"]) %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+
   </div>
 
   <% if has_vtt_transcript? %>

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -148,13 +148,13 @@
         <% video_assets.each do |asset| %>
           <div class="d-flex border-top border-1 av-transcript-line <%= "av-now-playing" if asset == initial_video_asset %>">
             <div class="p-2 ps-0 mt-1">
-              <%= link_to "#", data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id } do %>
+              <%= link_to asset_transcript_path(asset), data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id } do %>
                 <%= render ThumbComponent.new(asset, thumb_size: :mini) %>
               <% end %>
             </div>
             <div class="text-break p-2">
               <div>
-                <%= link_to "#", data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id } do %>
+                <%= link_to asset_transcript_path(asset), data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id } do %>
                   <%= asset.title %>
                 <% end %>
               </div>

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -118,7 +118,7 @@
       <% end %>
 
       <% if video_assets.length > 1 %>
-        <div class="av-transcript-list mt-2 border border-dark">
+        <div class="av-transcript-list border border-dark">
           <h2 class="bg-dark text-light fs-5 py-1 px-2 m-0">Multiple Segments</h2>
           <ul class="av-transcript-list-items list-unstyled m-0">
             <% video_assets.each do |asset| %>
@@ -150,8 +150,6 @@
       <% end %>
     </div>
 
-    <%= render "works/rights_and_social", work: work %>
-
     <% if has_any_transcript? %>
       <div class="transcript-toggle">
         <%# href leads to separate page with transcript, that we hope google will follow, but don't expect users to,
@@ -160,8 +158,14 @@
         <a href="<%= asset_transcript_path(initial_video_asset) %>" data-bs-target="#show-video-transcript-collapse" id="showVideoTranscriptToggle" class="btn btn-lg btn-brand-main" type="button" data-bs-toggle="collapse"  aria-expanded="false" aria-controls="show-video-transcript" data-show-label="Show transcript" data-hide-label="Hide transcript">
           Show transcript
         </a>
+      </div>
+    <% end %>
 
-        <p class="alert alert-warning mt-3">
+    <%= render "works/rights_and_social", work: work %>
+
+    <% if has_any_transcript? %>
+      <div class="transcript-disclaimer">
+        <p class="alert alert-warning">
           <%= t("transcript.asr_warning_html") %>
         </p>
       </div>

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -120,26 +120,28 @@
       <% if video_assets.length > 1 %>
         <div class="av-transcript-list mt-2 border border-dark">
           <h2 class="bg-dark text-light fs-5 py-1 px-2 m-0">Multiple Segments</h2>
-          <% video_assets.each do |asset| %>
-            <div class="d-flex px-2 av-transcript-line <%= "av-now-playing" if asset == initial_video_asset %>">
-              <div class="p-2 ps-0 mt-1">
-                <%= link_to asset_transcript_path(asset), data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id }, class: "av-thumb-wrap" do %>
-                  <%= render ThumbComponent.new(asset, thumb_size: :mini) %>
-                  <span class="av-thumb-play-icon" aria-hidden="true"></span>
-                <% end %>
-              </div>
-              <div class="text-break p-2">
-                <div>
-                  <%= link_to asset_transcript_path(asset), data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id } do %>
-                    <%= asset.title %>
+          <div class="av-transcript-list-items">
+            <% video_assets.each do |asset| %>
+              <div class="d-flex px-2 av-transcript-line <%= "av-now-playing" if asset == initial_video_asset %>">
+                <div class="p-2 ps-0 mt-1">
+                  <%= link_to asset_transcript_path(asset), data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id }, class: "av-thumb-wrap" do %>
+                    <%= render ThumbComponent.new(asset, thumb_size: :mini) %>
+                    <span class="av-thumb-play-icon" aria-hidden="true"></span>
                   <% end %>
                 </div>
-                <div class="small text-muted">
-                  <%= format_ohms_timestamp(asset.file_metadata["duration_seconds"]) %>
+                <div class="text-break p-2">
+                  <div>
+                    <%= link_to asset_transcript_path(asset), data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id } do %>
+                      <%= asset.title %>
+                    <% end %>
+                  </div>
+                  <div class="small text-muted">
+                    <%= format_ohms_timestamp(asset.file_metadata["duration_seconds"]) %>
+                  </div>
                 </div>
               </div>
-            </div>
-          <% end %>
+            <% end %>
+          </div>
         </div>
       <% end %>
     </div>

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -116,6 +116,13 @@
       <% else %> <%# no video file available %>
         <%= tag "img", src: asset_path("placeholderbox.svg", alt: "") %>
       <% end %>
+
+      <% if video_assets.length > 1 %>
+        <div class="av-now-playing-label bg-dark text-light d-flex justify-content-between px-2 py-1">
+          <span class="av-now-playing-title"><%= initial_video_asset.title %></span>
+          <span class="av-now-playing-position"><%= video_assets.index(initial_video_asset) + 1 %> / <%= video_assets.length %></span>
+        </div>
+      <% end %>
     </div>
 
     <%= render "works/rights_and_social", work: work %>

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -120,9 +120,9 @@
       <% if video_assets.length > 1 %>
         <div class="av-transcript-list mt-2 border border-dark">
           <h2 class="bg-dark text-light fs-5 py-1 px-2 m-0">Multiple Segments</h2>
-          <div class="av-transcript-list-items">
+          <ul class="av-transcript-list-items list-unstyled m-0">
             <% video_assets.each do |asset| %>
-              <div class="d-flex px-2 av-transcript-line <%= "av-now-playing" if asset == initial_video_asset %>">
+              <li class="d-flex px-2 av-transcript-line <%= "av-now-playing" if asset == initial_video_asset %>">
                 <div class="p-2 ps-0 mt-1">
                   <%= link_to asset_transcript_path(asset), data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id }, class: "av-thumb-wrap" do %>
                     <%= render ThumbComponent.new(asset, thumb_size: :mini) %>
@@ -131,7 +131,7 @@
                 </div>
                 <div class="text-break p-2">
                   <div>
-                    <%= link_to asset_transcript_path(asset), data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id } do %>
+                    <%= link_to asset_transcript_path(asset), data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id }, aria: ({ current: true } if asset == initial_video_asset) do %>
                       <%= asset.title %>
                     <% end %>
                   </div>
@@ -139,9 +139,9 @@
                     <%= format_ohms_timestamp(asset.file_metadata["duration_seconds"]) %>
                   </div>
                 </div>
-              </div>
+              </li>
             <% end %>
-          </div>
+          </ul>
         </div>
       <% end %>
     </div>

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -152,7 +152,7 @@
 
     <%= render "works/rights_and_social", work: work %>
 
-    <% if has_vtt_transcript? %>
+    <% if has_any_transcript? %>
       <div class="transcript-toggle">
         <%# href leads to separate page with transcript, that we hope google will follow, but don't expect users to,
             although they can with eg "open in new tab". Normally data-bs-target will be used by Bootstrap collapse JS
@@ -168,7 +168,7 @@
     <% end %>
   </div>
 
-  <% if has_vtt_transcript? %>
+  <% if has_any_transcript? %>
     <div class="collapse" id="show-video-transcript-collapse">
       <div class="show-video-transcript mb-4">
         <div class="show-video-transcript-heading">

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -139,7 +139,7 @@
       <h2 class="attribute-sub-head">Includes Multiple Segments</h2>
       <div class="av-transcript-list">
         <% video_assets.each do |asset| %>
-          <div class="d-flex border-top border-1 av-transcript-line">
+          <div class="d-flex border-top border-1 av-transcript-line <%= "av-now-playing" if asset == initial_video_asset %>">
             <div class="p-2 ps-0 mt-1">
               <%= link_to "#", data: { av_media: av_media_for(asset) } do %>
                 <%= render ThumbComponent.new(asset, thumb_size: :mini) %>

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -14,11 +14,11 @@
   <%# uploadDate REQUIRED by google for VideoObject, don't know why %>
   <%= tag.meta itemprop: "uploadDate", content: work.published_at&.iso8601 %>
 
-  <% if video_asset&.file_metadata&.has_key?("duration_seconds") %>
+  <% if initial_video_asset&.file_metadata&.has_key?("duration_seconds") %>
     <%=
         # schema.org 'duration' requires ISO8601 duration which looks like `PTnHnMnS`
 
-        seconds = video_asset.file_metadata["duration_seconds"]
+        seconds = initial_video_asset.file_metadata["duration_seconds"]
         tag.meta itemprop: "duration",
           content: ActiveSupport::Duration.build(
                       seconds
@@ -34,9 +34,9 @@
 
   <div class="show-video">
     <div class="video-player">
-      <% if video_asset.present? %>
+      <% if initial_video_asset.present? %>
         <div class="position-relative vjs-theme-scihist-wrapper">
-          <% if ! video_asset.published? %>
+          <% if ! initial_video_asset.published? %>
             <%= private_label %>
           <% end %>
 
@@ -48,7 +48,7 @@
                   controls: true,
                   preload: "metadata",
                   poster: poster_src,
-                  style: "aspect-ratio: #{video_asset.width }/#{ video_asset.height };",
+                  style: "aspect-ratio: #{initial_video_asset.width }/#{ initial_video_asset.height };",
                   # the data-setup with serialized json triggers video.js
                   data: {
                     setup: {
@@ -88,18 +88,18 @@
                         },
                         durationDisplay: true
                       },
-                      aspectRatio: "#{video_asset.width}:#{video_asset.height}"
+                      aspectRatio: "#{initial_video_asset.width}:#{initial_video_asset.height}"
                     }.to_json
                   }
           ) do %>
-            <% if video_asset.hls_playlist_file.present? %>
-              <%= tag "source", src: video_asset.hls_playlist_file.url, type: "application/x-mpegURL" %>
+            <% if initial_video_asset.hls_playlist_file.present? %>
+              <%= tag "source", src: initial_video_asset.hls_playlist_file.url, type: "application/x-mpegURL" %>
             <% else %>
-              <%= tag "source", src: video_src_url, type: video_asset.content_type %>
+              <%= tag "source", src: video_src_url(initial_video_asset), type: initial_video_asset.content_type %>
             <% end %>
 
-            <% if auto_caption_track_url %>
-              <%= tag "track", id: "scihistAutoCaptions", src: auto_caption_track_url, label: "Auto-captions", kind: "captions" %>
+            <% if caption_url = auto_caption_track_url(initial_video_asset) %>
+              <%= tag "track", id: "scihistAutoCaptions", src: caption_url, label: "Auto-captions", kind: "captions" %>
             <% end %>
 
             <p class="vjs-no-js">
@@ -125,7 +125,7 @@
         <%# href leads to separate page with transcript, that we hope google will follow, but don't expect users to,
             although they can with eg "open in new tab". Normally data-bs-target will be used by Bootstrap collapse JS
             to open box on page with transcript instead %>
-        <a href="<%= asset_transcript_path(video_asset) %>" data-bs-target="#show-video-transcript-collapse" id="showVideoTranscriptToggle" class="btn btn-lg btn-brand-main" type="button" data-bs-toggle="collapse"  aria-expanded="false" aria-controls="show-video-transcript" data-show-label="Show transcript" data-hide-label="Hide transcript">
+        <a href="<%= asset_transcript_path(initial_video_asset) %>" data-bs-target="#show-video-transcript-collapse" id="showVideoTranscriptToggle" class="btn btn-lg btn-brand-main" type="button" data-bs-toggle="collapse"  aria-expanded="false" aria-controls="show-video-transcript" data-show-label="Show transcript" data-hide-label="Hide transcript">
           Show transcript
         </a>
 
@@ -173,7 +173,7 @@
 
 
         <div class="show-video-transcript-content" data-transcript-content-target itemprop="transcript">
-          <%= render OralHistory::VttTranscriptComponent.new(OralHistoryContent::OhmsXml::VttTranscript.new(vtt_transcript_str)) %>
+          <%= render OralHistory::VttTranscriptComponent.new(OralHistoryContent::OhmsXml::VttTranscript.new(initial_vtt_transcript_str)) %>
         </div>
       </div>
     </div>

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -48,7 +48,7 @@
                   controls: true,
                   preload: "metadata",
                   poster: poster_src,
-                  style: "aspect-ratio: #{initial_video_asset.width }/#{ initial_video_asset.height };",
+                  style: ("aspect-ratio: #{initial_video_asset.width }/#{ initial_video_asset.height };" if initial_video_asset.width && initial_video_asset.height),
                   # the data-setup with serialized json triggers video.js
                   data: {
                     setup: {
@@ -88,7 +88,7 @@
                         },
                         durationDisplay: true
                       },
-                      aspectRatio: "#{initial_video_asset.width}:#{initial_video_asset.height}"
+                      aspectRatio: ("#{initial_video_asset.width}:#{initial_video_asset.height}" if initial_video_asset.width && initial_video_asset.height)
                     }.to_json
                   }
           ) do %>

--- a/app/components/work_video_show_component.rb
+++ b/app/components/work_video_show_component.rb
@@ -42,9 +42,6 @@ class WorkVideoShowComponent < ApplicationComponent
       video_type:   asset.hls_playlist_file.present? ? "application/x-mpegURL" : asset.content_type,
       poster_url:   asset.file_derivatives(:thumb_large)&.url,
       captions_url: auto_caption_track_url(asset),
-      title:        asset.title,
-      position:     video_assets.index(asset) + 1,
-      total:        video_assets.length,
       width:        asset.width,
       height:       asset.height,
       transcript_fragment_url: (asset_transcript_path(asset, fragment: true) if asset.has_webvtt?)

--- a/app/components/work_video_show_component.rb
+++ b/app/components/work_video_show_component.rb
@@ -9,7 +9,8 @@
 # it a separate class instead of trying to use lots of conditionals in one class, betting
 # that will be simpler overall, and allow them to diverge as more features are added.
 class WorkVideoShowComponent < ApplicationComponent
-  delegate :construct_page_title, :can_see_unpublished_records?, to: :helpers
+  delegate :construct_page_title, :can_see_unpublished_records?, :format_ohms_timestamp,
+    to: :helpers
 
   attr_reader :work
 
@@ -49,12 +50,16 @@ class WorkVideoShowComponent < ApplicationComponent
     end
   end
 
-  # the first video asset we find; otherwise nil.
-  def video_asset
-    @video_asset ||= begin
-      candidate = @work.members.find { |mem| mem.asset? && mem&.content_type&.start_with?("video/") }
-      candidate if (candidate&.published? || can_see_unpublished_records?)
+  def video_assets
+    @video_assets ||= @work.members.find_all do |mem|
+      mem.asset? &&
+      mem&.content_type&.start_with?("video/") &&
+      (mem.published? || can_see_unpublished_records?)
     end
+  end
+
+  def video_asset
+    @video_asset = video_assets.first
   end
 
   def private_label

--- a/app/components/work_video_show_component.rb
+++ b/app/components/work_video_show_component.rb
@@ -45,6 +45,8 @@ class WorkVideoShowComponent < ApplicationComponent
       title:        asset.title,
       position:     video_assets.index(asset) + 1,
       total:        video_assets.length,
+      width:        asset.width,
+      height:       asset.height,
       # nil if asset has no transcript, so JS knows not to bother fetching
       transcript_fragment_url: (asset_transcript_path(asset, fragment: true) if asset.has_webvtt?)
     }

--- a/app/components/work_video_show_component.rb
+++ b/app/components/work_video_show_component.rb
@@ -44,7 +44,9 @@ class WorkVideoShowComponent < ApplicationComponent
       captions_url: auto_caption_track_url(asset),
       title:        asset.title,
       position:     video_assets.index(asset) + 1,
-      total:        video_assets.length
+      total:        video_assets.length,
+      # nil if asset has no transcript, so JS knows not to bother fetching
+      transcript_fragment_url: (asset_transcript_path(asset, fragment: true) if asset.has_webvtt?)
     }
   end
 

--- a/app/components/work_video_show_component.rb
+++ b/app/components/work_video_show_component.rb
@@ -48,8 +48,10 @@ class WorkVideoShowComponent < ApplicationComponent
     }
   end
 
-  def has_vtt_transcript?
-    (initial_video_asset&.audio_asr_enabled? && initial_video_asset&.asr_webvtt?) || initial_video_asset&.corrected_webvtt?
+  def has_any_transcript?
+    !! video_assets.find do |asset|
+      (asset&.audio_asr_enabled? && asset&.asr_webvtt?) || asset&.corrected_webvtt?
+    end
   end
 
   def initial_vtt_transcript_str

--- a/app/components/work_video_show_component.rb
+++ b/app/components/work_video_show_component.rb
@@ -47,7 +47,6 @@ class WorkVideoShowComponent < ApplicationComponent
       total:        video_assets.length,
       width:        asset.width,
       height:       asset.height,
-      # nil if asset has no transcript, so JS knows not to bother fetching
       transcript_fragment_url: (asset_transcript_path(asset, fragment: true) if asset.has_webvtt?)
     }
   end

--- a/app/components/work_video_show_component.rb
+++ b/app/components/work_video_show_component.rb
@@ -27,15 +27,22 @@ class WorkVideoShowComponent < ApplicationComponent
   end
 
   def auto_caption_track_url(video_asset)
-    unless defined? @auto_caption_track_url
-      @auto_caption_track_url = if video_asset.corrected_webvtt?
-        download_derivative_path(video_asset, Asset::CORRECTED_WEBVTT_DERIVATIVE_KEY, disposition: :inline)
-      elsif video_asset&.audio_asr_enabled? && video_asset.asr_webvtt?
-        download_derivative_path(video_asset, Asset::ASR_WEBVTT_DERIVATIVE_KEY, disposition: :inline)
-      end
+    if video_asset.corrected_webvtt?
+      download_derivative_path(video_asset, Asset::CORRECTED_WEBVTT_DERIVATIVE_KEY, disposition: :inline)
+    elsif video_asset&.audio_asr_enabled? && video_asset.asr_webvtt?
+      download_derivative_path(video_asset, Asset::ASR_WEBVTT_DERIVATIVE_KEY, disposition: :inline)
     end
+  end
 
-    @auto_caption_track_url
+  # will be used in `data-av-media` attribute, necesesary metadata to load
+  # segment into player.
+  def av_media_for(asset)
+    {
+      video_url:    asset.hls_playlist_file&.url || video_src_url(asset),
+      video_type:   asset.hls_playlist_file.present? ? "application/x-mpegURL" : asset.content_type,
+      poster_url:   asset.file_derivatives(:thumb_large)&.url,
+      captions_url: auto_caption_track_url(asset)
+    }
   end
 
   def has_vtt_transcript?

--- a/app/components/work_video_show_component.rb
+++ b/app/components/work_video_show_component.rb
@@ -51,7 +51,7 @@ class WorkVideoShowComponent < ApplicationComponent
   end
 
   def video_assets
-    @video_assets ||= @work.members.find_all do |mem|
+    @video_assets ||= @work.members.order(:position).find_all do |mem|
       mem.asset? &&
       mem&.content_type&.start_with?("video/") &&
       (mem.published? || can_see_unpublished_records?)

--- a/app/components/work_video_show_component.rb
+++ b/app/components/work_video_show_component.rb
@@ -19,14 +19,14 @@ class WorkVideoShowComponent < ApplicationComponent
   end
 
   def poster_src
-    @work.leaf_representative&.file_derivatives(:thumb_large)&.url || video_asset.file_derivatives(:thumb_large)&.url || asset_path("placeholderbox.svg")
+    @work.leaf_representative&.file_derivatives(:thumb_large)&.url || initial_video_asset.file_derivatives(:thumb_large)&.url || asset_path("placeholderbox.svg")
   end
 
-  def video_src_url
-    video_asset.file_url(expires_in: 5.days.to_i)
+  def video_src_url(asset)
+    asset.file_url(expires_in: 5.days.to_i)
   end
 
-  def auto_caption_track_url
+  def auto_caption_track_url(video_asset)
     unless defined? @auto_caption_track_url
       @auto_caption_track_url = if video_asset.corrected_webvtt?
         download_derivative_path(video_asset, Asset::CORRECTED_WEBVTT_DERIVATIVE_KEY, disposition: :inline)
@@ -39,14 +39,14 @@ class WorkVideoShowComponent < ApplicationComponent
   end
 
   def has_vtt_transcript?
-    (video_asset&.audio_asr_enabled? && video_asset&.asr_webvtt?) || video_asset&.corrected_webvtt?
+    (initial_video_asset&.audio_asr_enabled? && initial_video_asset&.asr_webvtt?) || initial_video_asset&.corrected_webvtt?
   end
 
-  def vtt_transcript_str
-    if video_asset.corrected_webvtt?
-      video_asset.corrected_webvtt_str
-    elsif video_asset.asr_webvtt?
-      video_asset.asr_webvtt_str
+  def initial_vtt_transcript_str
+    if initial_video_asset.corrected_webvtt?
+      initial_video_asset.corrected_webvtt_str
+    elsif initial_video_asset.asr_webvtt?
+      initial_video_asset.asr_webvtt_str
     end
   end
 
@@ -58,8 +58,8 @@ class WorkVideoShowComponent < ApplicationComponent
     end
   end
 
-  def video_asset
-    @video_asset = video_assets.first
+  def initial_video_asset
+    @initial_video_asset = video_assets.first
   end
 
   def private_label

--- a/app/components/work_video_show_component.rb
+++ b/app/components/work_video_show_component.rb
@@ -34,14 +34,17 @@ class WorkVideoShowComponent < ApplicationComponent
     end
   end
 
-  # will be used in `data-av-media` attribute, necesesary metadata to load
-  # segment into player.
+  # will be used in `data-av-media` attribute: what JS needs to load a segment
+  # into the player
   def av_media_for(asset)
     {
       video_url:    asset.hls_playlist_file&.url || video_src_url(asset),
       video_type:   asset.hls_playlist_file.present? ? "application/x-mpegURL" : asset.content_type,
       poster_url:   asset.file_derivatives(:thumb_large)&.url,
-      captions_url: auto_caption_track_url(asset)
+      captions_url: auto_caption_track_url(asset),
+      title:        asset.title,
+      position:     video_assets.index(asset) + 1,
+      total:        video_assets.length
     }
   end
 

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -89,10 +89,19 @@ class DownloadsController < ApplicationController
   # Kind of a mismatch in DownloadsController, but this is all we got for assets,
   # also kind of confusing compare with work transcription and translation PDF downloads.
   # We've added a lot of features, they've gotten a bit scrambled.
+  #
+  # `?fragment=true` gets the transcript with no page chrome (no layout, no title/date/
+  # warning) -- used by JS to `fetch` and inject when switching between segments of a
+  # multi-segment video work. See video_player.js. Default (no param) is the full page,
+  # meant for crawlers and direct navigation.
   def transcript_html
     unless @asset.has_webvtt?
       raise ActiveRecord::RecordNotFound.new("asset has no vtt available")
     end
+
+    @only_fragment = params[:fragment] == "true"
+
+    render layout: !@only_fragment
   end
 
   # For OH, we redirect to transcript PDF if present, looking up from work id

--- a/app/frontend/javascript/audio/timecode_in_anchor.js
+++ b/app/frontend/javascript/audio/timecode_in_anchor.js
@@ -1,18 +1,22 @@
 // If page anchor has a timecode in it like #t=13434 where that's a number of seconds, then
-// on page load, we should jump to that timecode in audio or video player.
-//
-// Used for both Oral History audio, and work show video.
+// on page load, we should jump to that timecode in the Oral History audio player.
 //
 // Confusingly, now also used for #p={paragraph number} anchor linking in oral histories.
 //
 // Using "t" as a key is roughly compatible with WC3 "media fragment" standard, and other
 // common practice.
 //
+// ORAL HISTORY AUDIO ONLY. The work show video page handles its own anchor (in
+// video_player.js), because there a `t` may be accompanied by an `a` naming which
+// segment to switch to first -- switch and seek have to be one ordered sequence.
+// Both use seekAndAutoPlayWhenReady for the seek itself.
+//
 // Note this is similar to but different from the play_at_timecode JS that has an on-screen element that
 // can be clicked to advance to timecode, without changing the #fragmentIdentifier.
 
 import domready from 'domready';
 import {gotoTocSegmentAtTimecode, gotoTranscriptTimecode, scrollToElement} from './helpers/ohms_player_helpers.js';
+import {seekAndAutoPlayWhenReady} from '../media_seek.js';
 import * as bootstrap from 'bootstrap';
 import videojs from 'video.js';
 
@@ -27,31 +31,12 @@ domready(function() {
       history.scrollRestoration = 'manual';
     }
 
-    var playerDomEl = document.querySelector("*[data-role=now-playing-container] audio, .video-player video");
+    var playerDomEl = document.querySelector("*[data-role=now-playing-container] audio");
 
     // Another file should actually be creating the videoJSPlayer obj we need, wait for it if needed.
     onVideoJSSetupFor(playerDomEl, function(videoJsPlayer) {
 
-      // Try to seek and then auto-play. player might not be in state where it can
-      // seek yet, if it is not then try to wait and seek when we can.
-      if (playerDomEl.readyState >=  playerDomEl.HAVE_METADATA) {
-        seekAndAutoPlay(videoJsPlayer, timeCodeSeconds);
-      } else {
-        playerDomEl.addEventListener("loadedmetadata", function(event) {
-          seekAndAutoPlay(videoJsPlayer, timeCodeSeconds);
-        });
-      }
-
-      // If all else fails, on some very persnickety user-agents (iOS), there's no
-      // way to seek UNTIL user presses play. Using video.js event and seek API is also important,
-      // as it seems to work around some iOS issues with doing both those operations too!
-      //
-      // If it runs when not needed cause earlier seek DID work -- it should just be
-      // seeking to where we already are anyway!
-      videoJsPlayer.one('play', function() { // 'one' will only hook once then de-register
-        videoJsPlayer.currentTime(timeCodeSeconds);
-        // it's already playing, it will not help to play again, no need we're good.
-      });
+      seekAndAutoPlayWhenReady(videoJsPlayer, timeCodeSeconds);
 
       // For OH
       //
@@ -113,23 +98,6 @@ function execWhenOhTabActive(targetTabId, procArg) {
 
 function hasOhTabs() {
   return !!document.querySelector("#ohmsScrollable .tab-pane.active")
-}
-
-// Seek to selected time, and TRY to auto-play the audio. Either or both might
-// not work in some browsers trying to prevent spammy playing.
-//
-// Must be called when player is in a readyState where we can seek,
-// at least HAVE_METADATA. https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState
-function seekAndAutoPlay(videoJsPlayer, timeCodeSeconds) {
-  videoJsPlayer.currentTime(timeCodeSeconds);
-
-  var playPromise  = videoJsPlayer.play();
-
-  if (playPromise !== undefined) {
-    playPromise.catch(error => {
-      console.log(`could not autoplay: ${error}`);
-    });
-  }
 }
 
  // Another file is creating the videoJS object, asyncrornous to this file.

--- a/app/frontend/javascript/media_seek.js
+++ b/app/frontend/javascript/media_seek.js
@@ -1,0 +1,54 @@
+// Seeking a video.js player to a timecode, shared by Oral History audio and
+// work show video.
+//
+// IMPORTANT: written against the video.js Player API only, never a captured
+// <video>/<audio> DOM element. The Player object survives a change of loaded
+// media (eg switching segments of a multi-segment video work), but the underlying
+// tech element is disposed and replaced -- so a `loadedmetadata` listener left on
+// the element would be sitting on a detached node, and never fire.
+
+// https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState
+const HAVE_METADATA = 1;
+
+// Seek to timeCodeSeconds and try to auto-play, now if the player can already
+// seek, otherwise once it can.
+export function seekAndAutoPlayWhenReady(player, timeCodeSeconds) {
+  // Try to seek and then auto-play. player might not be in state where it can
+  // seek yet, if it is not then try to wait and seek when we can.
+  if (player.readyState() >= HAVE_METADATA) {
+    seekAndAutoPlay(player, timeCodeSeconds);
+  } else {
+    player.one("loadedmetadata", function() {
+      seekAndAutoPlay(player, timeCodeSeconds);
+    });
+  }
+
+  // If all else fails, on some very persnickety user-agents (iOS), there's no
+  // way to seek UNTIL user presses play. Using video.js event and seek API is also
+  // important, as it seems to work around some iOS issues with doing both those
+  // operations too!
+  //
+  // If it runs when not needed cause earlier seek DID work -- it should just be
+  // seeking to where we already are anyway!
+  player.one("play", function() { // 'one' will only hook once then de-register
+    player.currentTime(timeCodeSeconds);
+    // it's already playing, it will not help to play again, no need we're good.
+  });
+}
+
+// Seek to selected time, and TRY to auto-play. Either or both might not work in
+// some browsers trying to prevent spammy playing.
+//
+// Must be called when player is in a readyState where we can seek, at least
+// HAVE_METADATA.
+export function seekAndAutoPlay(player, timeCodeSeconds) {
+  player.currentTime(timeCodeSeconds);
+
+  var playPromise = player.play();
+
+  if (playPromise !== undefined) {
+    playPromise.catch(error => {
+      console.log(`could not autoplay: ${error}`);
+    });
+  }
+}

--- a/app/frontend/javascript/video_player.js
+++ b/app/frontend/javascript/video_player.js
@@ -152,8 +152,57 @@ function loadMediaForLink(player, segmentLink) {
   }
 
   player.loadMedia(media);
-
+  swapTranscript(mediaData.transcript_fragment_url);
   markSegmentNowPlaying(segmentLink, mediaData);
+}
+
+
+// AbortController that let's us abort in-flight transcript fetches if they
+// overlap.
+let transcriptFetchController = null;
+
+// Fetch and inject the transcript for the segment just switched to, replacing
+// anything there before.
+function swapTranscript(transcriptFragmentUrl) {
+  const container = document.querySelector("*[data-transcript-content-target]");
+  if (!container) {
+    return;
+  }
+
+  transcriptFetchController?.abort();
+
+  if (!transcriptFragmentUrl) {
+    setTranscriptContent(container, "");
+    return;
+  }
+
+  transcriptFetchController = new AbortController();
+
+  fetch(transcriptFragmentUrl, { signal: transcriptFetchController.signal })
+    .then(function(response) {
+      if (!response.ok) {
+        throw new Error(`transcript_fragment request failed with status ${response.status}`);
+      }
+      return response.text();
+    })
+    .then(function(html) {
+      setTranscriptContent(container, html);
+    })
+    .catch(function(error) {
+      if (error.name === "AbortError") {
+        return; // superseded by a newer switch, not a real failure
+      }
+      console.error("Could not load transcript for switched segment", error);
+      setTranscriptContent(container, "Error, could not load transcript.");
+    });
+}
+
+// Replace the transcript container's content, and scroll it back to top -- a
+// switch's transcript should always open at the beginning, not wherever the
+// previous segment's transcript happened to be scrolled to.
+function setTranscriptContent(container, html) {
+  container.innerHTML = html;
+  container.scrollTop = 0;
 }
 
 // Reflect the segment just loaded: move the "now playing" highlight to its row,

--- a/app/frontend/javascript/video_player.js
+++ b/app/frontend/javascript/video_player.js
@@ -83,7 +83,20 @@ function setupVideoPlayer(player) {
 
     event.preventDefault();
     loadSegmentMedia(player, JSON.parse(segmentData.dataset.avMedia));
+    markSegmentNowPlaying(segmentData);
   });
+}
+
+
+// Move the "now playing" highlight to the segment just loaded. The server marks
+// the initial segment (see WorkVideoShowComponent); this takes over on switch.
+function markSegmentNowPlaying(segmentLink) {
+  const list = segmentLink.closest(".av-transcript-list");
+
+  list.querySelectorAll(".av-now-playing").forEach(function(el) {
+    el.classList.remove("av-now-playing");
+  });
+  segmentLink.closest(".av-transcript-line")?.classList.add("av-now-playing");
 }
 
 

--- a/app/frontend/javascript/video_player.js
+++ b/app/frontend/javascript/video_player.js
@@ -63,10 +63,6 @@ function setupVideoPlayer(player) {
   });
 
   // When transcript window opens, scroll to current highlight if needed.
-  //
-  // Page-level DOM that outlives any one media file, so registered once here --
-  // in setupTranscriptHighlighting it would stack up a duplicate listener for
-  // every media file loaded. Not present at all on video without a transcript.
   const transcriptCollapsible = document.getElementById('show-video-transcript-collapse');
   transcriptCollapsible?.addEventListener('shown.bs.collapse', event => {
     let highlighted = document.querySelector(`.${highlightCssClass}`);
@@ -74,6 +70,41 @@ function setupVideoPlayer(player) {
       scrollToTranscriptHighlight(highlighted);
     }
   });
+
+  // Multi-segment works list their video segments below the player. Clicking one
+  // loads that video (and its caption track) into the existing player, from
+  // JSON serialized info on the link.
+  //
+  document.querySelector(".av-transcript-list")?.addEventListener("click", function(event) {
+    const segmentData = event.target.closest("[data-av-media]");
+    if (!segmentData) {
+      return;
+    }
+
+    event.preventDefault();
+    loadSegmentMedia(player, JSON.parse(segmentData.dataset.avMedia));
+  });
+}
+
+
+// Load a segment into the player from serialized data
+// (see WorkVideoShowComponent#av_media_for).
+function loadSegmentMedia(player, mediaData) {
+  const media = {
+    src: { src: mediaData.video_url, type: mediaData.video_type },
+    poster: mediaData.poster_url
+  };
+
+  if (mediaData.captions_url) {
+    media.textTracks = [{
+      id: AUTO_CAPTION_TRACK_ID,
+      src: mediaData.captions_url,
+      kind: "captions",
+      label: "Auto-captions"
+    }];
+  }
+
+  player.loadMedia(media);
 }
 
 

--- a/app/frontend/javascript/video_player.js
+++ b/app/frontend/javascript/video_player.js
@@ -10,6 +10,12 @@ const AUTO_CAPTION_TRACK_ID = "scihistAutoCaptions";
 // css class marking the transcript line matching current playback position
 const highlightCssClass = "transcript-highlighted";
 
+// track user's captions choice under closure, so we can restore on segment change
+let captionsPreferredShowing = false;
+
+// volume/muted/playbackRate awaiting restore on the next canplay, if a switch is in flight
+let pendingRestoreOptions = null;
+
 const videoPlayerEl = document.querySelector("#work-video-player");
 
 if (videoPlayerEl) {
@@ -57,10 +63,15 @@ function setupVideoPlayer(player) {
   // even when not visible.
   textTracks.addEventListener("change", function() {
     const track = player.textTracks().getTrackById(AUTO_CAPTION_TRACK_ID);
+    if (!track) {
+      return;
+    }
 
-    if (track && track.mode == "disabled") {
+    if (track.mode == "disabled") {
       track.mode = "hidden";
     }
+
+    captionsPreferredShowing = track.mode === "showing";
   });
 
   // When transcript window opens, scroll to current highlight if needed.
@@ -137,6 +148,14 @@ function loadMediaFromAnchor(player) {
 function loadMediaForLink(player, segmentLink) {
   const mediaData = JSON.parse(segmentLink.dataset.avMedia);
 
+  // carry forward if a prior switch's restore is still pending, don't re-read a reset default
+  const persistedPlayerOptions = pendingRestoreOptions || {
+    volume: player.volume(),
+    muted: player.muted(),
+    playbackRate: player.playbackRate(),
+  };
+  pendingRestoreOptions = persistedPlayerOptions;
+
   const media = {
     src: { src: mediaData.video_url, type: mediaData.video_type },
     poster: mediaData.poster_url
@@ -151,7 +170,22 @@ function loadMediaForLink(player, segmentLink) {
     }];
   }
 
+  // switching while actively playing causes obscure race conditions in video.js,
+  // make sure it's not. double pausing also causes mysterious race conditions, only
+  // pause if playing!
+  if (!player.paused()) {
+    player.pause();
+  }
+
   player.loadMedia(media);
+
+  // restore once safe to do so, without getting reset again by video.js loading new media
+  player.one("canplay", function() {
+    player.playbackRate(persistedPlayerOptions.playbackRate);
+    player.volume(persistedPlayerOptions.volume);
+    player.muted(persistedPlayerOptions.muted);
+    pendingRestoreOptions = null;
+  });
 
   // in case new video has different aspect ratio, update.
   if (mediaData.width && mediaData.height) {
@@ -161,7 +195,6 @@ function loadMediaForLink(player, segmentLink) {
   swapTranscript(mediaData.transcript_fragment_url);
   markSegmentNowPlaying(segmentLink, mediaData);
 }
-
 
 // AbortController that let's us abort in-flight transcript fetches if they
 // overlap.
@@ -236,11 +269,8 @@ function setupAutoCaptionTrack(player, track) {
     return;
   }
 
-  // hidden rather than disabled, so we get cuechange events for transcript syncing
-  // even when the user has captions turned off.
-  if (track.mode == "disabled") {
-    track.mode = "hidden";
-  }
+  // showing if user had it on before, else hidden so cue events still fire
+  track.mode = captionsPreferredShowing ? "showing" : "hidden";
 
   setupTranscriptHighlighting(player, track);
 }

--- a/app/frontend/javascript/video_player.js
+++ b/app/frontend/javascript/video_player.js
@@ -1,4 +1,5 @@
 import videojs from 'video.js';
+import { seekAndAutoPlayWhenReady } from './media_seek.js';
 
 // css is imported through our CSS pipelines, with custom theming, in video_js.scss
 
@@ -84,6 +85,49 @@ function setupVideoPlayer(player) {
     event.preventDefault();
     loadMediaForLink(player, segmentLink);
   });
+
+  // On initial load, link anchor may include a specific segment to load
+  // (`a=friendlier_id`) and/or a specific timecode to seek to (in that segment)
+  player.ready(function() {
+    loadMediaFromAnchor(player);
+  });
+}
+
+
+// Switch to segment named in anchor if needed and/or seek to timecode named
+function loadMediaFromAnchor(player) {
+  const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ""));
+  const assetId = hashParams.get("a");
+  const timeCodeSeconds = hashParams.get("t");
+
+  let switching = false;
+
+  if (assetId) {
+    // CSS.escape since assetId comes straight from the URL fragment
+    const segmentLink = document.querySelector(`a[data-friendlier-id="${CSS.escape(assetId)}"]`);
+
+    // already the loaded segment, nothing to switch
+    const alreadyLoaded = segmentLink?.closest(".av-transcript-line")?.classList?.contains("av-now-playing");
+
+    if (segmentLink && !alreadyLoaded) {
+      switching = true;
+
+      // If we want to see after, we have to make sure to do it AFTER the new
+      // media is loaded, so we don't seek on old media first!
+      if (timeCodeSeconds) {
+        player.one("loadstart", function() {
+          seekAndAutoPlayWhenReady(player, timeCodeSeconds);
+        });
+      }
+
+      loadMediaForLink(player, segmentLink);
+    }
+  }
+
+  // If we didn't switch media first, now we can seek in a normal way.
+  if (timeCodeSeconds && !switching) {
+    seekAndAutoPlayWhenReady(player, timeCodeSeconds);
+  }
 }
 
 

--- a/app/frontend/javascript/video_player.js
+++ b/app/frontend/javascript/video_player.js
@@ -152,6 +152,12 @@ function loadMediaForLink(player, segmentLink) {
   }
 
   player.loadMedia(media);
+
+  // in case new video has different aspect ratio, update.
+  if (mediaData.width && mediaData.height) {
+    player.aspectRatio(`${mediaData.width}:${mediaData.height}`);
+  }
+
   swapTranscript(mediaData.transcript_fragment_url);
   markSegmentNowPlaying(segmentLink, mediaData);
 }

--- a/app/frontend/javascript/video_player.js
+++ b/app/frontend/javascript/video_player.js
@@ -112,15 +112,15 @@ function loadMediaFromAnchor(player) {
     if (segmentLink && !alreadyLoaded) {
       switching = true;
 
-      // If we want to see after, we have to make sure to do it AFTER the new
-      // media is loaded, so we don't seek on old media first!
+      loadMediaForLink(player, segmentLink);
+
       if (timeCodeSeconds) {
-        player.one("loadstart", function() {
+        // We need to seek sufficiently after media is really loaded to make it stick,
+        // it was tricky to get this to work, but this does in the end.
+        player.one("canplay", function() {
           seekAndAutoPlayWhenReady(player, timeCodeSeconds);
         });
       }
-
-      loadMediaForLink(player, segmentLink);
     }
   }
 

--- a/app/frontend/javascript/video_player.js
+++ b/app/frontend/javascript/video_player.js
@@ -2,10 +2,98 @@ import videojs from 'video.js';
 
 // css is imported through our CSS pipelines, with custom theming, in video_js.scss
 
-const videoPlayerEl = document.querySelector("#work-video-player")
+// id of the <track> element we render for our own ASR/corrected captions. Must
+// match id in initial track rendered in ERB.
+const AUTO_CAPTION_TRACK_ID = "scihistAutoCaptions";
 
-// if we have a video player, look for extra track empty captions safari loads
-// from HLS manifests that do not declare no captions, and remove them.
+// css class marking the transcript line matching current playback position
+const highlightCssClass = "transcript-highlighted";
+
+const videoPlayerEl = document.querySelector("#work-video-player");
+
+if (videoPlayerEl) {
+  setupVideoPlayer(videojs(videoPlayerEl));
+}
+
+// Wiring registered ONCE for the life of the page. Media loaded in player
+// may change, don't assume it will remain what was there at load.
+//
+function setupVideoPlayer(player) {
+  const textTracks = player.textTracks();
+
+  // Safari adds empty captions that we have to remove
+  if (navigator.vendor?.includes("Apple")) {
+    textTracks.addEventListener("addtrack", function() {
+      removeEmptySafariTextTracks(player);
+    });
+  }
+
+  // For custom skin/theme, we want to underline when captions are showing.
+  //
+  // We listen for tracks coming and going as well as for "change", so the button
+  // is still correct after a change of media -- "change" alone does not fire when
+  // tracks simply go away with the old source.
+  ["change", "addtrack", "removetrack"].forEach(function(eventName) {
+    textTracks.addEventListener(eventName, function() {
+      updateCaptionsButtonState(player);
+    });
+  });
+
+  // When a caption track is loaded -- either initial page load, or when
+  // switching media segments -- we need to set it up for transcript syncing.
+  textTracks.addEventListener("addtrack", function(event) {
+    if (event.track.id === AUTO_CAPTION_TRACK_ID) {
+      setupAutoCaptionTrack(player, event.track);
+    }
+  });
+
+  // Shouldn't be needed, but just in case our listener was added too late somehow,
+  // we've written idempotently.
+  setupAutoCaptionTrack(player, textTracks.getTrackById(AUTO_CAPTION_TRACK_ID));
+
+  // When user disables captions, our caption tracks are set to 'disabled' again--
+  // but we need them as 'hidden' because we use them for transcript syncing
+  // even when not visible.
+  textTracks.addEventListener("change", function() {
+    const track = player.textTracks().getTrackById(AUTO_CAPTION_TRACK_ID);
+
+    if (track && track.mode == "disabled") {
+      track.mode = "hidden";
+    }
+  });
+
+  // When transcript window opens, scroll to current highlight if needed.
+  //
+  // Page-level DOM that outlives any one media file, so registered once here --
+  // in setupTranscriptHighlighting it would stack up a duplicate listener for
+  // every media file loaded. Not present at all on video without a transcript.
+  const transcriptCollapsible = document.getElementById('show-video-transcript-collapse');
+  transcriptCollapsible?.addEventListener('shown.bs.collapse', event => {
+    let highlighted = document.querySelector(`.${highlightCssClass}`);
+    if (highlighted && !elementFullyVisibleWithin(highlighted, transcriptCollapsible)) {
+      scrollToTranscriptHighlight(highlighted);
+    }
+  });
+}
+
+
+function setupAutoCaptionTrack(player, track) {
+  if (!track) {
+    return;
+  }
+
+  // hidden rather than disabled, so we get cuechange events for transcript syncing
+  // even when the user has captions turned off.
+  if (track.mode == "disabled") {
+    track.mode = "hidden";
+  }
+
+  setupTranscriptHighlighting(player, track);
+}
+
+
+// Look for extra empty caption tracks safari loads from HLS manifests that do
+// not declare no captions, and remove them.
 //
 // See:
 //   * https://github.com/videojs/video.js/issues/2808
@@ -14,32 +102,30 @@ const videoPlayerEl = document.querySelector("#work-video-player")
 // And in ramp project (not sure why they aren't doing it on desktop Safari, we
 // do need it there):
 //   * https://github.com/samvera-labs/ramp/blob/23aae5c5aa9e7c95d1c94cba5cf870daf76df1aa/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js#L571-L597
-if (videoPlayerEl && navigator.vendor?.includes("Apple")) {
-  const textTracks = videojs(videoPlayerEl).textTracks();
+function removeEmptySafariTextTracks(player) {
+  const textTracks = player.textTracks();
 
-  textTracks.on('addtrack', function() {
-    for (let i = 0; i < textTracks.length; i++) {
-      // empty language and label are ones safari adds for HLS manifest without CLOSED_CAPTION=none,
-      // we don't want em.
-      if (textTracks[i].language === '' && textTracks[i].label === '') {
-        textTracks.removeTrack(textTracks[i]);
-      }
+  for (let i = 0; i < textTracks.length; i++) {
+    // empty language and label are ones safari adds for HLS manifest without
+    // CLOSED_CAPTION=none, we don't want em.
+    if (textTracks[i].language === '' && textTracks[i].label === '') {
+      textTracks.removeTrack(textTracks[i]);
     }
-  });
+  }
 }
 
+// Add a class to the "CC" captions button to add the underline when
+// captions are visible.
+function updateCaptionsButtonState(player) {
+  // Odd JS way to turn it to a standard array so we can iterate
+  const trackArr = Array.prototype.slice.call(player.textTracks(), 0);
+  const button = document.querySelector("button.vjs-subs-caps-button");
 
-// For custom skin/theme, we want to underline when captions are showing
-if (videoPlayerEl) {
-  videojs(videoPlayerEl).textTracks().on("change", function() {
-    // Odd JS way to turn it to a standard array so we can interate
-    let trackArr = Array.prototype.slice.call(this, 0);
-    if (trackArr.find( track => track.mode == "showing")) {
-      document.querySelector("button.vjs-subs-caps-button")?.classList?.add("text-track-visible");
-    } else {
-      document.querySelector("button.vjs-subs-caps-button")?.classList?.remove("text-track-visible");
-    }
-  });
+  if (trackArr.find( track => track.mode == "showing")) {
+    button?.classList?.add("text-track-visible");
+  } else {
+    button?.classList?.remove("text-track-visible");
+  }
 }
 
 
@@ -49,121 +135,91 @@ if (videoPlayerEl) {
 // We count on the fact that we have our VTT loaded in the video as a text track, so
 // we can use HTML5 video API to find "activeCues" at any given time, and then locate those
 // in the transcript. Using HTML5 video API via video.js, which delegates or polyfills as needed.
-if (videoPlayerEl) {
-  const highlightCssClass = "transcript-highlighted"
+//
+function setupTranscriptHighlighting(player, captionsTrack) {
+  // whether captionsTrack is visible or hidden, we'll get cuechange
+  // events we can use to highlight our transcript
+  captionsTrack.addEventListener("cuechange", function() {
+    // remove transcript highlights
+    document.querySelectorAll(`.${highlightCssClass}`).forEach( (el) => el.classList.remove(highlightCssClass));
 
-  videojs(videoPlayerEl).ready(function() {
-    const autoCaptionTrack = this.textTracks().getTrackById("scihistAutoCaptions");
+    // Now highlight in transcript for current cue, if available.
+    const highlightedEl = addTranscriptHighlights(player, captionsTrack.activeCues);
 
-    if (autoCaptionTrack) {
-
-      //We need text track to be hidden instead of disabled, so we can still track
-      //cuechange events for transcript
-      autoCaptionTrack.mode = "hidden";
-      this.textTracks().addEventListener("change", function() {
-        if (autoCaptionTrack.mode == "disabled") {
-          autoCaptionTrack.mode = "hidden";
-        }
-      });
-
-      // whether track is visible or hidden, we'll get cuechange
-      // events we can use to highlight our transcript
-      autoCaptionTrack.addEventListener("cuechange", function() {
-        removeTranscriptHighlights();
-
-        const highlightedEl = addTranscriptHighlights(autoCaptionTrack.activeCues);
-
-        // Scroll to highlighted El if present, the transcript is open, and the
-        // mouse cursor isn't currently over transcript window. UX modelled on Youtube.
-        if (highlightedEl &&
-            document.querySelector("#show-video-transcript-collapse.show") &&
-            !document.querySelector("*[data-transcript-content-target]").matches(':hover')) {
-          scrollToTranscriptHighlight(highlightedEl);
-        }
-      });
-
-      // When transcript window opens, scroll to if needed
-      const transcriptCollapsible = document.getElementById('show-video-transcript-collapse');
-      transcriptCollapsible.addEventListener('shown.bs.collapse', event => {
-        let highlighted = document.querySelector(`.${highlightCssClass}`);
-        if (highlighted && !elementFullyVisibleWithin(highlighted, transcriptCollapsible)) {
-          scrollToTranscriptHighlight(highlighted);
-        }
-      })
-    }
-
-    const vjsPlayer = this;
-
-    function removeTranscriptHighlights() {
-      document.querySelectorAll(`.${highlightCssClass}`).forEach( (el) => el.classList.remove(highlightCssClass))
-    }
-
-    function addTranscriptHighlights(activeCues) {
-      if (!activeCues || activeCues.length == 0) {
-        return;
-      }
-
-      // Odd JS way to turn it to a standard array so we can interate
-      let activeCuesArr = Array.prototype.slice.call(activeCues, 0)
-
-      // Sometimes there's more than one because end time for one cue is start time for the other,
-      // we dont' need to show the one that's about to end.
-      if (activeCuesArr.length > 1) {
-        activeCuesArr = activeCuesArr.filter( cue => {
-          vjsPlayer.currentTime() <= (cue.endTime - 0.25)
-        });
-      }
-
-      let firstHighlightedEl = undefined;
-
-      activeCuesArr.forEach( (cue) => {
-        // when outputting seconds float in vtt_transcript_component.html.erb, it must be output
-        // with exact same number of decimal places including trailing zeroes as here.
-        document.querySelectorAll(`*[data-ohms-timestamp-s="${cue.startTime.toFixed(3)}"]`).forEach( (el) => {
-          firstHighlightedEl = firstHighlightedEl || el;
-
-          el.closest(".ohms-transcript-paragraph-wrapper")?.classList?.add(highlightCssClass);
-        });
-      });
-
-      // Return first one to scroll to
-      return firstHighlightedEl;
-    }
-
-    function scrollToTranscriptHighlight(highlightedEl) {
-      const container = document.querySelector("*[data-transcript-content-target]");
-      const line = highlightedEl.closest('.ohms-transcript-paragraph-wrapper');
-
-      // Do nothing if it's already scrolled *entirely* in container view
-      if (elementFullyVisibleWithin(line, container)) {
-        return false;
-      }
-
-      // otherwise continue, do two lines before if possible, matching youtube UX
-      let scrollToEl = line.previousElementSibling || line;
-      //scrollToEl = scrollToEl.previousElementSibling || scrollToEl;
-
-      container.scrollTo(0, scrollToEl.offsetTop);
-
-      // on small screen with really big lines, maybe it's still not visible,
-      // we need to skip the previous line and just put this on top
-      if (!elementFullyVisibleWithin(line, container)) {
-        container.scrollTo(0, line.offsetTop);
-      }
-    }
-
-    function elementFullyVisibleWithin(element, container) {
-      const elementRect = element.getBoundingClientRect();
-      const containerRect = container.getBoundingClientRect();
-
-      return (elementRect.bottom >= containerRect.top &&
-              elementRect.bottom <= containerRect.bottom &&
-              elementRect.top <= containerRect.bottom &&
-              elementRect.top >= containerRect.top);
-
+    // Scroll to highlighted El if present, the transcript is open, and the
+    // mouse cursor isn't currently over transcript window. UX modelled on Youtube.
+    if (highlightedEl &&
+        document.querySelector("#show-video-transcript-collapse.show") &&
+        !document.querySelector("*[data-transcript-content-target]").matches(':hover')) {
+      scrollToTranscriptHighlight(highlightedEl);
     }
   });
 }
 
 
+// add css class to highlight transcript lines for current active cues from
+// caption track.
+function addTranscriptHighlights(player, activeCues) {
+  if (!activeCues || activeCues.length == 0) {
+    return;
+  }
 
+  // Odd JS way to turn it to a standard array so we can interate
+  let activeCuesArr = Array.prototype.slice.call(activeCues, 0)
+
+  // Sometimes there's more than one because end time for one cue is start time for the other,
+  // we dont' need to show the one that's about to end.
+  if (activeCuesArr.length > 1) {
+    activeCuesArr = activeCuesArr.filter( cue => player.currentTime() <= (cue.endTime - 0.25) );
+  }
+
+  let firstHighlightedEl = undefined;
+
+  activeCuesArr.forEach( (cue) => {
+    // when outputting seconds float in vtt_transcript_component.html.erb, it must be output
+    // with exact same number of decimal places including trailing zeroes as here.
+    document.querySelectorAll(`*[data-ohms-timestamp-s="${cue.startTime.toFixed(3)}"]`).forEach( (el) => {
+      firstHighlightedEl = firstHighlightedEl || el;
+
+      el.closest(".ohms-transcript-paragraph-wrapper")?.classList?.add(highlightCssClass);
+    });
+  });
+
+  // Return first one to scroll to
+  return firstHighlightedEl;
+}
+
+
+function scrollToTranscriptHighlight(highlightedEl) {
+  const container = document.querySelector("*[data-transcript-content-target]");
+  const line = highlightedEl.closest('.ohms-transcript-paragraph-wrapper');
+
+  // Do nothing if it's already scrolled *entirely* in container view
+  if (elementFullyVisibleWithin(line, container)) {
+    return false;
+  }
+
+  // otherwise continue, do two lines before if possible, matching youtube UX
+  let scrollToEl = line.previousElementSibling || line;
+  //scrollToEl = scrollToEl.previousElementSibling || scrollToEl;
+
+  container.scrollTo(0, scrollToEl.offsetTop);
+
+  // on small screen with really big lines, maybe it's still not visible,
+  // we need to skip the previous line and just put this on top
+  if (!elementFullyVisibleWithin(line, container)) {
+    container.scrollTo(0, line.offsetTop);
+  }
+}
+
+
+function elementFullyVisibleWithin(element, container) {
+  const elementRect = element.getBoundingClientRect();
+  const containerRect = container.getBoundingClientRect();
+
+  return (elementRect.bottom >= containerRect.top &&
+          elementRect.bottom <= containerRect.bottom &&
+          elementRect.top <= containerRect.bottom &&
+          elementRect.top >= containerRect.top);
+
+}

--- a/app/frontend/javascript/video_player.js
+++ b/app/frontend/javascript/video_player.js
@@ -94,6 +94,11 @@ function setupVideoPlayer(player) {
     }
 
     event.preventDefault();
+
+    if (segmentLink.closest(".av-transcript-line")?.classList.contains("av-now-playing")) {
+      return;
+    }
+
     loadMediaForLink(player, segmentLink);
   });
 

--- a/app/frontend/javascript/video_player.js
+++ b/app/frontend/javascript/video_player.js
@@ -177,13 +177,20 @@ function loadMediaForLink(player, segmentLink) {
     player.pause();
   }
 
-  player.loadMedia(media);
-
-  // restore once safe to do so, without getting reset again by video.js loading new media
-  player.one("canplay", function() {
+  function applyPersistedOptions() {
     player.playbackRate(persistedPlayerOptions.playbackRate);
     player.volume(persistedPlayerOptions.volume);
     player.muted(persistedPlayerOptions.muted);
+  }
+
+  player.loadMedia(media);
+
+  // apply immediately so there's no visible flash back to defaults, and again
+  // on canplay since video.js resets playbackRate a second time once the new
+  // source is fully attached
+  applyPersistedOptions();
+  player.one("canplay", function() {
+    applyPersistedOptions();
     pendingRestoreOptions = null;
   });
 

--- a/app/frontend/javascript/video_player.js
+++ b/app/frontend/javascript/video_player.js
@@ -193,7 +193,7 @@ function loadMediaForLink(player, segmentLink) {
   }
 
   swapTranscript(mediaData.transcript_fragment_url);
-  markSegmentNowPlaying(segmentLink, mediaData);
+  markSegmentNowPlaying(segmentLink);
 }
 
 // AbortController that let's us abort in-flight transcript fetches if they
@@ -244,23 +244,14 @@ function setTranscriptContent(container, html) {
   container.scrollTop = 0;
 }
 
-// Reflect the segment just loaded: move the "now playing" highlight to its row,
-// and update the "now playing" line under the player with its title and position.
-function markSegmentNowPlaying(segmentLink, avMedia) {
+// Move the "now playing" highlight to the segment's row.
+function markSegmentNowPlaying(segmentLink) {
   const list = segmentLink.closest(".av-transcript-list");
 
-  // highlight correct row
   list.querySelectorAll(".av-now-playing").forEach(function(el) {
     el.classList.remove("av-now-playing");
   });
   segmentLink.closest(".av-transcript-line")?.classList.add("av-now-playing");
-
-  // Add now playing title and position to bar under player
-  const label = document.querySelector(".av-now-playing-label");
-  if (label) {
-    label.querySelector(".av-now-playing-title").textContent = avMedia.title;
-    label.querySelector(".av-now-playing-position").textContent = `${avMedia.position} / ${avMedia.total}`;
-  }
 }
 
 

--- a/app/frontend/javascript/video_player.js
+++ b/app/frontend/javascript/video_player.js
@@ -76,42 +76,23 @@ function setupVideoPlayer(player) {
   // JSON serialized info on the link.
   //
   document.querySelector(".av-transcript-list")?.addEventListener("click", function(event) {
-    const segmentData = event.target.closest("[data-av-media]");
-    if (!segmentData) {
+    const segmentLink = event.target.closest("[data-av-media]");
+    if (!segmentLink) {
       return;
     }
 
     event.preventDefault();
-    const avMedia = JSON.parse(segmentData.dataset.avMedia);
-    loadSegmentMedia(player, avMedia);
-    markSegmentNowPlaying(segmentData, avMedia);
+    loadMediaForLink(player, segmentLink);
   });
 }
 
 
-// Reflect the segment just loaded: move the "now playing" highlight to its row,
-// and update the "now playing" line under the player with its title and position.
-// The server renders the initial state (see WorkVideoShowComponent); this takes
-// over on switch.
-function markSegmentNowPlaying(segmentLink, avMedia) {
-  const list = segmentLink.closest(".av-transcript-list");
+// Load the segment a segment link points to into the player, from serialized
+// data on the link (see WorkVideoShowComponent#av_media_for), and reflect it
+// as now playing.
+function loadMediaForLink(player, segmentLink) {
+  const mediaData = JSON.parse(segmentLink.dataset.avMedia);
 
-  list.querySelectorAll(".av-now-playing").forEach(function(el) {
-    el.classList.remove("av-now-playing");
-  });
-  segmentLink.closest(".av-transcript-line")?.classList.add("av-now-playing");
-
-  const label = document.querySelector(".av-now-playing-label");
-  if (label) {
-    label.querySelector(".av-now-playing-title").textContent = avMedia.title;
-    label.querySelector(".av-now-playing-position").textContent = `${avMedia.position} / ${avMedia.total}`;
-  }
-}
-
-
-// Load a segment into the player from serialized data
-// (see WorkVideoShowComponent#av_media_for).
-function loadSegmentMedia(player, mediaData) {
   const media = {
     src: { src: mediaData.video_url, type: mediaData.video_type },
     poster: mediaData.poster_url
@@ -127,6 +108,27 @@ function loadSegmentMedia(player, mediaData) {
   }
 
   player.loadMedia(media);
+
+  markSegmentNowPlaying(segmentLink, mediaData);
+}
+
+// Reflect the segment just loaded: move the "now playing" highlight to its row,
+// and update the "now playing" line under the player with its title and position.
+function markSegmentNowPlaying(segmentLink, avMedia) {
+  const list = segmentLink.closest(".av-transcript-list");
+
+  // highlight correct row
+  list.querySelectorAll(".av-now-playing").forEach(function(el) {
+    el.classList.remove("av-now-playing");
+  });
+  segmentLink.closest(".av-transcript-line")?.classList.add("av-now-playing");
+
+  // Add now playing title and position to bar under player
+  const label = document.querySelector(".av-now-playing-label");
+  if (label) {
+    label.querySelector(".av-now-playing-title").textContent = avMedia.title;
+    label.querySelector(".av-now-playing-position").textContent = `${avMedia.position} / ${avMedia.total}`;
+  }
 }
 
 

--- a/app/frontend/javascript/video_player.js
+++ b/app/frontend/javascript/video_player.js
@@ -82,21 +82,30 @@ function setupVideoPlayer(player) {
     }
 
     event.preventDefault();
-    loadSegmentMedia(player, JSON.parse(segmentData.dataset.avMedia));
-    markSegmentNowPlaying(segmentData);
+    const avMedia = JSON.parse(segmentData.dataset.avMedia);
+    loadSegmentMedia(player, avMedia);
+    markSegmentNowPlaying(segmentData, avMedia);
   });
 }
 
 
-// Move the "now playing" highlight to the segment just loaded. The server marks
-// the initial segment (see WorkVideoShowComponent); this takes over on switch.
-function markSegmentNowPlaying(segmentLink) {
+// Reflect the segment just loaded: move the "now playing" highlight to its row,
+// and update the "now playing" line under the player with its title and position.
+// The server renders the initial state (see WorkVideoShowComponent); this takes
+// over on switch.
+function markSegmentNowPlaying(segmentLink, avMedia) {
   const list = segmentLink.closest(".av-transcript-list");
 
   list.querySelectorAll(".av-now-playing").forEach(function(el) {
     el.classList.remove("av-now-playing");
   });
   segmentLink.closest(".av-transcript-line")?.classList.add("av-now-playing");
+
+  const label = document.querySelector(".av-now-playing-label");
+  if (label) {
+    label.querySelector(".av-now-playing-title").textContent = avMedia.title;
+    label.querySelector(".av-now-playing-position").textContent = `${avMedia.position} / ${avMedia.total}`;
+  }
 }
 
 

--- a/app/frontend/stylesheets/local/oh_audio.scss
+++ b/app/frontend/stylesheets/local/oh_audio.scss
@@ -389,6 +389,7 @@
 .transcript-highlighted {
   // shi-teal-1
   background-color: #eaf6f3;
+  box-shadow: inset 4px 0 0 0 $shi-red;
 
   .ohms-transcript-timestamp {
     font-weight: bold;

--- a/app/frontend/stylesheets/local/show-layout.scss
+++ b/app/frontend/stylesheets/local/show-layout.scss
@@ -184,16 +184,18 @@ $max-image-column-breakpoint: ($max-image_column * 2) + $main_gutter_width + 90p
   grid-template-areas:
     "show-title"
     "video-player"
+    "transcript-toggle"
     "show-video-transcript"
     "rights-and-social"
-    "transcript-toggle"
+    "transcript-disclaimer"
     "show-metadata";
   .video-player { grid-area: video-player; }
   .transcript-toggle { grid-area: transcript-toggle; }
+  .transcript-disclaimer { grid-area: transcript-disclaimer; }
   .rights-and-social { grid-area: rights-and-social; }
 
   .show-title, .video-player {
-    margin-bottom: $paragraph-spacer * 2;
+    margin-bottom: $paragraph-spacer;
   }
 
   .show-video-transcript {
@@ -210,7 +212,7 @@ $max-image-column-breakpoint: ($max-image_column * 2) + $main_gutter_width + 90p
       "show-video show-metadata";
 
     .show-video { display: block; }
-    .video-player, .transcript-toggle, .rights-and-social { grid-area: unset; }
+    .video-player, .transcript-toggle, .rights-and-social, .transcript-disclaimer { grid-area: unset; }
     .show-title { margin-bottom: unset; }
     .show-video-transcript { margin-top: unset; }
   }
@@ -261,6 +263,9 @@ $max-image-column-breakpoint: ($max-image_column * 2) + $main_gutter_width + 90p
       // leaving room for margin and padding for highlighted paragraphs
       padding: ($paragraph-spacer * 0.5) ($paragraph-spacer * 0.75);
     }
+  }
+  .av-transcript-list {
+    margin-top: 2px;
   }
 }
 

--- a/app/frontend/stylesheets/local/work_show.scss
+++ b/app/frontend/stylesheets/local/work_show.scss
@@ -267,22 +267,4 @@
   .av-transcript-line.av-now-playing {
     background-color: $shi-teal-1;
   }
-
-  // "Now playing" line under the player, showing current segment title + "X / Y".
-  .av-now-playing-label {
-    .av-now-playing-title {
-      // allow a long title (e.g. an unbroken filename) to wrap instead of
-      // overflowing the flex row. min-width:0 lets the flex item shrink below
-      // its content size; overflow-wrap breaks the long "word".
-      min-width: 0;
-      overflow-wrap: anywhere;
-    }
-
-    .av-now-playing-position {
-      // keep "X / Y" intact on one line, to the right
-      flex-shrink: 0;
-      margin-left: 0.75rem;
-      white-space: nowrap;
-    }
-  }
 }

--- a/app/frontend/stylesheets/local/work_show.scss
+++ b/app/frontend/stylesheets/local/work_show.scss
@@ -260,4 +260,11 @@
       }
     }
   }
+
+  // "Now playing" highlight for the current segment in the multi-segment video
+  // list. Same highlight color as the transcript current-line highlight
+  // (.transcript-highlighted).
+  .av-transcript-line.av-now-playing {
+    background-color: $shi-teal-1;
+  }
 }

--- a/app/frontend/stylesheets/local/work_show.scss
+++ b/app/frontend/stylesheets/local/work_show.scss
@@ -261,6 +261,12 @@
     }
   }
 
+  // scrolls after ~4.5 rows (each row is ~4rem tall) instead of growing the page forever
+  .av-transcript-list-items {
+    max-height: 18rem;
+    overflow-y: auto;
+  }
+
   // "Now playing" highlight for the current segment in the multi-segment video
   // list. Same highlight color as the transcript current-line highlight
   // (.transcript-highlighted).

--- a/app/frontend/stylesheets/local/work_show.scss
+++ b/app/frontend/stylesheets/local/work_show.scss
@@ -267,4 +267,22 @@
   .av-transcript-line.av-now-playing {
     background-color: $shi-teal-1;
   }
+
+  // "Now playing" line under the player, showing current segment title + "X / Y".
+  .av-now-playing-label {
+    .av-now-playing-title {
+      // allow a long title (e.g. an unbroken filename) to wrap instead of
+      // overflowing the flex row. min-width:0 lets the flex item shrink below
+      // its content size; overflow-wrap breaks the long "word".
+      min-width: 0;
+      overflow-wrap: anywhere;
+    }
+
+    .av-now-playing-position {
+      // keep "X / Y" intact on one line, to the right
+      flex-shrink: 0;
+      margin-left: 0.75rem;
+      white-space: nowrap;
+    }
+  }
 }

--- a/app/frontend/stylesheets/local/work_show.scss
+++ b/app/frontend/stylesheets/local/work_show.scss
@@ -272,11 +272,32 @@
   // (.transcript-highlighted).
   .av-transcript-line.av-now-playing {
     background-color: $shi-teal-1;
+    box-shadow: inset 4px 0 0 0 $shi-red;
+
+    .av-thumb-play-icon { display: none; }
+    .av-thumb-now-playing-icon { display: flex; }
   }
 
   .av-thumb-wrap {
     position: relative;
     display: block;
+  }
+
+  // TV icon overlay on the currently-loaded segment's thumbnail, replacing the play triangle
+  .av-thumb-now-playing-icon {
+    display: none; // shown only when parent li has av-now-playing
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 2.4em;
+    height: 2.4em;
+    font-size: 0.85rem;
+    border-radius: 50%;
+    background-color: rgba(43, 51, 63, 0.7);
+    color: #fff;
+    align-items: center;
+    justify-content: center;
   }
 
   // small play icon centered on each segment thumbnail, scaled-down copy of the

--- a/app/frontend/stylesheets/local/work_show.scss
+++ b/app/frontend/stylesheets/local/work_show.scss
@@ -267,4 +267,34 @@
   .av-transcript-line.av-now-playing {
     background-color: $shi-teal-1;
   }
+
+  .av-thumb-wrap {
+    position: relative;
+    display: block;
+  }
+
+  // small play icon centered on each segment thumbnail, scaled-down copy of the
+  // video player's own big play button (video.js's default colors/border)
+  .av-thumb-play-icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 1.6em;
+    height: 1.6em;
+    font-size: 0.85rem;
+    border-radius: 50%;
+    background-color: rgba(43, 51, 63, 0.7);
+
+    &:before {
+      font-family: VideoJS;
+      content: "\f101";
+      color: #fff;
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+  }
 }

--- a/app/views/downloads/transcript_html.html.erb
+++ b/app/views/downloads/transcript_html.html.erb
@@ -3,11 +3,16 @@
     Transcript: <%= link_to @asset.parent.title, work_path(@asset.parent) %>
   </h1>
   <p><%= DateDisplayFormatter.new(@asset.parent.date_of_work).display_dates.join(",") %></p>
+  <p><code><%= @asset.title %></code></p>
 
   <p class="alert alert-warning mt-3">
     <%= t("transcript.asr_warning_html") %>
   </p>
 
 
-  <%= render OralHistory::VttTranscriptComponent.new(OralHistoryContent::OhmsXml::VttTranscript.new(@asset.webvtt_str), base_link: work_path(@asset.parent)) %>
+  <%= render OralHistory::VttTranscriptComponent.new(
+                OralHistoryContent::OhmsXml::VttTranscript.new(@asset.webvtt_str),
+                base_link: work_path(@asset.parent),
+                asset_friendlier_id: @asset.friendlier_id,
+             ) %>
 </div>

--- a/app/views/downloads/transcript_html.html.erb
+++ b/app/views/downloads/transcript_html.html.erb
@@ -1,18 +1,28 @@
-<div class="text-page">
-  <h1>
-    Transcript: <%= link_to @asset.parent.title, work_path(@asset.parent) %>
-  </h1>
-  <p><%= DateDisplayFormatter.new(@asset.parent.date_of_work).display_dates.join(",") %></p>
-  <p><code><%= @asset.title %></code></p>
+<%
+  # Fragment version (embedded directly in the work's video page via JS) links
+  # timestamps to the current page (#t=...&a=...). Full page version links back to
+  # the work's own page, since this is a separate, standalone page.
+  transcript_component = OralHistory::VttTranscriptComponent.new(
+    OralHistoryContent::OhmsXml::VttTranscript.new(@asset.webvtt_str),
+    base_link: (work_path(@asset.parent) unless @only_fragment),
+    asset_friendlier_id: @asset.friendlier_id,
+  )
+%>
+<% if @only_fragment %>
+  <%= render transcript_component %>
+<% else %>
+  <div class="text-page">
+    <h1>
+      Transcript: <%= link_to @asset.parent.title, work_path(@asset.parent) %>
+    </h1>
+    <p><%= DateDisplayFormatter.new(@asset.parent.date_of_work).display_dates.join(",") %></p>
+    <p><code><%= @asset.title %></code></p>
 
-  <p class="alert alert-warning mt-3">
-    <%= t("transcript.asr_warning_html") %>
-  </p>
+    <p class="alert alert-warning mt-3">
+      <%= t("transcript.asr_warning_html") %>
+    </p>
 
 
-  <%= render OralHistory::VttTranscriptComponent.new(
-                OralHistoryContent::OhmsXml::VttTranscript.new(@asset.webvtt_str),
-                base_link: work_path(@asset.parent),
-                asset_friendlier_id: @asset.friendlier_id,
-             ) %>
-</div>
+    <%= render transcript_component %>
+  </div>
+<% end %>

--- a/spec/components/oral_history/vtt_transcript_component_spec.rb
+++ b/spec/components/oral_history/vtt_transcript_component_spec.rb
@@ -100,4 +100,29 @@ describe OralHistory::VttTranscriptComponent, type: :component do
       ).to be_present
     end
   end
+
+  describe "with asset_friendlier_id" do
+    let(:vtt_transcript_component) { described_class.new(vtt_transcript, asset_friendlier_id: "abc123") }
+
+    it "includes &a=<id> in every timestamp link anchor" do
+      parsed = render_inline(vtt_transcript_component)
+
+      timestamp_links = parsed.css("a.ohms-transcript-timestamp")
+      expect(timestamp_links).to be_present
+
+      expect(timestamp_links.map { |a| a["href"] }).to all(match(%r{\A#t=[\d.]+&a=abc123\z}))
+    end
+  end
+
+  describe "without asset_friendlier_id" do
+    it "does not add &a= to timestamp links" do
+      parsed = render_inline(vtt_transcript_component)
+
+      hrefs = parsed.css("a.ohms-transcript-timestamp").map { |a| a["href"] }
+      expect(hrefs).to be_present
+
+      expect(hrefs).to all(start_with("#t="))
+      expect(hrefs).to all(satisfy { |href| !href.include?("&a=") })
+    end
+  end
 end

--- a/spec/components/work_video_show_component_spec.rb
+++ b/spec/components/work_video_show_component_spec.rb
@@ -151,7 +151,7 @@ describe WorkVideoShowComponent, type: :component do
         instance = described_class.new(work)
         render_inline instance
 
-        expect(instance.vtt_transcript_str).to eq asset.corrected_webvtt_str
+        expect(instance.initial_vtt_transcript_str).to eq asset.corrected_webvtt_str
 
         expect(page).to have_selector("video track", count: 1)
         track_element = page.first("video track")
@@ -181,7 +181,7 @@ describe WorkVideoShowComponent, type: :component do
       expect(container).to have_selector("meta[itemprop='duration'][content='#{iso8601_duration}']")
 
       expect(container).to have_selector("*[itemprop='transcript']",
-        text: OralHistoryContent::OhmsXml::VttTranscript.new(instance.vtt_transcript_str).transcript_text)
+        text: OralHistoryContent::OhmsXml::VttTranscript.new(instance.initial_vtt_transcript_str).transcript_text)
     end
   end
 

--- a/spec/components/work_video_show_component_spec.rb
+++ b/spec/components/work_video_show_component_spec.rb
@@ -32,6 +32,24 @@ describe WorkVideoShowComponent, type: :component do
     end
   end
 
+  describe "when video is missing width/height" do
+    # :video factory trait sets faked_width/faked_height nil by default -- unlike an
+    # image, a video asset doesn't always have these -- so the default :video_work
+    # fixture already covers this case.
+    let(:work) { create(:video_work, :published) }
+
+    it "omits aspectRatio and style, instead of emitting an invalid value" do
+      render_inline described_class.new(work)
+
+      video_element = page.first("video")
+      expect(video_element).to be_present
+      expect(video_element["style"]).to be_nil
+
+      setup_json = JSON.parse(video_element["data-setup"])
+      expect(setup_json["aspectRatio"]).to be nil
+    end
+  end
+
   describe "when we have an HLS URL" do
     # Work with an hls url that doesn't actually point anywhere, but fine,
     # we just set it to point to a non-existent thing using shrine

--- a/spec/factories/asset_factory.rb
+++ b/spec/factories/asset_factory.rb
@@ -210,11 +210,15 @@ FactoryBot.define do
       end
 
       trait :asr_vtt do
+        transient do
+          vtt_source { "WEBVTT\n\n00:00.000 --> 00:01.500\nASR WebVTT #{rand 100}" }
+        end
+
         audio_asr_enabled { true }
 
-        after(:build) do |asset|
+        after(:build) do |asset, evaluator|
           asset.file_attacher.merge_derivatives({
-            Asset::ASR_WEBVTT_DERIVATIVE_KEY => build(:stored_uploaded_file, file: StringIO.new("WEBVTT\n\n00:00.000 --> 00:01.500\nASR WebVTT #{rand 100}"), filename: "vtt.vtt", content_type: "text/vtt")
+            Asset::ASR_WEBVTT_DERIVATIVE_KEY => build(:stored_uploaded_file, file: StringIO.new(evaluator.vtt_source), filename: "vtt.vtt", content_type: "text/vtt")
           })
         end
       end
@@ -284,6 +288,7 @@ FactoryBot.define do
         uploaded_file = create(:stored_uploaded_file,
           file: evaluator.faked_file,
           content_type: evaluator.faked_content_type,
+          storage: (evaluator.faked_content_type&.start_with?("video/") ? "video_store" : "store"),
           width: evaluator.faked_width,
           height: evaluator.faked_height,
           bitrate:           evaluator.faked_bitrate,

--- a/spec/factories/uploaded_file_factory.rb
+++ b/spec/factories/uploaded_file_factory.rb
@@ -58,7 +58,7 @@ FactoryBot.define do
 
     after(:build) do |uploaded_file, evaluator|
       # actually upload the file to shrine storage
-      Shrine.storages[:store].upload(evaluator.file, uploaded_file.id)
+      Shrine.storages[evaluator.storage.to_sym].upload(evaluator.file, uploaded_file.id)
     end
   end
 end

--- a/spec/factory_specs/work_factory_spec.rb
+++ b/spec/factory_specs/work_factory_spec.rb
@@ -95,7 +95,8 @@ describe "work factory" do
       end
 
       it "has an attached video with the proper mime type" do
-        expect(work.representative.file_data['storage']).to eq("store")
+        # videos are stored separately from other originals, see asset_uploader.rb
+        expect(work.representative.file_data['storage']).to eq("video_store")
         expect(work.representative.file_data['metadata']['mime_type']).to eq("video/mpeg")
       end
     end

--- a/spec/models/asset_factory_spec.rb
+++ b/spec/models/asset_factory_spec.rb
@@ -25,6 +25,8 @@ describe "FactoryBot Asset factory" do
         expect(asset.file).to be_present
         expect(asset.file.exists?).to be(true)
         expect(asset.file.size > 0).to be(true)
+
+        expect(asset.stored?).to be(true)
       end
     end
 
@@ -75,6 +77,13 @@ describe "FactoryBot Asset factory" do
         expect(asset.file_derivatives.count).to eq(2)
         expect(asset.file_derivatives[:jpeg].content_type).to eq("image/jpeg")
         expect(asset.file_derivatives[:pdf].content_type).to eq("application/pdf")
+      end
+    end
+
+    describe ":video"  do
+      it "is stored" do
+        asset = FactoryBot.create(:asset_with_faked_file, :video)
+        expect(asset.stored?).to be(true)
       end
     end
   end

--- a/spec/system/work_show_spec.rb
+++ b/spec/system/work_show_spec.rb
@@ -276,7 +276,6 @@ describe "Public work show page", type: :system, js: false do
 
       # First segment loaded initially
       expect(page).to have_selector(".av-transcript-line.av-now-playing", text: "First segment")
-      expect(page).to have_selector(".av-now-playing-title", text: "First segment")
 
       # Open the transcript panel, showing the first segment's transcript
       click_on "Show transcript"
@@ -287,7 +286,6 @@ describe "Public work show page", type: :system, js: false do
 
       # Player switches to the second segment
       expect(page).to have_selector(".av-transcript-line.av-now-playing", text: "Second segment")
-      expect(page).to have_selector(".av-now-playing-title", text: "Second segment")
 
       # Transcript switches too (fetched async, Capybara waits for it)
       expect(page).to have_content("This is the transcript of the second segment.")

--- a/spec/system/work_show_spec.rb
+++ b/spec/system/work_show_spec.rb
@@ -240,6 +240,60 @@ describe "Public work show page", type: :system, js: false do
       end
     end
   end
+
+  describe "Multi-segment with captions", type: :system, js: true do
+    let(:first_asset) do
+      create(:asset_with_faked_file, :video, :asr_vtt,
+        title: "First segment",
+        position: 0,
+        # :video trait leaves width/height nil, but video.js throws (and our
+        # player setup JS never finishes running) if aspectRatio can't be
+        # computed -- give it realistic values, like a real processed video would have.
+        faked_width: 640,
+        faked_height: 480,
+        vtt_source: "WEBVTT\n\n00:00.000 --> 00:01.500\nThis is the transcript of the first segment.")
+    end
+
+    let(:second_asset) do
+      create(:asset_with_faked_file, :video, :asr_vtt,
+        title: "Second segment",
+        position: 1,
+        faked_width: 640,
+        faked_height: 480,
+        vtt_source: "WEBVTT\n\n00:00.000 --> 00:01.500\nThis is the transcript of the second segment.")
+    end
+
+    let(:work) { create(:video_work, :published, members: [first_asset, second_asset], representative: first_asset) }
+
+    it "lists both segments, and switches media and transcript when the second is clicked" do
+      visit work_path(work)
+
+      # Both segments listed
+      segment_rows = page.find_all(".av-transcript-line")
+      expect(segment_rows.count).to eq 2
+      expect(page).to have_content("First segment")
+      expect(page).to have_content("Second segment")
+
+      # First segment loaded initially
+      expect(page).to have_selector(".av-transcript-line.av-now-playing", text: "First segment")
+      expect(page).to have_selector(".av-now-playing-title", text: "First segment")
+
+      # Open the transcript panel, showing the first segment's transcript
+      click_on "Show transcript"
+      expect(page).to have_content("This is the transcript of the first segment.")
+
+      # Click the second segment
+      click_on "Second segment", match: :first
+
+      # Player switches to the second segment
+      expect(page).to have_selector(".av-transcript-line.av-now-playing", text: "Second segment")
+      expect(page).to have_selector(".av-now-playing-title", text: "Second segment")
+
+      # Transcript switches too (fetched async, Capybara waits for it)
+      expect(page).to have_content("This is the transcript of the second segment.")
+      expect(page).not_to have_content("This is the transcript of the first segment.")
+    end
+  end
 end
 
 describe "Public work show page", :logged_in_user, type: :system, js: false do


### PR DESCRIPTION
This ended up much more complicated than anticipated, mostly in the Javascript.  Closes #3550 

Loading new video, captions track, transcript, keeping them all sync'd -- ends up being a lot to keep track of, and video.js ends up having a lot of async race conditions here. Coudl nota have gotten through it without Claude Code, which found and suggested fixes and tested many race conditions. 

Almost all fo this code is by Claude Code, with lots of back and forth with me, tried to keep the code well-organized and readable, did my best. But it's a lot of JS for us. 

Sorry for such a large PR, the individual commits are mostly good readable units if you want to look at them. 

- **first step, can list multiple video files**
- **refactor a bit to prepare for multiple files**
- **make sure to order by position**
- **refactored with much help from claude for future dynamic track switching"**
- **JS to load segments in for multi-segment AV**
- **add "now playing" highlighting to row in list, using same highlight color as in transcript**
- **now playing bar under player**
- **VttTranscriptComponent can take friendlier_id to link to specific timecode in specific segment for multi-segment videos**
- **audio/timecode_in_anchor now for OH audio only, but factor out utility methods to re-use for video**
- **refactor to have loadMedia always set highlighting**
- **handle video anchor links with segment assetID as well as timecode**
- **fix seeking on load after loading different segment**
- **link to separate transcript page with good timecode links**
- **fix :asset_with_faked_file :video factory**
- **video.js don't use aspect ratio if we don't have one**
- **swapping video media swaps transcripts too**
- **correct aspect ratio on media swap**
- **preserve user selected player settings on media file change**
