### PR TITLE
Refactor python command adapter to return an array instead of a string

### DIFF
--- a/app/lib/scihist_digicoll/util.rb
+++ b/app/lib/scihist_digicoll/util.rb
@@ -78,9 +78,9 @@ module ScihistDigicoll
     # it uses uv to install dependencies, it installs them into PATH directly and you
     # don't/can't use `uv run`, a bit inconvenient.
     #
-    # command_array = ScihistDigicoll::Util.python_exec_command("img2pdf")
+    # command_array = ScihistDigicoll::Util.prefix_python_exec_command("img2pdf")
     # TTY::Command.new(printer: :null).run( *command_array, [other args...] )
-    def self.python_exec_command(bare_command)
+    def self.prefix_python_exec_command(bare_command)
       if Rails.env.development? || Rails.env.test? || system("which uv >/dev/null 2>&1")
         ["uv", "run", bare_command]
       elsif bare_command.start_with?("./")

--- a/app/lib/scihist_digicoll/util.rb
+++ b/app/lib/scihist_digicoll/util.rb
@@ -77,16 +77,19 @@ module ScihistDigicoll
     # On Dev and CI we use (and have to use) `uv run`, but on Heroku, even though
     # it uses uv to install dependencies, it installs them into PATH directly and you
     # don't/can't use `uv run`, a bit inconvenient.
-    def self.prefix_python_exec_command(bare_command)
-      if Rails.env.development? || Rails.env.test? || system("which uv 2>1 >/dev/null")
-        "uv run #{bare_command}"
+    #
+    # command_array = ScihistDigicoll::Util.python_exec_command("img2pdf")
+    # TTY::Command.new(printer: :null).run( *command_array, [other args...] )
+    def self.python_exec_command(bare_command)
+      if Rails.env.development? || Rails.env.test? || system("which uv >/dev/null 2>&1")
+        ["uv", "run", bare_command]
       elsif bare_command.start_with?("./")
         # it's a path to script inside our app like ./python_script/something, we use `python3` on heroku
-        "python3 #{bare_command}"
+        ["python3", bare_command]
       else
         # it's a python-dependent command installed by a package, like img2pdf, we
         # just use the command itself which will be avail in PATH
-        bare_command
+        [bare_command]
       end
     end
 

--- a/app/services/asset_graphic_only_pdf_creator.rb
+++ b/app/services/asset_graphic_only_pdf_creator.rb
@@ -13,8 +13,7 @@ class AssetGraphicOnlyPdfCreator
 
   # A python pip package, that we still haven't totally figured out how we're
   # going to get installed.
-  class_attribute :img2pdf_convert_command, default: ScihistDigicoll::Util.prefix_python_exec_command("img2pdf")
-
+  class_attribute :img2pdf_convert_command, default: ScihistDigicoll::Util.python_exec_command("img2pdf")
 
   # Will resize output to this DPI, based on known input DPI
   DEFAULT_TARGET_DPI = 150
@@ -125,10 +124,10 @@ class AssetGraphicOnlyPdfCreator
     output_pdf_tempfile = Tempfile.new(["scihist_digicoll_asset_pdf_creator", ".pdf"])
 
     tty_command.run(
-      img2pdf_convert_command,
+      *img2pdf_convert_command,
       graphic_temp_file.path,
       "--imgsize", "#{target_dpi} dpi",
-      "-o",output_pdf_tempfile.path
+      "-o", output_pdf_tempfile.path
     )
 
     output_pdf_tempfile

--- a/app/services/asset_graphic_only_pdf_creator.rb
+++ b/app/services/asset_graphic_only_pdf_creator.rb
@@ -15,6 +15,7 @@ class AssetGraphicOnlyPdfCreator
   # going to get installed.
   class_attribute :img2pdf_convert_command, default: ScihistDigicoll::Util.prefix_python_exec_command("img2pdf")
 
+
   # Will resize output to this DPI, based on known input DPI
   DEFAULT_TARGET_DPI = 150
 

--- a/app/services/asset_graphic_only_pdf_creator.rb
+++ b/app/services/asset_graphic_only_pdf_creator.rb
@@ -13,7 +13,7 @@ class AssetGraphicOnlyPdfCreator
 
   # A python pip package, that we still haven't totally figured out how we're
   # going to get installed.
-  class_attribute :img2pdf_convert_command, default: ScihistDigicoll::Util.python_exec_command("img2pdf")
+  class_attribute :img2pdf_convert_command, default: ScihistDigicoll::Util.prefix_python_exec_command("img2pdf")
 
   # Will resize output to this DPI, based on known input DPI
   DEFAULT_TARGET_DPI = 150

--- a/app/services/oral_history/extract_pdf_text.rb
+++ b/app/services/oral_history/extract_pdf_text.rb
@@ -11,7 +11,7 @@ module OralHistory
     class Error < StandardError ; end
 
     class_attribute :extract_pdf_text_command,
-      default: ScihistDigicoll::Util.prefix_python_exec_command("./python_script/extract_pdf_text.py")
+      default: ScihistDigicoll::Util.python_exec_command("./python_script/extract_pdf_text.py")
 
     attr_reader :pdf_file_path
 
@@ -28,7 +28,7 @@ module OralHistory
     #
     # Will validate against our JSON schema and raise if invalid!
     def extract_pdf_text(validate: true)
-      out, err = extract_pdf_text_tty_command.run(extract_pdf_text_command, pdf_file_path)
+      out, err = extract_pdf_text_tty_command.run(*extract_pdf_text_command, pdf_file_path)
 
       parsed = JSON.parse(out)
       if validate

--- a/app/services/oral_history/extract_pdf_text.rb
+++ b/app/services/oral_history/extract_pdf_text.rb
@@ -11,7 +11,7 @@ module OralHistory
     class Error < StandardError ; end
 
     class_attribute :extract_pdf_text_command,
-      default: ScihistDigicoll::Util.python_exec_command("./python_script/extract_pdf_text.py")
+      default: ScihistDigicoll::Util.prefix_python_exec_command("./python_script/extract_pdf_text.py")
 
     attr_reader :pdf_file_path
 


### PR DESCRIPTION
Two small tweaks suggested by chat_gpt, in a side note, while I was working on a separate project:

* Refactors the utility method that prefixes 'uv' to a python command.
  * Before it returned a string;
  * Now it returns an array that can be converted back to method arguments using the splat operator.
Rationale: "Preserves argument boundaries and avoids shell quoting/injection problems", said ChatGPT. Fair enough.

* Changes the call to `which` to fix a small bug.