### PR TITLE
Add visibility auth protection for refactored WorkVideoShowComponent

### DIFF
--- a/app/components/work_video_show_component.html.erb
+++ b/app/components/work_video_show_component.html.erb
@@ -150,6 +150,9 @@
                   <%= link_to asset_transcript_path(asset), data: { av_media: av_media_for(asset), friendlier_id: asset.friendlier_id }, aria: ({ current: true } if asset == initial_video_asset) do %>
                     <%= asset.title %>
                   <% end %>
+                  <% if ! asset.published? %>
+                    <span title="Private" class="badge text-bg-warning">Private</span>
+                  <% end %>
                 </div>
                 <div class="small text-muted">
                   <%= format_ohms_timestamp(asset.file_metadata["duration_seconds"]) %>

--- a/app/components/work_video_show_component.rb
+++ b/app/components/work_video_show_component.rb
@@ -9,7 +9,7 @@
 # it a separate class instead of trying to use lots of conditionals in one class, betting
 # that will be simpler overall, and allow them to diverge as more features are added.
 class WorkVideoShowComponent < ApplicationComponent
-  delegate :construct_page_title, :can_see_unpublished_records?, :format_ohms_timestamp,
+  delegate :construct_page_title, :can_see_unpublished_records?, :format_ohms_timestamp, :current_user,
     to: :helpers
 
   attr_reader :work
@@ -63,10 +63,18 @@ class WorkVideoShowComponent < ApplicationComponent
   end
 
   def video_assets
-    @video_assets ||= @work.members.order(:position).find_all do |mem|
-      mem.asset? &&
-      mem&.content_type&.start_with?("video/") &&
-      (mem.published? || can_see_unpublished_records?)
+    @video_assets ||= begin
+      scope = @work.members.order(:position)
+
+      unless AccessPolicy.new(current_user).can_see_unpublished_records?
+        scope = scope.where(published: true)
+      end
+
+      scope.find_all do |mem|
+        mem.asset? &&
+        mem&.content_type&.start_with?("video/") &&
+        (mem.published? || can_see_unpublished_records?)
+      end
     end
   end
 

--- a/spec/components/work_video_show_component_spec.rb
+++ b/spec/components/work_video_show_component_spec.rb
@@ -187,7 +187,7 @@ describe WorkVideoShowComponent, type: :component do
 
     it "is included" do
       instance = described_class.new(work)
-      render_inline described_class.new(work)
+      render_inline instance
 
       container = page.find('*[itemscope][itemtype="http://schema.org/VideoObject"]')
       expect(container).to be_present


### PR DESCRIPTION
When we refactored at #3544, we forgot to limit based on published status. Oops. Quick fix get it in now.

There are no tests yet, which is not good, but we aren't really using this feature yet in production, still testing it. We will add tests. But getting in some access control is a priority.
