### PR TITLE
update to Blacklight 9.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,8 +58,8 @@ gem 'scout_apm'
 # NOTE ALSO: We are using `blacklight-frontend` JS NPM package, updating blacklight
 # version may require an update with yarn to `blacklight-frontend`, has to be
 # checked manually.
-gem "blacklight", "~> 9.0.0"
-gem "blacklight_range_limit", "~> 9.2.0" # version no longer sync'd with blacklight, not sure how we tell what version works with what version of BL
+gem "blacklight", "~> 9.1.0"
+gem "blacklight_range_limit", "~> 9.3.0" # version no longer sync'd with blacklight, not sure how we tell what version works with what version of BL
 
 # for some code to deal with transcoding video, via AWS MediaConvert
 # Lower than 1.2.1 had far too big gem builds! https://github.com/samvera-labs/active_encode/issues/126

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,16 +142,16 @@ GEM
     bcrypt (3.1.22)
     bigdecimal (3.3.1)
     bindex (0.8.1)
-    blacklight (9.0.0)
+    blacklight (9.1.0)
       globalid
       i18n (>= 1.7.0)
       jbuilder (~> 2.7)
       kaminari (>= 0.15)
       ostruct (>= 0.3.2)
-      rails (>= 7.0, < 9)
-      view_component (>= 3.0, < 5.0)
+      rails (>= 7.2, < 9)
+      view_component (~> 4.0)
       zeitwerk
-    blacklight_range_limit (9.2.0)
+    blacklight_range_limit (9.3.0)
       blacklight (>= 7.25.2, < 10)
       view_component (>= 2.54, < 5)
     bootsnap (1.25.0)
@@ -857,8 +857,8 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1.208)
   axe-core-rspec (~> 4.3)
   barnes (~> 1.0)
-  blacklight (~> 9.0.0)
-  blacklight_range_limit (~> 9.2.0)
+  blacklight (~> 9.1.0)
+  blacklight_range_limit (~> 9.3.0)
   bootsnap (>= 1.4.4)
   bootstrap4-kaminari-views
   bot_challenge_page (>= 1.1.0, < 2)
@@ -945,7 +945,7 @@ DEPENDENCIES
   webvtt-ruby (< 2)
 
 RUBY VERSION
-   ruby 4.0.3p0
+  ruby 4.0.3p0
 
 BUNDLED WITH
-   4.0.19
+  4.0.19

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -22,6 +22,6 @@ class SearchBuilder < Blacklight::SearchBuilder
   #   self.default_processor_chain += [:add_custom_data_to_query]
   #
   #   def add_custom_data_to_query(solr_parameters)
-  #     solr_parameters[:custom] = blacklight_params[:user_value]
+  #     solr_parameters[:custom] = search_state.params["user_value"]
   #   end
 end

--- a/app/models/search_builder/custom_sort_logic.rb
+++ b/app/models/search_builder/custom_sort_logic.rb
@@ -6,7 +6,7 @@ class SearchBuilder
     # https://github.com/projectblacklight/blacklight/blob/v6.7.2/lib/blacklight/search_builder.rb#L224
     def sort
       # if no sort is specified by the user, and there's no search phrase
-      if blacklight_params[:sort].blank? && blacklight_params[:q].blank?
+      if search_state.params["sort"].blank? && search_state.params["q"].blank?
         # use the default sort order from catalog controller
         @default_blank_query_sort ||= default_sort_order
       else

--- a/app/models/search_builder/within_featured_topic_builder.rb
+++ b/app/models/search_builder/within_featured_topic_builder.rb
@@ -10,7 +10,7 @@ class SearchBuilder
     self.default_processor_chain += [:within_featured_topic]
 
     def within_featured_topic(solr_parameters)
-      featured_topic = FeaturedTopic.from_slug(blacklight_params[:slug])
+      featured_topic = FeaturedTopic.from_slug(search_state.params["slug"])
       solr_parameters[:fq] ||= []
       solr_parameters[:fq] << featured_topic.solr_fq
     end


### PR DESCRIPTION
Fix deprecation warnings for accessing #blacklight_params in a SearchBuilder. Now you should access #search_state.params instead

upgrade to just released blacklight_range_limit that avoids this deprecation notice as well.

Closes #3580
