### PR TITLE
move video transcript toggle

### DIFF
--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -33,7 +33,7 @@
       <%# href leads to separate page with transcript, that we hope google will follow, but don't expect users to,
           although they can with eg "open in new tab". Normally data-bs-target will be used by Bootstrap collapse JS
           to open box on page with transcript instead %>
-      <a href="<%= asset_transcript_path(initial_video_asset) %>" data-bs-target="#show-video-transcript-collapse" id="showVideoTranscriptToggle" class="btn btn-lg btn-brand-main mb-4" type="button" data-bs-toggle="collapse"  aria-expanded="false" aria-controls="show-video-transcript">
+      <a href="<%= asset_transcript_path(initial_video_asset) %>" data-bs-target="#show-video-transcript-collapse" id="showVideoTranscriptToggle" class="btn btn-lg btn-brand-main mb-4" type="button" data-bs-toggle="collapse"  aria-expanded="false" aria-controls="show-video-transcript-collapse">
         Show transcript
       </a>
     </div>
@@ -176,13 +176,13 @@
     <div class="collapse" id="show-video-transcript-collapse">
       <div class="show-video-transcript mb-4">
         <div class="show-video-transcript-heading">
-          <h2 class="h3">Transcript</h2>
+          <h2 class="h3" id="showVideoTranscriptHeading">Transcript</h2>
           <button type="button" class="btn-close" aria-label="Close" data-bs-toggle="collapse" data-bs-target="#show-video-transcript-collapse" aria-expanded="true">
           </button>
         </div>
 
 
-        <div class="show-video-transcript-content" data-transcript-content-target itemprop="transcript">
+        <div class="show-video-transcript-content" data-transcript-content-target itemprop="transcript" tabindex="0" role="region" aria-labelledby="showVideoTranscriptHeading">
           <%= render OralHistory::VttTranscriptComponent.new(OralHistoryContent::OhmsXml::VttTranscript.new(initial_vtt_transcript_str), asset_friendlier_id: initial_video_asset.friendlier_id) %>
         </div>
       </div>

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -127,39 +127,39 @@
       <% else %> <%# no video file available %>
         <%= tag "img", src: asset_path("placeholderbox.svg", alt: "") %>
       <% end %>
+    </div>
 
-      <% if video_assets.length > 1 %>
-        <div class="av-transcript-list border border-dark">
-          <h2 class="bg-dark text-light fs-5 py-1 px-2 m-0">Multiple Segments</h2>
-          <ul class="av-transcript-list-items list-unstyled m-0">
-            <% video_assets.each do |asset| %>
-              <li class="d-flex px-2 av-transcript-line <%= "av-now-playing" if asset == initial_video_asset %>">
-                <div class="p-2 ps-0 mt-1">
-                  <%= link_to asset_transcript_path(asset), data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id }, class: "av-thumb-wrap" do %>
-                    <%= render ThumbComponent.new(asset, thumb_size: :mini) %>
-                    <span class="av-thumb-play-icon" aria-hidden="true"></span>
-                    <span class="av-thumb-now-playing-icon">
-                      <i class="fa fa-television" aria-hidden="true"></i>
-                      <span class="visually-hidden">Currently loaded</span>
-                    </span>
+    <% if video_assets.length > 1 %>
+      <div class="av-transcript-list border border-dark">
+        <h2 class="bg-dark text-light fs-5 py-1 px-2 m-0">Multiple Segments</h2>
+        <ul class="av-transcript-list-items list-unstyled m-0">
+          <% video_assets.each do |asset| %>
+            <li class="d-flex px-2 av-transcript-line <%= "av-now-playing" if asset == initial_video_asset %>">
+              <div class="p-2 ps-0 mt-1">
+                <%= link_to asset_transcript_path(asset), data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id }, class: "av-thumb-wrap" do %>
+                  <%= render ThumbComponent.new(asset, thumb_size: :mini) %>
+                  <span class="av-thumb-play-icon" aria-hidden="true"></span>
+                  <span class="av-thumb-now-playing-icon">
+                    <i class="fa fa-television" aria-hidden="true"></i>
+                    <span class="visually-hidden">Currently loaded</span>
+                  </span>
+                <% end %>
+              </div>
+              <div class="text-break p-2">
+                <div>
+                  <%= link_to asset_transcript_path(asset), data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id }, aria: ({ current: true } if asset == initial_video_asset) do %>
+                    <%= asset.title %>
                   <% end %>
                 </div>
-                <div class="text-break p-2">
-                  <div>
-                    <%= link_to asset_transcript_path(asset), data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id }, aria: ({ current: true } if asset == initial_video_asset) do %>
-                      <%= asset.title %>
-                    <% end %>
-                  </div>
-                  <div class="small text-muted">
-                    <%= format_ohms_timestamp(asset.file_metadata["duration_seconds"]) %>
-                  </div>
+                <div class="small text-muted">
+                  <%= format_ohms_timestamp(asset.file_metadata["duration_seconds"]) %>
                 </div>
-              </li>
-            <% end %>
-          </ul>
-        </div>
-      <% end %>
-    </div>
+              </div>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
 
     <%= render "works/rights_and_social", work: work %>
 

--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -28,6 +28,17 @@
   <%= tag.meta itemprop: "thumbnailUrl", content: WorkSocialShareAttributes.new(work, view_context: view_context).share_media_url %>
 
 
+  <% if has_any_transcript? %>
+    <div class="transcript-toggle">
+      <%# href leads to separate page with transcript, that we hope google will follow, but don't expect users to,
+          although they can with eg "open in new tab". Normally data-bs-target will be used by Bootstrap collapse JS
+          to open box on page with transcript instead %>
+      <a href="<%= asset_transcript_path(initial_video_asset) %>" data-bs-target="#show-video-transcript-collapse" id="showVideoTranscriptToggle" class="btn btn-lg btn-brand-main mb-4" type="button" data-bs-toggle="collapse"  aria-expanded="false" aria-controls="show-video-transcript">
+        Show transcript
+      </a>
+    </div>
+  <% end %>
+
   <div class="show-title">
     <%= render WorkTitleAndDatesComponent.new(work) %>
   </div>
@@ -149,17 +160,6 @@
         </div>
       <% end %>
     </div>
-
-    <% if has_any_transcript? %>
-      <div class="transcript-toggle">
-        <%# href leads to separate page with transcript, that we hope google will follow, but don't expect users to,
-            although they can with eg "open in new tab". Normally data-bs-target will be used by Bootstrap collapse JS
-            to open box on page with transcript instead %>
-        <a href="<%= asset_transcript_path(initial_video_asset) %>" data-bs-target="#show-video-transcript-collapse" id="showVideoTranscriptToggle" class="btn btn-lg btn-brand-main" type="button" data-bs-toggle="collapse"  aria-expanded="false" aria-controls="show-video-transcript" data-show-label="Show transcript" data-hide-label="Hide transcript">
-          Show transcript
-        </a>
-      </div>
-    <% end %>
 
     <%= render "works/rights_and_social", work: work %>
 

--- a/app/frontend/javascript/transcript_toggle.js
+++ b/app/frontend/javascript/transcript_toggle.js
@@ -4,6 +4,7 @@ import { Collapse } from 'bootstrap';
 domready(function() {
   const toggle = document.getElementById("showVideoTranscriptToggle");
   const transcriptCollapsible = document.getElementById('show-video-transcript-collapse');
+  const transcriptContent = transcriptCollapsible && transcriptCollapsible.querySelector('[data-transcript-content-target]');
 
   if (transcriptCollapsible && toggle) {
     transcriptCollapsible.addEventListener('shown.bs.collapse', event => {
@@ -11,6 +12,11 @@ domready(function() {
       const bounding = transcriptCollapsible.getBoundingClientRect();
       if (bounding && !(bounding.bottom >= 0 && bounding.top <= document.documentElement.clientHeight)) {
         transcriptCollapsible.scrollIntoView();
+      }
+
+      // move focus into the transcript, since the toggle button that had focus is now hidden
+      if (transcriptContent) {
+        transcriptContent.focus();
       }
     });
 
@@ -20,6 +26,11 @@ domready(function() {
 
     transcriptCollapsible.addEventListener('hide.bs.collapse', event => {
       toggle.style.display = ""; // show toggle botton
+    });
+
+    transcriptCollapsible.addEventListener('hidden.bs.collapse', event => {
+      // return focus to toggle, since the close button that had focus is now hidden
+      toggle.focus();
     });
   }
 });

--- a/app/frontend/javascript/transcript_toggle.js
+++ b/app/frontend/javascript/transcript_toggle.js
@@ -7,16 +7,19 @@ domready(function() {
 
   if (transcriptCollapsible && toggle) {
     transcriptCollapsible.addEventListener('shown.bs.collapse', event => {
-      toggle.textContent = toggle.dataset.hideLabel;
-
       // jump to transcript if needed
       const bounding = transcriptCollapsible.getBoundingClientRect();
       if (bounding && !(bounding.bottom >= 0 && bounding.top <= document.documentElement.clientHeight)) {
         transcriptCollapsible.scrollIntoView();
       }
     });
-    transcriptCollapsible.addEventListener('hidden.bs.collapse', event => {
-      toggle.textContent = toggle.dataset.showLabel;
+
+    transcriptCollapsible.addEventListener('show.bs.collapse', event => {
+      toggle.style.display = "none"; // hide toggle botton
+    });
+
+    transcriptCollapsible.addEventListener('hide.bs.collapse', event => {
+      toggle.style.display = ""; // show toggle botton
     });
   }
 });

--- a/app/frontend/stylesheets/local/show-layout.scss
+++ b/app/frontend/stylesheets/local/show-layout.scss
@@ -186,6 +186,7 @@ $max-image-column-breakpoint: ($max-image_column * 2) + $main_gutter_width + 90p
     "video-player"
     "transcript-toggle"
     "show-video-transcript"
+    "av-transcript-list"
     "rights-and-social"
     "transcript-disclaimer"
     "show-metadata";
@@ -193,13 +194,13 @@ $max-image-column-breakpoint: ($max-image_column * 2) + $main_gutter_width + 90p
   .transcript-toggle { grid-area: transcript-toggle; }
   .transcript-disclaimer { grid-area: transcript-disclaimer; }
   .rights-and-social { grid-area: rights-and-social; }
+  // margin-top provides the gap above the transcript box (below video-player, since
+  // transcript-toggle occupies no height once the toggle button is hidden). Kept equal
+  // to .av-transcript-list's margin-top below so the gap looks consistent above and below.
+  .av-transcript-list { grid-area: av-transcript-list; margin-top: $paragraph-spacer; }
 
   .show-title, .video-player {
     margin-bottom: $paragraph-spacer;
-  }
-
-  .show-video-transcript {
-    margin-top: $paragraph-spacer;
   }
 
   // Big enough for grid
@@ -213,9 +214,9 @@ $max-image-column-breakpoint: ($max-image_column * 2) + $main_gutter_width + 90p
       "show-video show-metadata";
 
     .show-video { display: block; }
-    .video-player, .rights-and-social, .transcript-disclaimer { grid-area: unset; }
-    .show-title { margin-bottom: unset; }
-    .show-video-transcript { margin-top: unset; }
+    .video-player, .rights-and-social, .transcript-disclaimer, .av-transcript-list { grid-area: unset; }
+    .show-title, .video-player { margin-bottom: unset; }
+    .av-transcript-list { margin-top: 2px; }
   }
 
   // Keep vide from getting too too large
@@ -264,9 +265,6 @@ $max-image-column-breakpoint: ($max-image_column * 2) + $main_gutter_width + 90p
       // leaving room for margin and padding for highlighted paragraphs
       padding: ($paragraph-spacer * 0.5) ($paragraph-spacer * 0.75);
     }
-  }
-  .av-transcript-list {
-    margin-top: 2px;
   }
 }
 

--- a/app/frontend/stylesheets/local/show-layout.scss
+++ b/app/frontend/stylesheets/local/show-layout.scss
@@ -208,11 +208,12 @@ $max-image-column-breakpoint: ($max-image_column * 2) + $main_gutter_width + 90p
     column-gap: $main_gutter_width;
     grid-template-areas:
       "show-video show-video-transcript"
+      "show-video transcript-toggle"
       "show-video show-title"
       "show-video show-metadata";
 
     .show-video { display: block; }
-    .video-player, .transcript-toggle, .rights-and-social, .transcript-disclaimer { grid-area: unset; }
+    .video-player, .rights-and-social, .transcript-disclaimer { grid-area: unset; }
     .show-title { margin-bottom: unset; }
     .show-video-transcript { margin-top: unset; }
   }


### PR DESCRIPTION
Move video transcript toggle to be ABOVE work title, per discussion with team. 

Especially required for multiple-file players, followup to #3544 

- **move video transcript toggle**
- **acessiblity improvements for show/hide AV transcript**
- **move multiple segment list on narrow screen, below transcript**
