### PR TITLE
Vips use: avoid malicious file triggering unintended unsafe loaders

### DIFF
--- a/app/derivative_transformers/kithe/vips_cli_pdf_to_jpeg.rb
+++ b/app/derivative_transformers/kithe/vips_cli_pdf_to_jpeg.rb
@@ -29,6 +29,11 @@ module Kithe
     class_attribute :vips_thumbnail_command, default: "vipsthumbnail"
     class_attribute :vips_command, default: "vips"
     class_attribute :vips_header_command, default: "vipsheader"
+    class_attribute :pdfinfo_command, default: "pdfinfo"
+
+    # libvips default render resolution for pdfload, used as a ceiling so we never
+    # try to render at higher-than-native resolution.
+    DEFAULT_PDF_DPI = 72.0
 
     attr_reader :max_width, :jpeg_q
 
@@ -68,28 +73,46 @@ module Kithe
     # Creates a thumbnail of the specified width.
     # If you want to add a border later on, you want to pass in a
     # slightly smaller width to accomodate that.
+    #
+    # Renders the PDF's first page ourselves via the explicit `pdfload` operation,
+    # rather than letting `vipsthumbnail` do its own format-sniffing load, so a
+    # malicious file can't get mis-detected as some other, more dangerous, loader.
+    # https://www.libvips.org/2022/05/28/What's-new-in-8.13.html
+    #
+    # Once we've rendered a raster ourselves, it's safe to use vipsthumbnail on
+    # the file WE produced.
     def thumbnail(width, input, output)
-      profile_normalization_args=["--eprofile", srgb_profile_path, "--delete"]
       vips_jpg_params="[Q=#{@jpeg_q },interlace,optimize_coding,strip]"
-      args = if width
-        # The image will be resized to fit within a box
-        # which is `width` wide and very, very very tall.
-        # See:
-        # https://github.com/libvips/libvips/issues/781
-        # https://github.com/libvips/ruby-vips/issues/150
-        [
-          vips_thumbnail_command, input.path,
-          *profile_normalization_args,
-          "--size", "#{width}x1000000",
-          "-o", "#{output.path}#{vips_jpg_params}"
-        ]
+
+      rendered_image = Tempfile.new(["kithe_vips_pdf_page", ".tif"])
+
+      dpi = estimated_dpi_for_width(input.path, width)
+      @cmd.run(vips_command, "pdfload", input.path, rendered_image.path, "--page", "0", "--dpi", dpi.to_s)
+
+      @cmd.run(
+        vips_thumbnail_command, rendered_image.path,
+        "--eprofile", srgb_profile_path, "--delete", # profile normalization args
+        "--size", "#{width}x1000000",
+        "-o", "#{output.path}#{vips_jpg_params}",
+        env: { "VIPS_BLOCK_UNTRUSTED" => "1" }
+      )
+    ensure
+      rendered_image.close! if rendered_image
+    end
+
+    # Uses `pdfinfo` to estimate dpi of PDF, for more efficiently creating thumbnail.
+    def estimated_dpi_for_width(pdf_path, target_width)
+      out, _err = @cmd.run(pdfinfo_command, pdf_path)
+
+      if out =~ /^Page size:\s*([\d.]+)\s*x\s*[\d.]+\s*pts/ && $1.to_f > 0
+        native_width_points = $1.to_f
+        # native_width_points is exactly the page's pixel width at the default 72 DPI,
+        # so this ratio gives us the DPI to hit target_width. Never render above the
+        # default DPI (i.e. don't try to upscale beyond native resolution).
+        (DEFAULT_PDF_DPI * (target_width.to_f / native_width_points)).clamp(1.0, DEFAULT_PDF_DPI)
       else
-        [ vips_command, "copy", input.path,
-          *profile_normalization_args,
-          "#{output.path}#{vips_jpg_params}"
-        ]
+        DEFAULT_PDF_DPI
       end
-      @cmd.run(*args)
     end
 
     # Sharpen a thumbnail.
@@ -107,7 +130,7 @@ module Kithe
         "--m1",        "0"   , # (no sharpening in flat areas)
         "--m2",        "3"   , # (some sharpening in jaggy areas)
       ]
-      @cmd.run(*args)
+      @cmd.run(*args, env: { "VIPS_BLOCK_UNTRUSTED" => "1" })
     end
 
     # Add a rectangular border (@border_pixels wide) around the thumbnail.
@@ -129,13 +152,13 @@ module Kithe
         '--extend', 'background',
         '--background', border_color
       ]
-      @cmd.run(*args)
+      @cmd.run(*args, env: { "VIPS_BLOCK_UNTRUSTED" => "1" })
     end
 
     # Return the height of an image in pixels.
     def image_height(image)
       args = [vips_header_command, '-f', 'Ysize', image.path]
-      @cmd.run(*args).out.to_i
+      @cmd.run(*args, env: { "VIPS_BLOCK_UNTRUSTED" => "1" }).out.to_i
     end
   end
 end

--- a/app/models/dzi_package.rb
+++ b/app/models/dzi_package.rb
@@ -110,7 +110,7 @@ class DziPackage
         vips_output_pathname = Pathname.new(tmp_output_dir).join(base_file_path_to_use)
         FileUtils.mkdir_p(vips_output_pathname.dirname)
 
-        out, err = TTY::Command.new(printer: :null).run(*vips_command_args(original_file.path, vips_output_pathname))
+        out, err = TTY::Command.new(printer: :null).run(*vips_command_args(original_file.path, vips_output_pathname), env: { "VIPS_BLOCK_UNTRUSTED" => "1" })
         out =~ /vips[ \-](\d+\.\d+\.\d+.*$)/
 
         if $1

--- a/app/services/asset_graphic_only_pdf_creator.rb
+++ b/app/services/asset_graphic_only_pdf_creator.rb
@@ -98,7 +98,8 @@ class AssetGraphicOnlyPdfCreator
       temp_orig.path,
       "--size","#{target_width}x65500",
       "--export-profile", "srgb",
-      "-o", "#{output_jp2_tempfile.path}[Q=#{compression_quality},subsample-mode=off]"
+      "-o", "#{output_jp2_tempfile.path}[Q=#{compression_quality},subsample-mode=off]",
+      env: { "VIPS_BLOCK_UNTRUSTED" => "1" }
     )
 
     # note dpi metadata on output jp2 is always 72. :(

--- a/app/services/asset_ocr_creator.rb
+++ b/app/services/asset_ocr_creator.rb
@@ -140,7 +140,8 @@ class AssetOcrCreator
       "thumbnail",
       input_file.path,
       output_tmpfile.path,
-      new_width
+      new_width,
+      env: { "VIPS_BLOCK_UNTRUSTED" => "1" }
     )
 
     Rails.logger.warn("#{self.class.name}: Downsampling asset #{asset.friendlier_id} for tesseract: #{number_to_human_size orig_size} @ #{orig_dpi} dpi, #{orig_width} px wide => #{number_to_human_size output_tmpfile.size} @ #{new_width} px wide")

--- a/app/services/pdf_to_page_images.rb
+++ b/app/services/pdf_to_page_images.rb
@@ -129,10 +129,14 @@ class PdfToPageImages
 
     TTY::Command.new(printer: :null).run(
       vips_command,
-      "copy",
+      # using pdfload to avoid file being able to disguise itself as pdf but get a
+      # non-pdf loader to exploit. https://www.libvips.org/2022/05/28/What's-new-in-8.13.html
+      "pdfload",
+      pdf_file_path,
+      tempfile.path,
       # this tool uses 0-based page numbers
-      "#{pdf_file_path}[page=#{page_num - 1},dpi=#{dpi}]",
-      tempfile.path
+      "--page", (page_num - 1).to_s,
+      "--dpi", dpi.to_s
     )
 
     return tempfile

--- a/spec/derivative_transformers/kithe/vips_cli_pdf_to_jpeg_spec.rb
+++ b/spec/derivative_transformers/kithe/vips_cli_pdf_to_jpeg_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+require 'marcel'
+require 'fastimage'
+
+describe Kithe::VipsCliPdfToJpeg do
+  let(:original_path) { Rails.root + "spec/test_support/pdf/sample-text-and-image-small.pdf" }
+  let(:original_file) { File.open(original_path) }
+  let(:max_width) { 200 }
+
+  it "creates a jpg thumbnail of the requested width" do
+    output_file = described_class.new(max_width: max_width).call(original_file)
+
+    expect(output_file).to be_kind_of(Tempfile)
+    expect(Marcel::MimeType.for(output_file)).to eq "image/jpeg"
+
+    width, height = FastImage.size(output_file.path)
+    expect(width).to eq(max_width)
+    expect(height).to be > width
+
+    output_file.close
+    output_file.unlink
+  end
+end


### PR DESCRIPTION
Recent [rails vulnerability announcement](https://github.com/rails/rails/security/advisories/GHSA-xr9x-r78c-5hrm) drew our attention to a vips vulnerability we could be safer with, against malicious files as inputs to vips. 

All our files are uploaded by staff, so our risk is less, but defense in depth is still wise. 

Vips by default will auto-select a file type specific 'loader' by the _contents_ of the file. Some loaders are from third party libraries and often have insecurities, the vips author trusts them less than vips own loaders. A malicious file could appear disguise itself as a safe file, but then trigger processing by a vulnerable loader, and trigger reveal of file system or even remote code execution. 

(And indeed one of the loaders DID have a vulnerability, which Rails default handling was then vulnerable to, in the recent Rails CVE). 

[Vips provided](https://www.libvips.org/2022/05/28/What's-new-in-8.13.html) a `VIPS_BLOCK_UNTRUSTED` env flag which prevents use of any of these less trusted loaders.  

In this PR, we now use that in many cases where we are processing images. 

However, we also process pdfs, and the pdf loader is considered untrusted.  We have to use pdf loader to process pdf's, we just hope that poppler  (the library which provides the pdf loader) patches it's vulnerabilities. However, in that case, we rewrite our vips commands to _force_ use of pdf loader, so at least a file can't trick it into using some _other_ loader with vulnerabities we do not need to be exposed to. 

Rewriting vips CLI commands was a bit tricky, thanks Claude for help. Claude Code authored most of this code, in dialog with me to try to ensure it was simple and readable code.  

- **use VIPS_BLOCK_UNTRUSTED to prevent malicious file from triggering vulnerable loader that's not for intended file type**
- **read PDFs with vips cli 'pdfload' to prevent auto-selection of unintended vulnerable loader for file**
