### PR TITLE
Increase vite timeout waiting for dev server

### DIFF
--- a/config/vite.json
+++ b/config/vite.json
@@ -6,7 +6,8 @@
   "development": {
     "autoBuild": true,
     "publicOutputDir": "vite-dev",
-    "port": 3036
+    "port": 3036,
+    "devServerConnectTimeout": 0.5
   },
   "test": {
     "autoBuild": true,


### PR DESCRIPTION
Was having trouble getting vite dev server to be recognized, which results in much degraded vite functionality and performance in dev. Claude suggested recent vite was slower and increased timeout would fix it -- it did. I don't entirely understand what's going on, but this works for me to get vite dev server reliable again.

Reported to vite-ruby at https://github.com/ElMassimo/vite_ruby/issues/616
