### PR TITLE
fix exclusive or on two objects

### DIFF
--- a/app/jobs/oh_transcript_chunker_job.rb
+++ b/app/jobs/oh_transcript_chunker_job.rb
@@ -50,7 +50,7 @@ class OhTranscriptChunkerJob < ApplicationJob
   #    create fresh extracted_paragraph_container if it is possible and paragraphs are missing
   #    or not fresh.
   def perform(oral_history_content:nil, work:nil, delete_existing: false, use_dummy_embedding: false, only_if_invalid: false, refresh_extracted_pdf_paragraphs: false)
-    unless work ^ oral_history_content
+    unless (!!work) ^ (!!oral_history_content)
       raise ArgumentError.new("Exactly one of work:#{work} and oral_history_content#{oral_history_content} must be provided")
     end
     # look it up from work if needed


### PR DESCRIPTION
^ is not defined on all types, convert to boolean first to do exactly one and not both of X, Y

- [x] After deploying, re-run failed job on prod:

      OhTranscriptChunkerJob.perform_later(work: Work.find_by_id!("1a20ac4f-7e80-4838-9333-61659d16fe17"))


